### PR TITLE
WIP: smartagent: Allow specifying metadata exporters for dimension updates

### DIFF
--- a/internal/receiver/smartagentreceiver/README.md
+++ b/internal/receiver/smartagentreceiver/README.md
@@ -17,10 +17,17 @@ and associated [Observer extensions](https://github.com/open-telemetry/opentelem
 should be used.
 1. All metric content replacement and transformation rules should utilize existing
 [Collector processors](https://github.com/open-telemetry/opentelemetry-collector/blob/master/processor/README.md).
+1. Monitors with [dimension property and tag update
+functionality](https://dev.splunk.com/observability/docs/datamodel#Creating-or-updating-custom-properties-and-tags)
+require an associated `metadataClients` field that references the name of the SignalFx exporter you are using in your
+pipeline.
 
 Example:
 
 ```yaml
+exporters:
+  signalfx:
+
 receivers:
   smartagent/haproxy:
     type: haproxy
@@ -30,6 +37,7 @@ receivers:
     type: postgresql
     host: mypostgresinstance
     port: 5432
+    metadataClients: [signalfx]
 ```
 
 The full list of settings exposed for this receiver are documented for

--- a/internal/receiver/smartagentreceiver/testdata/config.yaml
+++ b/internal/receiver/smartagentreceiver/testdata/config.yaml
@@ -1,10 +1,12 @@
 receivers:
   smartagent/haproxy:
+    metadataClients: [exampleexporter/one, exampleexporter/two]
     type: haproxy
     intervalSeconds: 123
     username: SomeUser
     password: secret
   smartagent/redis:
+    metadataClients: []
     type: collectd/redis
     host: localhost
     port: 6379
@@ -29,6 +31,8 @@ processors:
 
 exporters:
   exampleexporter:
+  exampleexporter/one:
+  exampleexporter/two:
 
 service:
   pipelines:
@@ -40,4 +44,4 @@ service:
         - smartagent/etcd
         - smartagent/ntpq
       processors: [exampleprocessor]
-      exporters: [exampleexporter]
+      exporters: [exampleexporter, exampleexporter/one, exampleexporter/two]

--- a/internal/receiver/smartagentreceiver/testdata/invalid_float_metadata_clients.yaml
+++ b/internal/receiver/smartagentreceiver/testdata/invalid_float_metadata_clients.yaml
@@ -1,0 +1,21 @@
+receivers:
+  smartagent/haproxy:
+    metadataClients: [1234.45, 2345.56]
+    type: haproxy
+    intervalSeconds: 123
+    username: SomeUser
+    password: secret
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - smartagent/haproxy
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]

--- a/internal/receiver/smartagentreceiver/testdata/invalid_nonarray_metadata_clients.yaml
+++ b/internal/receiver/smartagentreceiver/testdata/invalid_nonarray_metadata_clients.yaml
@@ -1,0 +1,21 @@
+receivers:
+  smartagent/haproxy:
+    metadataClients: notanarray
+    type: haproxy
+    intervalSeconds: 123
+    username: SomeUser
+    password: secret
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - smartagent/haproxy
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]


### PR DESCRIPTION
These changes build upon https://github.com/signalfx/splunk-otel-collector/pull/120 but add a `metadataClients` config field to denote the SFx exporter to use to send dimension updates.  If a client array is isn't provided the current behavior of defaulting to the nextConsumer if possible remains.

Camelcasing is inherited by the Agent config conventions to avoid mixing it w/ snake case.

I am not happy with the configuration experience here and hope something comes out of https://github.com/open-telemetry/opentelemetry-collector/issues/2536 or the existing sdk has features that can improve it I wasn't able to find.  It's unfortunate that we'd need to require the user to specify the exporter they're using without otherwise having to make the assumption that all SFx exporters are desired and in our pipeline(s).

I am opening for a review now and will add a more robust test to get coverage up.