### PR TITLE
Sign and release deb/rpm packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,6 +265,16 @@ jobs:
       - publish_docker_images:
           repo: splunk-otel-collector
           tag: ${CIRCLE_TAG:1}
+      - run:
+          name: Prepare release artifacts
+          command: |
+            cp bin/* dist/
+      - run:
+          name: Calculate checksums
+          command: cd dist && shasum -a 256 * > checksums.txt
+      - run:
+          name: Create Github release and upload artifacts
+          command: ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $CIRCLE_TAG dist/
 
   publish-dev:
     docker:
@@ -328,3 +338,5 @@ jobs:
       - persist_to_workspace:
           root: ~/
           paths: project/dist/*.<< parameters.package_type >>
+      - store_artifacts:
+          path: dist

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ coverage.html
 # Wix
 *.wixobj
 *.wixpdb
+
+# Python
+venv/
+__pycache__
+*.pyc

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ install-tools:
 	go install github.com/pavius/impi/cmd/impi
 	go install github.com/securego/gosec/cmd/gosec
 	go install honnef.co/go/tools/cmd/staticcheck
+	go install github.com/tcnksm/ghr
 
 .PHONY: otelcol
 otelcol:

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,47 @@
+# Release Process
+
+## Prerequisites and Setup
+
+1. Connect to the Splunk corporate network on your workstation.
+1. You must have permissions to push tags to this repository.
+1. You must be able to sign git commits/tags. Follow [this guide](
+   https://docs.github.com/en/github/authenticating-to-github/signing-commits)
+   to setup it up.
+1. Access the required service account tokens for Chaperone, Splunk staging
+   repository, and Splunk Artifactory.  Check with a team member for details.
+1. Install Docker, Python 3, [pip](https://pip.pypa.io/en/stable/installing/),
+   and [virtualenv](https://virtualenv.pypa.io/en/latest/) on your workstation.
+1. Install the required dependencies with pip in virtualenv on your workstation:
+   ```
+   virtualenv venv
+   source venv/bin/activate
+   pip install -r internal/buildscripts/packaging/release/requirements.txt
+   ```
+
+## Steps
+
+1. If necessary, update the OpenTelemetry Core and Contrib dependency versions
+   in [go.mod](../go.mod) and run `go mod tidy`.  Create a PR with the changes
+   and ensure that the build and tests are successful.  Wait for the PR to be
+   approved and merged, and ensure that the `main` branch build and tests are
+   successful.
+1. Create and push the tag with the appropriate version:
+   ```
+   make add-tag TAG=v1.2.3
+   git push --tags origin  # assuming "origin" is the upstream repository and not your fork
+   ```
+1. Ensure that the build and tests for the tag are successful.
+1. Ensure that the release was created and the packages were published to
+   [Github Releases](https://github.com/signalfx/splunk-otel-collector/releases/)
+1. Run the following script in virtualenv with the respective service account
+   tokens to sign the packages from github and release them to Artifactory.
+   `STAGE` should be `test`, `beta`, or `release` (default).
+   ```
+   source venv/bin/activate  # if not already in virtualenv
+   ./internal/buildscripts/packaging/release/sign_release.py --stage=STAGE --artifactory-token=ARTIFACTORY_TOKEN --chaperone-token=CHAPERONE_TOKEN --staging-token=STAGING_TOKEN
+   ```
+   This may 10+ minutes to complete.
+
+   **Hint:** You can set the `ARTIFACTORY_TOKEN`, `CHAPERONE_TOKEN`, and
+   `STAGING_TOKEN` environment variables instead of passing the tokens via
+   the command line options.

--- a/internal/buildscripts/packaging/release/helpers/util.py
+++ b/internal/buildscripts/packaging/release/helpers/util.py
@@ -1,0 +1,289 @@
+import hashlib
+import os
+import re
+import tempfile
+import time
+
+import requests
+from github import Github
+
+ARTIFACTORY_URL = "https://splunk.jfrog.io/artifactory"
+ARTIFACTORY_API_URL = f"{ARTIFACTORY_URL}/api"
+CHAPERONE_API_URL = "https://chaperone.re.splunkdev.com/api-service"
+SIGNED_ARTIFACTS_REPO_URL = "https://repo.splunk.com/artifactory/signed-artifacts"
+STAGING_URL = "https://repo.splunk.com/artifactory"
+STAGING_REPO = os.environ.get("STAGING_REPO", "otel-collector-local")
+STAGING_REPO_URL = f"{STAGING_URL}/{STAGING_REPO}"
+SIGN_TYPES = ("GPG", "RPM", "WIN")
+DEFAULT_ARTIFACTORY_USERNAME = "otel-collector"
+DEFAULT_STAGING_USERNAME = "srv-otel-collector"
+DEFAULT_TIMEOUT = 300
+
+
+def upload_file_to_artifactory(src, dest, user, token):
+    print(f"uploading {src} to {dest} ...")
+
+    with open(src, "rb") as fd:
+        data = fd.read()
+        headers = {"X-Checksum-MD5": hashlib.md5(data).hexdigest()}
+        resp = requests.put(dest, auth=(user, token), headers=headers, data=data)
+
+        assert resp.status_code == 201, f"upload failed:\n{resp.reason}\n{resp.text}"
+
+        return resp
+
+
+def submit_signing_request(src, sign_type, token):
+    print(f"submitting '{sign_type}' signing request for {src} ...")
+
+    headers = {"Accept": "application/json", "Authorization": f"Bearer {token}"}
+    data = {"artifact_url": src, "sign_type": sign_type, "project_key": "otel-collector"}
+
+    resp = requests.post(CHAPERONE_API_URL + "/sign/submit", headers=headers, data=data)
+
+    assert resp.status_code == 200, f"signing request failed:\n{resp.reason}"
+    assert "item_key" in resp.json().keys(), f"'item_key' not found in response:\n{resp.text}"
+
+    print(resp.text)
+
+    return resp.json().get("item_key")
+
+
+def run_chaperone_check(item_key, token):
+    url = f"{CHAPERONE_API_URL}/{item_key}/check"
+    headers = {"Accept": "application/json", "Authorization": f"Bearer {token}"}
+
+    print(f"running chaperone check {url}:")
+
+    resp = requests.get(url, headers=headers)
+
+    assert resp.status_code == 200, f"chaperone check failed for {item_key}:\n{resp.reason}\n{resp.text}"
+
+    return resp
+
+
+def artifactory_file_exists(url, user, token):
+    return requests.head(url, auth=(user, token)).status_code == 200
+
+
+def download_file(url, dest, user=None, token=None):
+    print(f"downloading {url} to {dest} ...")
+
+    resp = requests.get(url, auth=(user, token))
+
+    assert resp.status_code == 200, f"download failed:\n{resp.reason}\n{resp.text}"
+
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+
+    with open(dest, "wb") as fd:
+        fd.write(resp.content)
+
+
+def delete_artifactory_file(url, user, token):
+    print(f"deleting {url} ...")
+
+    resp = requests.delete(url, auth=(user, token))
+
+    assert resp.status_code == 204, f"delete failed:\n{resp.reason}\n{resp.text}"
+
+
+def get_md5_from_artifactory(url, user, token):
+    if not artifactory_file_exists(url, user, token):
+        return None
+
+    resp = requests.get(url, auth=(user, token))
+
+    assert resp.status_code == 200, f"md5 request failed:\n{resp.reason}\n{resp.text}"
+
+    md5 = resp.json().get("checksums", {}).get("md5", "")
+
+    assert md5, f"md5 not found in response:\n{resp.text}"
+
+    return md5
+
+
+def wait_for_artifactory_metadata(url, orig_md5, user, token, timeout=DEFAULT_TIMEOUT):
+    print(f"waiting for {url} to be updated ...")
+
+    start_time = time.time()
+    while True:
+        assert (time.time() - start_time) < timeout, f"timed out waiting for {url} to be updated"
+
+        new_md5 = get_md5_from_artifactory(url, user, token)
+
+        if new_md5 and str(orig_md5).lower() != str(new_md5).lower():
+            break
+
+        time.sleep(5)
+
+
+def wait_for_signed_artifact(
+    item_key, artifact_name, chaperone_token, staging_user, staging_token, timeout=DEFAULT_TIMEOUT
+):
+    url = f"{SIGNED_ARTIFACTS_REPO_URL}/{item_key}/{artifact_name}"
+
+    print(f"waiting for {url} ...")
+
+    start_time = time.time()
+    while True:
+        assert (time.time() - start_time) < timeout, f"timed out waiting for {url}"
+
+        resp = run_chaperone_check(item_key, chaperone_token)
+        status = resp.json().get("status", "").lower()
+        node = resp.json().get("node", "").lower()
+
+        assert status and node and status != "exception" and node != "failed", f"signing request failed:\n{resp.text}"
+
+        print(resp.text)
+
+        if node == "signed" and artifactory_file_exists(url, staging_user, staging_token):
+            break
+
+        time.sleep(10)
+
+    return url
+
+
+def sign_file(
+    src,
+    dest,
+    sign_type,
+    chaperone_token,
+    staging_user,
+    staging_token,
+    src_user=None,
+    src_token=None,
+    timeout=DEFAULT_TIMEOUT,
+):
+    if not re.match("^http(s)?://.*", src):
+        assert os.path.isfile(src), f"{src} not found"
+
+    assert sign_type.upper() in SIGN_TYPES, f"sign type '{sign_type}' not supported"
+
+    base = os.path.basename(src)
+    staged_artifact_url = f"{STAGING_REPO_URL}/{base}"
+
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            if not os.path.isfile(src):
+                tmpsrc = os.path.join(tmpdir, base)
+                download_file(src, tmpsrc, src_user, src_token)
+                src = tmpsrc
+            upload_file_to_artifactory(src, staged_artifact_url, staging_user, staging_token)
+
+        item_key = submit_signing_request(staged_artifact_url, sign_type.upper(), chaperone_token)
+
+        artifact_name = f"{base}.asc" if sign_type.lower() == "gpg" else base
+
+        signed_artifact_url = wait_for_signed_artifact(
+            item_key, artifact_name, chaperone_token, staging_user, staging_token, timeout
+        )
+
+        download_file(signed_artifact_url, dest, staging_user, staging_token)
+    finally:
+        if artifactory_file_exists(staged_artifact_url, staging_user, staging_token):
+            delete_artifactory_file(staged_artifact_url, staging_user, staging_token)
+
+
+def sign_artifactory_metadata(
+    src, artifactory_user, artifactory_token, chaperone_token, staging_user, staging_token, timeout=DEFAULT_TIMEOUT
+):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base = os.path.basename(src)
+        signature_ext = ".gpg" if base == "Release" else ".asc"
+        signature_path = os.path.join(tmpdir, base) + signature_ext
+        signature_url = src + signature_ext
+
+        sign_file(
+            src,
+            signature_path,
+            "GPG",
+            chaperone_token,
+            staging_user,
+            staging_token,
+            artifactory_user,
+            artifactory_token,
+            timeout,
+        )
+
+        upload_file_to_artifactory(signature_path, signature_url, artifactory_user, artifactory_token)
+
+
+def add_signing_args(parser):
+    parser.add_argument(
+        "--chaperone-token",
+        type=str,
+        default=os.environ.get("CHAPERONE_TOKEN"),
+        metavar="CHAPERONE_TOKEN",
+        required=False,
+        help="Chaperone token. Required if the CHAPERONE_TOKEN env var is not set.",
+    )
+    parser.add_argument(
+        "--staging-user",
+        type=str,
+        default=os.environ.get("STAGING_USERNAME", DEFAULT_STAGING_USERNAME),
+        metavar="STAGING_USERNAME",
+        required=False,
+        help=f"""
+            {STAGING_URL} username. Defaults to the STAGING_USERNAME env var if set,
+            otherwise '{DEFAULT_STAGING_USERNAME}'.
+        """,
+    )
+    parser.add_argument(
+        "--staging-token",
+        type=str,
+        default=os.environ.get("STAGING_TOKEN"),
+        metavar="STAGING_TOKEN",
+        required=False,
+        help=f"{STAGING_URL} token. Required if the STAGING_TOKEN env var is not set.",
+    )
+
+
+def check_signing_args(args):
+    assert args.chaperone_token, f"Chaperone token not set"
+    assert args.staging_user, f"{STAGING_URL} username not set"
+    assert args.staging_token, f"{STAGING_URL} token not set"
+
+
+def add_artifactory_args(parser):
+    parser.add_argument(
+        "--artifactory-user",
+        type=str,
+        default=os.environ.get("ARTIFACTORY_USERNAME", DEFAULT_ARTIFACTORY_USERNAME),
+        metavar="ARTIFACTORY_USERNAME",
+        required=False,
+        help=f"""
+            {ARTIFACTORY_URL} username. Defaults to the ARTIFACTORY_USERNAME env var if set,
+            otherwise '{DEFAULT_ARTIFACTORY_USERNAME}'.
+        """,
+    )
+    parser.add_argument(
+        "--artifactory-token",
+        type=str,
+        default=os.environ.get("ARTIFACTORY_TOKEN"),
+        metavar="ARTIFACTORY_TOKEN",
+        required=False,
+        help=f"{ARTIFACTORY_URL} token. Required if the ARTIFACTORY_TOKEN env var is not set.",
+    )
+
+
+def check_artifactory_args(args):
+    assert args.artifactory_user, f"{ARTIFACTORY_URL} username not set"
+    assert args.artifactory_token, f"{ARTIFACTORY_URL} token not set"
+
+
+def get_github_release_packages(repo_name, release_tag=None, github_token=None):
+    gh = Github(github_token)
+    repo = gh.get_repo(repo_name)
+    if not release_tag or release_tag == "latest":
+        release = repo.get_latest_release()
+    else:
+        release = repo.get_release(release_tag)
+
+    packages = {"deb": [], "rpm": []}
+    for asset in release.get_assets():
+        package_type = asset.name.strip().split(".")[-1]
+        if package_type in ("deb", "rpm"):
+            packages[package_type].append(asset.browser_download_url)
+
+    return release, packages

--- a/internal/buildscripts/packaging/release/pyproject.toml
+++ b/internal/buildscripts/packaging/release/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 120
+py36 = true

--- a/internal/buildscripts/packaging/release/requirements.txt
+++ b/internal/buildscripts/packaging/release/requirements.txt
@@ -1,0 +1,3 @@
+docker==4.3.1
+PyGithub==1.40
+requests==2.22.0

--- a/internal/buildscripts/packaging/release/sign_release.py
+++ b/internal/buildscripts/packaging/release/sign_release.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+
+import argparse
+import glob
+import os
+import re
+import sys
+import tempfile
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import docker
+
+from helpers.util import (
+    ARTIFACTORY_URL,
+    ARTIFACTORY_API_URL,
+    add_artifactory_args,
+    add_signing_args,
+    artifactory_file_exists,
+    download_file,
+    check_artifactory_args,
+    check_signing_args,
+    get_github_release_packages,
+    get_md5_from_artifactory,
+    sign_artifactory_metadata,
+    sign_file,
+    upload_file_to_artifactory,
+    wait_for_artifactory_metadata,
+)
+
+COLLECTOR_REPO = os.environ.get("COLLECTOR_REPO", "signalfx/splunk-otel-collector")
+PACKAGE_NAME = os.environ.get("PACKAGE_NAME", "splunk-otel-collector")
+ARTIFACTORY_DEB_REPO = "otel-collector-deb"
+ARTIFACTORY_DEB_REPO_URL = f"{ARTIFACTORY_URL}/{ARTIFACTORY_DEB_REPO}"
+ARTIFACTORY_RPM_REPO = "otel-collector-rpm"
+ARTIFACTORY_RPM_REPO_URL = f"{ARTIFACTORY_URL}/{ARTIFACTORY_RPM_REPO}"
+DEFAULT_TIMEOUT = 600
+STAGES = ("test", "beta", "release")
+TESTS_DIR = Path(__file__).parent.resolve() / "tests"
+
+
+def getargs():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="Sign and release deb/rpm packages from Github to Artifactory.",
+    )
+    parser.add_argument(
+        "--path",
+        type=str,
+        default=[],
+        metavar="PATH",
+        action="append",
+        help="""
+            Instead of releasing packages from Github, release packages on the local filesystem.
+            PATH can be a deb/rpm file or a directory containing deb/rpm files. "
+            This option may be specified multiple times for multiple paths.
+        """,
+    )
+    parser.add_argument(
+        "--stage",
+        type=str,
+        default="release",
+        metavar="STAGE",
+        choices=STAGES,
+        help=f"Stage for artifactory packages. Should be one of {STAGES}. Defaults to release.",
+    )
+    parser.add_argument(
+        "--version",
+        type=str,
+        default=None,
+        metavar="TAG",
+        required=False,
+        help="Github release tag (e.g. 'v1.2.3'). Defaults to the latest release tag if not specified.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        metavar="TIMEOUT",
+        required=False,
+        help=f"Signing request timeout in seconds. Defaults to {DEFAULT_TIMEOUT}.",
+    )
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Never prompt and assume yes when overwriting existing files in artifactory.",
+    )
+    parser.add_argument(
+        "--only-test",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Do not release packages from Github. Only run install tests with existing packages in artifactory.",
+    )
+
+    add_artifactory_args(parser)
+    add_signing_args(parser)
+
+    args = parser.parse_args()
+
+    check_artifactory_args(args)
+    check_signing_args(args)
+
+    return args
+
+
+def sign_metadata(metadata_url, args):
+    sign_artifactory_metadata(
+        metadata_url,
+        args.artifactory_user,
+        args.artifactory_token,
+        args.chaperone_token,
+        args.staging_user,
+        args.staging_token,
+        args.timeout,
+    )
+
+
+def add_debs_to_repo(paths, args):
+    metadata_api_url = f"{ARTIFACTORY_API_URL}/storage/{ARTIFACTORY_DEB_REPO}/dists/{args.stage}/Release"
+    metadata_url = f"{ARTIFACTORY_DEB_REPO_URL}/dists/{args.stage}/Release"
+
+    for path in paths:
+        base = os.path.basename(path)
+        match = re.match(r".*_(amd64|arm64)\.deb$", base)
+        assert match, f"Failed to get arch from {path}!"
+        arch = match.groups()[0]
+        deb_url = f"{ARTIFACTORY_DEB_REPO_URL}/pool/{args.stage}/{arch}/{base}"
+        dest_opts = f"deb.distribution={args.stage};deb.component=main;deb.architecture={arch}"
+        dest_url = f"{deb_url};{dest_opts}"
+
+        if not args.yes and artifactory_file_exists(deb_url, args.artifactory_user, args.artifactory_token):
+            overwrite = input(f"package {deb_url} already exists. Overwrite? [y/N] ")
+            if overwrite.lower() not in ("y", "yes"):
+                sys.exit(1)
+
+        orig_metadata_md5 = get_md5_from_artifactory(metadata_api_url, args.artifactory_user, args.artifactory_token)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            if re.match(r"^http(s)?://.*", path):
+                download_file(path, os.path.join(tmpdir, base))
+                path = os.path.join(tmpdir, base)
+
+            upload_file_to_artifactory(path, dest_url, args.artifactory_user, args.artifactory_token)
+
+            wait_for_artifactory_metadata(
+                metadata_api_url, orig_metadata_md5, args.artifactory_user, args.artifactory_token, args.timeout
+            )
+
+    if paths:
+        sign_metadata(metadata_url, args)
+
+
+def add_rpms_to_repo(paths, args):
+    for path in paths:
+        base = os.path.basename(path)
+        match = re.match(r".*\.(x86_64|arm64)\.rpm$", base)
+        assert match, f"Failed to get arch from {path}!"
+        arch = match.groups()[0]
+        dest_url = f"{ARTIFACTORY_RPM_REPO_URL}/{args.stage}/{arch}/{base}"
+        metadata_api_url = (
+            f"{ARTIFACTORY_API_URL}/storage/{ARTIFACTORY_RPM_REPO}/{args.stage}/{arch}/repodata/repomd.xml"
+        )
+        metadata_url = f"{ARTIFACTORY_RPM_REPO_URL}/{args.stage}/{arch}/repodata/repomd.xml"
+
+        if not args.yes and artifactory_file_exists(dest_url, args.artifactory_user, args.artifactory_token):
+            overwrite = input(f"package {dest_url} already exists. Overwrite? [y/N] ")
+            if overwrite.lower() not in ("y", "yes"):
+                sys.exit(1)
+
+        orig_metadata_md5 = get_md5_from_artifactory(metadata_api_url, args.artifactory_user, args.artifactory_token)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            unsigned_rpm_path = path
+            if re.match(r"^http(s)?://.*", path):
+                unsigned_rpm_path = os.path.join(tmpdir, "unsigned", base)
+                download_file(path, unsigned_rpm_path)
+            signed_rpm_path = os.path.join(tmpdir, "signed", base)
+            print(f"Signing {base} (may take 10+ minutes):")
+            sign_file(
+                unsigned_rpm_path,
+                signed_rpm_path,
+                "RPM",
+                args.chaperone_token,
+                args.staging_user,
+                args.staging_token,
+                timeout=args.timeout,
+            )
+            upload_file_to_artifactory(signed_rpm_path, dest_url, args.artifactory_user, args.artifactory_token)
+
+        wait_for_artifactory_metadata(
+            metadata_api_url, orig_metadata_md5, args.artifactory_user, args.artifactory_token, args.timeout
+        )
+
+        sign_metadata(metadata_url, args)
+
+
+@contextmanager
+def run_container(package_type, stage):
+    client = docker.from_env()
+
+    path = TESTS_DIR / package_type
+    dockerfile = path / "Dockerfile"
+    image, _ = client.images.build(
+        path=str(path), dockerfile=str(dockerfile), pull=True, rm=True, forcerm=True, buildargs={"STAGE": stage}
+    )
+
+    container = client.containers.create(
+        image.id, detach=True, privileged=True, volumes={"/sys/fs/cgroup": {"bind": "/sys/fs/cgroup", "mode": "ro"}}
+    )
+
+    try:
+        container.start()
+
+        start_time = time.time()
+        while True:
+            container.reload()
+            if container.attrs["NetworkSettings"]["IPAddress"]:
+                break
+            assert (time.time() - start_time) < 5, "timed out waiting for container to start"
+
+        yield container
+    finally:
+        container.remove(force=True, v=True)
+
+
+def run_container_cmd(container, cmd):
+    print(f"Running '{cmd}' ...")
+    code, output = container.exec_run(cmd)
+    assert code == 0, f"{cmd}:\n{output.decode('utf-8')}"
+
+
+def get_packages(args):
+    packages = {"deb": [], "rpm": []}
+
+    if args.path:
+        for path in args.path:
+            if os.path.isdir(path):
+                packages["deb"] = glob.glob(f"{path}/**/*.deb", recursive=True)
+                packages["rpm"] = glob.glob(f"{path}/**/*.rpm", recursive=True)
+            else:
+                assert os.path.isfile(path), f"File {path} not found!"
+                if os.path.splitext(path)[-1] == ".deb":
+                    packages["deb"].append(path)
+                elif os.path.splitext(path)[-1] == ".rpm":
+                    packages["rpm"].append(path)
+                else:
+                    print(f"Unsupported file '{path}'")
+                    sys.exit(1)
+
+        assert packages["deb"] or packages["rpm"], f"No files found to release from {args.path}!"
+
+        print(f"Releasing {packages} to {args.stage} stage.")
+        if not args.yes:
+            resp = input("Continue? [y/n]: ")
+            if resp.lower() not in ("y", "yes"):
+                sys.exit(0)
+    else:
+        gh_release, packages = get_github_release_packages(COLLECTOR_REPO, args.version)
+        args.version = gh_release.tag_name if args.version is None else args.version
+
+        assert packages["rpm"], f"Failed to get rpms from {COLLECTOR_REPO} {args.version} github release!"
+
+        assert packages["deb"], f"Failed to get debs from {COLLECTOR_REPO} {args.version} github release!"
+
+        print(f"Releasing deb/rpm from {COLLECTOR_REPO}:{args.version} to {args.stage} stage.")
+        if not args.yes:
+            resp = input("Continue? [y/n]: ")
+            if resp.lower() not in ("y", "yes"):
+                sys.exit(0)
+
+    return packages
+
+
+def main():
+    args = getargs()
+
+    if not args.only_test:
+        packages = get_packages(args)
+
+        add_debs_to_repo(packages["deb"], args)
+
+        add_rpms_to_repo(packages["rpm"], args)
+
+    print(f"Testing apt installation from {args.stage} stage ...")
+    with run_container("deb", args.stage) as container:
+        cmd = "apt -y update"
+        run_container_cmd(container, cmd)
+        cmd = f"apt install -y {PACKAGE_NAME}"
+        if args.version:
+            cmd = f"{cmd}={args.version.lstrip('v')}"
+        run_container_cmd(container, cmd)
+
+    print(f"Testing yum installation from {args.stage} stage ...")
+    with run_container("rpm", args.stage) as container:
+        cmd = f"yum install -y {PACKAGE_NAME}"
+        if args.version:
+            cmd = f"{cmd}-{args.version.lstrip('v')}"
+        run_container_cmd(container, cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/buildscripts/packaging/release/tests/deb/Dockerfile
+++ b/internal/buildscripts/packaging/release/tests/deb/Dockerfile
@@ -1,0 +1,26 @@
+# A debian9 image with systemd enabled.  Must be run with:
+# `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
+FROM debian:9
+
+RUN apt-get update &&\
+    apt-get install -yq apt-transport-https ca-certificates curl procps systemd
+
+ENV container docker
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
+    "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+RUN systemctl set-default multi-user.target
+ENV init /lib/systemd/systemd
+
+ARG STAGE=release
+RUN curl -sSL https://splunk.jfrog.io/splunk/otel-collector-deb/splunk-B3CD4420.gpg > /etc/apt/trusted.gpg.d/splunk.gpg
+RUN echo "deb https://splunk.jfrog.io/splunk/otel-collector-deb $STAGE main" > /etc/apt/sources.list.d/splunk-otel-collector.list
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+ENTRYPOINT ["/lib/systemd/systemd"]

--- a/internal/buildscripts/packaging/release/tests/rpm/Dockerfile
+++ b/internal/buildscripts/packaging/release/tests/rpm/Dockerfile
@@ -1,0 +1,26 @@
+# A centos8 image with systemd enabled.  Must be run with:
+# `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
+FROM centos:8
+
+ENV container docker
+
+RUN dnf install -y initscripts
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
+    "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;\
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+COPY splunk-otel-collector.repo /etc/yum.repos.d/splunk-otel-collector.repo
+
+ARG STAGE=release
+RUN mkdir -p /etc/yum/vars && \
+    echo "$STAGE" > /etc/yum/vars/stage
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/internal/buildscripts/packaging/release/tests/rpm/splunk-otel-collector.repo
+++ b/internal/buildscripts/packaging/release/tests/rpm/splunk-otel-collector.repo
@@ -1,0 +1,6 @@
+[splunk-otel-collector]
+name=Splunk OpenTelemetry Collector Repository
+baseurl=https://splunk.jfrog.io/splunk/otel-collector-rpm/$stage/$basearch
+gpgcheck=1
+gpgkey=https://splunk.jfrog.io/splunk/otel-collector-rpm/splunk-B3CD4420.pub
+enabled=1


### PR DESCRIPTION
- Requires `GITHUB_TOKEN` env var to be added to circleci in order to publish assets to Github Releases for tags.
- sign_release.py ported from signalfx-agent and currently required to be run manually since it needs to access the Splunk signing service on the corporate network.