### PR TITLE
tests: CollectorProcess helper

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/docker/go-connections v0.4.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.19.1-0.20210203200406-65673ad3657b
 	github.com/stretchr/testify v1.7.0
 	github.com/testcontainers/testcontainers-go v0.9.0
 	go.opentelemetry.io/collector v0.19.1-0.20210127225953-68c5961f7bc2

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -755,6 +755,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.10.2 h1:aY/nuoWlKJud2J6U0E3NWsjlg+0GtwXxgEqthRdzlcs=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.19.1-0.20210203200406-65673ad3657b h1:SO5vDJ4cjzfvgdSfH856pmNbHhOm4CBDox0ajX2EWW4=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.19.1-0.20210203200406-65673ad3657b/go.mod h1:Z6l63JH9f66uSmD38ZRpEwNpM8T6SRjeA7V/rEf1/Gk=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
@@ -895,8 +897,9 @@ github.com/securego/gosec v0.0.0-20200203094520-d13bb6d2420c/go.mod h1:gp0gaHj0W
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/shirou/gopsutil v3.20.12-0.20201210134652-afe0c04c5d5a+incompatible h1:uvFOXu1W/nsxgfbLu0jGTad6j0PbFDsXkwxK/rqT/AA=
 github.com/shirou/gopsutil v3.20.12-0.20201210134652-afe0c04c5d5a+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/gopsutil v3.21.1+incompatible h1:2LwXWdbjXwyDgq26Yy/OT4xozlpmssQfy/rtfhWb0bY=
+github.com/shirou/gopsutil v3.21.1+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=

--- a/tests/testutils/README.md
+++ b/tests/testutils/README.md
@@ -124,6 +124,9 @@ The `CollectorProcess` is a helper type that will run the desired Collector exec
 config you provide.  If an executable path isn't specified via builder method, the first `bin/otelcol` match walking up
 your current directory tree will be used, which can be helpful to ease test development and execution.
 
+You can also specify the desired command line arguments using `builder.WithArgs()` if not simply running with the
+specified config.
+
 ```go
 import "github.com/signafx/splunk-otel-collector/tests/testutils"
 
@@ -133,4 +136,9 @@ collector, err := testutils.NewCollectorProcess().WithPath("my_otel_collector_pa
 err = collector.Start()
 require.NoError(t, err)
 defer func() { require.NoError(t, collector.Shutdown()) }()
+
+// Also able to specify other arguments for feature, performance, and soak testing.
+// path will be first `bin/otelcol` match in a parent directory
+collector, err = testutils.NewCollectorProcess().WithArgs("--tested-feature", "--etc").Build()
 ```
+____

--- a/tests/testutils/README.md
+++ b/tests/testutils/README.md
@@ -117,3 +117,20 @@ require.NoError(t, otlp.Start())
 
 require.NoError(t, otlp.AssertAllMetricsReceived(t, expectedResourceMetrics, 10*time.Second))
 ```
+
+### Collector Process
+
+The `CollectorProcess` is a helper type that will run the desired Collector executable as a subprocess using whatever 
+config you provide.  If an executable path isn't specified via builder method, the first `bin/otelcol` match walking up
+your current directory tree will be used, which can be helpful to ease test development and execution.
+
+```go
+import "github.com/signafx/splunk-otel-collector/tests/testutils"
+
+collector, err := testutils.NewCollectorProcess().WithPath("my_otel_collector_path",
+).WithConfigPath("my_config_path").WithLogger(logger).WithLogLevel("debug").Build()
+
+err = collector.Start()
+require.NoError(t, err)
+defer func() { require.NoError(t, collector.Shutdown()) }()
+```

--- a/tests/testutils/collector_process.go
+++ b/tests/testutils/collector_process.go
@@ -1,0 +1,144 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver/subprocess"
+	"go.uber.org/zap"
+)
+
+const binaryPathSuffix = "/bin/otelcol"
+const findExecutableErrorMsg = "unable to find collector executable path.  Be sure to run `make otelcol`"
+
+type CollectorProcess struct {
+	Path             string
+	ConfigPath       string
+	Logger           *zap.Logger
+	LogLevel         string
+	Process          *subprocess.Subprocess
+	subprocessConfig *subprocess.Config
+}
+
+// To be used as a builder whose Build() method provides the actual instance capable of launching the process.
+func NewCollectorProcess() CollectorProcess {
+	return CollectorProcess{}
+}
+
+// Nearest `bin/otelcol` by default
+func (collector CollectorProcess) WithPath(path string) CollectorProcess {
+	collector.Path = path
+	return collector
+}
+
+// Required
+func (collector CollectorProcess) WithConfigPath(path string) CollectorProcess {
+	collector.ConfigPath = path
+	return collector
+}
+
+// Nop logger by default
+func (collector CollectorProcess) WithLogger(logger *zap.Logger) CollectorProcess {
+	collector.Logger = logger
+	return collector
+}
+
+// info by default
+func (collector CollectorProcess) WithLogLevel(level string) CollectorProcess {
+	collector.LogLevel = level
+	return collector
+}
+
+func (collector CollectorProcess) Build() (*CollectorProcess, error) {
+	if collector.ConfigPath == "" {
+		return nil, fmt.Errorf("you must specify a ConfigPath for your CollectorProcess before building")
+	}
+	if collector.Path == "" {
+		collectorPath, err := findCollectorPath()
+		if err != nil {
+			return nil, err
+		}
+		collector.Path = collectorPath
+	}
+	if collector.Logger == nil {
+		collector.Logger = zap.NewNop()
+	}
+	if collector.LogLevel == "" {
+		collector.LogLevel = "info"
+	}
+	collector.subprocessConfig = &subprocess.Config{
+		ExecutablePath: collector.Path,
+		Args:           []string{"--log-level", collector.LogLevel, "--config", collector.ConfigPath},
+	}
+	collector.Process = subprocess.NewSubprocess(collector.subprocessConfig, collector.Logger)
+	return &collector, nil
+}
+
+func (collector *CollectorProcess) Start() error {
+	if collector.Process == nil {
+		return fmt.Errorf("cannot Start a CollectorProcess that hasn't been successfully built")
+	}
+	go func() {
+		// drain stdout/err buffer (already logged for us)
+		for _ = range collector.Process.Stdout {
+		}
+	}()
+
+	return collector.Process.Start(context.Background())
+}
+
+func (collector *CollectorProcess) Shutdown() error {
+	if collector.Process == nil {
+		return fmt.Errorf("cannot Shutdown a CollectorProcess that hasn't been successfully built")
+	}
+
+	return collector.Process.Shutdown(context.Background())
+}
+
+// Walks up parent directories looking for bin/otelcol
+func findCollectorPath() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	binaryPath := binaryPathSuffix
+	var collectorPath string
+	for i := 0; true; i++ {
+		attemptedPath := path.Join(dir, binaryPath)
+		info, err := os.Stat(attemptedPath)
+		if err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("%s: %w", findExecutableErrorMsg, err)
+		}
+
+		if info != nil {
+			collectorPath = attemptedPath
+			break
+		}
+		if attemptedPath == binaryPathSuffix {
+			break // at root
+		}
+		dir = path.Join(dir, "..")
+	}
+
+	if collectorPath == "" {
+		err = fmt.Errorf(findExecutableErrorMsg)
+	}
+	return collectorPath, err
+}

--- a/tests/testutils/collector_process_integration_test.go
+++ b/tests/testutils/collector_process_integration_test.go
@@ -1,0 +1,60 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// +build integration
+
+package testutils
+
+import (
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectorPath(t *testing.T) {
+	p, err := findCollectorPath()
+	require.NoError(t, err)
+	require.NotEmpty(t, p)
+	assert.True(t, strings.HasSuffix(p, "/bin/otelcol"))
+}
+
+func TestCollectorProcessConfigSourced(t *testing.T) {
+	otlp, err := NewOTLPMetricsReceiverSink().WithEndpoint("localhost:23456").Build()
+	require.NoError(t, err)
+	require.NotNil(t, otlp)
+
+	err = otlp.Start()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, otlp.Shutdown()) }()
+
+	configPath := path.Join(".", "testdata", "collector_process_config.yaml")
+	collector, err := NewCollectorProcess().WithConfigPath(configPath).Build()
+	require.NoError(t, err)
+	require.NotNil(t, collector)
+
+	err = collector.Start()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, collector.Shutdown()) }()
+
+	metricsPath := path.Join(".", "testdata", "expected_host_metrics.yaml")
+	expectedMetrics, err := LoadResourceMetrics(metricsPath)
+	require.NoError(t, err)
+	require.NotNil(t, expectedMetrics)
+
+	err = otlp.AssertAllMetricsReceived(t, *expectedMetrics, 10*time.Second)
+	require.NoError(t, err)
+}

--- a/tests/testutils/collector_process_test.go
+++ b/tests/testutils/collector_process_test.go
@@ -1,0 +1,98 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestCollectorProcessBuilders(t *testing.T) {
+	builder := NewCollectorProcess()
+	require.NotNil(t, builder)
+
+	assert.Empty(t, builder.Path)
+	assert.Empty(t, builder.ConfigPath)
+	assert.Nil(t, builder.Logger)
+	assert.Empty(t, builder.LogLevel)
+
+	withPath := builder.WithPath("somepath")
+	assert.Equal(t, "somepath", withPath.Path)
+	assert.Empty(t, builder.Path)
+
+	withConfigPath := builder.WithConfigPath("someconfigpath")
+	assert.Equal(t, "someconfigpath", withConfigPath.ConfigPath)
+	assert.Empty(t, builder.ConfigPath)
+
+	logger := zap.NewNop()
+	withLogger := builder.WithLogger(logger)
+	assert.Same(t, logger, withLogger.Logger)
+	assert.Nil(t, builder.Logger)
+
+	withLogLevel := builder.WithLogLevel("someloglevel")
+	assert.Equal(t, "someloglevel", withLogLevel.LogLevel)
+	assert.Empty(t, builder.LogLevel)
+}
+
+func TestConfigPathRequiredUponBuild(t *testing.T) {
+	builder := NewCollectorProcess()
+
+	collector, err := builder.Build()
+	assert.Nil(t, collector)
+	require.Error(t, err)
+	assert.EqualError(t, err, "you must specify a ConfigPath for your CollectorProcess before building")
+}
+
+func TestStartAndShutdownInvalidWithoutBuilding(t *testing.T) {
+	builder := NewCollectorProcess()
+
+	err := builder.Start()
+	require.Error(t, err)
+	require.EqualError(t, err, "cannot Start a CollectorProcess that hasn't been successfully built")
+
+	err = builder.Shutdown()
+	require.Error(t, err)
+	require.EqualError(t, err, "cannot Shutdown a CollectorProcess that hasn't been successfully built")
+}
+
+func TestCollectorProcessWithInvalidPaths(t *testing.T) {
+	logCore, logObserver := observer.New(zap.DebugLevel)
+	logger := zap.New(logCore)
+	collector, err := NewCollectorProcess().WithPath("nototel").WithConfigPath("notaconfig").WithLogger(logger).Build()
+	require.NotNil(t, collector)
+	require.NoError(t, err)
+
+	err = collector.Start()
+	require.NoError(t, err)
+
+	require.Equal(t, -1, collector.Process.Pid())
+
+	assert.Eventually(t, func() bool {
+		for _, entry := range logObserver.All() {
+			if field, ok := entry.ContextMap()["error"]; ok {
+				return field.(string) == `exec: "nototel": executable file not found in $PATH`
+			}
+		}
+		return false
+	}, 5*time.Second, 1*time.Millisecond)
+
+	err = collector.Shutdown()
+	require.NoError(t, err)
+}

--- a/tests/testutils/testdata/collector_process_config.yaml
+++ b/tests/testutils/testdata/collector_process_config.yaml
@@ -1,0 +1,16 @@
+receivers:
+  hostmetrics:
+    collection_interval: 1s
+    scrapers:
+      memory:
+
+exporters:
+  otlp:
+    endpoint: localhost:23456
+    insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [hostmetrics]
+      exporters: [otlp]

--- a/tests/testutils/testdata/expected_host_metrics.yaml
+++ b/tests/testutils/testdata/expected_host_metrics.yaml
@@ -1,0 +1,7 @@
+resource_metrics:
+  - instrumentation_library_metrics:
+      - metrics:
+          - name: system.memory.usage
+            type: IntNonmonotonicCumulativeSum
+            labels:
+              state: used


### PR DESCRIPTION
These changes introduce the last basic helper for the integration testing module - a runner for the Collector.  It uses the subprocess manager from the JMX receiver, a specified or detected Collector binary path, and provided config to launch the collector process for the lifetime of a test or suite.

Also introduces the first `integration` tagged test file, but as with the previous changes I'm holding off on sourcing/running these in CI until a future PR.