### PR TITLE
translate Smart Agent events into log records

### DIFF
--- a/internal/receiver/smartagentreceiver/event.go
+++ b/internal/receiver/smartagentreceiver/event.go
@@ -1,0 +1,119 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smartagentreceiver
+
+import (
+	"fmt"
+
+	"github.com/signalfx/golib/v3/event"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+)
+
+const (
+	SFxEventCategoryKey   = "com.splunk.signalfx.event_category"
+	SFxEventPropertiesKey = "com.splunk.signalfx.event_properties"
+)
+
+// eventToLog converts a SFx event to a pdata.Logs entry suitable for consumption by LogConsumer.
+// based on https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/5de076e9773bdb7617b544a57fa0a4b848cec92c/receiver/signalfxreceiver/signalfxv2_event_to_logdata.go#L27
+func eventToLog(event *event.Event, logger *zap.Logger) pdata.Logs {
+	logs, lr := newLogs()
+
+	lr.SetName(event.EventType)
+
+	var unixNano int64
+	if !event.Timestamp.IsZero() {
+		unixNano = event.Timestamp.UnixNano()
+	}
+	lr.SetTimestamp(pdata.TimestampUnixNano(unixNano))
+
+	// size for event category and dimension attributes
+	attrsCapacity := 1 + len(event.Dimensions)
+	if len(event.Properties) > 0 {
+		attrsCapacity++
+	}
+	attrs := lr.Attributes()
+	attrs.InitEmptyWithCapacity(attrsCapacity)
+
+	if event.Category == 0 {
+		// This attribute must be present or SFx exporter will not know it's an event
+		attrs.InsertNull(SFxEventCategoryKey)
+	} else {
+		attrs.InsertInt(SFxEventCategoryKey, int64(event.Category))
+	}
+
+	for k, v := range event.Dimensions {
+		attrs.InsertString(k, v)
+	}
+
+	if len(event.Properties) > 0 {
+		propMapVal := pdata.NewAttributeValueMap()
+		propMap := propMapVal.MapVal()
+		propMap.InitEmptyWithCapacity(len(event.Properties))
+
+		for property, value := range event.Properties {
+			if value == nil {
+				logger.Debug("property with nil value will not be reported", zap.String("property", property))
+				continue
+			}
+
+			switch v := value.(type) {
+			// https://github.com/signalfx/com_signalfx_metrics_protobuf/blob/master/model/signalfx_metrics.pb.go#L567
+			// bool, float64, int64, and string are only supported types.
+			case string:
+				propMap.InsertString(property, v)
+			case bool:
+				propMap.InsertBool(property, v)
+			case int:
+				propMap.InsertInt(property, int64(v))
+			case int8:
+				propMap.InsertInt(property, int64(v))
+			case int16:
+				propMap.InsertInt(property, int64(v))
+			case int32:
+				propMap.InsertInt(property, int64(v))
+			case int64:
+				propMap.InsertInt(property, v)
+			case float32:
+				propMap.InsertDouble(property, float64(v))
+			case float64:
+				propMap.InsertDouble(property, v)
+			default:
+				// Default to string representation.
+				propMap.InsertString(property, fmt.Sprintf("%v", value))
+			}
+		}
+
+		attrs.Insert(SFxEventPropertiesKey, propMapVal)
+	}
+
+	return logs
+}
+
+func newLogs() (pdata.Logs, pdata.LogRecord) {
+	ld := pdata.NewLogs()
+
+	rls := ld.ResourceLogs()
+	rls.Resize(1)
+	rl := rls.At(0)
+	ills := rl.InstrumentationLibraryLogs()
+	ills.Resize(1)
+	logSlice := ills.At(0).Logs()
+	logSlice.Resize(1)
+	lr := logSlice.At(0)
+
+	return ld, lr
+}

--- a/internal/receiver/smartagentreceiver/event_test.go
+++ b/internal/receiver/smartagentreceiver/event_test.go
@@ -1,0 +1,179 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smartagentreceiver
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/signalfx/golib/v3/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+)
+
+func TestEventToLog(tt *testing.T) {
+	for _, test := range []struct {
+		name        string
+		event       event.Event
+		expectedLog pdata.Logs
+	}{
+		{
+			name:  "event zero value",
+			event: event.Event{},
+			expectedLog: newExpectedLog(
+				"",
+				map[string]pdata.AttributeValue{
+					"com.splunk.signalfx.event_category": pdata.NewAttributeValueNull(),
+				}, 0,
+			),
+		},
+		{
+			name: "complete event",
+			event: event.Event{
+				EventType: "some_event_type",
+				Category:  1,
+				Dimensions: map[string]string{
+					"dimension_name": "dimension_value",
+				},
+				Properties: map[string]interface{}{
+					"bool_property_name":    true,
+					"string_property_name":  "some value",
+					"int_property_name":     int(12345),
+					"int8_property_name":    int8(127),
+					"int16_property_name":   int16(23456),
+					"int32_property_name":   int32(34567),
+					"int64_property_name":   int64(45678),
+					"float32_property_name": float32(12345.678),
+					"float64_property_name": float64(23456.789),
+				},
+				Timestamp: time.Unix(1, 1),
+			},
+			expectedLog: newExpectedLog(
+				"some_event_type",
+				func() map[string]pdata.AttributeValue {
+					attrs := map[string]pdata.AttributeValue{
+						"com.splunk.signalfx.event_category": pdata.NewAttributeValueInt(1),
+						"dimension_name":                     pdata.NewAttributeValueString("dimension_value"),
+					}
+					properties := pdata.NewAttributeValueMap()
+					properties.MapVal().InitFromMap(
+						map[string]pdata.AttributeValue{
+							"bool_property_name":    pdata.NewAttributeValueBool(true),
+							"string_property_name":  pdata.NewAttributeValueString("some value"),
+							"int_property_name":     pdata.NewAttributeValueInt(12345),
+							"int8_property_name":    pdata.NewAttributeValueInt(127),
+							"int16_property_name":   pdata.NewAttributeValueInt(23456),
+							"int32_property_name":   pdata.NewAttributeValueInt(34567),
+							"int64_property_name":   pdata.NewAttributeValueInt(45678),
+							"float32_property_name": pdata.NewAttributeValueDouble(12345.678),
+							"float64_property_name": pdata.NewAttributeValueDouble(23456.789),
+						})
+					attrs["com.splunk.signalfx.event_properties"] = properties
+					return attrs
+				}(), 1000000001,
+			),
+		},
+		{
+			name: "unsupported properties",
+			event: event.Event{
+				EventType: "some_event_type",
+				Category:  10000000,
+				Properties: map[string]interface{}{
+					"nil_property":    nil,
+					"struct_property": struct{ field string }{"something"},
+					"uint_property":   uint(12345),
+				},
+			},
+			expectedLog: newExpectedLog(
+				"some_event_type",
+				func() map[string]pdata.AttributeValue {
+					attrs := map[string]pdata.AttributeValue{
+						"com.splunk.signalfx.event_category": pdata.NewAttributeValueInt(10000000),
+					}
+					properties := pdata.NewAttributeValueMap()
+					properties.MapVal().InitFromMap(
+						map[string]pdata.AttributeValue{
+							"struct_property": pdata.NewAttributeValueString("{something}"),
+							"uint_property":   pdata.NewAttributeValueString("12345"),
+						})
+					attrs["com.splunk.signalfx.event_properties"] = properties
+					return attrs
+				}(), 0,
+			),
+		},
+	} {
+		tt.Run(test.name, func(t *testing.T) {
+			log := eventToLog(&test.event, zap.NewNop())
+			assertLogsEqual(t, test.expectedLog, log)
+		})
+	}
+}
+
+func newExpectedLog(eventType string, properties map[string]pdata.AttributeValue, timestamp uint64) pdata.Logs {
+	ld := pdata.NewLogs()
+	rls := ld.ResourceLogs()
+	rls.Resize(1)
+	rl := rls.At(0)
+	ills := rl.InstrumentationLibraryLogs()
+	ills.Resize(1)
+	logSlice := ills.At(0).Logs()
+	logSlice.Resize(1)
+	lr := logSlice.At(0)
+	lr.SetName(eventType)
+	lr.SetTimestamp(pdata.TimestampUnixNano(timestamp))
+
+	attrs := lr.Attributes()
+	for k, v := range properties {
+		attrs.Insert(k, v)
+	}
+
+	return ld
+}
+
+func assertLogsEqual(t *testing.T, expected, received pdata.Logs) {
+	expectedLog := expected.ResourceLogs().At(0).InstrumentationLibraryLogs().At(0).Logs().At(0)
+	receivedLog := received.ResourceLogs().At(0).InstrumentationLibraryLogs().At(0).Logs().At(0)
+
+	assert.Equal(t, expectedLog.Name(), receivedLog.Name())
+	assert.Equal(t, expectedLog.Timestamp(), receivedLog.Timestamp())
+
+	assertAttributeMapContainsAll(t, expectedLog.Attributes(), receivedLog.Attributes())
+	assertAttributeMapContainsAll(t, receivedLog.Attributes(), expectedLog.Attributes())
+}
+
+func assertAttributeMapContainsAll(t *testing.T, first, second pdata.AttributeMap) {
+	first.ForEach(func(firstKey string, firstValue pdata.AttributeValue) {
+		secondValue, ok := second.Get(firstKey)
+		require.True(t, ok, fmt.Sprintf("first attribute %s not in second", firstKey))
+		require.Equal(t, firstValue.Type(), secondValue.Type())
+		if secondValue.Type() == pdata.AttributeValueMAP {
+			assertAttributeMapContainsAll(t, firstValue.MapVal(), secondValue.MapVal())
+			return
+		}
+
+		if secondValue.Type() == pdata.AttributeValueDOUBLE {
+			// account for float32 -> float64 precision
+			assert.InDelta(t, firstValue.DoubleVal(), secondValue.DoubleVal(), .001)
+			return
+		}
+
+		assert.EqualValues(t, firstValue, secondValue,
+			"second value doesn't match first for first key %s", firstKey,
+		)
+	})
+}


### PR DESCRIPTION
These changes introduce a conversion helper that will be later adopted by the Smart Agent receiver's Output `SendEvent` method to provide the configured SFx exporter monitor-created events as log records.  They are based on the logic in the SFx receiver, but are unable to source it directly since it isn't exported and operates on the protobuf-generated types instead of the type defined in SFx golib as used by the agent.