### PR TITLE
smartagentreceiver: add Dynamic Monitor creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/pavius/impi v0.0.3
 	github.com/securego/gosec/v2 v2.5.0
 	github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657
+	github.com/signalfx/golib/v3 v3.3.16
 	github.com/signalfx/signalfx-agent v0.0.0-00010101000000-000000000000
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -101,11 +101,9 @@ github.com/Azure/go-autorest/autorest/mocks v0.3.0/go.mod h1:a8FDP3DYzQ4RYfVAxAN
 github.com/Azure/go-autorest/autorest/mocks v0.4.0/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPuGXlNkbVvq4cW4nIHk=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
-github.com/Azure/go-autorest/autorest/to v0.3.0 h1:zebkZaadz7+wIQYgC7GXaz3Wb28yKYfVkkBKwc38VF8=
 github.com/Azure/go-autorest/autorest/to v0.3.0/go.mod h1:MgwOyqaIuKdG4TL/2ywSsIWKAfJfgHDo8ObuUk3t5sA=
 github.com/Azure/go-autorest/autorest/to v0.4.0 h1:oXVqrxakqqV1UZdSazDOPOLvOIz+XA683u8EctwboHk=
 github.com/Azure/go-autorest/autorest/to v0.4.0/go.mod h1:fE8iZBn7LQR7zH/9XU2NcPR4o9jEImooCeWJcYV/zLE=
-github.com/Azure/go-autorest/autorest/validation v0.2.0 h1:15vMO4y76dehZSq7pAaOLQxC6dZYsSrj2GQpflyM/L4=
 github.com/Azure/go-autorest/autorest/validation v0.2.0/go.mod h1:3EEqHnBxQGHXRYq3HT1WyXAvT7LLY3tl70hw6tQIbjI=
 github.com/Azure/go-autorest/autorest/validation v0.3.0 h1:3I9AAI63HfcLtphd9g39ruUwRI+Ca+z/f36KHPFRUss=
 github.com/Azure/go-autorest/autorest/validation v0.3.0/go.mod h1:yhLgjC0Wda5DYXl6JAsWyUe4KVNffhoDhG0zVzUMo3E=
@@ -135,7 +133,6 @@ github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF0
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.4.13/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
-github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 h1:ygIc8M6trr62pF5DucadTWGdEB4mEyvzi0e2nbcmcyA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
@@ -213,7 +210,6 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQhVx52RsWOnlkpikZr01T/yAVN2gn0861vByNg=
 github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD+gJD3GYs=
-github.com/armon/go-metrics v0.3.3 h1:a9F4rlj7EWWrbj7BYw8J8+x+ZZkJeqzNyRk8hdPF+ro=
 github.com/armon/go-metrics v0.3.3/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-metrics v0.3.4 h1:Xqf+7f2Vhl9tsqDYmXhnXInUdcrtgpRNpIA15/uldSc=
 github.com/armon/go-metrics v0.3.4/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
@@ -405,7 +401,6 @@ github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/dropbox/godropbox v0.0.0-20180512210157-31879d3884b9 h1:NAvZb7gqQfLSNBPzVsvI7eZMosXtg2g2kxXrei90CtU=
 github.com/dropbox/godropbox v0.0.0-20180512210157-31879d3884b9/go.mod h1:glr97hP/JuXb+WMYCizc4PIFuzw1lCR97mwbe1VVXhQ=
 github.com/dropbox/godropbox v0.0.0-20190501155911-5749d3b71cbe h1:h9O84K0R+PKy6G8nNBMyUwChvF9EwQQOgXwr92uTHfM=
 github.com/dropbox/godropbox v0.0.0-20190501155911-5749d3b71cbe/go.mod h1:glr97hP/JuXb+WMYCizc4PIFuzw1lCR97mwbe1VVXhQ=
@@ -630,7 +625,6 @@ github.com/gobuffalo/packd v0.1.0/go.mod h1:M2Juc+hhDXf/PnmBANFCqx4DM3wRbgDvnVWe
 github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGtJQZ0Odn4pQ=
 github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/VCm/3ptBN+0=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
-github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gobwas/glob v0.2.4-0.20181002190808-e7a84e9525fe h1:zn8tqiUbec4wR94o7Qj3LZCAT6uGobhEgnDRg6isG5U=
 github.com/gobwas/glob v0.2.4-0.20181002190808-e7a84e9525fe/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
@@ -744,7 +738,6 @@ github.com/google/addlicense v0.0.0-20200622132530-df58acafd6d5/go.mod h1:EMjYTR
 github.com/google/addlicense v0.0.0-20200906110928-a0294312aa76 h1:JypWNzPMSgH5yL0NvFoAIsDRlKFgL0AsS3GO5bg4Pto=
 github.com/google/addlicense v0.0.0-20200906110928-a0294312aa76/go.mod h1:EMjYTRimagHs1FwlIqKyX3wAM0u3rA+McvlIIWmSamA=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1-0.20190321164330-bfb38958ad22 h1:GBnith66ViL/ZPY9pFWyRVGAqwlyvUriBBY6Se8ce2A=
 github.com/google/btree v1.0.1-0.20190321164330-bfb38958ad22/go.mod h1:KPLJImlGmCXVHjMRPHvVvsnK6w8xtANRk3w3QfinNG8=
@@ -806,7 +799,6 @@ github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gophercloud/gophercloud v0.13.0 h1:1XkslZZRm6Ks0bLup+hBNth+KQf+0JA1UeoB7YKw9E8=
 github.com/gophercloud/gophercloud v0.13.0/go.mod h1:VX0Ibx85B60B5XOrZr6kaNwrmPUzcmMpwxvQ1WQIIWM=
 github.com/gopherjs/gopherjs v0.0.0-20180628210949-0892b62f0d9f/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e h1:JKmoR8x90Iww1ks85zJ1lfDGgIiMDuIptTOhJq+zKyg=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -890,7 +882,6 @@ github.com/hashicorp/go-hclog v0.9.1/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrj
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.12.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v0.14.0 h1:1X+ga+2ki9aUJJaliI2isvjNLI8rNCGHFkZ1FaVpvCA=
 github.com/hashicorp/go-hclog v0.14.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.14.1 h1:nQcJDQwIAGnmoUWp8ubocEX40cCml/17YkF6csQLReU=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
@@ -936,7 +927,6 @@ github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2I
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
 github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
@@ -1182,7 +1172,6 @@ github.com/jsternberg/zap-logfmt v1.0.0/go.mod h1:uvPs/4X51zdkcm5jXl5SYoN+4RK21K
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/juju/errors v0.0.0-20181012004132-a4583d0a56ea h1:g2k+8WR7cHch4g0tBDhfiEvAp7fXxTNBiD1oC1Oxj3E=
 github.com/juju/errors v0.0.0-20181012004132-a4583d0a56ea/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9 h1:hJix6idebFclqlfZCHE7EUX7uqLCyb70nHNHH1XKGBg=
 github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
@@ -1307,7 +1296,6 @@ github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4f
 github.com/mattn/go-xmlrpc v0.0.3 h1:Y6WEMLEsqs3RviBrAa1/7qmbGB7DVD3brZIbqMbQdGY=
 github.com/mattn/go-xmlrpc v0.0.3/go.mod h1:mqc2dz7tP5x5BKlCahN/n+hs7OSZKJkS9JsHNBRlrxA=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
-github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
@@ -1350,7 +1338,6 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.2.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/mapstructure v1.3.2 h1:mRS76wmkOn3KkKAyXDu42V+6ebnXWIztFSYGN7GeoRg=
 github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.3.3 h1:SzB1nHZ2Xi+17FP0zVQBHIZqvwRN9408fJO8h+eeNA8=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
@@ -1582,7 +1569,6 @@ github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCr
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d h1:CdDQnGF8Nq9ocOS/xlSptM1N3BbrA6/kmaep5ggwaIA=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
-github.com/philhofer/fwd v1.1.0 h1:PAdZw9+/BCf4gc/kA2L/PbGPkFe72Kl2GLZXTG8HpU8=
 github.com/philhofer/fwd v1.1.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/philhofer/fwd v1.1.1 h1:GdGcTjf5RNAxwS4QLsiMzJYj5KEvPJD3Abr261yRQXQ=
 github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
@@ -1775,7 +1761,6 @@ github.com/signalfx/golib v2.3.1+incompatible/go.mod h1:nWYefOwlUKWm/SpN/LgVSBny
 github.com/signalfx/golib v2.4.1+incompatible h1:UZaLOB4i2Dz7/Fkal2+xY9NRtv+adghUCsXj9csN7xo=
 github.com/signalfx/golib v2.4.1+incompatible/go.mod h1:nWYefOwlUKWm/SpN/LgVSBnyH1T9NpT1ANlmgRIi1Cs=
 github.com/signalfx/golib/v3 v3.0.0/go.mod h1:p+krygP/cDlWvCBEgdkQp3H16rbP4NW7YQa81TDMRe8=
-github.com/signalfx/golib/v3 v3.3.13 h1:Q+WDU2CeOGAJ2uZtb3Ov5cIUKS6tyvR2KU87SjVlXg0=
 github.com/signalfx/golib/v3 v3.3.13/go.mod h1:LKKCrEw4rU8ZL/8dVwX5i1+kqm4utB7uaHQpRx587rs=
 github.com/signalfx/golib/v3 v3.3.16 h1:AKcwihBfHJIK3oQyYdpebHSt4btM56a180mrOQrwBdw=
 github.com/signalfx/golib/v3 v3.3.16/go.mod h1:LKKCrEw4rU8ZL/8dVwX5i1+kqm4utB7uaHQpRx587rs=
@@ -1811,7 +1796,6 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180725160413-e900ae048470/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
-github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.1 h1:voD4ITNjPL5jjBfgR/r8fPIIBrliWrWHeiJApdr3r4w=
@@ -1910,7 +1894,6 @@ github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e h1:RumXZ56IrCj4CL+g1b9OL/oH0QnsF976bC8xQFYUD5Q=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
-github.com/tinylib/msgp v1.1.4 h1:LoJjc8YHnBUXK7kR6ocUJ0xHuonGLzpzV3RxMZ/4G4M=
 github.com/tinylib/msgp v1.1.4/go.mod h1:fw0zyanbVLI0CNimiAzGT53nQhEXzCaKYmTfeon9xHc=
 github.com/tinylib/msgp v1.1.5 h1:2gXmtWueD2HefZHQe1QOy9HVzmFrLOVvsXwXBQ0ayy0=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
@@ -2166,7 +2149,6 @@ golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200927032502-5d4f70055728/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb h1:eBmm0M9fYhWpKZLjQUUKka/LtIxf46G4fxeEz5KJr9U=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -2497,7 +2479,6 @@ google.golang.org/genproto v0.0.0-20200929141702-51c3e5b607fe/go.mod h1:FWY/as6D
 google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc/examples v0.0.0-20200728065043-dfc0c05b2da9/go.mod h1:5j1uub0jRGhRiSghIlrThmBUgcgLXOVJQ/l1getT4uo=
-google.golang.org/grpc/examples v0.0.0-20200728194956-1c32b02682df h1:dzcY2V+Hq5AopGNrrPau/ZLX3Io4ma9h4e5E//dkeH4=
 google.golang.org/grpc/examples v0.0.0-20200728194956-1c32b02682df/go.mod h1:5j1uub0jRGhRiSghIlrThmBUgcgLXOVJQ/l1getT4uo=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/internal/receiver/smartagentreceiver/output.go
+++ b/internal/receiver/smartagentreceiver/output.go
@@ -1,0 +1,99 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smartagentreceiver
+
+import (
+	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/signalfx/golib/v3/event"
+	"github.com/signalfx/golib/v3/trace"
+	"github.com/signalfx/signalfx-agent/pkg/core/dpfilters"
+	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
+	"go.opentelemetry.io/collector/consumer"
+	"go.uber.org/zap"
+)
+
+// Output is an implementation of a Smart Agent FilteringOutput that receives datapoints from a configured monitor.
+// It is what provides metrics to the next MetricsConsumer (to be implemented later).  At this stage it is only
+// a logging instance.
+type Output struct {
+	nextConsumer consumer.MetricsConsumer
+	logger       *zap.Logger
+}
+
+var _ types.FilteringOutput = (*Output)(nil)
+
+func (output *Output) AddDatapointExclusionFilter(filter dpfilters.DatapointFilter) {
+	output.logger.Debug("AddDatapointExclusionFilter has been called", zap.Any("filter", filter))
+}
+
+func (output *Output) EnabledMetrics() []string {
+	output.logger.Debug("EnabledMetrics has been called.")
+	return []string{}
+}
+
+func (output *Output) HasEnabledMetricInGroup(group string) bool {
+	output.logger.Debug("HasEnabledMetricInGroup has been called", zap.String("group", group))
+	return false
+}
+
+func (output *Output) HasAnyExtraMetrics() bool {
+	output.logger.Debug("HasAnyExtraMetrics has been called.")
+	return false
+}
+
+func (output *Output) Copy() types.Output {
+	output.logger.Debug("Copy has been called.")
+	return output
+}
+
+func (output *Output) SendDatapoints(datapoints ...*datapoint.Datapoint) {
+	output.logger.Debug("SendDatapoints has been called.", zap.Any("datapoints", datapoints))
+}
+
+func (output *Output) SendEvent(event *event.Event) {
+	output.logger.Debug("SendEvent has been called.", zap.Any("event", event))
+}
+
+func (output *Output) SendSpans(spans ...*trace.Span) {
+	output.logger.Debug("SendSpans has been called.", zap.Any("Span", spans))
+}
+
+func (output *Output) SendDimensionUpdate(dimension *types.Dimension) {
+	output.logger.Debug("SendDimensionUpdate has been called.", zap.Any("dimension", dimension))
+}
+
+func (output *Output) AddExtraDimension(key, value string) {
+	output.logger.Debug("AddExtraDimension has been called.", zap.String("key", key), zap.String("value", value))
+}
+
+func (output *Output) RemoveExtraDimension(key string) {
+	output.logger.Debug("RemoveExtraDimension has been called.", zap.String("key", key))
+}
+
+func (output *Output) AddExtraSpanTag(key, value string) {
+	output.logger.Debug("AddExtraSpanTag has been called.", zap.String("key", key), zap.String("value", value))
+}
+
+func (output *Output) RemoveExtraSpanTag(key string) {
+	output.logger.Debug("RemoveExtraSpanTag has been called.", zap.String("key", key))
+}
+
+func (output *Output) AddDefaultSpanTag(key, value string) {
+	output.logger.Debug("AddDefaultSpanTag has been called.", zap.String("key", key), zap.String("value", value))
+}
+
+func (output *Output) RemoveDefaultSpanTag(key string) {
+	output.logger.Debug("RemoveDefaultSpanTag has been called.", zap.String("key", key))
+}

--- a/internal/receiver/smartagentreceiver/output_test.go
+++ b/internal/receiver/smartagentreceiver/output_test.go
@@ -1,0 +1,49 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smartagentreceiver
+
+import (
+	"testing"
+
+	"github.com/signalfx/golib/v3/event"
+	"github.com/signalfx/signalfx-agent/pkg/core/dpfilters"
+	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.uber.org/zap"
+)
+
+func TestOutput(t *testing.T) {
+	output := Output{
+		nextConsumer: consumertest.NewMetricsNop(),
+		logger:       zap.NewNop(),
+	}
+
+	output.AddDatapointExclusionFilter(dpfilters.DatapointFilter(nil))
+	assert.Empty(t, output.EnabledMetrics())
+	assert.False(t, output.HasEnabledMetricInGroup(""))
+	assert.False(t, output.HasAnyExtraMetrics())
+	assert.Same(t, &output, output.Copy())
+	output.SendDatapoints()
+	output.SendEvent(new(event.Event))
+	output.SendSpans()
+	output.SendDimensionUpdate(new(types.Dimension))
+	output.AddExtraDimension("", "")
+	output.RemoveExtraDimension("")
+	output.AddExtraSpanTag("", "")
+	output.RemoveExtraSpanTag("")
+	output.AddDefaultSpanTag("", "")
+	output.RemoveDefaultSpanTag("")
+}

--- a/internal/receiver/smartagentreceiver/receiver.go
+++ b/internal/receiver/smartagentreceiver/receiver.go
@@ -16,8 +16,17 @@ package smartagentreceiver
 
 import (
 	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
 
+	"github.com/signalfx/signalfx-agent/pkg/core/config"
+	"github.com/signalfx/signalfx-agent/pkg/monitors"
+	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
+	"github.com/signalfx/signalfx-agent/pkg/utils"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/consumer"
 	"go.uber.org/zap"
 )
@@ -25,7 +34,11 @@ import (
 type Receiver struct {
 	logger       *zap.Logger
 	config       *Config
+	monitor      interface{}
 	nextConsumer consumer.MetricsConsumer
+
+	startOnce sync.Once
+	stopOnce  sync.Once
 }
 
 var _ component.MetricsReceiver = (*Receiver)(nil)
@@ -39,9 +52,74 @@ func NewReceiver(logger *zap.Logger, config Config, nextConsumer consumer.Metric
 }
 
 func (r *Receiver) Start(_ context.Context, host component.Host) error {
-	return nil
+	err := r.config.validate()
+	if err != nil {
+		return fmt.Errorf("config validation failed for %q: %w", r.config.Name(), err)
+	}
+
+	configCore := r.config.monitorConfig.MonitorConfigCore()
+	monitorType := configCore.Type
+	monitorName := strings.ReplaceAll(r.config.Name(), "/", "")
+	configCore.MonitorID = types.MonitorID(monitorName)
+
+	r.monitor, err = r.createMonitor(monitorType)
+	if err != nil {
+		return fmt.Errorf("failed creating monitor %q: %w", monitorType, err)
+	}
+
+	err = componenterror.ErrAlreadyStarted
+	r.startOnce.Do(func() {
+		// starts the monitor
+		err = config.CallConfigure(r.monitor, r.config.monitorConfig)
+	})
+	return err
 }
 
 func (r *Receiver) Shutdown(context.Context) error {
-	return nil
+	err := componenterror.ErrAlreadyStopped
+	if r.monitor == nil {
+		err = fmt.Errorf("smartagentreceiver's Shutdown() called before Start() or with invalid monitor state")
+	} else if shutdownable, ok := (r.monitor).(monitors.Shutdownable); !ok {
+		err = fmt.Errorf("invalid monitor state at Shutdown(): %#v", r.monitor)
+	} else {
+		r.stopOnce.Do(func() {
+			shutdownable.Shutdown()
+			err = nil
+		})
+	}
+	return err
+}
+
+func (r *Receiver) createMonitor(monitorType string) (interface{}, error) {
+	// retrieve registered MonitorFactory from agent's registration store
+	monitorFactory, ok := monitors.MonitorFactories[monitorType]
+	if !ok {
+		return nil, fmt.Errorf("unable to find MonitorFactory for %q", monitorType)
+	}
+
+	monitor := monitorFactory() // monitor is a pointer to a monitor struct
+
+	// monitorOutputValue is the monitor struct's "Output" field value obtained via reflection to be set to
+	// an Output instance.
+	var monitorOutputValue reflect.Value
+	// reflect functions will panic if received Value is not of supported type for receiver methods.
+	monitorValue := reflect.Indirect(reflect.ValueOf(monitor))
+	// ensure that they are only called when applicable.
+	if monitorValue.IsValid() && monitorValue.Type().Kind() == reflect.Struct {
+		monitorOutputValue = utils.FindFieldWithEmbeddedStructs(monitor, "Output",
+			reflect.TypeOf((*types.Output)(nil)).Elem())
+		if !monitorOutputValue.IsValid() {
+			monitorOutputValue = utils.FindFieldWithEmbeddedStructs(monitor, "Output",
+				reflect.TypeOf((*types.FilteringOutput)(nil)).Elem())
+		}
+	}
+
+	if monitorOutputValue.IsValid() {
+		output := &Output{nextConsumer: r.nextConsumer, logger: r.logger}
+		monitorOutputValue.Set(reflect.ValueOf(output))
+	} else {
+		return nil, fmt.Errorf("invalid monitor instance: %#v", monitor)
+	}
+
+	return monitor, nil
 }

--- a/internal/receiver/smartagentreceiver/receiver_test.go
+++ b/internal/receiver/smartagentreceiver/receiver_test.go
@@ -16,46 +16,143 @@ package smartagentreceiver
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/signalfx/signalfx-agent/pkg/core/config"
+	"github.com/signalfx/signalfx-agent/pkg/monitors"
+	"github.com/signalfx/signalfx-agent/pkg/monitors/cpu"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
-func TestSmartAgentReceiver(t *testing.T) {
-	type args struct {
-		config       Config
-		nextConsumer consumer.MetricsConsumer
-	}
-	tests := []struct {
-		name string
-		args args
-	}{
-		{
-			name: "default",
-			args: args{
-				config: Config{
-					ReceiverSettings: configmodels.ReceiverSettings{
-						TypeVal: typeStr,
-						NameVal: typeStr + "/default",
-					},
-				},
-				nextConsumer: consumertest.NewMetricsNop(),
+func newConfig(nameVal, monitorType string, intervalSeconds int) Config {
+	return Config{
+		ReceiverSettings: configmodels.ReceiverSettings{
+			TypeVal: typeStr,
+			NameVal: fmt.Sprintf("%s/%s", typeStr, nameVal),
+		},
+		monitorConfig: &cpu.Config{
+			MonitorConfig: config.MonitorConfig{
+				Type:            monitorType,
+				IntervalSeconds: intervalSeconds,
 			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			consumer := tt.args.nextConsumer
-			receiver := NewReceiver(zap.NewNop(), tt.args.config, consumer)
+}
+
+func TestSmartAgentReceiver(t *testing.T) {
+	cfg := newConfig("valid", "cpu", 1)
+	observed, logs := observer.New(zapcore.DebugLevel)
+	receiver := NewReceiver(zap.New(observed), cfg, consumertest.NewMetricsNop())
+	err := receiver.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	assert.EqualValues(t, "smartagentvalid", cfg.monitorConfig.MonitorConfigCore().MonitorID)
+
+	monitorOutput := receiver.monitor.(*cpu.Monitor).Output
+	_, ok := monitorOutput.(*Output)
+	assert.True(t, ok)
+
+	assert.Eventuallyf(t, func() bool {
+		filtered := logs.FilterMessageSnippet("SendDatapoints has been called.")
+		return len(filtered.All()) == 1
+	}, 5*time.Second, 1*time.Millisecond, "failed to receive any metrics from monitor")
+
+	err = receiver.Shutdown(context.Background())
+	assert.NoError(t, err)
+
+}
+
+func TestStartReceiverWithInvalidMonitorConfig(t *testing.T) {
+	cfg := newConfig("invalid", "cpu", -123)
+	receiver := NewReceiver(zap.NewNop(), cfg, consumertest.NewMetricsNop())
+	err := receiver.Start(context.Background(), componenttest.NewNopHost())
+	assert.EqualError(t, err,
+		"config validation failed for \"smartagent/invalid\": intervalSeconds must be greater than 0s (-123 provided)",
+	)
+}
+
+func TestStartReceiverWithUnknownMonitorType(t *testing.T) {
+	cfg := newConfig("invalid", "notamonitortype", 1)
+	receiver := NewReceiver(zap.NewNop(), cfg, consumertest.NewMetricsNop())
+	err := receiver.Start(context.Background(), componenttest.NewNopHost())
+	assert.EqualError(t, err,
+		"failed creating monitor \"notamonitortype\": unable to find MonitorFactory for \"notamonitortype\"",
+	)
+}
+
+func TestMultipleStartAndShutdownInvocations(t *testing.T) {
+	cfg := newConfig("valid", "cpu", 1)
+	receiver := NewReceiver(zap.NewNop(), cfg, consumertest.NewMetricsNop())
+	err := receiver.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	err = receiver.Start(context.Background(), componenttest.NewNopHost())
+	require.Error(t, err)
+	assert.Equal(t, err, componenterror.ErrAlreadyStarted)
+
+	err = receiver.Shutdown(context.Background())
+	require.NoError(t, err)
+
+	err = receiver.Shutdown(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, err, componenterror.ErrAlreadyStopped)
+}
+
+func TestOutOfOrderShutdownInvocations(t *testing.T) {
+	cfg := newConfig("valid", "cpu", 1)
+	receiver := NewReceiver(zap.NewNop(), cfg, consumertest.NewMetricsNop())
+
+	err := receiver.Shutdown(context.Background())
+	require.Error(t, err)
+	assert.EqualError(t, err,
+		"smartagentreceiver's Shutdown() called before Start() or with invalid monitor state",
+	)
+}
+
+func TestInvalidMonitorStateAtShutdown(t *testing.T) {
+	cfg := newConfig("valid", "cpu", 1)
+	receiver := NewReceiver(zap.NewNop(), cfg, consumertest.NewMetricsNop())
+	receiver.monitor = new(interface{})
+
+	err := receiver.Shutdown(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid monitor state at Shutdown(): (*interface {})")
+}
+
+func TestConfirmStartingReceiverWithInvalidMonitorInstancesDoesntPanic(t *testing.T) {
+	tests := []struct {
+		name           string
+		monitorFactory func() interface{}
+		expectedError  string
+	}{
+		{"anonymous struct", func() interface{} { return struct{}{} }, "struct {}{}"},
+		{"anonymous struct pointer", func() interface{} { return &struct{}{} }, "&struct {}{}"},
+		{"nil interface pointer", func() interface{} { return new(interface{}) }, "(*interface {})"},
+		{"nil", func() interface{} { return nil }, "<nil>"},
+		{"boolean", func() interface{} { return false }, "false"},
+		{"string", func() interface{} { return "asdf" }, "\"asdf\""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			monitors.MonitorFactories["notarealmonitor"] = test.monitorFactory
+
+			cfg := newConfig("invalid", "notarealmonitor", 123)
+			receiver := NewReceiver(zap.NewNop(), cfg, consumertest.NewMetricsNop())
 			err := receiver.Start(context.Background(), componenttest.NewNopHost())
-			assert.NoError(t, err)
-			err = receiver.Shutdown(context.Background())
-			assert.NoError(t, err)
+			require.Error(tt, err)
+			assert.Contains(tt, err.Error(),
+				fmt.Sprintf("failed creating monitor \"notarealmonitor\": invalid monitor instance: %s", test.expectedError),
+			)
 		})
 	}
 }


### PR DESCRIPTION
These changes introduce the main receiver start and shutdown functionality (addressing the second remaining item detailed in https://github.com/signalfx/splunk-otel-collector/pull/53#issue-549208453).  They include dynamic SA monitor creation using the provided config and establish a means of accessing the SFx datapoints reported by the monitors.  These change don't include datapoint conversion, which will be introduced in the next proposed addition.

They also don't include the core collectd process creation, which will also be introduced in a later PR.