### PR TITLE
Smart Agent receiver: Postgresql integration test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,8 +65,8 @@ replace (
 	github.com/dancannon/gorethink => gopkg.in/gorethink/gorethink.v4 v4.0.0
 	github.com/influxdata/telegraf => github.com/signalfx/telegraf v0.10.2-0.20201211214327-200738592ced
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus v1.8.2-0.20201105135750-00f16d1ac3a4
-	github.com/signalfx/signalfx-agent => github.com/signalfx/signalfx-agent v1.0.1-0.20210114201625-befd9fc0070c
-	github.com/signalfx/signalfx-agent/pkg/apm => github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20210114201625-befd9fc0070c
-	github.com/soheilhy/cmux => github.com/signalfx/signalfx-agent/thirdparty/cmux v0.0.0-20210114201625-befd9fc0070c // required for smartagentreceiver to drop google.golang.org/grpc/examples/helloworld/helloworld test dep
+	github.com/signalfx/signalfx-agent => github.com/signalfx/signalfx-agent v1.0.1-0.20210216222257-73d8f0bb7fb6
+	github.com/signalfx/signalfx-agent/pkg/apm => github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20210216222257-73d8f0bb7fb6
+	github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.5-0.20210205191134-5ec6847320e5 // required for smartagentreceiver to drop google.golang.org/grpc/examples/helloworld/helloworld test dep
 	google.golang.org/grpc => google.golang.org/grpc v1.29.1 // required for smartagentreceiver's go.etcd.io/etcd dep
 )

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/securego/gosec/v2 v2.5.0
 	github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657
 	github.com/signalfx/golib/v3 v3.3.16
-	github.com/signalfx/signalfx-agent v0.0.0-00010101000000-000000000000
+	github.com/signalfx/signalfx-agent v1.0.1-0.20210218155823-9b6186460a32
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
@@ -65,8 +65,7 @@ replace (
 	github.com/dancannon/gorethink => gopkg.in/gorethink/gorethink.v4 v4.0.0
 	github.com/influxdata/telegraf => github.com/signalfx/telegraf v0.10.2-0.20201211214327-200738592ced
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus v1.8.2-0.20201105135750-00f16d1ac3a4
-	github.com/signalfx/signalfx-agent => github.com/signalfx/signalfx-agent v1.0.1-0.20210216222257-73d8f0bb7fb6
-	github.com/signalfx/signalfx-agent/pkg/apm => github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20210216222257-73d8f0bb7fb6
+	github.com/signalfx/signalfx-agent/pkg/apm => github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20210218155823-9b6186460a32
 	github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.5-0.20210205191134-5ec6847320e5 // required for smartagentreceiver to drop google.golang.org/grpc/examples/helloworld/helloworld test dep
 	google.golang.org/grpc => google.golang.org/grpc v1.29.1 // required for smartagentreceiver's go.etcd.io/etcd dep
 )

--- a/go.sum
+++ b/go.sum
@@ -1780,10 +1780,10 @@ github.com/signalfx/ondiskencoding v0.0.0-20191121154813-762ffb677f8e/go.mod h1:
 github.com/signalfx/sapm-proto v0.4.0/go.mod h1:x3gtwJ1GRejtkghB4nYpwixh2zqJrLbPU959ZNhM0Fk=
 github.com/signalfx/sapm-proto v0.6.2 h1:2LtB8AUGVyP5lSlsaBjFTsHfZNK/zn+jzWl1tWwniRA=
 github.com/signalfx/sapm-proto v0.6.2/go.mod h1:AHtWypa5paGVlvDjSZw9Bh5GLgS62ee2U0UcsrLlLhU=
-github.com/signalfx/signalfx-agent v1.0.1-0.20210216222257-73d8f0bb7fb6 h1:WaC68gTIl86ik57OU3bNvSExgwbe5lbAlYnoUzjRRvQ=
-github.com/signalfx/signalfx-agent v1.0.1-0.20210216222257-73d8f0bb7fb6/go.mod h1:QAlzDNY63Puk2rG5dTEOxzu4ZkAMfoLdElqxzWBir9o=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20210216222257-73d8f0bb7fb6 h1:iJzAZqVR8uTvDScbOd3tszoaEaTscEvQJH7HPYwltek=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20210216222257-73d8f0bb7fb6/go.mod h1:pNaqfprM2bSCBhE8sTT2NtasSWEsIJbrmnIF0ap/Cvg=
+github.com/signalfx/signalfx-agent v1.0.1-0.20210218155823-9b6186460a32 h1:grl/vtxBJV45QpA7xbwjMHl1MglTG9ikgDLgtaL5LEY=
+github.com/signalfx/signalfx-agent v1.0.1-0.20210218155823-9b6186460a32/go.mod h1:QAlzDNY63Puk2rG5dTEOxzu4ZkAMfoLdElqxzWBir9o=
+github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20210218155823-9b6186460a32 h1:sB9dzUPGfx5HT/LTTxOMbJG8NYAs9xBYOWgE1OPexxs=
+github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20210218155823-9b6186460a32/go.mod h1:pNaqfprM2bSCBhE8sTT2NtasSWEsIJbrmnIF0ap/Cvg=
 github.com/signalfx/signalfx-go v1.6.38-0.20200518153434-ceee8d2570d5 h1:+tu30Q5SkbYMBmI3sgDJTB9M1/Ga8z0V0LGDVY1D99g=
 github.com/signalfx/signalfx-go v1.6.38-0.20200518153434-ceee8d2570d5/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/signalfx-go-tracing v1.2.0/go.mod h1:JoTkkhSBe42ns9/AsvtqX7lLiiS6YwE0Q7J0DZFzt00=

--- a/go.sum
+++ b/go.sum
@@ -1780,12 +1780,10 @@ github.com/signalfx/ondiskencoding v0.0.0-20191121154813-762ffb677f8e/go.mod h1:
 github.com/signalfx/sapm-proto v0.4.0/go.mod h1:x3gtwJ1GRejtkghB4nYpwixh2zqJrLbPU959ZNhM0Fk=
 github.com/signalfx/sapm-proto v0.6.2 h1:2LtB8AUGVyP5lSlsaBjFTsHfZNK/zn+jzWl1tWwniRA=
 github.com/signalfx/sapm-proto v0.6.2/go.mod h1:AHtWypa5paGVlvDjSZw9Bh5GLgS62ee2U0UcsrLlLhU=
-github.com/signalfx/signalfx-agent v1.0.1-0.20210114201625-befd9fc0070c h1:7EIIFp0GcCDQ7zQhMUYfHh+1xgE9RiPTyCTypmtv9wg=
-github.com/signalfx/signalfx-agent v1.0.1-0.20210114201625-befd9fc0070c/go.mod h1:JuFbc2lNxCb/YvMKYCp+zeXqYO5ayPmgNLcc5sdtEac=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20210114201625-befd9fc0070c h1:G0s7DdEsGvK0yBbr+Cnp9Fqt/SnnC5uZIzXyWHYn72g=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20210114201625-befd9fc0070c/go.mod h1:pNaqfprM2bSCBhE8sTT2NtasSWEsIJbrmnIF0ap/Cvg=
-github.com/signalfx/signalfx-agent/thirdparty/cmux v0.0.0-20210114201625-befd9fc0070c h1:sNgKivDqmsCcIlsUPsOF0n8dSmp0XwAj8M9U9uqdvwE=
-github.com/signalfx/signalfx-agent/thirdparty/cmux v0.0.0-20210114201625-befd9fc0070c/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
+github.com/signalfx/signalfx-agent v1.0.1-0.20210216222257-73d8f0bb7fb6 h1:WaC68gTIl86ik57OU3bNvSExgwbe5lbAlYnoUzjRRvQ=
+github.com/signalfx/signalfx-agent v1.0.1-0.20210216222257-73d8f0bb7fb6/go.mod h1:QAlzDNY63Puk2rG5dTEOxzu4ZkAMfoLdElqxzWBir9o=
+github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20210216222257-73d8f0bb7fb6 h1:iJzAZqVR8uTvDScbOd3tszoaEaTscEvQJH7HPYwltek=
+github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20210216222257-73d8f0bb7fb6/go.mod h1:pNaqfprM2bSCBhE8sTT2NtasSWEsIJbrmnIF0ap/Cvg=
 github.com/signalfx/signalfx-go v1.6.38-0.20200518153434-ceee8d2570d5 h1:+tu30Q5SkbYMBmI3sgDJTB9M1/Ga8z0V0LGDVY1D99g=
 github.com/signalfx/signalfx-go v1.6.38-0.20200518153434-ceee8d2570d5/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
 github.com/signalfx/signalfx-go-tracing v1.2.0/go.mod h1:JoTkkhSBe42ns9/AsvtqX7lLiiS6YwE0Q7J0DZFzt00=
@@ -1815,6 +1813,8 @@ github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIK
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/softlayer/softlayer-go v0.0.0-20180806151055-260589d94c7d h1:bVQRCxQvfjNUeRqaY/uT0tFuvuFY0ulgnczuR684Xic=
 github.com/softlayer/softlayer-go v0.0.0-20180806151055-260589d94c7d/go.mod h1:Cw4GTlQccdRGSEf6KiMju767x0NEHE0YIVPJSaXjlsw=
+github.com/soheilhy/cmux v0.1.5-0.20210205191134-5ec6847320e5 h1:GJTW+uNMIV1RKwox+T4aN0/sQlYRg78uHZf2H0aBcDw=
+github.com/soheilhy/cmux v0.1.5-0.20210205191134-5ec6847320e5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/sonatard/noctx v0.0.1 h1:VC1Qhl6Oxx9vvWo3UDgrGXYCeKCe3Wbw7qAWL6FrmTY=
 github.com/sonatard/noctx v0.0.1/go.mod h1:9D2D/EoULe8Yy2joDHJj7bv3sZoq9AaSb8B4lqBjiZI=
 github.com/soniah/gosnmp v0.0.0-20190220004421-68e8beac0db9 h1:O4jq14rgUwG9Ssn0wZiRPl8Ya6q3a1h3xJzTAsBaRgo=

--- a/tests/receivers/smartagent/postgresql/postgresql_test.go
+++ b/tests/receivers/smartagent/postgresql/postgresql_test.go
@@ -1,0 +1,131 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/signalfx/splunk-otel-collector/tests/testutils"
+)
+
+func TestPostgresReceiverProvidesAllMetrics(t *testing.T) {
+	tc := newTestcase(t)
+	defer tc.printLogsOnFailure()
+	defer func() { require.NoError(t, tc.otlp.Shutdown()) }()
+
+	expectedResourceMetrics := tc.resourceMetrics("all.yaml")
+
+	server, client := tc.postgresContainers()
+	defer func() {
+		require.NoError(t, server.Stop(context.Background()))
+		require.NoError(t, client.Stop(context.Background()))
+	}()
+
+	collector := tc.splunkOtelCollector("all_metrics_config.yaml")
+	defer func() { require.NoError(tc, collector.Shutdown()) }()
+
+	require.NoError(t, tc.otlp.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
+}
+
+// While overkill for these test purposes, as a repeated pattern these should eventually be moved to testutils.
+type testcase struct {
+	*testing.T
+	logger       *zap.Logger
+	observedLogs *observer.ObservedLogs
+	otlp         *testutils.OTLPMetricsReceiverSink
+}
+
+func newTestcase(t *testing.T) *testcase {
+	tc := testcase{T: t}
+	var logCore zapcore.Core
+	logCore, tc.observedLogs = observer.New(zap.DebugLevel)
+	tc.logger = zap.New(logCore)
+
+	var err error
+	tc.otlp, err = testutils.NewOTLPMetricsReceiverSink().WithEndpoint("localhost:23456").WithLogger(tc.logger).Build()
+	require.NoError(tc, err)
+	require.NoError(tc, tc.otlp.Start())
+	return &tc
+}
+
+func (t *testcase) resourceMetrics(filename string) *testutils.ResourceMetrics {
+	expectedResourceMetrics, err := testutils.LoadResourceMetrics(
+		path.Join(".", "testdata", "resource_metrics", filename),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, expectedResourceMetrics)
+	return expectedResourceMetrics
+}
+
+func (t *testcase) postgresContainers() (server, client *testutils.Container) {
+	server = testutils.NewContainer().WithContext(
+		path.Join(".", "testdata", "server"),
+	).WithEnv(map[string]string{
+		"POSTGRES_DB":       "test_db",
+		"POSTGRES_USER":     "postgres",
+		"POSTGRES_PASSWORD": "postgres",
+	}).WithExposedPorts(
+		"5432:5432",
+	).WithName("postgres-server").WithNetworks(
+		"postgres",
+	).WillWaitForPorts("5432").WillWaitForLogs(
+		"database system is ready to accept connections",
+	).Build()
+
+	require.NoError(t, server.Start(context.Background()))
+
+	client = testutils.NewContainer().WithContext(
+		path.Join(".", "testdata", "client"),
+	).WithEnv(map[string]string{
+		"POSTGRES_SERVER": "postgres-server",
+	}).WithName("postgres-client").WithNetworks(
+		"postgres",
+	).WillWaitForLogs("Beginning psql requests").Build()
+
+	require.NoError(t, client.Start(context.Background()))
+
+	return server, client
+}
+
+func (t *testcase) splunkOtelCollector(configFilename string) *testutils.CollectorProcess {
+	collector, err := testutils.NewCollectorProcess().WithConfigPath(
+		path.Join(".", "testdata", configFilename),
+	).WithLogLevel("debug").WithLogger(t.logger).Build()
+
+	require.NoError(t, err)
+	require.NotNil(t, collector)
+	require.NoError(t, collector.Start())
+	return collector
+}
+
+func (t *testcase) printLogsOnFailure() {
+	if !t.Failed() {
+		return
+	}
+	fmt.Printf("Logs: \n")
+	for _, statement := range t.observedLogs.All() {
+		fmt.Printf("%v\n", statement)
+	}
+}
+

--- a/tests/receivers/smartagent/postgresql/testdata/all_metrics_config.yaml
+++ b/tests/receivers/smartagent/postgresql/testdata/all_metrics_config.yaml
@@ -1,0 +1,28 @@
+receivers:
+  smartagent/postgresql:
+    type: postgresql
+    host: localhost
+    port: 5432
+    connectionString: 'sslmode=disable user={{.username}} password={{.password}}'
+    params:
+      username: test_user
+      password: test_password
+    masterDBName: test_db
+    intervalSeconds: 1
+
+exporters:
+  otlp:
+    endpoint: localhost:23456
+    insecure: true
+
+  logging:
+    loglevel: debug
+    sampling_initial: 1
+    sampling_thereafter: 10
+
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - smartagent/postgresql
+      exporters: [otlp, logging]

--- a/tests/receivers/smartagent/postgresql/testdata/client/Dockerfile
+++ b/tests/receivers/smartagent/postgresql/testdata/client/Dockerfile
@@ -1,0 +1,6 @@
+ARG POSTGRES_VERSION=13-alpine
+FROM postgres:${POSTGRES_VERSION}
+
+COPY requests.sh /usr/local/bin/requests.sh
+
+CMD ["requests.sh"]

--- a/tests/receivers/smartagent/postgresql/testdata/client/requests.sh
+++ b/tests/receivers/smartagent/postgresql/testdata/client/requests.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+##################################################################################################
+# This file will exercise a target POSTGRES_SERVER's test_db whose schema is defined in the
+# corresponding server's initdb.d/db.sql.  It will create the necessary replication slots and make
+# a series of random insertions, updates, and deletions without end to help generate values for
+# produced metrics.
+# As implemented, test_db size will grow without bound if left is running, so this script isn't
+# currently suitable for extended demonstrations or soak test purposes.
+##################################################################################################
 
 echopsql() {
   set -x
@@ -25,7 +33,6 @@ random_float() {
 }
 
 modify_table_one() {
-x=1
 while true; do
   sleep .15
   s_one=$(random_str)
@@ -45,7 +52,6 @@ done
 }
 
 modify_table_two() {
-x=1
 while true; do
   sleep .15
   i_one=$(random_int)
@@ -68,7 +74,7 @@ while true; do
 done
 }
 
-# create replication slots for postgres_replication_state metric
+# create replication slots for postgres_replication_state metrics
 echopsql -c "SELECT * FROM pg_create_physical_replication_slot('some_physical_replication_slot');"
 echopsql -c "SELECT * FROM pg_create_logical_replication_slot('some_logical_replication_slot', 'test_decoding');"
 

--- a/tests/receivers/smartagent/postgresql/testdata/client/requests.sh
+++ b/tests/receivers/smartagent/postgresql/testdata/client/requests.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+echopsql() {
+  set -x
+  psql postgresql://test_user:test_password@${POSTGRES_SERVER:-localhost}:5432/test_db "$@"
+  { set +x; } 2>/dev/null
+}
+
+random_str() {
+  tr -dc A-Za-z0-9 </dev/urandom | head -c 16
+}
+
+r_int() {
+  tr -dc 0-9 </dev/urandom | head -c $1
+}
+
+random_int() {
+  r_int 7
+}
+
+random_float() {
+  a=$(r_int 7)
+  b=$(r_int 3)
+  echo "$a.$b"
+}
+
+modify_table_one() {
+x=1
+while true; do
+  sleep .15
+  s_one=$(random_str)
+  s_two=$(random_str)
+  echopsql -c "insert into test_schema.table_one values ( '$s_one', '$s_two', now(), now() );"
+  s_three=$(random_str)
+  echopsql -c "insert into test_schema.table_one values ( '$s_two', '$s_three', now(), now() );"
+  s_four=$(random_str)
+  echopsql -c "insert into test_schema.table_one values ( '$s_three', '$s_four', now(), now() );"
+
+  echopsql -c "select * from test_schema.table_one where string_one='$s_one';"
+  echopsql -c "select timestamp_one from test_schema.table_one where string_two='$s_two';"
+
+  echopsql -c "update test_schema.table_one set string_one='$s_four' where string_one='$s_three'"
+  echopsql -c "delete from test_schema.table_one where string_one='$s_four';"
+done
+}
+
+modify_table_two() {
+x=1
+while true; do
+  sleep .15
+  i_one=$(random_int)
+  i_two=$(random_int)
+  f_one=$(random_float)
+  f_two=$(random_float)
+  echopsql -c "insert into test_schema.table_two values ( $i_one, $i_two, $f_one, $f_two );"
+  i_three=$(random_int)
+  f_three=$(random_float)
+  echopsql -c "insert into test_schema.table_two values ( $i_two, $i_three, $f_two, $f_three );"
+  i_four=$(random_int)
+  f_four=$(random_float)
+  echopsql -c "insert into test_schema.table_two values ( $i_three, $i_four, $f_three, $f_four );"
+
+  echopsql -c "select * from test_schema.table_two where int_one=$i_one;"
+  echopsql -c "select float_one from test_schema.table_two where int_two=$i_two;"
+
+  echopsql -c "update test_schema.table_two set int_one=$i_four where int_one=$i_three"
+  echopsql -c "delete from test_schema.table_two where int_one=$i_four;"
+done
+}
+
+# create replication slots for postgres_replication_state metric
+echopsql -c "SELECT * FROM pg_create_physical_replication_slot('some_physical_replication_slot');"
+echopsql -c "SELECT * FROM pg_create_logical_replication_slot('some_logical_replication_slot', 'test_decoding');"
+
+echo "Beginning psql requests"
+modify_table_one &
+modify_table_two

--- a/tests/receivers/smartagent/postgresql/testdata/resource_metrics/all.yaml
+++ b/tests/receivers/smartagent/postgresql/testdata/resource_metrics/all.yaml
@@ -1,0 +1,358 @@
+resource_metrics:
+  - instrumentation_library_metrics:
+      - metrics:
+          - name: postgres_query_count
+            labels:
+              database: postgres
+              postgres_port: "5432"
+              user: postgres
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_query_count
+            labels:
+              database: postgres
+              postgres_port: "5432"
+              user: test_user
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_query_count
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              user: postgres
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_query_count
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              user: test_user
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_query_time
+            labels:
+              database: postgres
+              postgres_port: "5432"
+              user: postgres
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_query_time
+            labels:
+              database: postgres
+              postgres_port: "5432"
+              user: test_user
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_query_time
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              user: postgres
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_query_time
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              user: test_user
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_block_hit_ratio
+            labels:
+              database: test_db
+              index: table_two_pkey
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_two
+              type: user
+            type: DoubleGauge
+          - name: postgres_block_hit_ratio
+            labels:
+              database: test_db
+              postgres_port: "5432"
+            type: DoubleGauge
+          - name: postgres_block_hit_ratio
+            labels:
+              database: postgres
+              postgres_port: "5432"
+            type: DoubleGauge
+          - name: postgres_deadlocks
+            labels:
+              database: test_db
+              postgres_port: "5432"
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_locks
+            labels:
+              postgres_port: "5432"
+            type: DoubleGauge
+          - name: postgres_sessions
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              state: idle
+            type: DoubleGauge
+          - name: postgres_pct_connections
+            labels:
+              postgres_port: "5432"
+            type: DoubleGauge
+          - name: postgres_sessions
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              state: active
+            type: DoubleGauge
+          - name: postgres_deadlocks
+            labels:
+              database: postgres
+              postgres_port: "5432"
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_database_size
+            labels:
+              database: postgres
+              postgres_port: "5432"
+            type: DoubleGauge
+          - name: postgres_conflicts
+            labels:
+              database: template0
+              postgres_port: "5432"
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_xact_commits
+            labels:
+              database: template0
+              postgres_port: "5432"
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_xact_rollbacks
+            labels:
+              database: template0
+              postgres_port: "5432"
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_conflicts
+            labels:
+              database: template1
+              postgres_port: "5432"
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_xact_commits
+            labels:
+              database: template1
+              postgres_port: "5432"
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_xact_rollbacks
+            labels:
+              database: template1
+              postgres_port: "5432"
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_conflicts
+            labels:
+              database: test_db
+              postgres_port: "5432"
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_xact_commits
+            labels:
+              database: test_db
+              postgres_port: "5432"
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_xact_rollbacks
+            labels:
+              database: test_db
+              postgres_port: "5432"
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_conflicts
+            labels:
+              database: postgres
+              postgres_port: "5432"
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_xact_commits
+            labels:
+              database: postgres
+              postgres_port: "5432"
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_xact_rollbacks
+            labels:
+              database: postgres
+              postgres_port: "5432"
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_database_size
+            labels:
+              database: test_db
+              postgres_port: "5432"
+            type: DoubleGauge
+          - name: postgres_block_hit_ratio
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_one
+              type: user
+            type: DoubleGauge
+          - name: postgres_block_hit_ratio
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_two
+              type: user
+            type: DoubleGauge
+          - name: postgres_block_hit_ratio
+            labels:
+              database: test_db
+              index: table_one_pkey
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_one
+              type: user
+            type: DoubleGauge
+          - name: postgres_rows_inserted
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_two
+              tablespace: ""
+              type: user
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_rows_updated
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_two
+              tablespace: ""
+              type: user
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_rows_deleted
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_two
+              tablespace: ""
+              type: user
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_sequential_scans
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_two
+              tablespace: ""
+              type: user
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_index_scans
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_two
+              tablespace: ""
+              type: user
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_table_size
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_two
+              tablespace: ""
+              type: user
+            type: DoubleGauge
+          - name: postgres_live_rows
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_two
+              tablespace: ""
+              type: user
+            type: DoubleGauge
+          - name: postgres_live_rows
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_one
+              tablespace: ""
+              type: user
+            type: DoubleGauge
+          - name: postgres_rows_inserted
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_one
+              tablespace: ""
+              type: user
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_rows_updated
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_one
+              tablespace: ""
+              type: user
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_rows_deleted
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_one
+              tablespace: ""
+              type: user
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_sequential_scans
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_one
+              tablespace: ""
+              type: user
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_index_scans
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_one
+              tablespace: ""
+              type: user
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_table_size
+            labels:
+              database: test_db
+              postgres_port: "5432"
+              schemaname: test_schema
+              table: table_one
+              tablespace: ""
+              type: user
+            type: DoubleGauge
+          - name: postgres_sessions
+            labels:
+              database: postgres
+              postgres_port: "5432"
+              state: idle
+            type: DoubleGauge
+          - name: postgres_queries_average_time
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_queries_average_time
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_queries_calls
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_queries_calls
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_queries_total_time
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_queries_total_time
+            type: DoubleMonotonicCumulativeSum
+          - name: postgres_replication_lag
+            labels:
+              postgres_port: "5432"
+              replication_role: master
+            type: DoubleGauge
+          - name: postgres_replication_state
+            labels:
+              slot_name: some_physical_replication_slot
+              slot_type: physical
+              database:
+              postgres_port: "5432"
+            type: DoubleGauge
+          - name: postgres_replication_state
+            labels:
+              slot_name: some_logical_replication_slot
+              slot_type: logical
+              database: test_db
+              postgres_port: "5432"
+            type: DoubleGauge

--- a/tests/receivers/smartagent/postgresql/testdata/server/Dockerfile
+++ b/tests/receivers/smartagent/postgresql/testdata/server/Dockerfile
@@ -1,0 +1,10 @@
+ARG POSTGRES_VERSION=13-alpine
+FROM postgres:${POSTGRES_VERSION}
+
+COPY initdb.d /docker-entrypoint-initdb.d
+COPY init.sh /docker-entrypoint-initdb.d/
+
+CMD ["postgres", \
+"-c", "shared_preload_libraries=pg_stat_statements", \
+"-c", "wal_level=logical", \
+"-c", "max_replication_slots=2"]

--- a/tests/receivers/smartagent/postgresql/testdata/server/init.sh
+++ b/tests/receivers/smartagent/postgresql/testdata/server/init.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+##################################################################################################
+# This file will enable the required pg_stat_statements extension for a database named test_db to
+# allow the postgresql monitor queries to return valid results to generate metrics.  Any desired
+# functionality that should occur on server startup should be added here. It is intended to run at
+# server startup or via the postgresql container's docker-entrypoint-initdb.d autorun
+# functionality.  It does not create the test_db database and requires that to have been created
+# earlier (e.g. by the container's POSTGRES_DB env var).
+##################################################################################################
 set -euo pipefail
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "test_db" -c "CREATE EXTENSION pg_stat_statements;"

--- a/tests/receivers/smartagent/postgresql/testdata/server/init.sh
+++ b/tests/receivers/smartagent/postgresql/testdata/server/init.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "test_db" -c "CREATE EXTENSION pg_stat_statements;"

--- a/tests/receivers/smartagent/postgresql/testdata/server/initdb.d/db.sql
+++ b/tests/receivers/smartagent/postgresql/testdata/server/initdb.d/db.sql
@@ -1,3 +1,8 @@
+-- This sql script is intended to be run via initdb or with the postgres container's
+-- docker-entrypoint-initdb.d autorun functionality.  It will creeate the test schema
+-- and test user to be exercised by the corresponding pg client's requests script to
+-- assist in the postgresql monitor in generating metrics.
+
 drop schema if exists test_schema cascade;
 create schema test_schema;
 set schema 'test_schema';

--- a/tests/receivers/smartagent/postgresql/testdata/server/initdb.d/db.sql
+++ b/tests/receivers/smartagent/postgresql/testdata/server/initdb.d/db.sql
@@ -1,0 +1,25 @@
+drop schema if exists test_schema cascade;
+create schema test_schema;
+set schema 'test_schema';
+
+drop table if exists table_one;
+create table table_one (
+    string_one varchar(64) primary key,
+    string_two varchar(64),
+    timestamp_one timestamp not null,
+    timestamp_two timestamp
+);
+
+drop table if exists table_two;
+create table table_two (
+    int_one integer primary key,
+    int_two integer,
+    float_one decimal(11,4) not null,
+    float_two decimal(11,4)
+);
+
+drop role if exists test_user;
+create role test_user with login password 'test_password';
+
+alter user test_user with superuser;
+grant pg_read_all_settings to test_user;


### PR DESCRIPTION
These changes introduce the first integration test case for the tests module, and exercises the [native postgresql monitor](https://github.com/signalfx/signalfx-agent/blob/master/docs/monitors/postgresql.md).  Since output filtering is yet to be implemented it confirms that all metrics are received, though in the near future more restricted configs/tests could be added (@pmcollins).

requires: https://github.com/signalfx/splunk-otel-collector/pull/103 and https://github.com/signalfx/signalfx-agent/pull/1607

I will update the desired agent version once the PG13 support fix lands.