### PR TITLE
Fix circleci to build on the new default branch main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ workflows:
             - windows-test
           filters:
             branches:
-              only: master
+              only: main
             tags:
               ignore: /.*/
 


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>

Fixes https://github.com/signalfx/splunk-otel-collector/issues/10