### PR TITLE
Add --memory option to linux installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ which require the following environment variables:
 
 The following environment variables are optional:
 
-- `SPLUNK_CONFIG` (default = `/etc/otel/collector/splunk-config_linux.yaml`): Which configuration to load.
+- `SPLUNK_CONFIG` (default = `/etc/otel/collector/splunk_config_linux.yaml`): Which configuration to load.
 - `SPLUNK_BALLAST_SIZE_MIB` (no default): How much memory to allocate to the ballast.
 - For Linux systems:
   - `SPLUNK_MEMORY_LIMIT_PERCENTAGE` (default = `90`): Maximum total memory to be allocated by the process heap.
@@ -110,12 +110,12 @@ You can view the [source](internal/buildscripts/packaging/installer/install.sh)
 for more details and available options.
 
 Run the following command on your host. Replace `SPLUNK_REALM`,
-`SPLUNK_BALLAST_SIZE`, and `SPLUNK_ACCESS_TOKEN` for your
+`SPLUNK_TOTAL_MEMORY_MIB`, and `SPLUNK_ACCESS_TOKEN` for your
 environment:
 
 ```sh
 curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-collector.sh;
-sudo sh /tmp/splunk-otel-collector.sh --realm SPLUNK_REALM --ballast SPLUNK_BALLAST_SIZE \
+sudo sh /tmp/splunk-otel-collector.sh --realm SPLUNK_REALM --memory SPLUNK_TOTAL_MEMORY_MIB \
     -- SPLUNK_ACCESS_TOKEN
 ```
 
@@ -259,8 +259,8 @@ configuration as shown above.
 If the custom configuration includes a `memory_limiter` processor then the
 `ballast_size_mib` parameter should be the same as the
 `SPLUNK_BALLAST_SIZE_MIB` environment variable. See
-[splunk_config.yaml](cmd/otelcol/config/collector/splunk_config.yaml) as an
-example.
+[splunk_config_linux.yaml](cmd/otelcol/config/collector/splunk_config_linux.yaml)
+as an example.
 
 ## Monitoring
 

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -252,7 +252,11 @@ install_yum_package() {
     version="-${version}"
   fi
 
-  yum install -y ${package_name}${version}
+  if command -v yum >/dev/null 2>&1; then
+    yum install -y ${package_name}${version}
+  else
+    dnf install -y ${package_name}${version}
+  fi
 }
 
 ensure_not_installed() {

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -73,7 +73,7 @@ fluent_config_path="${fluent_config_dir}/fluent.conf"
 
 default_stage="release"
 default_realm="us0"
-default_ballast_size="683"
+default_memory_size="1024"
 default_collector_version="latest"
 default_td_agent_version="4.0.1"
 default_td_agent_version_jessie="3.3.0-1"
@@ -411,7 +411,9 @@ Options:
   --hec-url <url>                   Set the HEC endpoint URL explicitly instead of the endpoint inferred from the specified realm
                                     (default: https://ingest.REALM.signalfx.com/v1/log)
   --hec-token <token>               Set the HEC token if different than the specified Splunk access_token
-  --ballast <ballast size>          How much memory in MIB to allocate to the ballast (default: "$default_ballast_size")
+  --memory <memory size>            Total memory in MIB to allocate to the collector; automatically calculates the ballast size
+                                    (default: "$default_memory_size")
+  --ballast <ballast size>          Set the ballast size explicitly instead of the value calculated from the --memory option
                                     This should be set to 1/3 to 1/2 of configured memory
   --service-user <user>             Set the user for the splunk-otel-collector service (default: "$default_service_user")
                                     The user will be created if it does not exist
@@ -430,7 +432,8 @@ EOH
 parse_args_and_install() {
   local stage="$default_stage"
   local realm="$default_realm"
-  local ballast="$default_ballast_size"
+  local memory="$default_memory_size"
+  local ballast=
   local access_token=
   local insecure=
   local collector_version="$default_collector_version"
@@ -470,6 +473,10 @@ parse_args_and_install() {
         ;;
       --realm)
         realm="$2"
+        shift 1
+        ;;
+      --memory)
+        memory="$2"
         shift 1
         ;;
       --ballast)
@@ -546,11 +553,11 @@ parse_args_and_install() {
   fi
 
   if [ -z "$trace_url" ]; then
-    trace_url="https://ingest.${realm}.signalfx.com/v2/trace"
+    trace_url="${ingest_url}/v2/trace"
   fi
 
   if [ -z "$hec_url" ]; then
-    hec_url="https://ingest.${realm}.signalfx.com/v1/log"
+    hec_url="${ingest_url}/v1/log"
   fi
 
   if [ "$with_fluentd" != "true" ]; then
@@ -558,7 +565,11 @@ parse_args_and_install() {
   fi
 
   echo "Splunk OpenTelemetry Collector Version: ${collector_version}"
-  echo "Ballast Size in MIB: $ballast"
+  if [ -n "$ballast" ]; then
+    echo "Ballast Size in MIB: $ballast"
+  else
+    echo "Memory Size in MIB: $memory"
+  fi
   echo "Realm: $realm"
   echo "Ingest Endpoint: $ingest_url"
   echo "API Endpoint: $api_url"
@@ -583,9 +594,13 @@ parse_args_and_install() {
   configure_env_file "SPLUNK_API_URL" "$api_url" "$collector_env_path"
   configure_env_file "SPLUNK_INGEST_URL" "$ingest_url" "$collector_env_path"
   configure_env_file "SPLUNK_TRACE_URL" "$trace_url" "$collector_env_path"
-  configure_env_file "SPLUNK_BALLAST_SIZE_MIB" "$ballast" "$collector_env_path"
   configure_env_file "SPLUNK_HEC_URL" "$hec_url" "$collector_env_path"
   configure_env_file "SPLUNK_HEC_TOKEN" "$hec_token" "$collector_env_path"
+  if [ -n "$ballast" ]; then
+    configure_env_file "SPLUNK_BALLAST_SIZE_MIB" "$ballast" "$collector_env_path"
+  else
+    configure_env_file "SPLUNK_MEMORY_TOTAL_MIB" "$memory" "$collector_env_path"
+  fi
 
   # ensure the collector service owner has access to the config dir
   chown -R $service_user:$service_group "$collector_config_dir"

--- a/internal/buildscripts/packaging/tests/installer_test.py
+++ b/internal/buildscripts/packaging/tests/installer_test.py
@@ -12,6 +12,8 @@ from tests.helpers.util import (
     DEB_DISTROS,
     REPO_DIR,
     RPM_DISTROS,
+    SERVICE_NAME,
+    SERVICE_OWNER,
     TESTS_DIR,
 )
 
@@ -27,11 +29,11 @@ VERSIONS = os.environ.get("VERSIONS", "latest").split(",")
     "distro",
     [pytest.param(distro, marks=pytest.mark.deb) for distro in DEB_DISTROS]
     + [pytest.param(distro, marks=pytest.mark.rpm) for distro in RPM_DISTROS],
-)
-@pytest.mark.parametrize("service_owner", ["default_service_owner", "new_service_owner"])
+    )
 @pytest.mark.parametrize("version", VERSIONS)
-def test_installer(distro, service_owner, version):
-    install_cmd = "sh -x /test/install.sh -- testing123 --realm us0 --ballast 64"
+@pytest.mark.parametrize("memory_option", ["memory", "ballast"])
+def test_installer(distro, version, memory_option):
+    install_cmd = f"sh -x /test/install.sh -- testing123 --realm us0 --{memory_option} 256"
 
     if version != "latest":
         install_cmd = f"{install_cmd} --collector-version {version.lstrip('v')}"
@@ -39,11 +41,6 @@ def test_installer(distro, service_owner, version):
     if STAGE != "release":
         assert STAGE in ("test", "beta"), f"Unsupported stage '{STAGE}'!"
         install_cmd = f"{install_cmd} --{STAGE}"
-
-    if service_owner == "default_service_owner":
-        service_owner = "splunk-otel-collector"
-    else:
-        install_cmd = f"{install_cmd} --service-user {service_owner} --service-group {service_owner}"
 
     print(f"Testing installation on {distro} from {STAGE} stage ...")
     with run_distro_container(distro) as container:
@@ -56,7 +53,57 @@ def test_installer(distro, service_owner, version):
             # verify env file created with configured parameters
             run_container_cmd(container, "grep '^SPLUNK_ACCESS_TOKEN=testing123$' /etc/otel/collector/splunk_env")
             run_container_cmd(container, "grep '^SPLUNK_REALM=us0$' /etc/otel/collector/splunk_env")
-            run_container_cmd(container, "grep '^SPLUNK_BALLAST_SIZE_MIB=64$' /etc/otel/collector/splunk_env")
+            if memory_option == "memory":
+                run_container_cmd(container, "grep '^SPLUNK_MEMORY_TOTAL_MIB=256$' /etc/otel/collector/splunk_env")
+            elif memory_option == "ballast":
+                run_container_cmd(container, "grep '^SPLUNK_BALLAST_SIZE_MIB=256$' /etc/otel/collector/splunk_env")
+
+            # verify collector service status
+            assert wait_for(lambda: service_is_running(container, service_owner=SERVICE_OWNER))
+
+            # the td-agent service should only be running when installing
+            # collector packages that have our custom fluent config
+            if container.exec_run("test -f /etc/otel/collector/fluentd/fluent.conf").exit_code == 0:
+                assert container.exec_run("systemctl status td-agent").exit_code == 0
+            else:
+                assert container.exec_run("systemctl status td-agent").exit_code != 0
+
+        finally:
+            run_container_cmd(container, "journalctl -u td-agent --no-pager")
+            run_container_cmd(container, f"journalctl -u {SERVICE_NAME} --no-pager")
+
+
+@pytest.mark.installer
+@pytest.mark.parametrize(
+    "distro",
+    [pytest.param(distro, marks=pytest.mark.deb) for distro in DEB_DISTROS]
+    + [pytest.param(distro, marks=pytest.mark.rpm) for distro in RPM_DISTROS],
+)
+@pytest.mark.parametrize("version", VERSIONS)
+def test_installer_service_owner(distro, version):
+    service_owner = "test-user"
+    install_cmd = f"sh -x /test/install.sh -- testing123 --realm us0 --memory 256"
+    install_cmd = f"{install_cmd} --service-user {service_owner} --service-group {service_owner}"
+
+    if version != "latest":
+        install_cmd = f"{install_cmd} --collector-version {version.lstrip('v')}"
+
+    if STAGE != "release":
+        assert STAGE in ("test", "beta"), f"Unsupported stage '{STAGE}'!"
+        install_cmd = f"{install_cmd} --{STAGE}"
+
+    print(f"Testing installation on {distro} from {STAGE} stage ...")
+    with run_distro_container(distro) as container:
+        # run installer script
+        copy_file_into_container(container, INSTALLER_PATH, "/test/install.sh")
+        run_container_cmd(container, install_cmd, env={"VERIFY_ACCESS_TOKEN": "false"})
+        time.sleep(5)
+
+        try:
+            # verify env file created with configured parameters
+            run_container_cmd(container, "grep '^SPLUNK_ACCESS_TOKEN=testing123$' /etc/otel/collector/splunk_env")
+            run_container_cmd(container, "grep '^SPLUNK_REALM=us0$' /etc/otel/collector/splunk_env")
+            run_container_cmd(container, "grep '^SPLUNK_MEMORY_TOTAL_MIB=256$' /etc/otel/collector/splunk_env")
 
             # verify collector service status
             assert wait_for(lambda: service_is_running(container, service_owner=service_owner))
@@ -70,4 +117,4 @@ def test_installer(distro, service_owner, version):
 
         finally:
             run_container_cmd(container, "journalctl -u td-agent --no-pager")
-            run_container_cmd(container, "journalctl -u splunk-otel-collector --no-pager")
+            run_container_cmd(container, f"journalctl -u {SERVICE_NAME} --no-pager")


### PR DESCRIPTION
Sets the `SPLUNK_MEMORY_TOTAL_MIB` env var for the collector systemd service unless the `--ballast` option is specified.