### PR TITLE
smart agent: add extraDimensions support

### DIFF
--- a/internal/receiver/smartagentreceiver/output_test.go
+++ b/internal/receiver/smartagentreceiver/output_test.go
@@ -21,21 +21,18 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/core/dpfilters"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.uber.org/zap"
 )
 
 func TestOutput(t *testing.T) {
-	output := Output{
-		nextConsumer: consumertest.NewMetricsNop(),
-		logger:       zap.NewNop(),
-	}
-
+	output := NewOutput(Config{}, consumertest.NewMetricsNop(), zap.NewNop())
 	output.AddDatapointExclusionFilter(dpfilters.DatapointFilter(nil))
 	assert.Empty(t, output.EnabledMetrics())
 	assert.False(t, output.HasEnabledMetricInGroup(""))
 	assert.False(t, output.HasAnyExtraMetrics())
-	assert.Same(t, &output, output.Copy())
+	assert.NotSame(t, &output, output.Copy())
 	output.SendDatapoints()
 	output.SendEvent(new(event.Event))
 	output.SendSpans()
@@ -46,4 +43,26 @@ func TestOutput(t *testing.T) {
 	output.RemoveExtraSpanTag("")
 	output.AddDefaultSpanTag("", "")
 	output.RemoveDefaultSpanTag("")
+}
+
+func TestExtraDimensions(t *testing.T) {
+	output := NewOutput(Config{}, consumertest.NewMetricsNop(), zap.NewNop())
+	assert.Empty(t, output.extraDimensions)
+
+	output.RemoveExtraDimension("not_a_known_dimension_name")
+
+	output.AddExtraDimension("a_dimension_name", "a_value")
+	assert.Equal(t, "a_value", output.extraDimensions["a_dimension_name"])
+
+	cp, ok := output.Copy().(*Output)
+	require.True(t, ok)
+	assert.Equal(t, "a_value", cp.extraDimensions["a_dimension_name"])
+
+	cp.RemoveExtraDimension("a_dimension_name")
+	assert.Empty(t, cp.extraDimensions["a_dimension_name"])
+	assert.Equal(t, "a_value", output.extraDimensions["a_dimension_name"])
+
+	cp.AddExtraDimension("another_dimension_name", "another_dimension_value")
+	assert.Equal(t, "another_dimension_value", cp.extraDimensions["another_dimension_name"])
+	assert.Empty(t, output.extraDimensions["another_dimension_name"])
 }

--- a/internal/receiver/smartagentreceiver/receiver.go
+++ b/internal/receiver/smartagentreceiver/receiver.go
@@ -114,11 +114,16 @@ func (r *Receiver) createMonitor(monitorType string) (interface{}, error) {
 		}
 	}
 
+	var output *Output
 	if monitorOutputValue.IsValid() {
-		output := NewOutput(*r.config, r.nextConsumer, r.logger)
+		output = NewOutput(*r.config, r.nextConsumer, r.logger)
 		monitorOutputValue.Set(reflect.ValueOf(output))
 	} else {
 		return nil, fmt.Errorf("invalid monitor instance: %#v", monitor)
+	}
+
+	for k, v := range r.config.monitorConfig.MonitorConfigCore().ExtraDimensions {
+		output.AddExtraDimension(k, v)
 	}
 
 	return monitor, nil


### PR DESCRIPTION
These changes add `extraDimensions` config and output support to the Smart Agent receiver.  Also including `Output.Copy()` support to allow adopting monitors to manage multiple Output instances with different extra dimensions.