### PR TITLE
Customize config for Splunk Observability

### DIFF
--- a/cmd/otelcol/config.yaml
+++ b/cmd/otelcol/config.yaml
@@ -1,19 +1,14 @@
 extensions:
   health_check:
-  pprof:
-    endpoint: 0.0.0.0:1777
   zpages:
-    endpoint: 0.0.0.0:55679
 
 receivers:
   otlp:
     protocols:
       grpc:
       http:
-
-  opencensus:
-
-  # Collect own metrics
+  # This section is used to collect the OpenTelemetry Collector metrics
+  # Even if just a SignalFx µAPM customer, these metrics are included
   prometheus:
     config:
       scrape_configs:
@@ -21,35 +16,54 @@ receivers:
         scrape_interval: 10s
         static_configs:
         - targets: ['0.0.0.0:8888']
-
-  jaeger:
-    protocols:
-      grpc:
-      thrift_binary:
-      thrift_compact:
-      thrift_http:
-
+        metric_relabel_configs:
+          - source_labels: [ __name__ ]
+            regex: '.*grpc_io.*'
+            action: drop
+  sapm:
+  signalfx:
   zipkin:
 
 processors:
   batch:
+  # Enabling the memory_limiter is strongly recommended for every pipeline.
+  # Configuration is based on the amount of memory allocated to the collector.
+  # The configuration below assumes 2GB of memory. In general, the ballast
+  # should be set to 1/3 of the collector's memory, the limit should be 90% of
+  # the collector's memory up to 2GB, and the spike should be 25% of the
+  # collector's memory up to 2GB. In addition, the "--mem-ballast-size-mib" CLI
+  # flag must be set to the same value as the "ballast_size_mib". For more
+  # information, see
+  # https://github.com/open-telemetry/opentelemetry-collector/blob/master/processor/memorylimiter/README.md
+  memory_limiter:
+    ballast_size_mib: 683
+    check_interval: 2s
+    limit_mib: 1800
+    spike_limit_mib: 500
 
 exporters:
-  logging:
-    logLevel: debug
+  # Traces
+  sapm:
+    access_token: "${SPLUNK_ACCESS_TOKEN}"
+    endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com/v2/trace"
+  # Metrics + Events
+  signalfx:
+    access_token: "${SPLUNK_ACCESS_TOKEN}"
+    realm: "${SPLUNK_REALM}"
 
 service:
-
   pipelines:
-
     traces:
-      receivers: [opencensus, jaeger, zipkin]
-      processors: [batch]
-      exporters: [logging]
-
+      receivers: [otlp, sapm, zipkin]
+      processors: [memory_limiter, batch]
+      exporters: [sapm]
     metrics:
-      receivers: [otlp, opencensus, prometheus]
-      processors: [batch]
-      exporters: [logging]
+      receivers: [otlp, signalfx, prometheus]
+      processors: [memory_limiter, batch]
+      exporters: [signalfx]
+    logs:
+      receivers: [signalfx]
+      processors: [memory_limiter, batch]
+      exporters: [signalfx]
 
-  extensions: [health_check, pprof, zpages]
+  extensions: [health_check, zpages]


### PR DESCRIPTION
Adding support to setup 2 environment variables to pass token and realm:
- SPLUNK_ACCESS_TOKEN - user must configer their token
- SPLUNK_REALM - user must configer their realm

Fixes https://github.com/signalfx/splunk-otel-collector/issues/6

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>