### PR TITLE
Add SPLUNK_MEMORY_TOTAL_MIB

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -245,18 +245,18 @@ func checkMemorySettingsMiBFromEnvVar(envVar string, memTotalSizeMiB int) int {
 }
 
 func useMemorySettingsMiBFromEnvVar(memTotalSizeMiB int) {
-    // Check if memory limit is specified via environment variable
+	// Check if memory limit is specified via environment variable
 	memLimit := checkMemorySettingsMiBFromEnvVar(memLimitMiBEnvVarName, memTotalSizeMiB)
-    // Use if set, otherwise memory total size must be specified
+	// Use if set, otherwise memory total size must be specified
 	if memLimit == 0 {
 		if memTotalSizeMiB == 0 {
 			panic("PANIC: Both memory limit MiB and memory total size are set to zero. This should never happen.")
 		}
-        // If not set, compute based on memory total size specified
-        // and default memory limit percentage const
+		// If not set, compute based on memory total size specified
+		// and default memory limit percentage const
 		memLimitMiB := memTotalSizeMiB * defaultMemoryLimitPercentage / 100
-        // The memory limit should be set to defaultMemoryLimitPercentage of total memory
-        // while reserving a maximum of defaultMemoryLimitMaxMiB of memory.
+		// The memory limit should be set to defaultMemoryLimitPercentage of total memory
+		// while reserving a maximum of defaultMemoryLimitMaxMiB of memory.
 		if (memTotalSizeMiB - memLimitMiB) < defaultMemoryLimitMaxMiB {
 			memLimit = memLimitMiB
 		} else {
@@ -264,18 +264,18 @@ func useMemorySettingsMiBFromEnvVar(memTotalSizeMiB int) {
 		}
 		log.Printf("Set memory limit to %d MiB", memLimit)
 	}
-    // Check if memory spike is specified via environment variable
+	// Check if memory spike is specified via environment variable
 	memSpike := checkMemorySettingsMiBFromEnvVar(memSpikeMiBEnvVarName, memTotalSizeMiB)
-    // Use if set, otherwise memory total size must be specified
+	// Use if set, otherwise memory total size must be specified
 	if memSpike == 0 {
 		if memTotalSizeMiB == 0 {
 			panic("PANIC: Both memory limit MiB and memory total size are set to zero. This should never happen.")
 		}
-        // If not set, compute based on memory total size specified
-        // and default memory spike percentage const
+		// If not set, compute based on memory total size specified
+		// and default memory spike percentage const
 		memSpikeMiB := memTotalSizeMiB * defaultMemorySpikePercentage / 100
-        // The memory spike should be set to defaultMemorySpikePercentage of total memory
-        // while specifying a maximum of defaultMemorySpikeMaxMiB of memory.
+		// The memory spike should be set to defaultMemorySpikePercentage of total memory
+		// while specifying a maximum of defaultMemorySpikeMaxMiB of memory.
 		if memSpikeMiB < defaultMemorySpikeMaxMiB {
 			memSpike = memSpikeMiB
 		} else {

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -222,7 +222,7 @@ func useConfigFromEnvVar() {
 func checkMemorySettingsMiBFromEnvVar(envVar string, memTotalSize int) int {
 	// Check if the memory limit is specified via the env var
 	// Ensure memory limit is valid
-	var envVarResult int
+	var envVarResult int = 0
 	envVarVal := os.Getenv(envVar)
 	switch {
 	case envVarVal != "":
@@ -236,7 +236,7 @@ func checkMemorySettingsMiBFromEnvVar(envVar string, memTotalSize int) int {
 		}
 		envVarResult = val
 	case memTotalSize > 0:
-		envVarResult = 0
+		break
 	default:
 		log.Printf("Usage: %s=12345 %s=us0 %s=684 %s=1024 %s=256 %s", tokenEnvVarName, realmEnvVarName, ballastEnvVarName, memLimitMiBEnvVarName, memSpikeMiBEnvVarName, os.Args[0])
 		log.Fatalf("ERROR: Missing environment variable %s", envVar)
@@ -247,21 +247,27 @@ func checkMemorySettingsMiBFromEnvVar(envVar string, memTotalSize int) int {
 func useMemorySettingsMiBFromEnvVar(memTotalSize int) {
 	memLimit := checkMemorySettingsMiBFromEnvVar(memLimitMiBEnvVarName, memTotalSize)
 	if memLimit == 0 {
+		if memTotalSize == 0 {
+			panic("PANIC: Both memory limit MiB and memory total size are set to zero. This should never happen.")
+		}
 		memLimitMiB := memTotalSize * defaultMemoryLimitPercentage / 100
-		if memLimitMiB < defaultMemoryLimitMaxMiB {
+		if (memTotalSize - memLimitMiB) < defaultMemoryLimitMaxMiB {
 			memLimit = memLimitMiB
 		} else {
-			memLimit = defaultMemoryLimitMaxMiB
+			memLimit = (memTotalSize - defaultMemoryLimitMaxMiB)
 		}
 		log.Printf("Set memory limit to %d MiB", memLimit)
 	}
 	memSpike := checkMemorySettingsMiBFromEnvVar(memSpikeMiBEnvVarName, memTotalSize)
 	if memSpike == 0 {
+		if memTotalSize == 0 {
+			panic("PANIC: Both memory limit MiB and memory total size are set to zero. This should never happen.")
+		}
 		memSpikeMiB := memTotalSize * defaultMemorySpikePercentage / 100
 		if memSpikeMiB < defaultMemorySpikeMaxMiB {
 			memSpike = memSpikeMiB
 		} else {
-			memLimit = defaultMemorySpikeMaxMiB
+			memSpike = defaultMemorySpikeMaxMiB
 		}
 		log.Printf("Set memory spike limit to %d MiB", memSpike)
 	}

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -39,6 +39,7 @@ const (
 	memLimitMiBEnvVarName = "SPLUNK_MEMORY_LIMIT_MIB"
 	memSpikeEnvVarName    = "SPLUNK_MEMORY_SPIKE_PERCENTAGE"
 	memSpikeMiBEnvVarName = "SPLUNK_MEMORY_SPIKE_MIB"
+	memTotalEnvVarName    = "SPLUNK_MEMORY_TOTAL_MIB"
 	realmEnvVarName       = "SPLUNK_REALM"
 	tokenEnvVarName       = "SPLUNK_ACCESS_TOKEN"
 
@@ -50,22 +51,50 @@ const (
 	defaultLocalSAPMNonLinuxConfig  = "cmd/otelcol/config/collector/splunk_config_non_linux.yaml"
 	defaultLocalOTLPLinuxConfig     = "cmd/otelcol/config/collector/otlp_config_linux.yaml"
 	defaultLocalOTLPNonLinuxConfig  = "cmd/otelcol/config/collector/otlp_config_non_linux.yaml"
+	defaultMemoryBallastPercentage  = 50
 	defaultMemoryLimitPercentage    = 90
+	defaultMemoryLimitMaxMiB        = 2048
 	defaultMemorySpikePercentage    = 25
+	defaultMemorySpikeMaxMiB        = 2048
 )
 
 func main() {
+    // TODO: Use same format as the collector
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+
+	// Check if the total memory is specified via the env var.
+	memTotalEnvVarVal := os.Getenv(memTotalEnvVarName)
+	memTotalSize := 0
+	if memTotalEnvVarVal != "" {
+		// Check if it is a numeric value.
+		val, err := strconv.Atoi(memTotalEnvVarVal)
+		if err != nil {
+			log.Fatalf("Expected a number in %s env variable but got %s", memTotalEnvVarName, memTotalEnvVarVal)
+		}
+		if 10 > val {
+			log.Fatalf("Expected a number greater than 10 for %s env variable but got %s", memTotalEnvVarName, memTotalEnvVarVal)
+		}
+		memTotalSize = val
+	}
 
 	// Check runtime parameters
 	// Runtime parameters take priority over environment variables
 	// Runtime parameters are not validated
 	args := os.Args[1:]
 	if !contains(args, "--mem-ballast-size-mib") {
-		useBallastSizeFromEnvVar()
+		useMemorySizeFromEnvVar(memTotalSize)
+	} else {
+		log.Printf("Ballast CLI argument found, ignoring %s if set", ballastEnvVarName)
 	}
 	if !contains(args, "--config") {
-		useConfigFromEnvVar()
+		useConfigFromEnvVar(memTotalSize)
+	} else {
+		log.Printf("Config CLI argument found, please ensure memory_limiter settings are correct")
+	}
+	if runtime.GOOS == "linux" {
+		useMemorySettingsPercentageFromEnvVar()
+	} else {
+		useMemorySettingsMiBFromEnvVar(memTotalSize)
 	}
 
 	factories, err := components.Get()
@@ -98,7 +127,7 @@ func contains(arr []string, str string) bool {
 	return false
 }
 
-func useBallastSizeFromEnvVar() {
+func useMemorySizeFromEnvVar(memTotalSize int) {
 	// Check if the ballast is specified via the env var.
 	ballastSize := os.Getenv(ballastEnvVarName)
 	if ballastSize != "" {
@@ -110,10 +139,16 @@ func useBallastSizeFromEnvVar() {
 
 		// Inject the command line flag that controls the ballast size.
 		os.Args = append(os.Args, "--mem-ballast-size-mib="+ballastSize)
+	} else if memTotalSize > 0 {
+		halfMem := strconv.Itoa(memTotalSize * defaultMemoryBallastPercentage / 100)
+		log.Printf("Set ballast to %s MiB", halfMem)
+		// Inject the command line flag that controls the ballast size.
+		os.Args = append(os.Args, "--mem-ballast-size-mib="+halfMem)
+		os.Setenv(ballastEnvVarName, halfMem)
 	}
 }
 
-func useConfigFromEnvVar() {
+func useConfigFromEnvVar(memTotalSize int) {
 	// Check if the config is specified via the env var.
 	config := os.Getenv(configEnvVarName)
 	// If not attempt to use a default config; supports Docker and local
@@ -130,7 +165,6 @@ func useConfigFromEnvVar() {
 			if config == "" {
 				log.Fatalf("Unable to find the default configuration file, ensure %s environment variable is set properly", configEnvVarName)
 			}
-			useMemorySettingsPercentageFromEnvVar()
 		} else {
 			_, err := os.Stat(defaultDockerSAPMNonLinuxConfig)
 			if err == nil {
@@ -143,7 +177,6 @@ func useConfigFromEnvVar() {
 			if config == "" {
 				log.Fatalf("Unable to find the default configuration file, ensure %s environment variable is set properly", configEnvVarName)
 			}
-			useMemorySettingsMiBFromEnvVar()
 		}
 	} else {
 		// Check if file exists.
@@ -165,12 +198,17 @@ func useConfigFromEnvVar() {
 		defaultLocalOTLPNonLinuxConfig:
 		// The following environment variables are required.
 		// If any are missing stop here.
-		requiredEnvVars := []string{ballastEnvVarName, realmEnvVarName, tokenEnvVarName}
+		requiredEnvVars := []string{realmEnvVarName, tokenEnvVarName}
 		for _, v := range requiredEnvVars {
 			if len(os.Getenv(v)) == 0 {
-				log.Printf("Usage: %s=12345 %s=us0 %s=684 %s", tokenEnvVarName, realmEnvVarName, ballastEnvVarName, os.Args[0])
+				log.Printf("Usage: %s=12345 %s=us0 %s=1024 %s", tokenEnvVarName, realmEnvVarName, memTotalEnvVarName, os.Args[0])
 				log.Fatalf("ERROR: Missing environment variable %s", v)
 			}
+		}
+		// Needed for backwards compatibility
+		if len(os.Getenv(memTotalEnvVarName)) == 0 && len(os.Getenv(ballastEnvVarName)) == 0 {
+			log.Printf("Usage: %s=12345 %s=us0 %s=1024 %s", tokenEnvVarName, realmEnvVarName, memTotalEnvVarName, os.Args[0])
+			log.Fatalf("ERROR: Missing environment variable %s", memTotalEnvVarName)
 		}
 	}
 
@@ -178,7 +216,7 @@ func useConfigFromEnvVar() {
 	os.Args = append(os.Args, "--config="+config)
 }
 
-func checkMemorySettingsMiBFromEnvVar(envVar string) int {
+func checkMemorySettingsMiBFromEnvVar(envVar string, memTotalSize int) int {
 	// Check if the memory limit is specified via the env var
 	// Ensure memory limit is valid
 	var envVarResult int
@@ -193,6 +231,8 @@ func checkMemorySettingsMiBFromEnvVar(envVar string) int {
 			log.Fatalf("Expected a number greater than 0 for %s env variable but got %s", envVar, envVarVal)
 		}
 		envVarResult = val
+	} else if memTotalSize > 0 {
+		envVarResult = 0
 	} else {
 		log.Printf("Usage: %s=12345 %s=us0 %s=684 %s=1024 %s=256 %s", tokenEnvVarName, realmEnvVarName, ballastEnvVarName, memLimitMiBEnvVarName, memSpikeMiBEnvVarName, os.Args[0])
 		log.Fatalf("ERROR: Missing environment variable %s", envVar)
@@ -200,9 +240,27 @@ func checkMemorySettingsMiBFromEnvVar(envVar string) int {
 	return envVarResult
 }
 
-func useMemorySettingsMiBFromEnvVar() {
-	memLimit := checkMemorySettingsMiBFromEnvVar(memLimitMiBEnvVarName)
-	memSpike := checkMemorySettingsMiBFromEnvVar(memSpikeMiBEnvVarName)
+func useMemorySettingsMiBFromEnvVar(memTotalSize int) {
+	memLimit := checkMemorySettingsMiBFromEnvVar(memLimitMiBEnvVarName, memTotalSize)
+	if memLimit == 0 {
+		memLimitMiB := memTotalSize * defaultMemoryLimitPercentage / 100
+		if memLimitMiB < defaultMemoryLimitMaxMiB {
+			memLimit = memLimitMiB
+		} else {
+			memLimit = defaultMemoryLimitMaxMiB
+		}
+		log.Printf("Set memory limit to %d MiB", memLimit)
+	}
+	memSpike := checkMemorySettingsMiBFromEnvVar(memSpikeMiBEnvVarName, memTotalSize)
+	if memSpike == 0 {
+		memSpikeMiB := memTotalSize * defaultMemorySpikePercentage / 100
+		if memSpikeMiB < defaultMemorySpikeMaxMiB {
+			memSpike = memSpikeMiB
+		} else {
+			memLimit = defaultMemorySpikeMaxMiB
+		}
+		log.Printf("Set memory spike limit to %d MiB", memSpike)
+	}
 	setMemorySettingsToEnvVar(memLimit, memLimitMiBEnvVarName, memSpike, memSpikeMiBEnvVarName)
 }
 

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -59,7 +59,7 @@ const (
 )
 
 func main() {
-    // TODO: Use same format as the collector
+	// TODO: Use same format as the collector
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 
 	// Check if the total memory is specified via the env var.
@@ -221,7 +221,8 @@ func checkMemorySettingsMiBFromEnvVar(envVar string, memTotalSize int) int {
 	// Ensure memory limit is valid
 	var envVarResult int
 	envVarVal := os.Getenv(envVar)
-	if envVarVal != "" {
+	switch {
+	case envVarVal != "":
 		// Check if it is a numeric value.
 		val, err := strconv.Atoi(envVarVal)
 		if err != nil {
@@ -231,9 +232,9 @@ func checkMemorySettingsMiBFromEnvVar(envVar string, memTotalSize int) int {
 			log.Fatalf("Expected a number greater than 0 for %s env variable but got %s", envVar, envVarVal)
 		}
 		envVarResult = val
-	} else if memTotalSize > 0 {
+	case memTotalSize > 0:
 		envVarResult = 0
-	} else {
+	default:
 		log.Printf("Usage: %s=12345 %s=us0 %s=684 %s=1024 %s=256 %s", tokenEnvVarName, realmEnvVarName, ballastEnvVarName, memLimitMiBEnvVarName, memSpikeMiBEnvVarName, os.Args[0])
 		log.Fatalf("ERROR: Missing environment variable %s", envVar)
 	}

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -87,7 +87,7 @@ func main() {
 		log.Printf("Ballast CLI argument found, ignoring %s if set", ballastEnvVarName)
 	}
 	if !contains(args, "--config") {
-		useConfigFromEnvVar(memTotalSize)
+		useConfigFromEnvVar()
 	} else {
 		log.Printf("Config CLI argument found, please ensure memory_limiter settings are correct")
 	}
@@ -132,9 +132,12 @@ func useMemorySizeFromEnvVar(memTotalSize int) {
 	ballastSize := os.Getenv(ballastEnvVarName)
 	if ballastSize != "" {
 		// Check if it is a numeric value.
-		_, err := strconv.Atoi(ballastSize)
+		val, err := strconv.Atoi(ballastSize)
 		if err != nil {
 			log.Fatalf("Expected a number in %s env variable but got %s", ballastEnvVarName, ballastSize)
+		}
+		if 0 > val {
+			log.Fatalf("Expected a number greater than 0 for %s env variable but got %s", ballastEnvVarName, ballastSize)
 		}
 
 		// Inject the command line flag that controls the ballast size.
@@ -148,7 +151,7 @@ func useMemorySizeFromEnvVar(memTotalSize int) {
 	}
 }
 
-func useConfigFromEnvVar(memTotalSize int) {
+func useConfigFromEnvVar() {
 	// Check if the config is specified via the env var.
 	config := os.Getenv(configEnvVarName)
 	// If not attempt to use a default config; supports Docker and local

--- a/cmd/otelcol/main_test.go
+++ b/cmd/otelcol/main_test.go
@@ -1,3 +1,18 @@
+// Copyright 2020 Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -8,8 +23,8 @@ import (
 
 func TestContains(t *testing.T) {
 	testArgs := [][]string{
-		[]string{"cmd", "--test=foo"},
-		[]string{"cmd", "--test", "foo"},
+		{"cmd", "--test=foo"},
+		{"cmd", "--test", "foo"},
 	}
 	for _, v := range testArgs {
 		result := contains(v, "--test")
@@ -18,8 +33,8 @@ func TestContains(t *testing.T) {
 		}
 	}
 	testArgs = [][]string{
-		[]string{"cmd", "--test-fail", "foo"},
-		[]string{"cmd", "--test-fail=--test"},
+		{"cmd", "--test-fail", "foo"},
+		{"cmd", "--test-fail=--test"},
 	}
 	for _, v := range testArgs {
 		result := contains(v, "--test")
@@ -31,7 +46,7 @@ func TestContains(t *testing.T) {
 
 func TestUseMemorySizeFromEnvVar(t *testing.T) {
 	testArgs := [][]string{
-		[]string{"", "0"},
+		{"", "0"},
 	}
 	for _, v := range testArgs {
 		n, _ := strconv.Atoi(v[1])
@@ -43,8 +58,8 @@ func TestUseMemorySizeFromEnvVar(t *testing.T) {
 		}
 	}
 	testArgs = [][]string{
-		[]string{"10", "0"},
-		[]string{"", "10"},
+		{"10", "0"},
+		{"", "10"},
 	}
 	for _, v := range testArgs {
 		n, _ := strconv.Atoi(v[1])
@@ -73,9 +88,9 @@ func TestUseConfigFromEnvVar(t *testing.T) {
 
 func TestCheckMemorySettingMiBFromEnvVar(t *testing.T) {
 	testArgs := [][]string{
-		[]string{"", "10", "0"},
-		[]string{"10", "0", "10"},
-		[]string{"10", "100", "10"},
+		{"", "10", "0"},
+		{"10", "0", "10"},
+		{"10", "100", "10"},
 	}
 	for _, v := range testArgs {
 		n, _ := strconv.Atoi(v[1])

--- a/cmd/otelcol/main_test.go
+++ b/cmd/otelcol/main_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"os"
+	"strconv"
+	"testing"
+)
+
+func TestContains(t *testing.T) {
+	testArgs := [][]string{
+		[]string{"cmd", "--test=foo"},
+		[]string{"cmd", "--test", "foo"},
+	}
+	for _, v := range testArgs {
+		result := contains(v, "--test")
+		if !(result) {
+			t.Errorf("Expected true got false while testing %v", v)
+		}
+	}
+	testArgs = [][]string{
+		[]string{"cmd", "--test-fail", "foo"},
+		[]string{"cmd", "--test-fail=--test"},
+	}
+	for _, v := range testArgs {
+		result := contains(v, "--test")
+		if result {
+			t.Errorf("Expected false got true while testing %v", v)
+		}
+	}
+}
+
+func TestUseMemorySizeFromEnvVar(t *testing.T) {
+	testArgs := [][]string{
+		[]string{"", "0"},
+	}
+	for _, v := range testArgs {
+		n, _ := strconv.Atoi(v[1])
+		os.Setenv(ballastEnvVarName, v[0])
+		useMemorySizeFromEnvVar(n)
+		result := contains(os.Args, "--mem-ballast-size-mib")
+		if result {
+			t.Errorf("Expected false got true while testing %v", v)
+		}
+	}
+	testArgs = [][]string{
+		[]string{"10", "0"},
+		[]string{"", "10"},
+	}
+	for _, v := range testArgs {
+		n, _ := strconv.Atoi(v[1])
+		os.Setenv(ballastEnvVarName, v[0])
+		useMemorySizeFromEnvVar(n)
+		result := contains(os.Args, "--mem-ballast-size-mib")
+		if !(result) {
+			t.Errorf("Expected true got false while testing %v", v)
+		}
+	}
+}
+
+func TestUseConfigFromEnvVar(t *testing.T) {
+	result := contains(os.Args, "--config")
+	if result {
+		t.Error("Expected false got true while looking for --config")
+	}
+	os.Setenv(configEnvVarName, "../../"+defaultLocalSAPMNonLinuxConfig)
+	useConfigFromEnvVar()
+	result = contains(os.Args, "--config")
+	if !(result) {
+		t.Error("Expected true got false while looking for --config")
+	}
+	os.Unsetenv(configEnvVarName)
+}
+
+func TestCheckMemorySettingMiBFromEnvVar(t *testing.T) {
+	testArgs := [][]string{
+		[]string{"", "10", "0"},
+		[]string{"10", "0", "10"},
+		[]string{"10", "100", "10"},
+	}
+	for _, v := range testArgs {
+		n, _ := strconv.Atoi(v[1])
+		r, _ := strconv.Atoi(v[2])
+		os.Setenv(memLimitMiBEnvVarName, v[0])
+		result := checkMemorySettingsMiBFromEnvVar(memLimitMiBEnvVarName, n)
+		if result != r {
+			t.Errorf("Expected %d but got %d", r, result)
+		}
+	}
+	os.Unsetenv(memLimitMiBEnvVarName)
+}
+
+func HelperUseMemorySettingsFromEnvVar(limitEnv string, limit int, spikeEnv string, spike int, t *testing.T) {
+	envVarVal, _ := strconv.Atoi(os.Getenv(limitEnv))
+	if envVarVal != limit {
+		t.Errorf("Expected %d but got %d", limit, envVarVal)
+	}
+	envVarVal, _ = strconv.Atoi(os.Getenv(spikeEnv))
+	if envVarVal != spike {
+		t.Errorf("Expected %d but got %d", spike, envVarVal)
+	}
+	os.Unsetenv(limitEnv)
+	os.Unsetenv(spikeEnv)
+}
+
+func TestSetMemorySettingsToEnvVar(t *testing.T) {
+	setMemorySettingsToEnvVar(10, memLimitMiBEnvVarName, 5, memSpikeMiBEnvVarName)
+	HelperUseMemorySettingsFromEnvVar(memLimitMiBEnvVarName, 10, memSpikeMiBEnvVarName, 5, t)
+}
+func TestUseMemorySettingsMiBFromEnvVar(t *testing.T) {
+	useMemorySettingsMiBFromEnvVar(100)
+	HelperUseMemorySettingsFromEnvVar(memLimitMiBEnvVarName, 90, memSpikeMiBEnvVarName, 25, t)
+	useMemorySettingsMiBFromEnvVar(30000)
+	HelperUseMemorySettingsFromEnvVar(memLimitMiBEnvVarName, 27952, memSpikeMiBEnvVarName, 2048, t)
+
+	setMemorySettingsToEnvVar(10, memLimitMiBEnvVarName, 5, memSpikeMiBEnvVarName)
+	useMemorySettingsMiBFromEnvVar(0)
+	HelperUseMemorySettingsFromEnvVar(memLimitMiBEnvVarName, 10, memSpikeMiBEnvVarName, 5, t)
+	useMemorySettingsMiBFromEnvVar(100)
+	HelperUseMemorySettingsFromEnvVar(memLimitMiBEnvVarName, 90, memSpikeMiBEnvVarName, 25, t)
+}
+
+func TestCheckMemorySettingsPercentageFromEnvVar(t *testing.T) {
+	result := checkMemorySettingsPercentageFromEnvVar(memLimitEnvVarName, defaultMemoryLimitPercentage)
+	if result != defaultMemoryLimitPercentage {
+		t.Errorf("Expected %d but got %d", defaultMemoryLimitPercentage, result)
+	}
+	setMemorySettingsToEnvVar(10, memLimitEnvVarName, 5, memSpikeEnvVarName)
+	result = checkMemorySettingsMiBFromEnvVar(memLimitEnvVarName, 10)
+	if result != 10 {
+		t.Errorf("Expected %d but got %d", 10, result)
+	}
+	os.Unsetenv(memLimitEnvVarName)
+	os.Unsetenv(memSpikeEnvVarName)
+}
+
+func TestUseMemorySettingsPercentageFromEnvVar(t *testing.T) {
+	useMemorySettingsPercentageFromEnvVar()
+	HelperUseMemorySettingsFromEnvVar(memLimitEnvVarName, 90, memSpikeEnvVarName, 25, t)
+	setMemorySettingsToEnvVar(10, memLimitEnvVarName, 5, memSpikeEnvVarName)
+	HelperUseMemorySettingsFromEnvVar(memLimitEnvVarName, 10, memSpikeEnvVarName, 5, t)
+}


### PR DESCRIPTION
Today, SPLUNK_BALLAST_SIZE_MIB needs to be computed and manually
configured by a user. Most users do not know or care about the ballast
and under normal circumstances they should not need to. Users will
understand the total amount of memory allocated to the Collector. As
such, introduce a SPLUNK_MEMORY_TOTAL_MIB env var that can be used
instead of or in addition to SPLUNK_BALLAST_SIZE_MIB. This has the added
bonus that now memory spike and limit env vars are no longer required
for non-linux systems. This change is backwards compatible.

A few other minor enhancements:

- Memory spike/limit env vars are now applied even if SPLUNK_CONFIG is
  passed
- Add logging for custom behavior so configuration is clear
- Add accessible endpoints to README
- Add tests