### PR TITLE
Build splunk-otel-collector deb/rpm packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,10 @@ commands:
           bin/otelcol_linux_arm64
           bin/otelcol_linux_amd64
           bin/otelcol_windows_amd64.exe
+          dist/splunk-otel-collector_*.amd64.deb
+          dist/splunk-otel-collector_*.arm64.deb
+          dist/splunk-otel-collector-*.arm64.rpm
+          dist/splunk-otel-collector-*.x86_64.rpm
     steps:
       - run:
           name: Check if files exist
@@ -139,6 +143,8 @@ workflows:
             - test
             - coverage
             - windows-test
+            - deb-package
+            - rpm-package
           filters:
             branches:
               ignore: /.*/
@@ -151,11 +157,29 @@ workflows:
             - test
             - coverage
             - windows-test
+            - deb-package
+            - rpm-package
           filters:
             branches:
               only: main
             tags:
               ignore: /.*/
+      - build-package:
+          name: deb-package
+          package_type: deb
+          requires:
+            - cross-compile
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+      - build-package:
+          name: rpm-package
+          package_type: rpm
+          requires:
+            - cross-compile
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
 
 jobs:
   setup-environment:
@@ -271,3 +295,36 @@ jobs:
           name: Unit tests
           command: go test ./...
       - save_module_cache
+
+  build-package:
+    machine:
+      image: ubuntu-1604:202007-01
+    parameters:
+      package_type:
+        type: enum
+        enum: ["deb", "rpm"]
+    steps:
+      - attach_to_workspace
+      - run:
+          name: Install fpm and dependencies
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y ruby ruby-dev rubygems build-essential rpm
+            gem install --no-document fpm -v 1.11.0
+      - run:
+          name: Build << parameters.package_type >> amd64 package
+          command: ./internal/buildscripts/packaging/fpm/<< parameters.package_type >>/build.sh "${CIRCLE_TAG:-}" "amd64" "./dist/"
+      - run:
+          name: Build << parameters.package_type >> arm64 package
+          command: ./internal/buildscripts/packaging/fpm/<< parameters.package_type >>/build.sh "${CIRCLE_TAG:-}" "arm64" "./dist/"
+      - run:
+          name: Test << parameters.package_type >> package installation
+          command: |
+            if [[ "<< parameters.package_type >>" = "deb" ]]; then
+                ./internal/buildscripts/packaging/fpm/test.sh dist/splunk-otel-collector_*amd64.deb
+            else
+                ./internal/buildscripts/packaging/fpm/test.sh dist/splunk-otel-collector-*x86_64.rpm
+            fi
+      - persist_to_workspace:
+          root: ~/
+          paths: project/dist/*.<< parameters.package_type >>

--- a/internal/buildscripts/packaging/fpm/Dockerfile
+++ b/internal/buildscripts/packaging/fpm/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:9
+
+RUN apt-get update && \
+    apt-get install -y ruby ruby-dev rubygems build-essential git rpm
+
+RUN gem install --no-document fpm -v 1.11.0
+
+VOLUME /repo
+WORKDIR /repo
+
+ENV PACKAGE="deb"
+ENV VERSION=""
+ENV ARCH="amd64"
+ENV OUTPUT_DIR="/repo/dist/"
+
+CMD ./internal/buildscripts/packaging/fpm/$PACKAGE/build.sh "$VERSION" "$ARCH" "$OUTPUT_DIR"

--- a/internal/buildscripts/packaging/fpm/common.sh
+++ b/internal/buildscripts/packaging/fpm/common.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+FPM_DIR="$( cd "$( dirname ${BASH_SOURCE[0]} )" && pwd )"
+REPO_DIR="$( cd "$FPM_DIR/../../../../" && pwd )"
+
+PKG_NAME="splunk-otel-collector"
+PKG_VENDOR="Splunk, Inc."
+PKG_MAINTAINER="Splunk, Inc."
+PKG_DESCRIPTION="Splunk OpenTelemetry Collector"
+PKG_LICENSE="Apache 2.0"
+PKG_URL="https://github.com/signalfx/splunk-otel-collector"
+
+SERVICE_NAME="splunk-otel-collector"
+SERVICE_USER="splunk-otel-collector"
+SERVICE_GROUP="splunk-otel-collector"
+PROCESS_NAME="otelcol"
+
+SERVICE_PATH="$FPM_DIR/$SERVICE_NAME.service"
+PREINSTALL_PATH="$FPM_DIR/preinstall.sh"
+POSTINSTALL_PATH="$FPM_DIR/postinstall.sh"
+PREUNINSTALL_PATH="$FPM_DIR/preuninstall.sh"
+
+OTELCOL_INSTALL_PATH="/usr/bin/otelcol"
+SPLUNK_CONFIG_REPO_PATH="$REPO_DIR/cmd/otelcol/config/collector/splunk_config.yaml"
+SPLUNK_CONFIG_INSTALL_PATH="/etc/otel/collector/splunk_config.yaml"
+OTLP_CONFIG_REPO_PATH="$REPO_DIR/cmd/otelcol/config/collector/otlp_config.yaml"
+OTLP_CONFIG_INSTALL_PATH="/etc/otel/collector/otlp_config.yaml"
+SPLUNK_ENV_REPO_PATH="$REPO_DIR/internal/buildscripts/packaging/fpm/splunk_env.sh.example"
+SPLUNK_ENV_INSTALL_PATH="/etc/otel/collector/splunk_env.sh.example"
+
+
+get_version() {
+    commit_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --tags --exact-match --match 'v[0-9]*' 2>/dev/null || true )"
+    if [[ -z "$commit_tag" ]]; then
+        latest_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true )"
+        if [[ -n "$latest_tag" ]]; then
+            echo "${latest_tag}-post"
+        else
+            echo "0.0.1-post"
+        fi
+    else
+        echo "$commit_tag"
+    fi
+}
+
+
+docker_cp() {
+    local container="$1"
+    local src="$2"
+    local dest="$3"
+    local dest_dir="$( dirname "$dest" )"
+
+    echo "Copying $src to $container:$dest ..."
+    docker exec $container mkdir -p "$dest_dir"
+    docker cp "$src" $container:"$dest"
+}
+
+
+install_pkg() {
+    local container="$1"
+    local pkg_path="$2"
+    local pkg_base=$( basename "$pkg_path" )
+
+    echo "Installing $pkg_base ..."
+    docker_cp $container "$pkg_path" /tmp/$pkg_base
+    if [[ "${pkg_base##*.}" = "deb" ]]; then
+        docker exec $container dpkg -i /tmp/$pkg_base
+    else
+        docker exec $container rpm -Uvh --replacepkgs /tmp/$pkg_base
+    fi
+}
+
+
+uninstall_pkg() {
+    local container="$1"
+    local pkg_type="$2"
+    local pkg_name="${3:-"$PKG_NAME"}"
+
+    echo "Uninstalling $pkg_name ..."
+    if [[ "$pkg_type" = "deb" ]]; then
+        docker exec $container dpkg -r $pkg_name
+    else
+        docker exec $container rpm -e $pkg_name
+    fi
+}

--- a/internal/buildscripts/packaging/fpm/deb/Dockerfile.test
+++ b/internal/buildscripts/packaging/fpm/deb/Dockerfile.test
@@ -1,0 +1,22 @@
+# A debian9 image with systemd enabled.  Must be run with:
+# `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
+FROM debian:9
+
+RUN apt-get update &&\
+    apt-get install -yq ca-certificates procps systemd
+
+ENV container docker
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
+    "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+RUN systemctl set-default multi-user.target
+ENV init /lib/systemd/systemd
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+ENTRYPOINT ["/lib/systemd/systemd"]

--- a/internal/buildscripts/packaging/fpm/deb/README.md
+++ b/internal/buildscripts/packaging/fpm/deb/README.md
@@ -1,0 +1,13 @@
+# Build splunk-otel-collector deb package
+
+Build the splunk-otel-collector deb package with [fpm](https://github.com/jordansissel/fpm).
+
+To build the deb package, run `make deb-package` from the repo root directory. The deb package will be written to
+`dist/splunk-otel-collector_<version>_<arch>.deb`.
+
+By default, `<arch>` is `amd64` and `<version>` is the latest git tag with `-post` appended, e.g. `1.2.3-post`.
+To override these defaults, set the `ARCH` and `VERSION` environment variables, e.g.
+`make deb-package ARCH=arm64 VERSION=4.5.6`.
+
+Run `./internal/buildscripts/packaging/fpm/test.sh PATH_TO_DEB_FILE` to run a basic installation test with the built
+package.

--- a/internal/buildscripts/packaging/fpm/deb/build.sh
+++ b/internal/buildscripts/packaging/fpm/deb/build.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname ${BASH_SOURCE[0]} )" && pwd )"
+. $SCRIPT_DIR/../common.sh
+
+VERSION="${1:-}"
+ARCH="${2:-"amd64"}"
+OUTPUT_DIR="${3:-"$REPO_DIR/dist/"}"
+OTELCOL_REPO_PATH="$REPO_DIR/bin/otelcol_linux_${ARCH}"
+
+
+if [[ ! -f "$OTELCOL_REPO_PATH" ]]; then
+    echo "$OTELCOL_REPO_PATH not found!"
+    exit 1
+fi
+
+if [[ -z "$VERSION" ]]; then
+    VERSION="$( get_version )"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+fpm -s dir -t deb -n $PKG_NAME -v ${VERSION#v} -f -p "$OUTPUT_DIR" \
+    --vendor "$PKG_VENDOR" \
+    --maintainer "$PKG_MAINTAINER" \
+    --description "$PKG_DESCRIPTION" \
+    --license "$PKG_LICENSE" \
+    --url "$PKG_URL" \
+    --architecture "$ARCH" \
+    --deb-dist "stable" \
+    --deb-user "$SERVICE_USER" \
+    --deb-group "$SERVICE_GROUP" \
+    --before-install "$PREINSTALL_PATH" \
+    --after-install "$POSTINSTALL_PATH" \
+    --pre-uninstall "$PREUNINSTALL_PATH" \
+    --config-files $SPLUNK_CONFIG_INSTALL_PATH \
+    --config-files $OTLP_CONFIG_INSTALL_PATH \
+    $SPLUNK_CONFIG_REPO_PATH=$SPLUNK_CONFIG_INSTALL_PATH \
+    $OTLP_CONFIG_REPO_PATH=$OTLP_CONFIG_INSTALL_PATH \
+    $SPLUNK_ENV_REPO_PATH=$SPLUNK_ENV_INSTALL_PATH \
+    $SERVICE_PATH=/lib/systemd/system/$SERVICE_NAME.service \
+    $OTELCOL_REPO_PATH=$OTELCOL_INSTALL_PATH

--- a/internal/buildscripts/packaging/fpm/postinstall.sh
+++ b/internal/buildscripts/packaging/fpm/postinstall.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl enable splunk-otel-collector.service
+    # only start the service after package is installed if the environment file exists
+    if [ -f /etc/otel/collector/splunk_env.sh ]; then
+        systemctl start splunk-otel-collector.service
+    fi
+fi

--- a/internal/buildscripts/packaging/fpm/preinstall.sh
+++ b/internal/buildscripts/packaging/fpm/preinstall.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+getent passwd splunk-otel-collector >/dev/null || \
+    useradd --system --user-group --no-create-home --shell /sbin/nologin splunk-otel-collector

--- a/internal/buildscripts/packaging/fpm/preuninstall.sh
+++ b/internal/buildscripts/packaging/fpm/preuninstall.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl stop splunk-otel-collector.service
+    systemctl disable splunk-otel-collector.service
+fi

--- a/internal/buildscripts/packaging/fpm/rpm/Dockerfile.test
+++ b/internal/buildscripts/packaging/fpm/rpm/Dockerfile.test
@@ -1,0 +1,20 @@
+# A centos8 image with systemd enabled.  Must be run with:
+# `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
+FROM centos:8
+
+ENV container docker
+
+RUN dnf install -y initscripts
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
+    "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;\
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/internal/buildscripts/packaging/fpm/rpm/README.md
+++ b/internal/buildscripts/packaging/fpm/rpm/README.md
@@ -1,0 +1,13 @@
+# Build splunk-otel-collector rpm package
+
+Build the splunk-otel-collector rpm package with [fpm](https://github.com/jordansissel/fpm).
+
+To build the rpm package, run `make rpm-package` from the repo root directory. The rpm package will be written to
+`dist/splunk-otel-collector-<version>.<arch>>.rpm`.
+
+By default, `<arch>` is `amd64` and `<version>` is the latest git tag with `~post` appended, e.g. `1.2.3~post`.
+To override these defaults, set the `ARCH` and `VERSION` environment variables, e.g.
+`make rpm-package ARCH=arm64 VERSION=4.5.6`.
+
+Run `./internal/buildscripts/packaging/fpm/test.sh PATH_TO_RPM_FILE` to run a basic installation test with the built
+package.

--- a/internal/buildscripts/packaging/fpm/rpm/build.sh
+++ b/internal/buildscripts/packaging/fpm/rpm/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname ${BASH_SOURCE[0]} )" && pwd )"
+. $SCRIPT_DIR/../common.sh
+
+VERSION="${1:-}"
+ARCH="${2:-"amd64"}"
+OUTPUT_DIR="${3:-"$REPO_DIR/dist/"}"
+OTELCOL_REPO_PATH="$REPO_DIR/bin/otelcol_linux_${ARCH}"
+
+
+if [[ ! -f "$OTELCOL_REPO_PATH" ]]; then
+    echo "$OTELCOL_REPO_PATH not found!"
+    exit 1
+fi
+
+if [[ -z "$VERSION" ]]; then
+    VERSION="$( get_version )"
+    # rpm doesn't like dashes in the version, replace with tildas
+    VERSION="${VERSION/'-'/'~'}"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+fpm -s dir -t rpm -n $PKG_NAME -v ${VERSION#v} -f -p "$OUTPUT_DIR" \
+    --vendor "$PKG_VENDOR" \
+    --maintainer "$PKG_MAINTAINER" \
+    --description "$PKG_DESCRIPTION" \
+    --license "$PKG_LICENSE" \
+    --url "$PKG_URL" \
+    --architecture "$ARCH" \
+    --rpm-summary "$PKG_DESCRIPTION" \
+    --rpm-user "$SERVICE_USER" \
+    --rpm-group "$SERVICE_GROUP" \
+    --before-install "$PREINSTALL_PATH" \
+    --after-install "$POSTINSTALL_PATH" \
+    --pre-uninstall "$PREUNINSTALL_PATH" \
+    --config-files $SPLUNK_CONFIG_INSTALL_PATH \
+    --config-files $OTLP_CONFIG_INSTALL_PATH \
+    $SPLUNK_CONFIG_REPO_PATH=$SPLUNK_CONFIG_INSTALL_PATH \
+    $OTLP_CONFIG_REPO_PATH=$OTLP_CONFIG_INSTALL_PATH \
+    $SPLUNK_ENV_REPO_PATH=$SPLUNK_ENV_INSTALL_PATH \
+    $SERVICE_PATH=/lib/systemd/system/$SERVICE_NAME.service \
+    $OTELCOL_REPO_PATH=$OTELCOL_INSTALL_PATH

--- a/internal/buildscripts/packaging/fpm/splunk-otel-collector.service
+++ b/internal/buildscripts/packaging/fpm/splunk-otel-collector.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Splunk OpenTelemetry Collector
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/otel/collector/splunk_env.sh
+ExecStart=/usr/bin/otelcol --config /etc/otel/collector/splunk_config.yaml
+KillMode=mixed
+Restart=on-failure
+Type=simple
+User=splunk-otel-collector
+Group=splunk-otel-collector
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/buildscripts/packaging/fpm/splunk_env.sh.example
+++ b/internal/buildscripts/packaging/fpm/splunk_env.sh.example
@@ -1,0 +1,12 @@
+# Sample environment file for passing variables to the splunk-otel-collector service.
+# See /etc/otel/collector/splunk_config.yaml for how these variables will be consumed.
+
+# To use this file, replace the values below with the Splunk access token and ingest realm (e.g. us0),
+# and save the changes to "/etc/otel/collector/splunk_env.sh".
+
+# Then run the following commands to apply the changes and restart the service:
+#   sudo systemctl daemon-reload
+#   sudo systemctl restart splunk-otel-collector.service
+
+SPLUNK_ACCESS_TOKEN=YOUR_SPLUNK_ACCESS_TOKEN
+SPLUNK_REALM=YOUR_SPLUNK_REALM

--- a/internal/buildscripts/packaging/fpm/test.sh
+++ b/internal/buildscripts/packaging/fpm/test.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname ${BASH_SOURCE[0]} )" && pwd )"
+. $SCRIPT_DIR/common.sh
+
+PKG_PATH="${1:-}"
+
+
+if [[ -z "$PKG_PATH" ]]; then
+    echo "usage: ${BASH_SOURCE[0]} DEB_OR_RPM_PATH" >&2
+    exit 1
+fi
+
+if [[ ! -f "$PKG_PATH" ]]; then
+    echo "$PKG_PATH not found!" >&2
+    exit 1
+fi
+
+pkg_base="$( basename "$PKG_PATH" )"
+pkg_type="${pkg_base##*.}"
+if [[ ! "$pkg_type" =~ ^(deb|rpm)$ ]]; then
+    echo "$PKG_PATH not supported!" >&2
+    exit 1
+fi
+image_name="splunk-otel-collector-$pkg_type-test"
+container_name="$image_name"
+docker_run_opts="--name $container_name -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro --privileged"
+docker_run="docker run $docker_run_opts $image_name"
+docker_exec="docker exec $container_name"
+
+trap "docker rm -fv $container_name >/dev/null 2>&1 || true" EXIT
+
+docker build -t $image_name -f "$SCRIPT_DIR/$pkg_type/Dockerfile.test" "$SCRIPT_DIR"
+docker rm -fv $container_name >/dev/null 2>&1 || true
+
+# test install
+echo
+$docker_run
+install_pkg $container_name "$PKG_PATH"
+
+# ensure service has not started after initial install
+sleep 5
+echo "Checking $SERVICE_NAME service status ..."
+if $docker_exec systemctl --no-pager status $SERVICE_NAME; then
+    $docker_exec journalctl -u $SERVICE_USER --no-pager
+    echo "$SERVICE_NAME service started after initial install but should not be"
+    exit 1
+fi
+
+# start the service with the sample env file
+$docker_exec cp /etc/otel/collector/splunk_env.sh.example /etc/otel/collector/splunk_env.sh
+$docker_exec systemctl daemon-reload
+$docker_exec systemctl start splunk-otel-collector.service
+
+# ensure service has started and still running after 5 seconds
+sleep 5
+echo "Checking $SERVICE_NAME service status ..."
+if ! $docker_exec systemctl --no-pager status $SERVICE_NAME; then
+    $docker_exec journalctl -u $SERVICE_USER --no-pager
+    echo "$SERVICE_NAME service not started"
+    exit 1
+fi
+
+echo "Checking $PROCESS_NAME process is running as $SERVICE_USER user ..."
+$docker_exec pgrep -a -u $SERVICE_USER $PROCESS_NAME
+
+# test reinstall
+install_pkg $container_name "$PKG_PATH"
+
+# ensure service has started and still running after 5 seconds
+sleep 5
+echo "Checking $SERVICE_NAME service status ..."
+if ! $docker_exec systemctl --no-pager status $SERVICE_NAME; then
+    $docker_exec journalctl -u $SERVICE_USER --no-pager
+    echo "$SERVICE_NAME service not started"
+    exit 1
+fi
+
+echo "Checking $PROCESS_NAME process is running as $SERVICE_USER user ..."
+$docker_exec pgrep -a -u $SERVICE_USER $PROCESS_NAME
+
+# test uninstall
+echo
+uninstall_pkg $container_name $pkg_type
+
+echo "Checking $SERVICE_NAME service status after uninstall ..."
+if $docker_exec systemctl --no-pager status $SERVICE_NAME; then
+    echo "$SERVICE_NAME service still running after uninstall" >&2
+    exit 1
+fi
+echo "$SERVICE_NAME service successfully stopped after uninstall"
+
+echo "Checking $SERVICE_NAME service existence after uninstall ..."
+if $docker_exec systemctl list-unit-files --all | grep $SERVICE_NAME; then
+    echo "$SERVICE_NAME service still exists after uninstall" >&2
+    exit 1
+fi
+echo "$SERVICE_NAME service successfully removed after uninstall"
+
+echo "Checking $PROCESS_NAME process after uninstall ..."
+if $docker_exec pgrep $PROCESS_NAME; then
+    echo "$PROCESS_NAME process still running after uninstall"
+    exit 1
+fi
+echo "$PROCESS_NAME process successfully killed after uninstall"


### PR DESCRIPTION
- Ported from opentelemetry core and contrib
- Includes `splunk_config.yaml` and `otlp_config.yaml` config, installs to `/etc/otel/collector/`
- Installs `splunk-otel-collector` systemd service with default config `/etc/otel/collector/splunk_config.yaml` and sources env vars from `/etc/otel/collector/splunk_env.sh`
- Installs sample env file `/etc/otel/collector/splunk_env.sh.example` for passing `SPLUNK_ACCESS_TOKEN` and `SPLUNK_REALM` env vars to the systemd service