### PR TITLE
Populate memory ballast size from SPLUNK_BALLAST_SIZE_MIB env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ which requires the following environment variables:
 
 - `${SPLUNK_REALM}`: Which realm to send the data to (for example: `us0`)
 - `${SPLUNK_ACCESS_TOKEN}`: Access token to authenticate requests
-- `${SPLUNK_BALLAST}`: How much memory to allocate to the ballast. This should be set to 1/3 to 1/2 of configured memory.
+- `${SPLUNK_BALLAST_SIZE_MIB}`: How much memory to allocate to the ballast. This should be set to 1/3 to 1/2 of configured memory.
 
 Deploy the collector as outlined in the below. More information
 about deploying and configuring the collector can be found
@@ -32,10 +32,9 @@ Deploy from a Docker container (replace `0.1.0-otel-0.11.0` with the latest
 stable version number if necessary):
 
 ```bash
-$ SPLUNK_REALM=us0 SPLUNK_ACCESS_TOKEN=12345 SPLUNK_BALLAST=683 \
+$ SPLUNK_REALM=us0 SPLUNK_ACCESS_TOKEN=12345 SPLUNK_BALLAST_SIZE_MIB=683 \
   docker run -p 7276:7276 -p 8888:8888 -p 9943:9943 -p 55679:55679 -p 55680:55680 -p 9411:9411 \
-    --name otelcol signalfx/splunk-otel-collector:0.1.0-otel-0.11.0 \
-        --mem-ballast-size-mib=683
+    --name otelcol signalfx/splunk-otel-collector:0.1.0-otel-0.11.0
 ```
 
 ### Kubernetes
@@ -50,8 +49,8 @@ file on GitHub.
 
 ```bash
 $ make otelcol
-$ SPLUNK_REALM=us0 SPLUNK_ACCESS_TOKEN=12345 SPLUNK_BALLAST=683 \
-  ./bin/otelcol --mem-ballast-size-mib=${SPLUNK_BALLAST}
+$ SPLUNK_REALM=us0 SPLUNK_ACCESS_TOKEN=12345 SPLUNK_BALLAST_SIZE_MIB=683 \
+  ./bin/otelcol
 ```
 
 ## Custom Configuration
@@ -62,9 +61,13 @@ be provided.
 For example in Docker:
 
 ```bash
-$ SPLUNK_REALM=us0 SPLUNK_ACCESS_TOKEN=12345 SPLUNK_BALLAST=683 \
+$ SPLUNK_REALM=us0 SPLUNK_ACCESS_TOKEN=12345 SPLUNK_BALLAST_SIZE_MIB=683 \
   docker run -p 7276:7276 -p 8888:8888 -p 9943:9943 -p 55679:55679 -p 55680:55680 -p 9411:9411 \
     -v collector.yaml:/etc/collector.yaml:ro \
     --name otelcol signalfx/splunk-otel-collector:0.1.0-otel-0.11.0 \
-        --config /etc/collector.yaml --mem-ballast-size-mib=683
+        --config /etc/collector.yaml
 ```
+
+Note that if the configuration includes a memorylimiter processor then it must set the
+value of `ballast_size_mib` setting of the processor to the env variable SPLUNK_BALLAST_SIZE_MIB.
+See for example splunk_config.yaml on how to do it.

--- a/cmd/otelcol/Dockerfile
+++ b/cmd/otelcol/Dockerfile
@@ -13,5 +13,5 @@ COPY --from=otelcol /otelcol /
 COPY config/collector/splunk_config.yaml /etc/otel/collector/splunk_config.yaml
 COPY config/collector/otlp_config.yaml /etc/otel/collector/otlp_config.yaml
 ENTRYPOINT ["/otelcol"]
-CMD ["--config", "/etc/otel/collector/splunk_config.yaml", "--mem-ballast-size-mib", "${SPLUNK_BALLAST}"]
+CMD ["--config", "/etc/otel/collector/splunk_config.yaml"]
 EXPOSE 13133 14250 14268 55678 55679 55680 7276 9411 9443

--- a/cmd/otelcol/config/collector/otlp_config.yaml
+++ b/cmd/otelcol/config/collector/otlp_config.yaml
@@ -41,12 +41,14 @@ processors:
   # The configuration below assumes 2GB of memory. In general, the ballast
   # should be set to 1/3 of the collector's memory, the limit should be 90% of
   # the collector's memory up to 2GB, and the spike should be 25% of the
-  # collector's memory up to 2GB. In addition, the "--mem-ballast-size-mib" CLI
-  # flag must be set to the same value as the "ballast_size_mib". For more
-  # information, see
+  # collector's memory up to 2GB. The simplest way to specify the ballast size is
+  # set the value of SPLUNK_BALLAST_SIZE_MIB env variable. This will overrides
+  # the value of --mem-ballast-size-mib command line flag. If SPLUNK_BALLAST_SIZE_MIB
+  # is not defined then --mem-ballast-size-mib command line flag must be manually specified.
+  # For more information about memory limiter, see
   # https://github.com/open-telemetry/opentelemetry-collector/blob/master/processor/memorylimiter/README.md
   memory_limiter:
-    ballast_size_mib: ${SPLUNK_BALLAST}
+    ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     check_interval: 2s
     limit_percentage: 90
     spike_limit_percentage: 25

--- a/cmd/otelcol/config/collector/splunk_config.yaml
+++ b/cmd/otelcol/config/collector/splunk_config.yaml
@@ -41,12 +41,14 @@ processors:
   # The configuration below assumes 2GB of memory. In general, the ballast
   # should be set to 1/3 of the collector's memory, the limit should be 90% of
   # the collector's memory up to 2GB, and the spike should be 25% of the
-  # collector's memory up to 2GB. In addition, the "--mem-ballast-size-mib" CLI
-  # flag must be set to the same value as the "ballast_size_mib". For more
-  # information, see
+  # collector's memory up to 2GB. The simplest way to specify the ballast size is
+  # set the value of SPLUNK_BALLAST_SIZE_MIB env variable. This will overrides
+  # the value of --mem-ballast-size-mib command line flag. If SPLUNK_BALLAST_SIZE_MIB
+  # is not defined then --mem-ballast-size-mib command line flag must be manually specified.
+  # For more information about memory limiter, see
   # https://github.com/open-telemetry/opentelemetry-collector/blob/master/processor/memorylimiter/README.md
   memory_limiter:
-    ballast_size_mib: ${SPLUNK_BALLAST}
+    ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     check_interval: 2s
     limit_percentage: 90
     spike_limit_percentage: 25

--- a/internal/buildscripts/packaging/fpm/splunk_env.example
+++ b/internal/buildscripts/packaging/fpm/splunk_env.example
@@ -18,4 +18,4 @@ SPLUNK_ACCESS_TOKEN=12345
 SPLUNK_REALM=us0
 
 # How much memory to allocate to the ballast. This should be set to 1/3 to 1/2 of configured memory.
-SPLUNK_BALLAST=683
+SPLUNK_BALLAST_SIZE_MIB=683


### PR DESCRIPTION
The value of memory ballast can be now provided via SPLUNK_BALLAST_SIZE_MIB
env variable. It will override the value provided via --mem-ballast-size-mib
command line flag.

The SPLUNK_BALLAST_SIZE_MIB env variable can be accessed from the config file.
This is particularly useful for the memorylimiter processor and helps to avoid
specifying the ballast size twice.