### PR TITLE
Add smartagent extension

### DIFF
--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -58,6 +58,7 @@ import (
 	"go.opentelemetry.io/collector/receiver/prometheusreceiver"
 	"go.opentelemetry.io/collector/receiver/zipkinreceiver"
 
+	"github.com/signalfx/splunk-otel-collector/internal/extension/smartagentextension"
 	"github.com/signalfx/splunk-otel-collector/internal/receiver/smartagentreceiver"
 )
 
@@ -69,6 +70,7 @@ func Get() (component.Factories, error) {
 		httpforwarder.NewFactory(),
 		k8sobserver.NewFactory(),
 		pprofextension.NewFactory(),
+		smartagentextension.NewFactory(),
 		zpagesextension.NewFactory(),
 	)
 	if err != nil {

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -31,6 +31,7 @@ func TestDefaultComponents(t *testing.T) {
 		"host_observer",
 		"k8s_observer",
 		"http_forwarder",
+		"smartagent",
 	}
 	expectedReceivers := []configmodels.Type{
 		"jaeger",

--- a/internal/extension/smartagentextension/README.md
+++ b/internal/extension/smartagentextension/README.md
@@ -1,0 +1,24 @@
+# SignalFx Smart Agent Extension
+
+The `smartagent` extension provides a mechanism to specify config options that are not
+just specific to a single instance of the `smartagent` receiver but are applicable to
+all instances of the `smartagent` receiver.
+
+To begin with, this extension will provide a mechanism to specify config options to configure
+collectd. These options are mapped to the [collectd config options](https://docs.signalfx.com/en/latest/integrations/agent/config-schema.html#collectd)
+in the SignalFx Agent. Note that if this extension is not configured, the defaults in `smartagent`
+receiver will be used.
+
+In the below example configuration, `config_dir` and `bundle_dir` will be used for all instances
+of the `smartagent` receiver that wrap around a collectd based monitor.
+
+```yaml
+extensions:
+  smartagent:
+    collectd:
+      config_dir: /etc/collectd/collectd.conf
+      bundle_dir: /opt/bin/collectd/
+```
+
+The full list of settings exposed for this receiver are documented [here](./config.go)
+with detailed sample configurations [here](./testdata/config.yaml).

--- a/internal/extension/smartagentextension/README.md
+++ b/internal/extension/smartagentextension/README.md
@@ -15,7 +15,7 @@ of the `smartagent` receiver that wrap around a collectd based monitor.
 ```yaml
 extensions:
   smartagent:
-  bundleDir: /opt/bin/collectd/
+    bundleDir: /bundle/
     collectd:
       configDir: /etc/collectd/collectd.conf
 ```

--- a/internal/extension/smartagentextension/README.md
+++ b/internal/extension/smartagentextension/README.md
@@ -1,7 +1,7 @@
 # SignalFx Smart Agent Extension
 
 The `smartagent` extension provides a mechanism to specify config options that are not
-just specific to a single instance of the `smartagent` receiver but are applicable to
+just specific to a single instance of the [`smartagent` receiver](../../receiver/smartagentreceiver/README.md) but are applicable to
 all instances of the `smartagent` receiver.
 
 To begin with, this extension will provide a mechanism to specify config options to configure

--- a/internal/extension/smartagentextension/README.md
+++ b/internal/extension/smartagentextension/README.md
@@ -15,9 +15,9 @@ of the `smartagent` receiver that wrap around a collectd based monitor.
 ```yaml
 extensions:
   smartagent:
+  bundleDir: /opt/bin/collectd/
     collectd:
-      config_dir: /etc/collectd/collectd.conf
-      bundle_dir: /opt/bin/collectd/
+      configDir: /etc/collectd/collectd.conf
 ```
 
 The full list of settings exposed for this receiver are documented [here](./config.go)

--- a/internal/extension/smartagentextension/README.md
+++ b/internal/extension/smartagentextension/README.md
@@ -9,7 +9,7 @@ collectd. These options are mapped to the [collectd config options](https://docs
 in the SignalFx Agent. Note that if this extension is not configured, the defaults in `smartagent`
 receiver will be used.
 
-In the below example configuration, `config_dir` and `bundle_dir` will be used for all instances
+In the below example configuration, `configDir` and `bundleDir` will be used for all instances
 of the `smartagent` receiver that wrap around a collectd based monitor.
 
 ```yaml
@@ -17,7 +17,7 @@ extensions:
   smartagent:
     bundleDir: /bundle/
     collectd:
-      configDir: /etc/collectd/collectd.conf
+      configDir: /etc/collectd/
 ```
 
 The full list of settings exposed for this receiver are documented [here](./config.go)

--- a/internal/extension/smartagentextension/config.go
+++ b/internal/extension/smartagentextension/config.go
@@ -27,9 +27,8 @@ import (
 )
 
 // SmartAgentConfigProvider exposes config fields to other packages.
-// This is needed since fields such as fields such as bundleDir and
-// collectdConfig are mapped to camel case fields in the config and
-// hence are not exposed.
+// This is needed since fields such  as bundleDir and collectdConfig
+// are mapped to camel case fields in the config and hence are not exposed.
 type SmartAgentConfigProvider interface {
 	BundleDir() string
 	CollectdConfig() config.CollectdConfig

--- a/internal/extension/smartagentextension/config.go
+++ b/internal/extension/smartagentextension/config.go
@@ -53,13 +53,13 @@ type CollectdConfig struct {
 	// Collectd's log level -- info, notice, warning, or err
 	LogLevel string `mapstructure:"logLevel"`
 	// A default read interval for collectd plugins.  If zero or undefined,
-	// will default to the global agent interval.  Some collectd python
-	// monitors do not support overridding the interval at the monitor level,
-	// but this setting will apply to them.
+	// will default to 10 seconds. Some collectd python monitors do not
+	// support overridding the interval at the monitor level, but this
+	// setting will apply to them.
 	IntervalSeconds int `mapstructure:"intervalSeconds"`
 	// The local IP address of the server that the agent exposes to which
-	// collectd will send metrics.  This defaults to an arbitrary address in
-	// the localhost subnet, but can be overridden if needed.
+	// collectd will send metrics.  This defaults to 127.9.8.7, but can be
+	// overridden if needed.
 	WriteServerIPAddr string `mapstructure:"writeServerIPAddr"`
 	// The port of the agent's collectd metric sink server.  If set to zero
 	// (the default) it will allow the OS to assign it a free port.

--- a/internal/extension/smartagentextension/config.go
+++ b/internal/extension/smartagentextension/config.go
@@ -20,10 +20,11 @@ import (
 
 type Config struct {
 	configmodels.ExtensionSettings `mapstructure:",squash"`
+	BundleDir                      string         `mapstructure:"bundleDir"`
 	CollectdConfig                 CollectdConfig `mapstructure:"collectd"`
 }
 
-// Fields on this struct have a direct mapping to fields on
+// CollectdConfig fields have a direct mapping to fields on
 // collect.CollectdConfig in the SignalFx Agent.
 // https://github.com/signalfx/signalfx-agent/blob/v5.7.2/pkg/core/config/config.go#L342
 type CollectdConfig struct {
@@ -33,42 +34,40 @@ type CollectdConfig struct {
 	Timeout int `mapstructure:"timeout"`
 	// Number of threads dedicated to executing read callbacks. See
 	// [ReadThreads](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#readthreads_num)
-	ReadThreads int `mapstructure:"read_threads"`
+	ReadThreads int `mapstructure:"readThreads"`
 	// Number of threads dedicated to writing value lists to write callbacks.
 	// This should be much less than readThreads because writing is batched in
 	// the write_http plugin that writes back to the agent.
 	// See [WriteThreads](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#writethreads_num).
-	WriteThreads int `mapstructure:"write_threads"`
+	WriteThreads int `mapstructure:"writeThreads"`
 	// The maximum numbers of values in the queue to be written back to the
 	// agent from collectd.  Since the values are written to a local socket
 	// that the agent exposes, there should be almost no queuing and the
 	// default should be more than sufficient. See
 	// [WriteQueueLimitHigh](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#writequeuelimithigh_highnum)
-	WriteQueueLimitHigh int `mapstructure:"write_queue_limit_high"`
+	WriteQueueLimitHigh int `mapstructure:"writeQueueLimitHigh"`
 	// The lowest number of values in the collectd queue before which metrics
 	// begin being randomly dropped.  See
 	// [WriteQueueLimitLow](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#writequeuelimitlow_lownum)
-	WriteQueueLimitLow int `mapstructure:"write_queue_limit_low"`
+	WriteQueueLimitLow int `mapstructure:"writeQueueLimitLow"`
 	// Collectd's log level -- info, notice, warning, or err
-	LogLevel string `mapstructure:"log_level"`
+	LogLevel string `mapstructure:"logLevel"`
 	// A default read interval for collectd plugins.  If zero or undefined,
 	// will default to the global agent interval.  Some collectd python
 	// monitors do not support overridding the interval at the monitor level,
 	// but this setting will apply to them.
-	IntervalSeconds int `mapstructure:"interval_seconds"`
+	IntervalSeconds int `mapstructure:"intervalSeconds"`
 	// The local IP address of the server that the agent exposes to which
 	// collectd will send metrics.  This defaults to an arbitrary address in
 	// the localhost subnet, but can be overridden if needed.
-	WriteServerIPAddr string `mapstructure:"write_server_ip"`
+	WriteServerIPAddr string `mapstructure:"writeServerIPAddr"`
 	// The port of the agent's collectd metric sink server.  If set to zero
 	// (the default) it will allow the OS to assign it a free port.
-	WriteServerPort uint16 `mapstructure:"write_server_port"`
+	WriteServerPort uint16 `mapstructure:"writeServerPort"`
 	// This is where the agent will write the collectd collect files that it
 	// manages.  If you have secrets in those files, consider setting this to a
 	// path on a tmpfs mount.  The files in this directory should be considered
 	// transient -- there is no value in editing them by hand.  If you want to
 	// add your own collectd collect, see the collectd/custom monitor.
-	ConfigDir string `mapstructure:"config_dir"`
-	// The following are propagated from the top-level collect
-	BundleDir string `mapstructure:"bundle_dir"`
+	ConfigDir string `mapstructure:"configDir"`
 }

--- a/internal/extension/smartagentextension/config.go
+++ b/internal/extension/smartagentextension/config.go
@@ -97,7 +97,6 @@ func customUnmarshaller(componentViperSection *viper.Viper, intoCfg interface{})
 	return nil
 }
 
-// Copied from smartagent receiver.
 func yamlTagsFromStruct(s reflect.Type) map[string]string {
 	yamlTags := map[string]string{}
 	for i := 0; i < s.NumField(); i++ {
@@ -107,14 +106,6 @@ func yamlTagsFromStruct(s reflect.Type) map[string]string {
 		lowerTag := strings.ToLower(yamlTag)
 		if yamlTag != lowerTag {
 			yamlTags[lowerTag] = yamlTag
-		}
-
-		fieldType := field.Type
-		if fieldType.Kind() == reflect.Struct {
-			otherFields := yamlTagsFromStruct(fieldType)
-			for k, v := range otherFields {
-				yamlTags[k] = v
-			}
 		}
 	}
 

--- a/internal/extension/smartagentextension/config.go
+++ b/internal/extension/smartagentextension/config.go
@@ -1,0 +1,74 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smartagentextension
+
+import (
+	"go.opentelemetry.io/collector/config/configmodels"
+)
+
+type Config struct {
+	configmodels.ExtensionSettings `mapstructure:",squash"`
+	CollectdConfig                 CollectdConfig `mapstructure:"collectd"`
+}
+
+// Fields on this struct have a direct mapping to fields on
+// collect.CollectdConfig in the SignalFx Agent.
+// https://github.com/signalfx/signalfx-agent/blob/v5.7.2/pkg/core/config/config.go#L342
+type CollectdConfig struct {
+	// How many read intervals before abandoning a metric. Doesn't affect much
+	// in normal usage.
+	// See [Timeout](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#timeout_iterations).
+	Timeout int `mapstructure:"timeout"`
+	// Number of threads dedicated to executing read callbacks. See
+	// [ReadThreads](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#readthreads_num)
+	ReadThreads int `mapstructure:"read_threads"`
+	// Number of threads dedicated to writing value lists to write callbacks.
+	// This should be much less than readThreads because writing is batched in
+	// the write_http plugin that writes back to the agent.
+	// See [WriteThreads](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#writethreads_num).
+	WriteThreads int `mapstructure:"write_threads"`
+	// The maximum numbers of values in the queue to be written back to the
+	// agent from collectd.  Since the values are written to a local socket
+	// that the agent exposes, there should be almost no queuing and the
+	// default should be more than sufficient. See
+	// [WriteQueueLimitHigh](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#writequeuelimithigh_highnum)
+	WriteQueueLimitHigh int `mapstructure:"write_queue_limit_high"`
+	// The lowest number of values in the collectd queue before which metrics
+	// begin being randomly dropped.  See
+	// [WriteQueueLimitLow](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#writequeuelimitlow_lownum)
+	WriteQueueLimitLow int `mapstructure:"write_queue_limit_low"`
+	// Collectd's log level -- info, notice, warning, or err
+	LogLevel string `mapstructure:"log_level"`
+	// A default read interval for collectd plugins.  If zero or undefined,
+	// will default to the global agent interval.  Some collectd python
+	// monitors do not support overridding the interval at the monitor level,
+	// but this setting will apply to them.
+	IntervalSeconds int `mapstructure:"interval_seconds"`
+	// The local IP address of the server that the agent exposes to which
+	// collectd will send metrics.  This defaults to an arbitrary address in
+	// the localhost subnet, but can be overridden if needed.
+	WriteServerIPAddr string `mapstructure:"write_server_ip"`
+	// The port of the agent's collectd metric sink server.  If set to zero
+	// (the default) it will allow the OS to assign it a free port.
+	WriteServerPort uint16 `mapstructure:"write_server_port"`
+	// This is where the agent will write the collectd collect files that it
+	// manages.  If you have secrets in those files, consider setting this to a
+	// path on a tmpfs mount.  The files in this directory should be considered
+	// transient -- there is no value in editing them by hand.  If you want to
+	// add your own collectd collect, see the collectd/custom monitor.
+	ConfigDir string `mapstructure:"config_dir"`
+	// The following are propagated from the top-level collect
+	BundleDir string `mapstructure:"bundle_dir"`
+}

--- a/internal/extension/smartagentextension/config_test.go
+++ b/internal/extension/smartagentextension/config_test.go
@@ -58,7 +58,7 @@ func TestLoadConfig(t *testing.T) {
 				WriteQueueLimitHigh: 500000,
 				WriteQueueLimitLow:  400000,
 				LogLevel:            "notice",
-				IntervalSeconds:     0,
+				IntervalSeconds:     10,
 				WriteServerIPAddr:   "127.9.8.7",
 				WriteServerPort:     0,
 				ConfigDir:           "/var/run/signalfx-agent/collectd",

--- a/internal/extension/smartagentextension/config_test.go
+++ b/internal/extension/smartagentextension/config_test.go
@@ -50,6 +50,7 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "smartagent",
 				NameVal: "smartagent/default_settings",
 			},
+			BundleDir:           os.Getenv(constants.BundleDirEnvVar),
 			CollectdConfig: CollectdConfig{
 				Timeout:             40,
 				ReadThreads:         5,
@@ -61,7 +62,6 @@ func TestLoadConfig(t *testing.T) {
 				WriteServerIPAddr:   "127.9.8.7",
 				WriteServerPort:     0,
 				ConfigDir:           "/var/run/signalfx-agent/collectd",
-				BundleDir:           os.Getenv(constants.BundleDirEnvVar),
 			},
 		}
 	}(), emptyConfig)
@@ -74,6 +74,7 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "smartagent",
 				NameVal: "smartagent/all_settings",
 			},
+			BundleDir:           "/opt/bin/collectd/",
 			CollectdConfig: CollectdConfig{
 				Timeout:             10,
 				ReadThreads:         1,
@@ -85,7 +86,6 @@ func TestLoadConfig(t *testing.T) {
 				WriteServerIPAddr:   "10.100.12.1",
 				WriteServerPort:     9090,
 				ConfigDir:           "/etc/collectd/collectd.conf",
-				BundleDir:           "/opt/bin/collectd/",
 			},
 		}
 	}(), allSettingsConfig)

--- a/internal/extension/smartagentextension/config_test.go
+++ b/internal/extension/smartagentextension/config_test.go
@@ -1,0 +1,92 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smartagentextension
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configtest"
+)
+
+func TestLoadConfig(t *testing.T) {
+	factories, err := componenttest.ExampleComponents()
+	assert.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Extensions[typeStr] = factory
+	cfg, err := configtest.LoadConfigFile(
+		t, path.Join(".", "testdata", "config.yaml"), factories,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, len(cfg.Extensions), 2)
+
+	emptyConfig := cfg.Extensions["smartagent/default_settings"]
+	require.NotNil(t, emptyConfig)
+	require.Equal(t, func() *Config {
+		return &Config{
+			ExtensionSettings: configmodels.ExtensionSettings{
+				TypeVal: "smartagent",
+				NameVal: "smartagent/default_settings",
+			},
+			CollectdConfig: CollectdConfig{
+				Timeout:             40,
+				ReadThreads:         5,
+				WriteThreads:        2,
+				WriteQueueLimitHigh: 500000,
+				WriteQueueLimitLow:  400000,
+				LogLevel:            "notice",
+				IntervalSeconds:     0,
+				WriteServerIPAddr:   "127.9.8.7",
+				WriteServerPort:     0,
+				ConfigDir:           "/var/run/signalfx-agent/collectd",
+				BundleDir:           os.Getenv(constants.BundleDirEnvVar),
+			},
+		}
+	}(), emptyConfig)
+
+	allSettingsConfig := cfg.Extensions["smartagent/all_settings"]
+	require.NotNil(t, allSettingsConfig)
+	require.Equal(t, func() *Config {
+		return &Config{
+			ExtensionSettings: configmodels.ExtensionSettings{
+				TypeVal: "smartagent",
+				NameVal: "smartagent/all_settings",
+			},
+			CollectdConfig: CollectdConfig{
+				Timeout:             10,
+				ReadThreads:         1,
+				WriteThreads:        4,
+				WriteQueueLimitHigh: 5,
+				WriteQueueLimitLow:  1,
+				LogLevel:            "info",
+				IntervalSeconds:     5,
+				WriteServerIPAddr:   "10.100.12.1",
+				WriteServerPort:     9090,
+				ConfigDir:           "/etc/collectd/collectd.conf",
+				BundleDir:           "/opt/bin/collectd/",
+			},
+		}
+	}(), allSettingsConfig)
+}

--- a/internal/extension/smartagentextension/config_test.go
+++ b/internal/extension/smartagentextension/config_test.go
@@ -50,7 +50,7 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "smartagent",
 				NameVal: "smartagent/default_settings",
 			},
-			BundleDir:           os.Getenv(constants.BundleDirEnvVar),
+			BundleDir: os.Getenv(constants.BundleDirEnvVar),
 			CollectdConfig: CollectdConfig{
 				Timeout:             40,
 				ReadThreads:         5,
@@ -74,7 +74,7 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "smartagent",
 				NameVal: "smartagent/all_settings",
 			},
-			BundleDir:           "/opt/bin/collectd/",
+			BundleDir: "/opt/bin/collectd/",
 			CollectdConfig: CollectdConfig{
 				Timeout:             10,
 				ReadThreads:         1,

--- a/internal/extension/smartagentextension/config_test.go
+++ b/internal/extension/smartagentextension/config_test.go
@@ -15,11 +15,9 @@
 package smartagentextension
 
 import (
-	"os"
 	"path"
 	"testing"
 
-	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -50,7 +48,7 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "smartagent",
 				NameVal: "smartagent/default_settings",
 			},
-			BundleDir: os.Getenv(constants.BundleDirEnvVar),
+			BundleDir: bundleDir,
 			CollectdConfig: CollectdConfig{
 				Timeout:             40,
 				ReadThreads:         5,

--- a/internal/extension/smartagentextension/config_test.go
+++ b/internal/extension/smartagentextension/config_test.go
@@ -18,7 +18,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -27,7 +27,7 @@ import (
 
 func TestLoadConfig(t *testing.T) {
 	factories, err := componenttest.ExampleComponents()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	factory := NewFactory()
 	factories.Extensions[typeStr] = factory
@@ -38,7 +38,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, len(cfg.Extensions), 2)
+	require.Equal(t, len(cfg.Extensions), 3)
 
 	emptyConfig := cfg.Extensions["smartagent/default_settings"]
 	require.NotNil(t, emptyConfig)
@@ -48,15 +48,15 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "smartagent",
 				NameVal: "smartagent/default_settings",
 			},
-			BundleDir: bundleDir,
-			CollectdConfig: CollectdConfig{
+			bundleDir: bundleDir,
+			collectdConfig: config.CollectdConfig{
 				Timeout:             40,
 				ReadThreads:         5,
 				WriteThreads:        2,
 				WriteQueueLimitHigh: 500000,
 				WriteQueueLimitLow:  400000,
 				LogLevel:            "notice",
-				IntervalSeconds:     10,
+				IntervalSeconds:     0,
 				WriteServerIPAddr:   "127.9.8.7",
 				WriteServerPort:     0,
 				ConfigDir:           "/var/run/signalfx-agent/collectd",
@@ -72,8 +72,8 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "smartagent",
 				NameVal: "smartagent/all_settings",
 			},
-			BundleDir: "/opt/bin/collectd/",
-			CollectdConfig: CollectdConfig{
+			bundleDir: "/opt/bin/collectd/",
+			collectdConfig: config.CollectdConfig{
 				Timeout:             10,
 				ReadThreads:         1,
 				WriteThreads:        4,
@@ -83,8 +83,32 @@ func TestLoadConfig(t *testing.T) {
 				IntervalSeconds:     5,
 				WriteServerIPAddr:   "10.100.12.1",
 				WriteServerPort:     9090,
-				ConfigDir:           "/etc/collectd/collectd.conf",
+				ConfigDir:           "/etc/",
 			},
 		}
 	}(), allSettingsConfig)
+
+	partialSettingsConfig := cfg.Extensions["smartagent/partial_settings"]
+	require.NotNil(t, partialSettingsConfig)
+	require.Equal(t, func() *Config {
+		return &Config{
+			ExtensionSettings: configmodels.ExtensionSettings{
+				TypeVal: "smartagent",
+				NameVal: "smartagent/partial_settings",
+			},
+			bundleDir: bundleDir,
+			collectdConfig: config.CollectdConfig{
+				Timeout:             10,
+				ReadThreads:         1,
+				WriteThreads:        4,
+				WriteQueueLimitHigh: 5,
+				WriteQueueLimitLow:  400000,
+				LogLevel:            "notice",
+				IntervalSeconds:     0,
+				WriteServerIPAddr:   "127.9.8.7",
+				WriteServerPort:     0,
+				ConfigDir:           "/etc/",
+			},
+		}
+	}(), partialSettingsConfig)
 }

--- a/internal/extension/smartagentextension/extension.go
+++ b/internal/extension/smartagentextension/extension.go
@@ -1,0 +1,39 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smartagentextension
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configmodels"
+)
+
+type smartAgentConfigExtension struct {
+}
+
+var _ component.ServiceExtension = (*smartAgentConfigExtension)(nil)
+
+func (sae *smartAgentConfigExtension) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+func (sae *smartAgentConfigExtension) Shutdown(_ context.Context) error {
+	return nil
+}
+
+func newSmartAgentConfigExtension(_ configmodels.Extension) (*smartAgentConfigExtension, error) {
+	return &smartAgentConfigExtension{}, nil
+}

--- a/internal/extension/smartagentextension/extension_test.go
+++ b/internal/extension/smartagentextension/extension_test.go
@@ -32,10 +32,10 @@ func TestExtension(t *testing.T) {
 			Logger: zap.NewNop(),
 		},
 		&Config{
+			BundleDir: "/bundle/",
 			CollectdConfig: CollectdConfig{
 				Timeout:   10,
 				ConfigDir: "/config/",
-				BundleDir: "/bundle/",
 			},
 		},
 	)

--- a/internal/extension/smartagentextension/extension_test.go
+++ b/internal/extension/smartagentextension/extension_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -32,8 +33,8 @@ func TestExtension(t *testing.T) {
 			Logger: zap.NewNop(),
 		},
 		&Config{
-			BundleDir: "/bundle/",
-			CollectdConfig: CollectdConfig{
+			bundleDir: "/bundle/",
+			collectdConfig: config.CollectdConfig{
 				Timeout:   10,
 				ConfigDir: "/config/",
 			},

--- a/internal/extension/smartagentextension/extension_test.go
+++ b/internal/extension/smartagentextension/extension_test.go
@@ -1,0 +1,47 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smartagentextension
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.uber.org/zap"
+)
+
+func TestExtension(t *testing.T) {
+	f := NewFactory()
+	e, err := f.CreateExtension(
+		context.Background(),
+		component.ExtensionCreateParams{
+			Logger: zap.NewNop(),
+		},
+		&Config{
+			CollectdConfig: CollectdConfig{
+				Timeout:   10,
+				ConfigDir: "/config/",
+				BundleDir: "/bundle/",
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, e)
+
+	require.NoError(t, e.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, e.Shutdown(context.Background()))
+}

--- a/internal/extension/smartagentextension/factory.go
+++ b/internal/extension/smartagentextension/factory.go
@@ -41,6 +41,7 @@ func createDefaultConfig() configmodels.Extension {
 			TypeVal: typeStr,
 			NameVal: string(typeStr),
 		},
+		BundleDir: os.Getenv(constants.BundleDirEnvVar),
 		CollectdConfig: CollectdConfig{
 			Timeout:             40,
 			ReadThreads:         5,
@@ -52,7 +53,6 @@ func createDefaultConfig() configmodels.Extension {
 			WriteServerIPAddr:   "127.9.8.7",
 			WriteServerPort:     0,
 			ConfigDir:           "/var/run/signalfx-agent/collectd",
-			BundleDir:           os.Getenv(constants.BundleDirEnvVar),
 		},
 	}
 }

--- a/internal/extension/smartagentextension/factory.go
+++ b/internal/extension/smartagentextension/factory.go
@@ -17,6 +17,7 @@ package smartagentextension
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
 	"go.opentelemetry.io/collector/component"
@@ -35,13 +36,28 @@ func NewFactory() component.ExtensionFactory {
 		createExtension)
 }
 
+var bundleDir = func() string {
+	out := os.Getenv(constants.BundleDirEnvVar)
+	if out == "" {
+		exePath, err := os.Executable()
+		if err != nil {
+			panic("Cannot determine agent executable path, cannot continue")
+		}
+		out, err = filepath.Abs(filepath.Join(filepath.Dir(exePath), ".."))
+		if err != nil {
+			panic("Cannot determine absolute path of executable parent dir " + exePath)
+		}
+	}
+	return out
+}()
+
 func createDefaultConfig() configmodels.Extension {
 	return &Config{
 		ExtensionSettings: configmodels.ExtensionSettings{
 			TypeVal: typeStr,
 			NameVal: string(typeStr),
 		},
-		BundleDir: os.Getenv(constants.BundleDirEnvVar),
+		BundleDir: bundleDir,
 		CollectdConfig: CollectdConfig{
 			Timeout:             40,
 			ReadThreads:         5,

--- a/internal/extension/smartagentextension/factory.go
+++ b/internal/extension/smartagentextension/factory.go
@@ -1,0 +1,66 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smartagentextension
+
+import (
+	"context"
+	"os"
+
+	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/extension/extensionhelper"
+)
+
+const (
+	typeStr configmodels.Type = "smartagent"
+)
+
+func NewFactory() component.ExtensionFactory {
+	return extensionhelper.NewFactory(
+		typeStr,
+		createDefaultConfig,
+		createExtension)
+}
+
+func createDefaultConfig() configmodels.Extension {
+	return &Config{
+		ExtensionSettings: configmodels.ExtensionSettings{
+			TypeVal: typeStr,
+			NameVal: string(typeStr),
+		},
+		CollectdConfig: CollectdConfig{
+			Timeout:             40,
+			ReadThreads:         5,
+			WriteThreads:        2,
+			WriteQueueLimitHigh: 500000,
+			WriteQueueLimitLow:  400000,
+			LogLevel:            "notice",
+			IntervalSeconds:     0,
+			WriteServerIPAddr:   "127.9.8.7",
+			WriteServerPort:     0,
+			ConfigDir:           "/var/run/signalfx-agent/collectd",
+			BundleDir:           os.Getenv(constants.BundleDirEnvVar),
+		},
+	}
+}
+
+func createExtension(
+	_ context.Context,
+	_ component.ExtensionCreateParams,
+	cfg configmodels.Extension,
+) (component.ServiceExtension, error) {
+	return newSmartAgentConfigExtension(cfg)
+}

--- a/internal/extension/smartagentextension/factory.go
+++ b/internal/extension/smartagentextension/factory.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
+	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/extension/extensionhelper"
@@ -33,7 +34,9 @@ func NewFactory() component.ExtensionFactory {
 	return extensionhelper.NewFactory(
 		typeStr,
 		createDefaultConfig,
-		createExtension)
+		createExtension,
+		extensionhelper.WithCustomUnmarshaler(customUnmarshaller),
+	)
 }
 
 var bundleDir = func() string {
@@ -57,15 +60,15 @@ func createDefaultConfig() configmodels.Extension {
 			TypeVal: typeStr,
 			NameVal: string(typeStr),
 		},
-		BundleDir: bundleDir,
-		CollectdConfig: CollectdConfig{
+		bundleDir: bundleDir,
+		collectdConfig: config.CollectdConfig{
 			Timeout:             40,
 			ReadThreads:         5,
 			WriteThreads:        2,
 			WriteQueueLimitHigh: 500000,
 			WriteQueueLimitLow:  400000,
 			LogLevel:            "notice",
-			IntervalSeconds:     10,
+			IntervalSeconds:     0,
 			WriteServerIPAddr:   "127.9.8.7",
 			WriteServerPort:     0,
 			ConfigDir:           "/var/run/signalfx-agent/collectd",

--- a/internal/extension/smartagentextension/factory.go
+++ b/internal/extension/smartagentextension/factory.go
@@ -49,7 +49,7 @@ func createDefaultConfig() configmodels.Extension {
 			WriteQueueLimitHigh: 500000,
 			WriteQueueLimitLow:  400000,
 			LogLevel:            "notice",
-			IntervalSeconds:     0,
+			IntervalSeconds:     10,
 			WriteServerIPAddr:   "127.9.8.7",
 			WriteServerPort:     0,
 			ConfigDir:           "/var/run/signalfx-agent/collectd",

--- a/internal/extension/smartagentextension/factory_test.go
+++ b/internal/extension/smartagentextension/factory_test.go
@@ -1,0 +1,32 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smartagentextension
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configmodels"
+)
+
+func TestFactory(t *testing.T) {
+	f := NewFactory()
+
+	expectedType := "smartagent"
+	require.Equal(t, configmodels.Type(expectedType), f.Type())
+
+	cfg := f.CreateDefaultConfig()
+	require.Equal(t, expectedType, string(cfg.Type()))
+}

--- a/internal/extension/smartagentextension/testdata/config.yaml
+++ b/internal/extension/smartagentextension/testdata/config.yaml
@@ -1,0 +1,32 @@
+extensions:
+  smartagent/default_settings:
+  smartagent/all_settings:
+    collectd:
+      timeout: 10
+      read_threads: 1
+      write_threads: 4
+      write_queue_limit_high: 5
+      write_queue_limit_low: 1
+      log_level: info
+      interval_seconds: 5
+      write_server_ip: 10.100.12.1
+      write_server_port: 9090
+      config_dir: /etc/collectd/collectd.conf
+      bundle_dir: /opt/bin/collectd/
+
+receivers:
+  examplereceiver:
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  extensions: [smartagent/default_settings, smartagent/all_settings]
+  pipelines:
+    metrics:
+      receivers: [examplereceiver]
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]

--- a/internal/extension/smartagentextension/testdata/config.yaml
+++ b/internal/extension/smartagentextension/testdata/config.yaml
@@ -12,7 +12,14 @@ extensions:
       intervalSeconds: 5
       writeServerIPAddr: 10.100.12.1
       writeServerPort: 9090
-      configDir: /etc/collectd/collectd.conf
+      configDir: /etc/
+  smartagent/partial_settings:
+    collectd:
+      timeout: 10
+      readThreads: 1
+      writeThreads: 4
+      writeQueueLimitHigh: 5
+      configDir: /etc/
 
 receivers:
   examplereceiver:

--- a/internal/extension/smartagentextension/testdata/config.yaml
+++ b/internal/extension/smartagentextension/testdata/config.yaml
@@ -1,18 +1,18 @@
 extensions:
   smartagent/default_settings:
   smartagent/all_settings:
+    bundleDir: /opt/bin/collectd/
     collectd:
       timeout: 10
-      read_threads: 1
-      write_threads: 4
-      write_queue_limit_high: 5
-      write_queue_limit_low: 1
-      log_level: info
-      interval_seconds: 5
-      write_server_ip: 10.100.12.1
-      write_server_port: 9090
-      config_dir: /etc/collectd/collectd.conf
-      bundle_dir: /opt/bin/collectd/
+      readThreads: 1
+      writeThreads: 4
+      writeQueueLimitHigh: 5
+      writeQueueLimitLow: 1
+      logLevel: info
+      intervalSeconds: 5
+      writeServerIPAddr: 10.100.12.1
+      writeServerPort: 9090
+      configDir: /etc/collectd/collectd.conf
 
 receivers:
   examplereceiver:

--- a/internal/extension/smartagentextension/testdata/invalid_config.yaml
+++ b/internal/extension/smartagentextension/testdata/invalid_config.yaml
@@ -1,0 +1,21 @@
+extensions:
+  smartagent/invalid_settings:
+    collectd:
+      timeout: ten
+
+receivers:
+  examplereceiver:
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  extensions: [smartagent/invalid_settings]
+  pipelines:
+    metrics:
+      receivers: [examplereceiver]
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]


### PR DESCRIPTION
This extension provides a centralized mechanism to configure things collectd that are common to all instances of the smartagent receiver. To begin with, this extension will enable users to override default config options such as "config_dir" and "bundle_dir" that are applicable for all collectd based monitors.

Also, note that it is not a requirement to configure this extension for collectd monitors to work. In such cases, the default collectd config will be applied.