### PR TITLE
Clean up getting started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,26 +53,26 @@ matrix](https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f4
 
 | Receivers        | Processors        | Exporters | Extensions    |
 | :--------------: | :--------:        | :-------: | :--------:    |
-| fluentforward    | attributes        | file      | fluentbit     |
-| host_observer    | batch             | logging   | healthcheck   |
-| jaeger           | filter            | otlp      | httpforwarder |
-| k8s_observer     | k8s_tagger        | sapm      | observer/host |
-| kubeletstats     | memorylimiter     | signalfx  | observer/k8s  |
-| opencensus       | metrictransform   | splunkhec | pprof         |
-| otlp             | resource          |           | zpages        |
-| sapm             | resourcedetection |           |               |
-| signalfx         | span              |           |               |
-| simpleprometheus |                   |           |               |
+| host_observer    | attributes        | file      | fluentbit     |
+| jaeger           | batch             | logging   | healthcheck   |
+| k8s_observer     | filter            | otlp      | httpforwarder |
+| kubeletstats     | k8s_tagger        | sapm      | observer/host |
+| opencensus       | memorylimiter     | signalfx  | observer/k8s  |
+| otlp             | metrictransform   | splunkhec | pprof         |
+| sapm             | resource          |           | zpages        |
+| signalfx         | resourcedetection |           |               |
+| simpleprometheus | span              |           |               |
 | splunkhec        |                   |           |               |
 | zipkin           |                   |           |               |
 
 ### Alpha
 
-| Receivers | Processors | Exporters | Extensions |
-| :-------: | :--------: | :-------: | :--------: |
-| carbon    |            |           |            |
-| collectd  |            |           |            |
-| statsd    |            |           |            |
+| Receivers      | Processors | Exporters | Extensions |
+| :-------:      | :--------: | :-------: | :--------: |
+| carbon         |            |           |            |
+| collectd       |            |           |            |
+| fluentdforward |            |           |            |
+| statsd         |            |           |            |
 
 ## Sizing
 

--- a/README.md
+++ b/README.md
@@ -45,62 +45,34 @@ You can consult additional use cases in the [examples](./examples) directory.
 
 ## Supported Components
 
-### Receivers
+The distribution offers support for the following components. Support is based
+on the [OpenTelemetry maturity
+matrix](https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f466a58bd2bb94edc72/maturity-matrix.yaml#L57).
 
-| Name             | Status |
-| :--:             | :----: |
-| carbon           | Alpha  |
-| collectd         | Alpha  |
-| fluentforward    | Beta   |
-| hostmetrics      | Beta   |
-| jaeger           | Beta   |
-| k8scluster       | Beta   |
-| kubletstats      | Beta   |
-| opencensus       | Beta   |
-| otlp             | Beta   |
-| sapm             | Beta   |
-| signalfx         | Beta   |
-| simpleprometheus | Beta   |
-| statsd           | Alpha  |
-| splunkhec        | Beta   |
-| zipkin           | Beta   |
+### Beta
 
-### Processors
+| Receivers        | Processors        | Exporters | Extensions    |
+| :--------------: | :--------:        | :-------: | :--------:    |
+| fluentforward    | attributes        | file      | fluentbit     |
+| hostmetrics      | batch             | logging   | healthcheck   |
+| jaeger           | filter            | otlp      | httpforwarder |
+| k8scluster       | k8s               | sapm      | observer/host |
+| kubletstats      | memorylimiter     | signalfx  | observer/k8s  |
+| opencensus       | metrictransform   | splunkhec | pprof         |
+| otlp             | resource          |           | zpages        |
+| sapm             | resourcedetection |           |               |
+| signalfx         | span              |           |               |
+| simpleprometheus |                   |           |               |
+| splunkhec        |                   |           |               |
+| zipkin           |                   |           |               |
 
-| Name              | Status |
-| :--:              | :----: |
-| attributes        | Beta   |
-| batch             | Beta   |
-| filter            | Beta   |
-| memorylimiter     | Beta   |
-| resource          | Beta   |
-| span              | Beta   |
-| k8s               | Beta   |
-| metricstransform  | Beta   |
-| resourcedetection | Beta   |
+### Alpha
 
-### Exporters
-
-| Name             | Status |
-| :--:             | :----: |
-| file             | Beta   |
-| logging          | Beta   |
-| otlp             | Beta   |
-| sapm             | Beta   |
-| signalfx         | Beta   |
-| splunkhec        | Beta   |
-
-### Extensions
-
-| Name          | Status |
-| :--:          | :----: |
-| fluentbit     | Beta   |
-| healthcheck   | Beta   |
-| httpforwarder | Beta   |
-| observer/host | Beta   |
-| observer/k8s  | Beta   |
-| pprof         | Beta   |
-| zpages        | Beta   |
+| Receivers | Processors | Exporters | Extensions |
+| :-------: | :--------: | :-------: | :--------: |
+| carbon    |            |           |            |
+| collectd  |            |           |            |
+| statsd    |            |           |            |
 
 ## Sizing
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ matrix](https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f4
 | hostmetrics      | attributes        | file      | fluentbit     |
 | jaeger           | batch             | logging   | healthcheck   |
 | k8s_cluster      | filter            | otlp      | httpforwarder |
-| kubeletstats     | k8s_tagger        | sapm      | observer/host |
-| opencensus       | memorylimiter     | signalfx  | observer/k8s  |
+| kubeletstats     | k8s_tagger        | sapm      | host_observer |
+| opencensus       | memorylimiter     | signalfx  | k8s_observer  |
 | otlp             | metrictransform   | splunkhec | pprof         |
 | receiver_creator | resource          |           | zpages        |
 | sapm             | resourcedetection |           |               |

--- a/README.md
+++ b/README.md
@@ -53,15 +53,16 @@ matrix](https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f4
 
 | Receivers        | Processors        | Exporters | Extensions    |
 | :--------------: | :--------:        | :-------: | :--------:    |
-| host_observer    | attributes        | file      | fluentbit     |
+| hostmetrics      | attributes        | file      | fluentbit     |
 | jaeger           | batch             | logging   | healthcheck   |
-| k8s_observer     | filter            | otlp      | httpforwarder |
+| k8s_cluster      | filter            | otlp      | httpforwarder |
 | kubeletstats     | k8s_tagger        | sapm      | observer/host |
 | opencensus       | memorylimiter     | signalfx  | observer/k8s  |
 | otlp             | metrictransform   | splunkhec | pprof         |
-| sapm             | resource          |           | zpages        |
-| signalfx         | resourcedetection |           |               |
-| simpleprometheus | span              |           |               |
+| receiver_creator | resource          |           | zpages        |
+| sapm             | resourcedetection |           |               |
+| signalfx         | span              |           |               |
+| simpleprometheus |                   |           |               |
 | splunkhec        |                   |           |               |
 | zipkin           |                   |           |               |
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ matrix](https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f4
 | Receivers        | Processors        | Exporters | Extensions    |
 | :--------------: | :--------:        | :-------: | :--------:    |
 | fluentforward    | attributes        | file      | fluentbit     |
-| hostmetrics      | batch             | logging   | healthcheck   |
+| host_observer    | batch             | logging   | healthcheck   |
 | jaeger           | filter            | otlp      | httpforwarder |
-| k8scluster       | k8s               | sapm      | observer/host |
-| kubletstats      | memorylimiter     | signalfx  | observer/k8s  |
+| k8s_observer     | k8s_tagger        | sapm      | observer/host |
+| kubeletstats     | memorylimiter     | signalfx  | observer/k8s  |
 | opencensus       | metrictransform   | splunkhec | pprof         |
 | otlp             | resource          |           | zpages        |
 | sapm             | resourcedetection |           |               |

--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -16,7 +16,7 @@ sudo sh /tmp/splunk-otel-collector.sh --realm SPLUNK_REALM --memory SPLUNK_TOTAL
     -- SPLUNK_ACCESS_TOKEN
 ```
 
-Currently, only the following Linux distributions and versions are supported:
+Currently, the following Linux distributions and versions are supported:
 
 - Amazon Linux: 2
 - CentOS / Red Hat / Oracle: 7, 8

--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -1,0 +1,46 @@
+# Linux Installer Script
+
+For non-containerized Linux environments, a convenience script is available for
+installing the Collector package and [TD Agent
+(Fluentd)](https://www.fluentd.org/).
+
+## Getting Started
+
+Run the following command on your host. Replace `SPLUNK_REALM`,
+`SPLUNK_TOTAL_MEMORY_MIB`, and `SPLUNK_ACCESS_TOKEN` for your
+environment:
+
+```sh
+curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-collector.sh;
+sudo sh /tmp/splunk-otel-collector.sh --realm SPLUNK_REALM --memory SPLUNK_TOTAL_MEMORY_MIB \
+    -- SPLUNK_ACCESS_TOKEN
+```
+
+Currently, only the following Linux distributions and versions are supported:
+
+- Amazon Linux: 2
+- CentOS / Red Hat / Oracle: 7, 8
+- Debian: 8, 9, 10
+- Ubuntu: 16.04, 18.04, 20.04
+
+You can view the [source](internal/buildscripts/packaging/installer/install.sh)
+for more details and available options.
+
+## Advanced Configuration
+
+By default, the fluentd service will be installed and configured to forward
+log events with the `@SPLUNK` label to the collector (see the note below for
+how to add fluentd log sources), and the collector will send these events to
+the HEC ingest endpoint determined by the `--realm SPLUNK_REALM` option, e.g.
+`https://ingest.SPLUNK_REALM.signalfx.com/v1/log`.  To configure the collector
+to send log events to a custom HEC endpoint URL, specify the `--hec-url URL`
+and `--hec-token TOKEN` options to the command above.
+
+**Note**: The installer script does not include any fluentd log sources. Custom
+fluentd source config files can be added to the
+`/etc/otel/collector/fluentd/conf.d` directory after installation. Config files
+added to this directory should have a `.conf` extension, and the `td-agent`
+service will need to be restarted to include/enable the new files, i.e.
+`sudo systemctl restart td-agent`.  A sample config and instructions for
+collecting journald log events is available at
+`/etc/otel/collector/fluentd/conf.d/journald.conf.example`.

--- a/docs/getting-started/linux-standalone.md
+++ b/docs/getting-started/linux-standalone.md
@@ -20,6 +20,7 @@ which require the following environment variables:
 <summary>
 Optional environment variables
 </summary>
+
 - `SPLUNK_CONFIG` (default = `/etc/otel/collector/splunk_config_linux.yaml`): Which configuration to load.
 - `SPLUNK_BALLAST_SIZE_MIB` (no default): How much memory to allocate to the ballast.
 - For Linux systems:

--- a/docs/getting-started/linux-standalone.md
+++ b/docs/getting-started/linux-standalone.md
@@ -143,9 +143,10 @@ $ docker run --rm -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_MEMORY_TOTAL_MIB=1024 \
 
 ### Custom Configuration
 
-In addition to using the default configuration, a custom configuration can also
-be provided. Use the `SPLUNK_CONFIG` environment variable or
-the `--config` command line argument to provide a custom configuration.
+When changes to the default configuration file is needed, a custom
+configuration file can specified and used instead. Use the `SPLUNK_CONFIG`
+environment variable or the `--config` command line argument to provide a
+custom configuration.
 
 > Command line arguments take precedence over environment variables. This
 > applies to `--config` and `--mem-ballast-size-mib`.

--- a/docs/getting-started/linux-standalone.md
+++ b/docs/getting-started/linux-standalone.md
@@ -65,14 +65,6 @@ $ docker run --rm -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_MEMORY_TOTAL_MIB=1024 \
     --name otelcol quay.io/signalfx/splunk-otel-collector:0.1.0
 ```
 
-### Kubernetes
-
-To deploy in Kubernetes, create a configuration file that defines a ConfigMap,
-Service, and Deployment for the cluster. For more information about creating a
-configuration file, see the example
-[signalfx-k8s.yaml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/master/exporter/sapmexporter/examples/signalfx-k8s.yaml)
-file on GitHub.
-
 ### Standalone
 
 ```bash

--- a/docs/getting-started/linux-standalone.md
+++ b/docs/getting-started/linux-standalone.md
@@ -1,0 +1,130 @@
+# Linux Standalone
+
+All Intel, AMD and ARM systemd-based operating systems are supported including
+CentOS, Debian, Oracle, Red Hat and Ubuntu. DEB and RPM packages are available
+to download at
+[https://github.com/signalfx/splunk-otel-collector/releases
+](https://github.com/signalfx/splunk-otel-collector/releases).
+
+## Getting Started
+
+This distribution comes with [default
+configurations](https://github.com/signalfx/splunk-otel-collector/blob/main/cmd/otelcol/config/collector)
+which require the following environment variables:
+
+- `SPLUNK_REALM` (no default): Which realm to send the data to (for example: `us0`)
+- `SPLUNK_ACCESS_TOKEN` (no default): Access token to authenticate requests
+- `SPLUNK_MEMORY_TOTAL_MIB` (no default): Total memory allocated to the Collector.
+
+<details>
+<summary>
+Optional environment variables
+</summary>
+- `SPLUNK_CONFIG` (default = `/etc/otel/collector/splunk_config_linux.yaml`): Which configuration to load.
+- `SPLUNK_BALLAST_SIZE_MIB` (no default): How much memory to allocate to the ballast.
+- For Linux systems:
+  - `SPLUNK_MEMORY_LIMIT_PERCENTAGE` (default = `90`): Maximum total memory to be allocated by the process heap.
+  - `SPLUNK_MEMORY_SPIKE_PERCENTAGE` (default = `20`): Maximum spike between the measurements of memory usage.
+- For non-Linux systems:
+  - `SPLUNK_MEMORY_LIMIT_MIB` (no default): Maximum total memory to be allocated by the process heap.
+  - `SPLUNK_MEMORY_SPIKE_MIB` (no default): Maximum spike between the measurements of memory usage.
+
+> `SPLUNK_MEMORY_TOTAL_MIB` automatically configures the ballast, memory limit,
+> and memory spike. If the optional environment variables are defined, they
+> will override the value calculated from `SPLUNK_MEMORY_TOTAL_MIB`.
+</details>
+
+<details>
+<summary>
+Accessible endpoints
+</summary>
+With the Collector configured, the following endpoints are accessible:
+
+- `http(s)://<collectorFQDN>:13133/` Health endpoint useful for load balancer monitoring
+- `http(s)://<collectorFQDN>:[14250|14268]` Jaeger [gRPC|Thrift HTTP] receiver
+- `http(s)://<collectorFQDN>:55678` OpenCensus gRPC and HTTP receiver
+- `http(s)://localhost:55679/debug/[tracez|pipelinez]` zPages monitoring
+- `http(s)://<collectorFQDN>:55680` OpenTelemetry gRPC receiver
+- `http(s)://<collectorFQDN>:6060` HTTP Forwarder used to receive Smart Agent `apiUrl` data
+- `http(s)://<collectorFQDN>:7276` SignalFx Infrastructure Monitoring gRPC receiver
+- `http(s)://localhost:8888/metrics` Prometheus metrics for the Collector
+- `http(s)://<collectorFQDN>:9411/api/[v1|v2]/spans` Zipkin JSON (can be set to proto)receiver
+- `http(s)://<collectorFQDN>:9943/v2/trace` SignalFx APM receiver
+</details>
+
+The following sections describe how to deploy the Collector in supported environments.
+
+### Docker
+
+Deploy from a Docker container. Replace `0.1.0` with the latest stable version number:
+
+```bash
+$ docker run --rm -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_MEMORY_TOTAL_MIB=1024 \
+    -e SPLUNK_REALM=us0 -p 13133:13133 -p 14250:14250 -p 14268:14268 -p 55678-55680:55678-55680 \
+    -p 6060:6060 -p 7276:7276 -p 8888:8888 -p 9411:9411 -p 9943:9943 \
+    --name otelcol quay.io/signalfx/splunk-otel-collector:0.1.0
+```
+
+### Kubernetes
+
+To deploy in Kubernetes, create a configuration file that defines a ConfigMap,
+Service, and Deployment for the cluster. For more information about creating a
+configuration file, see the example
+[signalfx-k8s.yaml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/master/exporter/sapmexporter/examples/signalfx-k8s.yaml)
+file on GitHub.
+
+### Standalone
+
+```bash
+$ make otelcol
+$ SPLUNK_REALM=us0 SPLUNK_ACCESS_TOKEN=12345 SPLUNK_MEMORY_TOTAL_MIB=1024 \
+    ./bin/otelcol
+```
+
+## Advanced Configuration
+
+### Command Line Arguments
+
+Following the binary command or Docker container command line arguments can be
+specified. Command line arguments take priority over environment variables.
+
+For example in Docker:
+
+```bash
+$ docker run --rm -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_MEMORY_TOTAL_MIB=1024 \
+    -e SPLUNK_REALM=us0 -p 13133:13133 -p 14250:14250 -p 14268:14268 -p 55678-55680:55678-55680 \
+    -p 6060:6060 -p 7276:7276 -p 8888:8888 -p 9411:9411 -p 9943:9943 \
+    --name otelcol quay.io/signalfx/splunk-otel-collector:0.1.0 \
+        --log-level=DEBUG
+```
+
+> Use `--help` to see all available CLI arguments.
+
+### Custom Configuration
+
+In addition to using the default configuration, a custom configuration can also
+be provided. Use the `SPLUNK_CONFIG` environment variable or
+the `--config` command line argument to provide a custom configuration.
+
+> Command line arguments take precedence over environment variables. This
+> applies to `--config` and `--mem-ballast-size-mib`.
+
+For example in Docker:
+
+```bash
+$ docker run --rm -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_MEMORY_TOTAL_MIB=1024 \
+    -e SPLUNK_REALM=us0 -e SPLUNK_CONFIG=/etc/collector.yaml -p 13133:13133 -p 14250:14250 \
+    -p 14268:14268 -p 55678-55680:55678-55680 -p 6060:6060 -p 7276:7276 -p 8888:8888 \
+    -p 9411:9411 -p 9943:9943 -v collector.yaml:/etc/collector.yaml:ro \
+    --name otelcol quay.io/signalfx/splunk-otel-collector:0.1.0
+```
+
+In the case of Docker, a volume mount may be required to load custom
+configuration as shown above.
+
+If the custom configuration includes a `memory_limiter` processor then the
+`ballast_size_mib` parameter should be the same as the
+`SPLUNK_BALLAST_SIZE_MIB` environment variable. See
+[splunk_config_linux.yaml](cmd/otelcol/config/collector/splunk_config_linux.yaml)
+as an example.
+

--- a/docs/getting-started/windows-standalone.md
+++ b/docs/getting-started/windows-standalone.md
@@ -6,7 +6,16 @@ A Windows MSI package (64-bit only) is available to download at
 
 ## Getting Started
 
-To install, double-click on the downloaded package or run the following command
+### GUI
+
+Double-click on the downloaded package and follow the wizard.
+
+### CLI
+
+TODO
+
+### PowerShell
+
 in a PowerShell terminal:
 
 ```sh
@@ -29,14 +38,11 @@ Before starting the `splunk-otel-collector` service, the following variables
 in the default config file need to be replaced by the appropriate values for
 your environment:
 
-- `${SPLUNK_ACCESS_TOKEN}`
-- `${SPLUNK_REALM}`
-- `${SPLUNK_BALLAST_SIZE_MIB}`
-- `${SPLUNK_MEMORY_LIMIT_MIB}`
-- `${SPLUNK_MEMORY_SPIKE_MIB}`
-
-See the [Getting Started](#getting-started) section for details about these
-variables.
+- `${SPLUNK_ACCESS_TOKEN}`: Access token to authenticate requests
+- `${SPLUNK_REALM}`: Which realm to send the data to (for example: `us0`)
+- `${SPLUNK_BALLAST_SIZE_MIB}`: How much memory to allocate to the ballast.
+- `${SPLUNK_MEMORY_LIMIT_MIB}`: Maximum total memory to be allocated by the process heap.
+- `${SPLUNK_MEMORY_SPIKE_MIB}`: Maximum spike between the measurements of memory usage.
 
 After updating all variables in the config file, start the
 `splunk-otel-collector` service by rebooting the system or running the

--- a/docs/getting-started/windows-standalone.md
+++ b/docs/getting-started/windows-standalone.md
@@ -10,10 +10,6 @@ A Windows MSI package (64-bit only) is available to download at
 
 Double-click on the downloaded package and follow the wizard.
 
-### CLI
-
-TODO
-
 ### PowerShell
 
 in a PowerShell terminal:

--- a/docs/getting-started/windows-standalone.md
+++ b/docs/getting-started/windows-standalone.md
@@ -4,22 +4,7 @@ A Windows MSI package (64-bit only) is available to download at
 [https://github.com/signalfx/splunk-otel-collector/releases
 ](https://github.com/signalfx/splunk-otel-collector/releases).
 
-## Getting Started
-
-### GUI
-
-Double-click on the downloaded package and follow the wizard.
-
-### PowerShell
-
-in a PowerShell terminal:
-
-```sh
-PS> Start-Process -Wait msiexec "/i PATH_TO_MSI /qn"
-```
-
-Replace `PATH_TO_MSI` with the *full* path to the downloaded package, e.g.
-`C:\your\download\folder\splunk-otel-collector-0.4.0-amd64.msi`.
+## Installation
 
 The collector will be installed to
 `\Program Files\Splunk\OpenTelemetry Collector`, and the
@@ -29,6 +14,23 @@ A default config file will be copied to
 `\ProgramData\Splunk\OpenTelemetry Collector\config.yaml` if it does not
 already exist.  This file is required to start the `splunk-otel-collector`
 service.
+
+### GUI
+
+Double-click on the downloaded package and follow the wizard.
+
+### PowerShell
+
+In a PowerShell terminal:
+
+```sh
+PS> Start-Process -Wait msiexec "/i PATH_TO_MSI /qn"
+```
+
+Replace `PATH_TO_MSI` with the *full* path to the downloaded package, e.g.
+`C:\your\download\folder\splunk-otel-collector-0.4.0-amd64.msi`.
+
+## Configuration
 
 Before starting the `splunk-otel-collector` service, the following variables
 in the default config file need to be replaced by the appropriate values for

--- a/docs/getting-started/windows-standalone.md
+++ b/docs/getting-started/windows-standalone.md
@@ -1,0 +1,49 @@
+# Windows Standalone
+
+A Windows MSI package (64-bit only) is available to download at
+[https://github.com/signalfx/splunk-otel-collector/releases
+](https://github.com/signalfx/splunk-otel-collector/releases).
+
+## Getting Started
+
+To install, double-click on the downloaded package or run the following command
+in a PowerShell terminal:
+
+```sh
+PS> Start-Process -Wait msiexec "/i PATH_TO_MSI /qn"
+```
+
+Replace `PATH_TO_MSI` with the *full* path to the downloaded package, e.g.
+`C:\your\download\folder\splunk-otel-collector-0.4.0-amd64.msi`.
+
+The collector will be installed to
+`\Program Files\Splunk\OpenTelemetry Collector`, and the
+`splunk-otel-collector` service will be created but not started.
+
+A default config file will be copied to
+`\ProgramData\Splunk\OpenTelemetry Collector\config.yaml` if it does not
+already exist.  This file is required to start the `splunk-otel-collector`
+service.
+
+Before starting the `splunk-otel-collector` service, the following variables
+in the default config file need to be replaced by the appropriate values for
+your environment:
+
+- `${SPLUNK_ACCESS_TOKEN}`
+- `${SPLUNK_REALM}`
+- `${SPLUNK_BALLAST_SIZE_MIB}`
+- `${SPLUNK_MEMORY_LIMIT_MIB}`
+- `${SPLUNK_MEMORY_SPIKE_MIB}`
+
+See the [Getting Started](#getting-started) section for details about these
+variables.
+
+After updating all variables in the config file, start the
+`splunk-otel-collector` service by rebooting the system or running the
+following command in a PowerShell terminal:
+
+```sh
+PS> Start-Service splunk-otel-collector
+```
+
+The collector logs and errors can be viewed in the Windows Event Viewer.


### PR DESCRIPTION
We continue to add getting started documentation as support for
different platforms increases and as installation scripts are
introduced. Instead of continuing to grow the main README, create
getting started docs and link to them.

Also add supported component information to main README.