### PR TITLE
Disable starting fluentd with default config

### DIFF
--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -497,7 +497,13 @@ parse_args_and_install() {
   configure_realm "$realm" "$service_user" "$service_group"
   configure_ballast "$ballast" "$service_user" "$service_group"
 
-  systemctl start td-agent
+  # disable fluentd from starting with default config
+  systemctl stop td-agent
+  if [ -f /etc/td-agent/td-agent.conf ]; then
+    mv -f /etc/td-agent/td-agent.conf /etc/td-agent/td-agent.conf.default
+  fi
+  systemctl disable td-agent
+
   systemctl start splunk-otel-collector
 
   cat <<EOH

--- a/internal/buildscripts/packaging/tests/installer_test.py
+++ b/internal/buildscripts/packaging/tests/installer_test.py
@@ -59,7 +59,7 @@ def test_installer(distro, service_owner, version):
             run_container_cmd(container, "grep '^SPLUNK_BALLAST_SIZE_MIB=64$' /etc/otel/collector/splunk_env")
 
             # verify service statuses
-            assert wait_for(lambda: run_container_cmd(container, "systemctl status td-agent"))
+            # assert wait_for(lambda: run_container_cmd(container, "systemctl status td-agent"))
             assert wait_for(lambda: service_is_running(container, service_owner=service_owner))
         finally:
             run_container_cmd(container, "journalctl -u td-agent --no-pager")


### PR DESCRIPTION
The default fluentd config `/etc/td-agent/td-agent.conf` listens on port 8888:
```# HTTP input
# POST http://localhost:8888/<tag>?json=<json>
# POST http://localhost:8888/td.myapp.login?json={"user"%3A"me"}
# @see http://docs.fluentd.org/articles/in_http
<source>
  @type http
  @id input_http
  port 8888
</source>
```

This conflicts with the default port for the prometheus receiver, causing the collector to fail to start.

The installer script is updated to disable the fluentd service from starting and moving the default config.