### PR TITLE
Sign/release exe and msi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,8 +332,8 @@ jobs:
           name: Calculate checksums
           command: cd dist && shasum -a 256 * > checksums.txt
       - run:
-          name: Create Github release and upload artifacts
-          command: ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $CIRCLE_TAG dist/
+          name: Create Github pre-release and upload artifacts
+          command: ghr --prerelease -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $CIRCLE_TAG dist/
 
   publish-dev:
     docker:

--- a/internal/buildscripts/packaging/release/helpers/constants.py
+++ b/internal/buildscripts/packaging/release/helpers/constants.py
@@ -1,0 +1,50 @@
+# Copyright 2020 Splunk, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+# Artifactory
+ARTIFACTORY_URL = "https://splunk.jfrog.io/artifactory"
+ARTIFACTORY_API_URL = f"{ARTIFACTORY_URL}/api"
+ARTIFACTORY_DEB_REPO = "otel-collector-deb"
+ARTIFACTORY_DEB_REPO_URL = f"{ARTIFACTORY_URL}/{ARTIFACTORY_DEB_REPO}"
+ARTIFACTORY_RPM_REPO = "otel-collector-rpm"
+ARTIFACTORY_RPM_REPO_URL = f"{ARTIFACTORY_URL}/{ARTIFACTORY_RPM_REPO}"
+DEFAULT_ARTIFACTORY_USERNAME = "otel-collector"
+
+# Signing
+CHAPERONE_API_URL = "https://chaperone.re.splunkdev.com/api-service"
+DEFAULT_STAGING_USERNAME = "srv-otel-collector"
+DEFAULT_TIMEOUT = 600
+SIGN_TYPES = ("GPG", "RPM", "WIN")
+SIGNED_ARTIFACTS_REPO_URL = "https://repo.splunk.com/artifactory/signed-artifacts"
+STAGING_URL = "https://repo.splunk.com/artifactory"
+STAGING_REPO = "otel-collector-local"
+STAGING_REPO_URL = f"{STAGING_URL}/{STAGING_REPO}"
+
+# Package/Release
+REPO_DIR = Path(__file__).parent.parent.parent.parent.parent.parent.resolve()
+ASSETS_BASE_DIR = REPO_DIR / "dist" / "release"
+COLLECTOR_REPO = "signalfx/splunk-otel-collector"
+COMPONENTS = ["deb", "rpm", "windows"]
+PACKAGE_NAME = "splunk-otel-collector"
+STAGES = ("release", "beta", "test", "github")
+S3_BUCKET = "public-downloads--signalfuse-com"
+S3_MSI_BASE_DIR = f"{PACKAGE_NAME}/msi"
+CLOUDFRONT_DISTRIBUTION_ID = "EJH671JAOI5SN"
+
+# MSI
+WIX_IMAGE = "felfert/wix:latest"
+WXS_PATH = "internal/buildscripts/packaging/msi/splunk-otel-collector.wxs"
+MSI_CONFIG = "cmd/otelcol/config/collector/agent_config_windows.yaml"

--- a/internal/buildscripts/packaging/release/helpers/release_args.py
+++ b/internal/buildscripts/packaging/release/helpers/release_args.py
@@ -1,0 +1,249 @@
+# Copyright 2020 Splunk, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+
+from .constants import (
+    ARTIFACTORY_URL,
+    COMPONENTS,
+    DEFAULT_ARTIFACTORY_USERNAME,
+    DEFAULT_STAGING_USERNAME,
+    DEFAULT_TIMEOUT,
+    STAGES,
+    STAGING_URL,
+)
+
+
+def add_signing_args(parser):
+    signing_args = parser.add_argument_group("Signing Credentials")
+    signing_args.add_argument(
+        "--chaperone-token",
+        type=str,
+        default=os.environ.get("CHAPERONE_TOKEN"),
+        metavar="CHAPERONE_TOKEN",
+        required=False,
+        help="Chaperone token. Required if the CHAPERONE_TOKEN env var is not set.",
+    )
+    signing_args.add_argument(
+        "--staging-user",
+        type=str,
+        default=os.environ.get("STAGING_USERNAME", DEFAULT_STAGING_USERNAME),
+        metavar="STAGING_USERNAME",
+        required=False,
+        help=f"""
+            Staging username for {STAGING_URL}.
+            Defaults to the STAGING_USERNAME env var if set, otherwise '{DEFAULT_STAGING_USERNAME}'.
+        """,
+    )
+    signing_args.add_argument(
+        "--staging-token",
+        type=str,
+        default=os.environ.get("STAGING_TOKEN"),
+        metavar="STAGING_TOKEN",
+        required=False,
+        help=f"""
+            Staging token for {STAGING_URL}.
+            Required if the STAGING_TOKEN env var is not set.
+        """,
+    )
+
+
+def check_signing_args(args):
+    assert args.chaperone_token, f"Chaperone token not set"
+    assert args.staging_user, f"Staging username not set for {STAGING_URL}"
+    assert args.staging_token, f"Staging token not set for {STAGING_URL}"
+
+
+def add_artifactory_args(parser):
+    artifactory_args = parser.add_argument_group("Artifactory Credentials")
+    artifactory_args.add_argument(
+        "--artifactory-user",
+        type=str,
+        default=os.environ.get("ARTIFACTORY_USERNAME", DEFAULT_ARTIFACTORY_USERNAME),
+        metavar="ARTIFACTORY_USERNAME",
+        required=False,
+        help=f"""
+            Artifactory username for {ARTIFACTORY_URL}.
+            Defaults to the ARTIFACTORY_USERNAME env var if set, otherwise '{DEFAULT_ARTIFACTORY_USERNAME}'.
+        """,
+    )
+    artifactory_args.add_argument(
+        "--artifactory-token",
+        type=str,
+        default=os.environ.get("ARTIFACTORY_TOKEN"),
+        metavar="ARTIFACTORY_TOKEN",
+        required=False,
+        help=f"""
+            Artifactory token for {ARTIFACTORY_URL}.
+            Required if the ARTIFACTORY_TOKEN env var is not set.
+        """,
+    )
+
+
+def check_artifactory_args(args):
+    assert args.artifactory_user, f"Artifactory username not set for {ARTIFACTORY_URL}"
+    assert args.artifactory_token, f"Artifactory token not set for {ARTIFACTORY_URL}"
+
+
+def add_github_args(parser):
+    github_args = parser.add_argument_group("Github Credentials")
+    github_args.add_argument(
+        "--github-token",
+        type=str,
+        default=os.environ.get("GITHUB_TOKEN"),
+        metavar="GITHUB_TOKEN",
+        required=False,
+        help=f"""
+            Personal Github token.
+            Required if the GITHUB_TOKEN env var is not set and STAGE is 'release'.
+        """,
+    )
+
+
+def check_github_args(args):
+    assert args.github_token, "Github token not set"
+
+
+def get_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="Sign and release assets from Github Releases.",
+    )
+    parser.add_argument(
+        "--stage",
+        type=str,
+        default="release",
+        metavar="STAGE",
+        choices=STAGES,
+        required=False,
+        help=f"""
+            Stage for pushing the packages to Artifactory and S3.
+            Should be one of {STAGES}.
+            If STAGE is 'test', the packages will *not* be signed and *only* pushed to Artifactory and S3.
+            If STAGE is 'beta', the packages will be signed and *only* pushed to Artifactory and S3.
+            If STAGE is 'github', the packages will be signed and *only* pushed to the Github release.
+            If STAGE is 'release', the packages will be signed, pushed to Artifactory, S3, and Github, and the
+            'Pre-release' label will be removed from the Github release.
+            Defaults to 'release'.
+        """,
+    )
+    parser.add_argument(
+        "--no-push",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Only download and sign the assets. Do not push the assets to Artifactory, S3, or Github.",
+    )
+    parser.add_argument(
+        "--tag",
+        type=str,
+        default=None,
+        metavar="TAG",
+        required=False,
+        help="Existing Github release tag (e.g. 'v1.2.3'). Defaults to the latest release tag.",
+    )
+    parser.add_argument(
+        "--download-only",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Download assets from the Github release and exit.",
+    )
+    parser.add_argument(
+        "--assets-dir",
+        type=str,
+        default=None,
+        metavar="DIR",
+        required=False,
+        help=f"""
+            Directory to save the downloaded assets from the Github release.
+            The directory will be created if it does not exist.
+            This option is ignored if the '--path' option is also specified.
+            Defaults to 'dist/release/<RELEASE_TAG>' in the repo root directory.
+            Signed assets will be saved to the 'signed' sub-directory, e.g. 'dist/release/<RELEASE_TAG>/signed'.
+        """,
+    )
+    parser.add_argument(
+        "--component",
+        type=str,
+        default=[],
+        metavar="COMPONENT",
+        choices=COMPONENTS,
+        action="append",
+        required=False,
+        help=f"""
+            Only download, sign, and release the specified component from the Github release.
+            Should be one of {COMPONENTS}.
+            If COMPONENT is 'windows', the exe will be signed, and the msi will be rebuilt with the signed exe.
+            This option may be specified multiple times for multiple components.
+            The default is to perform a full sign/release for all supported components.
+            This option is ignored if the '--path' option is also specified.
+        """,
+    )
+    parser.add_argument(
+        "--path",
+        type=str,
+        default=[],
+        metavar="PATH",
+        action="append",
+        required=False,
+        help="""
+            Sign/release a local file instead of downloading the assets from the Github release.
+            This option may be specified multiple times for multiple files.
+            Only files with .deb, .rpm, or .exe extensions are supported.
+            If the file is .exe, the msi will also be built and signed/released.
+            NOTE: This option is only applicable if STAGE is 'test' or 'beta'.
+        """,
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        metavar="TIMEOUT",
+        required=False,
+        help=f"Signing request timeout in seconds. Defaults to {DEFAULT_TIMEOUT}.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Never prompt when overwriting existing files.",
+    )
+
+    add_artifactory_args(parser)
+    add_signing_args(parser)
+    add_github_args(parser)
+
+    args = parser.parse_args()
+
+    if not args.component:
+        args.component = COMPONENTS
+
+    if args.stage != "test":
+        check_signing_args(args)
+
+    if not args.no_push:
+        if args.stage in ("beta", "release"):
+            check_artifactory_args(args)
+
+        if args.stage in ("github", "release"):
+            check_github_args(args)
+            if args.path:
+                print("The '--path' option is not supported for the 'github' or 'release' stage.")
+                sys.exit(1)
+
+    return args

--- a/internal/buildscripts/packaging/release/helpers/util.py
+++ b/internal/buildscripts/packaging/release/helpers/util.py
@@ -1,32 +1,132 @@
+# Copyright 2020 Splunk, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import hashlib
 import os
 import re
+import sys
 import tempfile
 import time
 
+import boto3
+import docker
 import requests
 from github import Github
 
-ARTIFACTORY_URL = "https://splunk.jfrog.io/artifactory"
-ARTIFACTORY_API_URL = f"{ARTIFACTORY_URL}/api"
-CHAPERONE_API_URL = "https://chaperone.re.splunkdev.com/api-service"
-SIGNED_ARTIFACTS_REPO_URL = "https://repo.splunk.com/artifactory/signed-artifacts"
-STAGING_URL = "https://repo.splunk.com/artifactory"
-STAGING_REPO = os.environ.get("STAGING_REPO", "otel-collector-local")
-STAGING_REPO_URL = f"{STAGING_URL}/{STAGING_REPO}"
-SIGN_TYPES = ("GPG", "RPM", "WIN")
-DEFAULT_ARTIFACTORY_USERNAME = "otel-collector"
-DEFAULT_STAGING_USERNAME = "srv-otel-collector"
-DEFAULT_TIMEOUT = 300
+from .constants import (
+    ARTIFACTORY_API_URL,
+    ARTIFACTORY_DEB_REPO,
+    ARTIFACTORY_DEB_REPO_URL,
+    ARTIFACTORY_RPM_REPO,
+    ARTIFACTORY_RPM_REPO_URL,
+    CHAPERONE_API_URL,
+    CLOUDFRONT_DISTRIBUTION_ID,
+    DEFAULT_TIMEOUT,
+    MSI_CONFIG,
+    PACKAGE_NAME,
+    REPO_DIR,
+    S3_BUCKET,
+    S3_MSI_BASE_DIR,
+    SIGN_TYPES,
+    SIGNED_ARTIFACTS_REPO_URL,
+    STAGING_REPO_URL,
+    WIX_IMAGE,
+    WXS_PATH,
+)
+
+
+class Asset(object):
+    def __init__(self, url=None, path=None):
+        assert url or path, "Either url= or path= is required!"
+        self.url = url
+        self.path = path
+        self.name = self._get_name()
+        self.component = self._get_component()
+        self.sign_type = self._get_sign_type()
+        self.checksum = None
+        self.signed = False
+        self.signed_path = None
+        self.signed_checksum = None
+        if self.path:
+            self.checksum = get_checksum(self.path, hashlib.sha256())
+
+    def _get_name(self):
+        if self.url:
+            return os.path.basename(self.url)
+        elif self.path:
+            return os.path.basename(self.path)
+        return None
+
+    def _get_component(self):
+        if self.name:
+            ext = os.path.splitext(self.name)[-1].strip(".")
+            if ext:
+                return ext.lower()
+        return None
+
+    def _get_sign_type(self):
+        if self.component:
+            if self.component == "rpm":
+                return "RPM"
+            elif self.component in ("exe", "msi"):
+                return "WIN"
+        return None
+
+    def download(self, dest, user=None, token=None, overwrite=False):
+        if self.url:
+            if not overwrite and os.path.isfile(dest):
+                resp = input(f"{dest} already exists.\nOverwrite? [y/N]: ")
+                if resp.lower() not in ("y", "yes"):
+                    return None
+                os.remove(dest)
+            download_file(self.url, dest, user, token)
+            self.path = dest
+            self.checksum = get_checksum(self.path, hashlib.sha256())
+            return self.path
+        return None
+
+    def sign(self, dest=None, overwrite=False, timeout=DEFAULT_TIMEOUT, **signing_args):
+        if self.path:
+            if not dest:
+                dest = os.path.join(os.path.dirname(self.path), "signed", self.name)
+            if not overwrite and os.path.isfile(dest):
+                resp = input(f"{dest} already exists.\nOverwrite? [y/N]: ")
+                if resp.lower() not in ("y", "yes"):
+                    return None
+                os.remove(dest)
+            sign_file(self.path, dest, self.sign_type, timeout=timeout, **signing_args)
+            self.signed_path = dest
+            self.signed_checksum = get_checksum(self.signed_path, hashlib.sha256())
+            self.signed = True
+            return self.signed_path
+        return None
+
+
+def get_checksum(path, hash_obj):
+    with open(path, "rb") as f:
+        # Read and update hash string value in blocks of 4K
+        for byte_block in iter(lambda: f.read(4096), b""):
+            hash_obj.update(byte_block)
+        return str(hash_obj.hexdigest()).lower()
 
 
 def upload_file_to_artifactory(src, dest, user, token):
     print(f"uploading {src} to {dest} ...")
 
     with open(src, "rb") as fd:
-        data = fd.read()
-        headers = {"X-Checksum-MD5": hashlib.md5(data).hexdigest()}
-        resp = requests.put(dest, auth=(user, token), headers=headers, data=data)
+        headers = {"X-Checksum-MD5": get_checksum(src, hashlib.md5())}
+        resp = requests.put(dest, auth=(user, token), headers=headers, data=fd)
 
         assert resp.status_code == 201, f"upload failed:\n{resp.reason}\n{resp.text}"
 
@@ -117,9 +217,10 @@ def wait_for_artifactory_metadata(url, orig_md5, user, token, timeout=DEFAULT_TI
         time.sleep(5)
 
 
-def wait_for_signed_artifact(
-    item_key, artifact_name, chaperone_token, staging_user, staging_token, timeout=DEFAULT_TIMEOUT
-):
+def wait_for_signed_artifact(item_key, artifact_name, timeout=DEFAULT_TIMEOUT, **signing_args):
+    chaperone_token = signing_args.get("chaperone_token")
+    staging_token = signing_args.get("staging_token")
+    staging_user = signing_args.get("staging_user")
     url = f"{SIGNED_ARTIFACTS_REPO_URL}/{item_key}/{artifact_name}"
 
     print(f"waiting for {url} ...")
@@ -144,17 +245,11 @@ def wait_for_signed_artifact(
     return url
 
 
-def sign_file(
-    src,
-    dest,
-    sign_type,
-    chaperone_token,
-    staging_user,
-    staging_token,
-    src_user=None,
-    src_token=None,
-    timeout=DEFAULT_TIMEOUT,
-):
+def sign_file(src, dest, sign_type, src_user=None, src_token=None, timeout=DEFAULT_TIMEOUT, **signing_args):
+    chaperone_token = signing_args.get("chaperone_token")
+    staging_token = signing_args.get("staging_token")
+    staging_user = signing_args.get("staging_user")
+
     if not re.match("^http(s)?://.*", src):
         assert os.path.isfile(src), f"{src} not found"
 
@@ -175,9 +270,7 @@ def sign_file(
 
         artifact_name = f"{base}.asc" if sign_type.lower() == "gpg" else base
 
-        signed_artifact_url = wait_for_signed_artifact(
-            item_key, artifact_name, chaperone_token, staging_user, staging_token, timeout
-        )
+        signed_artifact_url = wait_for_signed_artifact(item_key, artifact_name, timeout=timeout, **signing_args)
 
         download_file(signed_artifact_url, dest, staging_user, staging_token)
     finally:
@@ -185,9 +278,7 @@ def sign_file(
             delete_artifactory_file(staged_artifact_url, staging_user, staging_token)
 
 
-def sign_artifactory_metadata(
-    src, artifactory_user, artifactory_token, chaperone_token, staging_user, staging_token, timeout=DEFAULT_TIMEOUT
-):
+def sign_artifactory_metadata(src, artifactory_user, artifactory_token, timeout=DEFAULT_TIMEOUT, **signing_args):
     with tempfile.TemporaryDirectory() as tmpdir:
         base = os.path.basename(src)
         signature_ext = ".gpg" if base == "Release" else ".asc"
@@ -198,92 +289,257 @@ def sign_artifactory_metadata(
             src,
             signature_path,
             "GPG",
-            chaperone_token,
-            staging_user,
-            staging_token,
-            artifactory_user,
-            artifactory_token,
-            timeout,
+            src_user=artifactory_user,
+            src_token=artifactory_token,
+            timeout=timeout,
+            **signing_args,
         )
 
         upload_file_to_artifactory(signature_path, signature_url, artifactory_user, artifactory_token)
 
 
-def add_signing_args(parser):
-    parser.add_argument(
-        "--chaperone-token",
-        type=str,
-        default=os.environ.get("CHAPERONE_TOKEN"),
-        metavar="CHAPERONE_TOKEN",
-        required=False,
-        help="Chaperone token. Required if the CHAPERONE_TOKEN env var is not set.",
+def upload_package_to_artifactory(
+    path,
+    dest_url,
+    user,
+    token,
+    metadata_api_url,
+    metadata_url,
+    sign_metadata=True,
+    timeout=DEFAULT_TIMEOUT,
+    **signing_args,
+):
+    orig_md5 = get_md5_from_artifactory(metadata_api_url, user, token)
+
+    upload_file_to_artifactory(path, dest_url, user, token)
+
+    wait_for_artifactory_metadata(metadata_api_url, orig_md5, user, token, timeout=timeout)
+
+    if sign_metadata:
+        sign_artifactory_metadata(metadata_url, user, token, timeout=timeout, **signing_args)
+
+
+def release_deb_to_artifactory(asset, args, **signing_args):
+    if args.no_push or args.stage == "github":
+        # nothing to do for deb packages
+        return
+
+    user = args.artifactory_user
+    token = args.artifactory_token
+
+    match = re.match(r".*_(amd64|arm64)\.deb$", asset.name)
+    assert match, f"Failed to get arch from {asset.path}!"
+    arch = match.groups()[0]
+
+    metadata_api_url = f"{ARTIFACTORY_API_URL}/storage/{ARTIFACTORY_DEB_REPO}/dists/{args.stage}/Release"
+    metadata_url = f"{ARTIFACTORY_DEB_REPO_URL}/dists/{args.stage}/Release"
+    deb_url = f"{ARTIFACTORY_DEB_REPO_URL}/pool/{args.stage}/{arch}/{asset.name}"
+    dest_opts = f"deb.distribution={args.stage};deb.component=main;deb.architecture={arch}"
+    dest_url = f"{deb_url};{dest_opts}"
+
+    if not args.force and artifactory_file_exists(deb_url, user, token):
+        resp = input(f"{deb_url} already exists.\nOverwrite? [y/N]: ")
+        if resp.lower() not in ("y", "yes"):
+            sys.exit(1)
+
+    sign_metadata = False if args.stage == "test" else True
+
+    upload_package_to_artifactory(
+        asset.path,
+        dest_url,
+        user,
+        token,
+        metadata_api_url,
+        metadata_url,
+        sign_metadata=sign_metadata,
+        timeout=args.timeout,
+        **signing_args,
     )
-    parser.add_argument(
-        "--staging-user",
-        type=str,
-        default=os.environ.get("STAGING_USERNAME", DEFAULT_STAGING_USERNAME),
-        metavar="STAGING_USERNAME",
-        required=False,
-        help=f"""
-            {STAGING_URL} username. Defaults to the STAGING_USERNAME env var if set,
-            otherwise '{DEFAULT_STAGING_USERNAME}'.
-        """,
+
+
+def release_rpm_to_artifactory(asset, args, **signing_args):
+    user = args.artifactory_user
+    token = args.artifactory_token
+
+    match = re.match(r".*\.(x86_64|aarch64)\.rpm$", asset.name)
+    assert match, f"Failed to get arch from {asset.path}!"
+    arch = match.groups()[0]
+
+    metadata_api_url = f"{ARTIFACTORY_API_URL}/storage/{ARTIFACTORY_RPM_REPO}/{args.stage}/{arch}/repodata/repomd.xml"
+    metadata_url = f"{ARTIFACTORY_RPM_REPO_URL}/{args.stage}/{arch}/repodata/repomd.xml"
+    dest_url = f"{ARTIFACTORY_RPM_REPO_URL}/{args.stage}/{arch}/{asset.name}"
+
+    if args.stage != "github" and not args.no_push:
+        if not args.force and artifactory_file_exists(dest_url, user, token):
+            resp = input(f"{dest_url} already exists.\nOverwrite? [y/N]: ")
+            if resp.lower() not in ("y", "yes"):
+                sys.exit(1)
+
+    rpm_path = asset.path
+    sign_metadata = False
+
+    if args.stage != "test":
+        print(f"Signing {asset.name} (may take 10+ minutes):")
+        if not asset.sign(overwrite=args.force, timeout=args.timeout, **signing_args):
+            sys.exit(1)
+        rpm_path = asset.signed_path
+        sign_metadata = True
+
+    if args.stage != "github" and not args.no_push:
+        upload_package_to_artifactory(
+            rpm_path,
+            dest_url,
+            user,
+            token,
+            metadata_api_url,
+            metadata_url,
+            sign_metadata=sign_metadata,
+            timeout=args.timeout,
+            **signing_args,
+        )
+
+
+def msi_exists_in_s3(s3_client, path):
+    results = s3_client.list_objects(Bucket=S3_BUCKET, Prefix=f"{path}")
+    for content in results.get("Contents", []):
+        if content.get("Key") == path:
+            return True
+    return False
+
+
+def invalidate_cloudfront(paths):
+    cloudfront = boto3.client('cloudfront')
+    print(f"Invalidating cloudfront for {paths} ...")
+    resp = cloudfront.create_invalidation(
+        DistributionId=CLOUDFRONT_DISTRIBUTION_ID,
+        InvalidationBatch={
+            'Paths': {
+                'Quantity': len(paths),
+                'Items': [f"/{path}" for path in paths]
+            },
+            'CallerReference': f"splunk-otel-collector-msi-{time.time()}",
+        }
     )
-    parser.add_argument(
-        "--staging-token",
-        type=str,
-        default=os.environ.get("STAGING_TOKEN"),
-        metavar="STAGING_TOKEN",
-        required=False,
-        help=f"{STAGING_URL} token. Required if the STAGING_TOKEN env var is not set.",
-    )
+    print(resp)
+    assert resp.get("ResponseMetadata", {}).get("HTTPStatusCode") == 201, "Failed to submit invalidation request!"
 
 
-def check_signing_args(args):
-    assert args.chaperone_token, f"Chaperone token not set"
-    assert args.staging_user, f"{STAGING_URL} username not set"
-    assert args.staging_token, f"{STAGING_URL} token not set"
+def build_msi(exe_path, args):
+    assert exe_path, f"{exe_path} not found!"
+
+    msi_version = args.tag.strip("v")
+    msi_name = f"{PACKAGE_NAME}-{msi_version}-amd64.msi"
+    msi_path = os.path.join(args.assets_dir, msi_name)
+    wixobj = f"{PACKAGE_NAME}.wixobj"
+
+    print(f"Building {msi_path} with {exe_path} ...")
+    if not args.force and os.path.isfile(msi_path):
+        resp = input(f"{msi_path} already exists.\nOverwrite? [y/N]: ")
+        if resp.lower() not in ("y", "yes"):
+            sys.exit(1)
+        os.remove(msi_path)
+
+    client = docker.from_env()
+    container_options = {
+        "remove": True,
+        "volumes": {
+            REPO_DIR: {"bind": "/work", "mode": "rw"},
+            os.path.abspath(exe_path): {"bind": "/otelcol/otelcol.exe", "mode": "ro"},
+        },
+        "working_dir": "/work",
+    }
+
+    candle_opts = f'-arch x64 -dOtelcol="/otelcol/otelcol.exe" -dVersion="{msi_version}" -dConfig="{MSI_CONFIG}"'
+    cmd = f"candle {candle_opts} {WXS_PATH}"
+    output = client.containers.run(WIX_IMAGE, command=cmd, **container_options)
+    print(output.decode("utf-8"))
+    assert os.path.isfile(wixobj), f"{wixobj} not found!"
+
+    cmd = f"light {wixobj} -sval -spdb -out {msi_name}"
+    output = client.containers.run(WIX_IMAGE, command=cmd, **container_options)
+    print(output.decode("utf-8"))
+    assert os.path.isfile(msi_name), f"{msi_name} not found!"
+
+    os.makedirs(args.assets_dir, exist_ok=True)
+    os.rename(msi_name, msi_path)
+    if os.path.isfile(wixobj):
+        os.remove(wixobj)
+
+    return msi_path
 
 
-def add_artifactory_args(parser):
-    parser.add_argument(
-        "--artifactory-user",
-        type=str,
-        default=os.environ.get("ARTIFACTORY_USERNAME", DEFAULT_ARTIFACTORY_USERNAME),
-        metavar="ARTIFACTORY_USERNAME",
-        required=False,
-        help=f"""
-            {ARTIFACTORY_URL} username. Defaults to the ARTIFACTORY_USERNAME env var if set,
-            otherwise '{DEFAULT_ARTIFACTORY_USERNAME}'.
-        """,
-    )
-    parser.add_argument(
-        "--artifactory-token",
-        type=str,
-        default=os.environ.get("ARTIFACTORY_TOKEN"),
-        metavar="ARTIFACTORY_TOKEN",
-        required=False,
-        help=f"{ARTIFACTORY_URL} token. Required if the ARTIFACTORY_TOKEN env var is not set.",
-    )
+def sign_exe(asset, args, **signing_args):
+    if args.stage != "test":
+        print(f"Signing {asset.name} (may take 10+ minutes):")
+        if not asset.sign(timeout=args.timeout, overwrite=args.force, **signing_args):
+            sys.exit(1)
 
 
-def check_artifactory_args(args):
-    assert args.artifactory_user, f"{ARTIFACTORY_URL} username not set"
-    assert args.artifactory_token, f"{ARTIFACTORY_URL} token not set"
-
-
-def get_github_release_packages(repo_name, release_tag=None, github_token=None):
-    gh = Github(github_token)
-    repo = gh.get_repo(repo_name)
-    if not release_tag or release_tag == "latest":
-        release = repo.get_latest_release()
+def release_msi_to_s3(asset, args, **signing_args):
+    if args.stage != "test":
+        print(f"Signing {asset.name} (may take 10+ minutes):")
+        if not asset.sign(timeout=args.timeout, overwrite=args.force, **signing_args):
+            sys.exit(1)
+        msi_path = asset.signed_path
     else:
-        release = repo.get_release(release_tag)
+        msi_path = asset.path
 
-    packages = {"deb": [], "rpm": []}
-    for asset in release.get_assets():
-        package_type = asset.name.strip().split(".")[-1]
-        if package_type in ("deb", "rpm"):
-            packages[package_type].append(asset.browser_download_url)
+    if args.stage != "github" and not args.no_push:
+        session = boto3.Session(profile_name="prod")
+        s3_client = session.client('s3')
+        s3_path = f"{S3_MSI_BASE_DIR}/{args.stage}/{asset.name}"
+        print(f"Uploading {asset.name} to {S3_BUCKET}/{s3_path} ...")
+        if not args.force and msi_exists_in_s3(s3_client, s3_path):
+            resp = input(f"{S3_BUCKET}/{s3_path} already exists.\nOverwrite [y/N]: ")
+            if resp.lower() not in ("y", "yes"):
+                sys.exit(1)
+        s3_client.upload_file(msi_path, S3_BUCKET, s3_path)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            latest_txt = os.path.join(tmpdir, "latest.txt")
+            match = re.match(f"^{PACKAGE_NAME}-(\d+\.\d+\.\d+(\.\d+)?)-amd64.msi$", asset.name)
+            assert match, f"Failed to version from '{asset.name}'!"
+            msi_version = match.group(1)
+            with open(latest_txt, "w") as fd:
+                fd.write(msi_version)
+            s3_latest_path = f"{S3_MSI_BASE_DIR}/{args.stage}/latest.txt"
+            print(f"Updating {S3_BUCKET}/{s3_latest_path} for version '{msi_version}' ...")
+            s3_client.upload_file(latest_txt, S3_BUCKET, s3_latest_path)
+            invalidate_cloudfront([s3_path, s3_latest_path])
 
-    return release, packages
+
+def get_github_release(repo_name, tag=None, token=None):
+    gh = Github(token)
+    repo = gh.get_repo(repo_name)
+
+    if tag:
+        github_release = repo.get_release(tag)
+    else:
+        github_releases = repo.get_releases()
+        assert github_releases, f"No releases found for '{repo_name}' repository!"
+        github_release = github_releases[0]
+
+    return github_release
+
+
+def download_github_assets(github_release, args):
+    assets = []
+    checksums_asset = None
+
+    for asset in github_release.get_assets():
+        ext = os.path.splitext(asset.name)[-1].strip(".")
+        if asset.name == "checksums.txt":
+            checksums_asset = Asset(url=asset.browser_download_url)
+        elif ext and ext in args.component or ("windows" in args.component and ext == "exe"):
+            assets.append(Asset(url=asset.browser_download_url))
+
+    assert checksums_asset, f"checksums.txt not found in {github_release.html_url}!"
+    checksums_path = os.path.join(args.assets_dir, checksums_asset.name)
+    if not checksums_asset.download(checksums_path, token=args.github_token, overwrite=args.force):
+        sys.exit(1)
+
+    for asset in assets:
+        dest = os.path.join(args.assets_dir, asset.name)
+        if not asset.download(dest, token=args.github_token, overwrite=args.force):
+            sys.exit(1)
+
+    return assets, checksums_asset

--- a/internal/buildscripts/packaging/release/invalidate-cloudfront
+++ b/internal/buildscripts/packaging/release/invalidate-cloudfront
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Invalidates the AWS CloudFront cache for certain files that get overwritten
+# when releasing new package versions.
+
+set -euxo pipefail
+
+DISTRIBUTION_ID=${DISTRIBUTION_ID-EJH671JAOI5SN}
+
+aws configure set preview.cloudfront true
+
+aws cloudfront create-invalidation --distribution-id ${DISTRIBUTION_ID} --paths "$@"

--- a/internal/buildscripts/packaging/release/requirements.txt
+++ b/internal/buildscripts/packaging/release/requirements.txt
@@ -1,2 +1,4 @@
-PyGithub==1.40
-requests==2.22.0
+PyGithub==1.54.1
+boto3==1.16.43
+docker==4.3.1
+requests==2.25.1

--- a/internal/buildscripts/packaging/release/sign_release.py
+++ b/internal/buildscripts/packaging/release/sign_release.py
@@ -1,247 +1,197 @@
 #!/usr/bin/env python3
 
-import argparse
-import glob
+# Copyright 2020 Splunk, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import re
 import sys
-import tempfile
 
+from helpers.constants import ASSETS_BASE_DIR, COLLECTOR_REPO
+from helpers.release_args import get_args
 from helpers.util import (
-    ARTIFACTORY_URL,
-    ARTIFACTORY_API_URL,
-    add_artifactory_args,
-    add_signing_args,
-    artifactory_file_exists,
-    download_file,
-    check_artifactory_args,
-    check_signing_args,
-    get_github_release_packages,
-    get_md5_from_artifactory,
-    sign_artifactory_metadata,
-    sign_file,
-    upload_file_to_artifactory,
-    wait_for_artifactory_metadata,
+    Asset,
+    build_msi,
+    download_github_assets,
+    get_github_release,
+    release_deb_to_artifactory,
+    release_rpm_to_artifactory,
+    release_msi_to_s3,
+    sign_exe,
 )
 
-COLLECTOR_REPO = os.environ.get("COLLECTOR_REPO", "signalfx/splunk-otel-collector")
-PACKAGE_NAME = os.environ.get("PACKAGE_NAME", "splunk-otel-collector")
-ARTIFACTORY_DEB_REPO = "otel-collector-deb"
-ARTIFACTORY_DEB_REPO_URL = f"{ARTIFACTORY_URL}/{ARTIFACTORY_DEB_REPO}"
-ARTIFACTORY_RPM_REPO = "otel-collector-rpm"
-ARTIFACTORY_RPM_REPO_URL = f"{ARTIFACTORY_URL}/{ARTIFACTORY_RPM_REPO}"
-DEFAULT_TIMEOUT = 600
-STAGES = ("test", "beta", "release")
+
+def get_local_assets(args):
+    assets = []
+
+    for local_path in args.path:
+        assert os.path.isfile(local_path), f"{local_path} not found!"
+        ext = os.path.splitext(local_path)[-1].strip(".")
+        assert ext and ext in ("deb", "rpm", "exe", "msi"), f"{local_path} not supported"
+        assets.append(Asset(path=local_path))
+
+    return assets
 
 
-def getargs():
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="Sign and release deb/rpm packages from Github to Artifactory.",
-    )
-    parser.add_argument(
-        "--path",
-        type=str,
-        default=[],
-        metavar="PATH",
-        action="append",
-        help="""
-            Instead of releasing packages from Github, release packages on the local filesystem.
-            PATH can be a deb/rpm file or a directory containing deb/rpm files. "
-            This option may be specified multiple times for multiple paths.
-        """,
-    )
-    parser.add_argument(
-        "--stage",
-        type=str,
-        default="release",
-        metavar="STAGE",
-        choices=STAGES,
-        help=f"Stage for artifactory packages. Should be one of {STAGES}. Defaults to release.",
-    )
-    parser.add_argument(
-        "--version",
-        type=str,
-        default=None,
-        metavar="TAG",
-        required=False,
-        help="Github release tag (e.g. 'v1.2.3'). Defaults to the latest release tag if not specified.",
-    )
-    parser.add_argument(
-        "--timeout",
-        type=int,
-        default=DEFAULT_TIMEOUT,
-        metavar="TIMEOUT",
-        required=False,
-        help=f"Signing request timeout in seconds. Defaults to {DEFAULT_TIMEOUT}.",
-    )
-    parser.add_argument(
-        "--yes",
-        "-y",
-        action="store_true",
-        default=False,
-        required=False,
-        help="Never prompt and assume yes when overwriting existing files in artifactory.",
-    )
+def verify_checksums(checksums_path, assets, signed=False):
+    print(f"Verifying checksums with {checksums_path} ...")
+    checksums = {}
+    with open(checksums_path, "r") as f:
+        for line in f.readlines():
+            match = re.match(r"^([a-f0-9]{64})\s+(.+)", line)
+            assert match, f"Failed to parse {checksums_path}!"
+            checksum = match.group(1)
+            asset_name = match.group(2).strip()
+            checksums[asset_name] = checksum
 
-    add_artifactory_args(parser)
-    add_signing_args(parser)
-
-    args = parser.parse_args()
-
-    check_artifactory_args(args)
-
-    if args.stage != "test":
-        check_signing_args(args)
-
-    return args
+    for asset in assets:
+        if asset.signed and signed:
+            path = asset.signed_path
+            checksum = asset.signed_checksum
+        else:
+            path = asset.path
+            checksum = asset.checksum
+        assert path, f"Path not set for asset {asset.name}!"
+        assert os.path.isfile(path), f"{path} not found!"
+        assert checksum, f"Checksum not calculated for {path}!"
+        assert checksums.get(asset.name) == checksum, f"Checksum for {path} does not match {checksums_path}!"
 
 
-def sign_metadata(metadata_url, args):
-    sign_artifactory_metadata(
-        metadata_url,
-        args.artifactory_user,
-        args.artifactory_token,
-        args.chaperone_token,
-        args.staging_user,
-        args.staging_token,
-        args.timeout,
-    )
+def create_signed_checksums(checksums_asset, assets, assets_dir):
+    new_checksums = {}
+    for asset in assets:
+        if asset.signed:
+            new_checksums[asset.name] = asset.signed_checksum
+        else:
+            new_checksums[asset.name] = asset.checksum
+        assert new_checksums[asset.name], f"Checksum not calculated for {asset.name}!"
 
-
-def add_debs_to_repo(paths, args):
-    metadata_api_url = f"{ARTIFACTORY_API_URL}/storage/{ARTIFACTORY_DEB_REPO}/dists/{args.stage}/Release"
-    metadata_url = f"{ARTIFACTORY_DEB_REPO_URL}/dists/{args.stage}/Release"
-
-    for path in paths:
-        base = os.path.basename(path)
-        match = re.match(r".*_(amd64|arm64)\.deb$", base)
-        assert match, f"Failed to get arch from {path}!"
-        arch = match.groups()[0]
-        deb_url = f"{ARTIFACTORY_DEB_REPO_URL}/pool/{args.stage}/{arch}/{base}"
-        dest_opts = f"deb.distribution={args.stage};deb.component=main;deb.architecture={arch}"
-        dest_url = f"{deb_url};{dest_opts}"
-
-        if not args.yes and artifactory_file_exists(deb_url, args.artifactory_user, args.artifactory_token):
-            overwrite = input(f"package {deb_url} already exists. Overwrite? [y/N] ")
-            if overwrite.lower() not in ("y", "yes"):
-                sys.exit(1)
-
-        orig_metadata_md5 = get_md5_from_artifactory(metadata_api_url, args.artifactory_user, args.artifactory_token)
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            if re.match(r"^http(s)?://.*", path):
-                download_file(path, os.path.join(tmpdir, base))
-                path = os.path.join(tmpdir, base)
-
-            upload_file_to_artifactory(path, dest_url, args.artifactory_user, args.artifactory_token)
-
-            wait_for_artifactory_metadata(
-                metadata_api_url, orig_metadata_md5, args.artifactory_user, args.artifactory_token, args.timeout
-            )
-
-    if paths and args.stage != "test":
-        sign_metadata(metadata_url, args)
-
-
-def add_rpms_to_repo(paths, args):
-    for path in paths:
-        base = os.path.basename(path)
-        match = re.match(r".*\.(x86_64|aarch64)\.rpm$", base)
-        assert match, f"Failed to get arch from {path}!"
-        arch = match.groups()[0]
-        dest_url = f"{ARTIFACTORY_RPM_REPO_URL}/{args.stage}/{arch}/{base}"
-        metadata_api_url = (
-            f"{ARTIFACTORY_API_URL}/storage/{ARTIFACTORY_RPM_REPO}/{args.stage}/{arch}/repodata/repomd.xml"
-        )
-        metadata_url = f"{ARTIFACTORY_RPM_REPO_URL}/{args.stage}/{arch}/repodata/repomd.xml"
-
-        if not args.yes and artifactory_file_exists(dest_url, args.artifactory_user, args.artifactory_token):
-            overwrite = input(f"package {dest_url} already exists. Overwrite? [y/N] ")
-            if overwrite.lower() not in ("y", "yes"):
-                sys.exit(1)
-
-        orig_metadata_md5 = get_md5_from_artifactory(metadata_api_url, args.artifactory_user, args.artifactory_token)
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            unsigned_rpm_path = path
-            if re.match(r"^http(s)?://.*", path):
-                unsigned_rpm_path = os.path.join(tmpdir, "unsigned", base)
-                download_file(path, unsigned_rpm_path)
-            signed_rpm_path = os.path.join(tmpdir, "signed", base)
-            if args.stage != "test":
-                print(f"Signing {base} (may take 10+ minutes):")
-                sign_file(
-                    unsigned_rpm_path,
-                    signed_rpm_path,
-                    "RPM",
-                    args.chaperone_token,
-                    args.staging_user,
-                    args.staging_token,
-                    timeout=args.timeout,
-                )
-            else:
-                signed_rpm_path = unsigned_rpm_path
-            upload_file_to_artifactory(signed_rpm_path, dest_url, args.artifactory_user, args.artifactory_token)
-
-        wait_for_artifactory_metadata(
-            metadata_api_url, orig_metadata_md5, args.artifactory_user, args.artifactory_token, args.timeout
-        )
-
-        if args.stage != "test":
-            sign_metadata(metadata_url, args)
-
-
-def get_packages(args):
-    packages = {"deb": [], "rpm": []}
-
-    if args.path:
-        for path in args.path:
-            if os.path.isdir(path):
-                packages["deb"] = glob.glob(f"{path}/**/*.deb", recursive=True)
-                packages["rpm"] = glob.glob(f"{path}/**/*.rpm", recursive=True)
-            else:
-                assert os.path.isfile(path), f"File {path} not found!"
-                if os.path.splitext(path)[-1] == ".deb":
-                    packages["deb"].append(path)
-                elif os.path.splitext(path)[-1] == ".rpm":
-                    packages["rpm"].append(path)
+    checksums = {}
+    with open(checksums_asset.path, "r") as f:
+        # update original checksums with the signed checksums
+        for line in f.readlines():
+            if line.strip():
+                match = re.match(r"^([a-f0-9]{64})\s+(.+)", line)
+                assert match, f"Failed to parse {checksums_asset.path}!"
+                orig_checksum = match.group(1)
+                asset_name = match.group(2).strip()
+                if asset_name in new_checksums.keys():
+                    checksums[asset_name] = new_checksums.get(asset_name)
                 else:
-                    print(f"Unsupported file '{path}'")
-                    sys.exit(1)
+                    checksums[asset_name] = orig_checksum
+        # add checksums for any new assets
+        for asset_name in new_checksums.keys():
+            if not checksums.get(asset_name):
+                checksums[asset_name] = new_checksums.get(asset_name)
 
-        assert packages["deb"] or packages["rpm"], f"No files found to release from {args.path}!"
+    checksums_asset.signed_path = os.path.join(assets_dir, "signed", "checksums.txt")
 
-        print(f"Releasing {packages} to {args.stage} stage.")
-        if not args.yes:
-            resp = input("Continue? [y/n]: ")
-            if resp.lower() not in ("y", "yes"):
-                sys.exit(0)
-    else:
-        gh_release, packages = get_github_release_packages(COLLECTOR_REPO, args.version)
-        args.version = gh_release.tag_name if args.version is None else args.version
+    print(f"Creating {checksums_asset.signed_path} ...")
+    os.makedirs(os.path.dirname(checksums_asset.signed_path), exist_ok=True)
+    with open(checksums_asset.signed_path, "w") as f:
+        for asset_name in sorted(checksums):
+            f.write(f"{checksums.get(asset_name)}  {asset_name}\n")
 
-        assert packages["rpm"], f"Failed to get rpms from {COLLECTOR_REPO} {args.version} github release!"
-
-        assert packages["deb"], f"Failed to get debs from {COLLECTOR_REPO} {args.version} github release!"
-
-        print(f"Releasing deb/rpm from {COLLECTOR_REPO}:{args.version} to {args.stage} stage.")
-        if not args.yes:
-            resp = input("Continue? [y/n]: ")
-            if resp.lower() not in ("y", "yes"):
-                sys.exit(0)
-
-    return packages
+    checksums_asset.signed = True
 
 
 def main():
-    args = getargs()
+    args = get_args()
+    signing_args = {}
+    for key, val in vars(args).items():
+        if key in ("chaperone_token", "staging_token", "staging_user"):
+            signing_args[key] = val
 
-    packages = get_packages(args)
+    checksums_asset = None
 
-    add_debs_to_repo(packages["deb"], args)
+    github_release = get_github_release(COLLECTOR_REPO, args.tag, args.github_token)
+    if not args.tag:
+        args.tag = github_release.tag_name
 
-    add_rpms_to_repo(packages["rpm"], args)
+    if not args.no_push and not args.download_only and args.stage == "release" and not github_release.prerelease:
+        resp = input(f"{github_release.html_url} is not labeled 'Pre-release'.\nContinue? [y/N]: ")
+        if resp.lower() not in ("y", "yes"):
+            sys.exit(1)
+
+    if args.path:
+        assets = get_local_assets(args)
+    else:
+        if not args.assets_dir:
+            args.assets_dir = os.path.join(ASSETS_BASE_DIR, args.tag)
+        resp = input(f"Downloading assets from {github_release.html_url} to '{args.assets_dir}'.\nContinue? [y/N]: ")
+        if resp.lower() not in ("y", "yes"):
+            sys.exit(1)
+        assets, checksums_asset = download_github_assets(github_release, args)
+        verify_checksums(checksums_asset.path, assets)
+        if args.download_only:
+            sys.exit(0)
+
+    if args.no_push:
+        print("Signing the following asset(s):")
+    elif args.stage == "release":
+        print(f"Releasing the following asset(s) to the '{args.stage}' stage and {github_release.html_url}:")
+    elif args.stage == "github":
+        print(f"Releasing the following asset(s) to {github_release.html_url}:")
+    else:
+        print(f"Releasing the following asset(s) to the '{args.stage}' stage:")
+    for asset in assets:
+        print(asset.path)
+    resp = input("Continue? [y/N]: ")
+    if resp.lower() not in ("y", "yes"):
+        sys.exit(1)
+
+    for asset in assets:
+        if asset.component == "deb":
+            # Release deb to artifactory and sign metadata
+            release_deb_to_artifactory(asset, args, **signing_args)
+        elif asset.component == "rpm":
+            # Sign/release rpm to artifactory and sign metadata
+            release_rpm_to_artifactory(asset, args, **signing_args)
+        elif asset.component == "exe":
+            # Sign exe, build msi with signed exe, sign msi, and release msi to S3
+            if args.stage == "test":
+                exe_path = asset.path
+            else:
+                sign_exe(asset, args, **signing_args)
+                exe_path = asset.signed_path
+            msi_asset = Asset(path=build_msi(exe_path, args))
+            release_msi_to_s3(msi_asset, args, **signing_args)
+            assets.append(msi_asset)
+
+    # Create a copy of checksums.txt updated for the signed assets
+    if checksums_asset and args.stage != "test":
+        create_signed_checksums(checksums_asset, assets, args.assets_dir)
+        verify_checksums(checksums_asset.signed_path, assets, signed=True)
+
+    # Replace assets in the Github release with the signed assets and the updated checksums.txt
+    if assets and checksums_asset and args.stage in ("github", "release") and not args.no_push:
+        resp = input(f"Releasing assets to {github_release.html_url}.\nContinue [y/N]: ")
+        if resp.lower() not in ("y", "yes"):
+            sys.exit(1)
+        github_assets = github_release.get_assets()
+        for asset in assets + [checksums_asset]:
+            if asset.signed and asset.signed_path:
+                print(f"Uploading {asset.signed_path} to {github_release.html_url} ...")
+                for github_asset in github_assets:
+                    # delete pre-existing assets before upload
+                    if asset.name == github_asset.name:
+                        github_asset.delete_asset()
+                        break
+                github_release.upload_asset(asset.signed_path, name=asset.name)
+        if github_release.prerelease and args.stage == "release":
+            print(f"Removing 'Pre-release' label from {github_release.html_url}")
+            github_release.update_release(name=github_release.title, message=github_release.body, prerelease=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Refactor and update release script for more options and improve handling of Github assets
- Sign the exe, rebuild the msi with the signed exe, sign the msi, and upload the msi to S3
- Replace unsigned assets with the signed assets in the Github release