### PR TITLE
Fix Windows build failure

### DIFF
--- a/cmd/otelcol/main_test.go
+++ b/cmd/otelcol/main_test.go
@@ -83,6 +83,11 @@ func TestUseConfigFromEnvVar(t *testing.T) {
 	if !(result) {
 		t.Error("Expected true got false while looking for --config")
 	}
+	useMemorySettingsMiBFromEnvVar(0)
+	_, present := os.LookupEnv(memLimitMiBEnvVarName)
+	if present {
+		t.Error("Expected false got true while looking for environment variable")
+	}
 	os.Unsetenv(configEnvVarName)
 }
 


### PR DESCRIPTION
Addresses #77

A behavior change was introduced such that either total memory or
limit/spike environment variables had to be set even if the config
parameter was passed. This fails for Windows as you cannot pass env vars
to the service.

To address, total or limit/spike are no longer required if config
parameter is passed. Added a test to ensure this issue is not
reintroduced in the future.