### PR TITLE
tests: add container names and network support

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,10 +3,11 @@ module github.com/signalfx/splunk-otel-collector/tests
 go 1.15
 
 require (
+	github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.19.1-0.20210203200406-65673ad3657b
 	github.com/stretchr/testify v1.7.0
-	github.com/testcontainers/testcontainers-go v0.9.0
+	github.com/testcontainers/testcontainers-go v0.9.1-0.20210125083013-7e3c8f831f07
 	go.opentelemetry.io/collector v0.19.1-0.20210127225953-68c5961f7bc2
 	go.uber.org/zap v1.16.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -963,6 +963,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/testcontainers/testcontainers-go v0.9.0 h1:ZyftCfROjGrKlxk3MOUn2DAzWrUtzY/mj17iAkdUIvI=
 github.com/testcontainers/testcontainers-go v0.9.0/go.mod h1:b22BFXhRbg4PJmeMVWh6ftqjyZHgiIl3w274e9r3C2E=
+github.com/testcontainers/testcontainers-go v0.9.1-0.20210125083013-7e3c8f831f07 h1:XFZ7aTrYs4jdJ3Ec1gIMwAq7ctFCSukNZRN6h36gXkg=
+github.com/testcontainers/testcontainers-go v0.9.1-0.20210125083013-7e3c8f831f07/go.mod h1:rEjRpcTler61qDnAawtjzAge65prXSLbUZyCcP6E2dw=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tinylib/msgp v1.1.5 h1:2gXmtWueD2HefZHQe1QOy9HVzmFrLOVvsXwXBQ0ayy0=


### PR DESCRIPTION
These changes allow adding test containers to networks and specifying their name via builder methods.  If a network is determined not to exist, it will be created beforehand.

Also bumps the testcontainers dep to the most recent psuedoversion since there have been unreleased fixes in these paths.