### PR TITLE
Smart Agent: Add Endpoint Config field for receiver creator

### DIFF
--- a/internal/receiver/smartagentreceiver/config_test.go
+++ b/internal/receiver/smartagentreceiver/config_test.go
@@ -248,3 +248,135 @@ func TestLoadInvalidConfigs(t *testing.T) {
 	require.Error(t, err)
 	require.EqualError(t, err, "Validation error in field 'Config.host': host is a required field (got '')")
 }
+
+func TestLoadConfigWithEndpoints(t *testing.T) {
+	factories, err := componenttest.ExampleComponents()
+	assert.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Receivers[configmodels.Type(typeStr)] = factory
+	cfg, err := configtest.LoadConfigFile(
+		t, path.Join(".", "testdata", "endpoints_config.yaml"), factories,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, len(cfg.Receivers), 4)
+
+	haproxyCfg := cfg.Receivers["smartagent/haproxy"].(*Config)
+	require.Equal(t, &Config{
+		ReceiverSettings: configmodels.ReceiverSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr + "/haproxy",
+		},
+		Endpoint: "haproxyhost:2345",
+		monitorConfig: &haproxy.Config{
+			MonitorConfig: config.MonitorConfig{
+				Type:                "haproxy",
+				IntervalSeconds:     123,
+				DatapointsToExclude: []config.MetricFilter{},
+			},
+			Host:      "haproxyhost",
+			Port:      2345,
+			Username:  "SomeUser",
+			Password:  "secret",
+			Path:      "stats?stats;csv",
+			SSLVerify: true,
+			Timeout:   timeutil.Duration(5 * time.Second),
+		},
+	}, haproxyCfg)
+	require.NoError(t, haproxyCfg.validate())
+
+	redisCfg := cfg.Receivers["smartagent/redis"].(*Config)
+	require.Equal(t, &Config{
+		ReceiverSettings: configmodels.ReceiverSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr + "/redis",
+		},
+		Endpoint: "redishost",
+		monitorConfig: &redis.Config{
+			MonitorConfig: config.MonitorConfig{
+				Type:                "collectd/redis",
+				IntervalSeconds:     234,
+				DatapointsToExclude: []config.MetricFilter{},
+			},
+			Host: "redishost",
+			Port: 6379,
+		},
+	}, redisCfg)
+	require.NoError(t, redisCfg.validate())
+
+	hadoopCfg := cfg.Receivers["smartagent/hadoop"].(*Config)
+	require.Equal(t, &Config{
+		ReceiverSettings: configmodels.ReceiverSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr + "/hadoop",
+		},
+		Endpoint: "hadoophost:12345",
+		monitorConfig: &hadoop.Config{
+			MonitorConfig: config.MonitorConfig{
+				Type:                "collectd/hadoop",
+				IntervalSeconds:     345,
+				DatapointsToExclude: []config.MetricFilter{},
+			},
+			CommonConfig: python.CommonConfig{},
+			Host:         "localhost",
+			Port:         8088,
+		},
+	}, hadoopCfg)
+	require.NoError(t, hadoopCfg.validate())
+
+	etcdCfg := cfg.Receivers["smartagent/etcd"].(*Config)
+	require.Equal(t, &Config{
+		ReceiverSettings: configmodels.ReceiverSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr + "/etcd",
+		},
+		Endpoint: "etcdhost:5555",
+		monitorConfig: &prometheusexporter.Config{
+			MonitorConfig: config.MonitorConfig{
+				Type:                "etcd",
+				IntervalSeconds:     456,
+				DatapointsToExclude: []config.MetricFilter{},
+			},
+			HTTPConfig: httpclient.HTTPConfig{
+				HTTPTimeout: timeutil.Duration(10 * time.Second),
+			},
+			Host:       "localhost",
+			Port:       5555,
+			MetricPath: "/metrics",
+		},
+	}, etcdCfg)
+	require.NoError(t, etcdCfg.validate())
+}
+
+func TestLoadInvalidConfigWithInvalidEndpoint(t *testing.T) {
+	factories, err := componenttest.ExampleComponents()
+	assert.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Receivers[configmodels.Type(typeStr)] = factory
+	cfg, err := configtest.LoadConfigFile(
+		t, path.Join(".", "testdata", "invalid_endpoint.yaml"), factories,
+	)
+	require.Error(t, err)
+	require.EqualError(t, err,
+		"error reading receivers configuration for smartagent/haproxy: cannot determine port via Endpoint: strconv.ParseUint: parsing \"notaport\": invalid syntax")
+	require.Nil(t, cfg)
+}
+
+func TestLoadInvalidConfigWithUnsupportedEndpoint(t *testing.T) {
+	factories, err := componenttest.ExampleComponents()
+	assert.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Receivers[configmodels.Type(typeStr)] = factory
+	cfg, err := configtest.LoadConfigFile(
+		t, path.Join(".", "testdata", "unsupported_endpoint.yaml"), factories,
+	)
+	require.Error(t, err)
+	require.EqualError(t, err,
+		"error reading receivers configuration for smartagent/nagios: unable to set monitor Host field using Endpoint-derived value of localhost: no field Host of type string detected")
+	require.Nil(t, cfg)
+}

--- a/internal/receiver/smartagentreceiver/output.go
+++ b/internal/receiver/smartagentreceiver/output.go
@@ -42,6 +42,7 @@ type Output struct {
 	extraDimensions map[string]string
 }
 
+var _ types.Output = (*Output)(nil)
 var _ types.FilteringOutput = (*Output)(nil)
 
 func NewOutput(config Config, nextConsumer consumer.MetricsConsumer, logger *zap.Logger) *Output {

--- a/internal/receiver/smartagentreceiver/receiver_test.go
+++ b/internal/receiver/smartagentreceiver/receiver_test.go
@@ -221,12 +221,12 @@ func TestConfirmStartingReceiverWithInvalidMonitorInstancesDoesntPanic(t *testin
 		monitorFactory func() interface{}
 		expectedError  string
 	}{
-		{"anonymous struct", func() interface{} { return struct{}{} }, "struct {}{}"},
-		{"anonymous struct pointer", func() interface{} { return &struct{}{} }, "&struct {}{}"},
-		{"nil interface pointer", func() interface{} { return new(interface{}) }, "(*interface {})"},
-		{"nil", func() interface{} { return nil }, "<nil>"},
-		{"boolean", func() interface{} { return false }, "false"},
-		{"string", func() interface{} { return "asdf" }, "\"asdf\""},
+		{"anonymous struct", func() interface{} { return struct{}{} }, ""},
+		{"anonymous struct pointer", func() interface{} { return &struct{}{} }, ""},
+		{"nil interface pointer", func() interface{} { return new(interface{}) }, ": invalid struct instance: (*interface {})"},
+		{"nil", func() interface{} { return nil }, ": invalid struct instance: <nil>"},
+		{"boolean", func() interface{} { return false }, ": invalid struct instance: false"},
+		{"string", func() interface{} { return "asdf" }, ": invalid struct instance: \"asdf\""},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
@@ -237,7 +237,7 @@ func TestConfirmStartingReceiverWithInvalidMonitorInstancesDoesntPanic(t *testin
 			err := receiver.Start(context.Background(), componenttest.NewNopHost())
 			require.Error(tt, err)
 			assert.Contains(tt, err.Error(),
-				fmt.Sprintf("failed creating monitor \"notarealmonitor\": invalid monitor instance: %s", test.expectedError),
+				fmt.Sprintf("failed creating monitor \"notarealmonitor\": unable to set Output field of monitor%s", test.expectedError),
 			)
 		})
 	}

--- a/internal/receiver/smartagentreceiver/reflect.go
+++ b/internal/receiver/smartagentreceiver/reflect.go
@@ -1,0 +1,91 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smartagentreceiver
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Sets the first occurrence of a (potentially embedded) struct field w/ name fieldName and first occurring fieldType
+// to desired value, if available.  Returns true if successfully set, false otherwise.
+// Error contains if field undetected or if issues occur with reflect usage.
+func SetStructFieldWithExplicitType(strukt interface{}, fieldName string, value interface{}, fieldTypes ...reflect.Type) (bool, error) {
+	var err error
+	for _, fieldType := range fieldTypes {
+		var set bool
+		set, err = setStructField(strukt, fieldName, value, fieldType, false)
+		if set {
+			return true, err
+		}
+	}
+	return false, err
+}
+
+// Same as SetStructField() but only if first occurrence of the field is of zero value.
+func SetStructFieldIfZeroValue(strukt interface{}, fieldName string, value interface{}) (bool, error) {
+	fieldType := reflect.TypeOf(value)
+	return setStructField(strukt, fieldName, value, fieldType, true)
+}
+
+// Finds the first occurrence of a valid, settable field value from a potentially embedded struct
+// with a fieldName of desired type.
+// Based on https://github.com/signalfx/signalfx-agent/blob/731c2a0b5ff5ac324130453b02dd9cb7c912c0d5/pkg/utils/reflection.go#L36
+func GetSettableStructFieldValue(strukt interface{}, fieldName string, fieldType reflect.Type) (*reflect.Value, error) {
+	reflectedStruct := reflect.Indirect(reflect.ValueOf(strukt))
+	if reflectedStruct.IsValid() && reflectedStruct.Type().Kind() == reflect.Struct {
+		fieldValue := reflectedStruct.FieldByName(fieldName)
+		if !fieldValue.IsValid() || !fieldValue.CanSet() || fieldValue.Type() != fieldType {
+			valueCandidates := make([]reflect.Value, 0)
+			for i := 0; i < reflectedStruct.Type().NumField(); i++ {
+				field := reflectedStruct.Type().Field(i)
+				if field.Type.Kind() == reflect.Struct && field.Anonymous && reflectedStruct.Field(i).CanSet() {
+					candidate, _ := GetSettableStructFieldValue(reflectedStruct.Field(i).Interface(), fieldName, fieldType)
+					if candidate != nil {
+						valueCandidates = append(valueCandidates, *candidate)
+					}
+				}
+			}
+			for _, value := range valueCandidates {
+				if value.IsValid() {
+					return &value, nil
+				}
+			}
+			return nil, nil
+		}
+		return &fieldValue, nil
+	}
+	return nil, fmt.Errorf("invalid struct instance: %#v (CanAddr(): %t)", strukt, reflectedStruct.CanAddr())
+}
+
+func setStructField(strukt interface{}, fieldName string, value interface{}, fieldType reflect.Type, onlyIfZero bool) (bool, error) {
+	valuePtr, err := GetSettableStructFieldValue(strukt, fieldName, fieldType)
+	if err != nil {
+		return false, err
+	}
+
+	if valuePtr != nil {
+		fieldValue := *valuePtr
+		if !fieldValue.IsValid() {
+			return false, fmt.Errorf("canot set invalid field value: %v", fieldValue)
+		}
+		if !(onlyIfZero && !fieldValue.IsZero()) {
+			fieldValue.Set(reflect.ValueOf(value))
+			return true, nil
+		}
+		return false, nil
+	}
+	return false, fmt.Errorf("no field %s of type %s detected", fieldName, fieldType)
+}

--- a/internal/receiver/smartagentreceiver/reflect_test.go
+++ b/internal/receiver/smartagentreceiver/reflect_test.go
@@ -1,0 +1,107 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smartagentreceiver
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type DoublyEmbedded struct {
+	Thing string
+}
+
+type Embedded struct {
+	DoublyEmbedded
+	AnotherThing string
+}
+
+type Envelope struct {
+	Embedded
+	YetAnotherThing string
+}
+
+var stringType = reflect.TypeOf("")
+
+func TestGetSettableStructFieldValue(t *testing.T) {
+	envelope := &Envelope{
+		Embedded: Embedded{
+			AnotherThing: "another thing",
+			DoublyEmbedded: DoublyEmbedded{
+				Thing: "thing",
+			},
+		},
+		YetAnotherThing: "yet another thing",
+	}
+	fieldValue, err := GetSettableStructFieldValue(envelope, "Thing", stringType)
+	require.NoError(t, err)
+	require.NotNil(t, fieldValue)
+	require.Equal(t, "thing", fieldValue.String())
+	fieldValue.Set(reflect.ValueOf("something else"))
+	require.Equal(t, "something else", envelope.Thing)
+
+	fieldValue, err = GetSettableStructFieldValue(envelope, "AnotherThing", stringType)
+	require.NoError(t, err)
+	require.NotNil(t, fieldValue)
+	require.Equal(t, "another thing", fieldValue.String())
+	fieldValue.Set(reflect.ValueOf("used to be 'another thing'"))
+	require.Equal(t, "used to be 'another thing'", envelope.AnotherThing)
+
+	// Envelope isn't addressable so its exported fields cannot be set
+	fieldValue, err = GetSettableStructFieldValue(*envelope, "YetAnotherThing", stringType)
+	require.NoError(t, err)
+	require.Nil(t, fieldValue)
+
+	fieldValue, err = GetSettableStructFieldValue(envelope, "YetAnotherThing", stringType)
+	require.NoError(t, err)
+	require.NotNil(t, fieldValue)
+	require.Equal(t, "yet another thing", fieldValue.String())
+	fieldValue.Set(reflect.ValueOf("used to be 'yet another thing'"))
+	require.Equal(t, "used to be 'yet another thing'", envelope.YetAnotherThing)
+}
+
+func TestSetStructFieldWithExplicitType(t *testing.T) {
+	envelope := &Envelope{YetAnotherThing: "not zero value"}
+	set, err := SetStructFieldWithExplicitType(
+		envelope, "YetAnotherThing", "desired value",
+		reflect.TypeOf(nil), reflect.TypeOf(1), stringType, reflect.TypeOf(struct{}{}),
+	)
+	require.NoError(t, err)
+	require.True(t, set)
+	require.Equal(t, "desired value", envelope.YetAnotherThing)
+
+	set, err = SetStructFieldWithExplicitType(
+		envelope, "Thing", "another desired value",
+		reflect.TypeOf(nil), reflect.TypeOf(1), stringType, reflect.TypeOf(struct{}{}),
+	)
+	require.NoError(t, err)
+	require.True(t, set)
+	require.Equal(t, "another desired value", envelope.Thing)
+}
+
+func TestSetStructFieldWithZeroValue(t *testing.T) {
+	envelope := &Envelope{YetAnotherThing: "not zero value"}
+	set, err := SetStructFieldIfZeroValue(envelope, "Thing", "desired value")
+	require.NoError(t, err)
+	require.True(t, set)
+	require.Equal(t, "desired value", envelope.Thing)
+
+	set, err = SetStructFieldIfZeroValue(envelope, "YetAnotherThing", "should not take")
+	require.NoError(t, err)
+	require.False(t, set)
+	require.Equal(t, "not zero value", envelope.YetAnotherThing)
+}

--- a/internal/receiver/smartagentreceiver/testdata/endpoints_config.yaml
+++ b/internal/receiver/smartagentreceiver/testdata/endpoints_config.yaml
@@ -1,0 +1,40 @@
+receivers:
+  smartagent/haproxy:
+    endpoint: haproxyhost:2345
+    type: haproxy
+    intervalSeconds: 123
+    username: SomeUser
+    password: secret
+  smartagent/redis:
+    endpoint: redishost
+    type: collectd/redis
+    port: 6379
+    intervalSeconds: 234
+  smartagent/hadoop:
+    endpoint: hadoophost:12345
+    type: collectd/hadoop
+    host: localhost
+    port: 8088
+    intervalSeconds: 345
+  smartagent/etcd:
+    endpoint: etcdhost:5555
+    type: etcd
+    host: localhost
+    intervalSeconds: 456
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - smartagent/haproxy
+        - smartagent/redis
+        - smartagent/hadoop
+        - smartagent/etcd
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]

--- a/internal/receiver/smartagentreceiver/testdata/invalid_endpoint.yaml
+++ b/internal/receiver/smartagentreceiver/testdata/invalid_endpoint.yaml
@@ -1,0 +1,21 @@
+receivers:
+  smartagent/haproxy:
+    endpoint: haproxyhost:notaport
+    type: haproxy
+    intervalSeconds: 123
+    username: SomeUser
+    password: secret
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - smartagent/haproxy
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]

--- a/internal/receiver/smartagentreceiver/testdata/unsupported_endpoint.yaml
+++ b/internal/receiver/smartagentreceiver/testdata/unsupported_endpoint.yaml
@@ -1,0 +1,20 @@
+receivers:
+  smartagent/nagios:
+    endpoint: localhost:12345
+    type: nagios
+    command: some_command
+    service: some_service
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - smartagent/nagios
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]


### PR DESCRIPTION
These changes add a new Endpoint field to the Smart Agent receiver Config to make them compatible with the receiver creator and observer endpoint targets.  They will apply to corresponding host and port monitor config fields.

Also includes some refactoring since both these changes and the reflective Output value setting follow the same pattern.