### PR TITLE
Smart Agent: send SignalFx events to event clients

### DIFF
--- a/internal/receiver/smartagentreceiver/README.md
+++ b/internal/receiver/smartagentreceiver/README.md
@@ -19,7 +19,11 @@ should be used.
 [Collector processors](https://github.com/open-telemetry/opentelemetry-collector/blob/master/processor/README.md).
 1. Monitors with [dimension property and tag update
 functionality](https://dev.splunk.com/observability/docs/datamodel#Creating-or-updating-custom-properties-and-tags)
-require an associated `metadataClients` field that references the name of the SignalFx exporter you are using in your
+require an associated `dimensionClients` field that references the name of the SignalFx exporter you are using in your
+pipeline.
+1. Monitors with [event-sending
+functionality](https://dev.splunk.com/observability/docs/datamodel/ingest#Send-custom-events)
+require an associated `eventClients` field that references the name of the SignalFx exporter you are using in your
 pipeline.
 
 Example:
@@ -37,7 +41,8 @@ receivers:
     type: postgresql
     host: mypostgresinstance
     port: 5432
-    metadataClients: [signalfx]
+    dimensionClients: [signalfx]
+    eventClients: [signalfx]
 ```
 
 The full list of settings exposed for this receiver are documented for

--- a/internal/receiver/smartagentreceiver/config_test.go
+++ b/internal/receiver/smartagentreceiver/config_test.go
@@ -59,8 +59,8 @@ func TestLoadConfig(t *testing.T) {
 			TypeVal: typeStr,
 			NameVal: typeStr + "/haproxy",
 		},
-		DimensionClients: &expectedDimensionClients,
-		EventClients:     &expectedEventClients,
+		DimensionClients: expectedDimensionClients,
+		EventClients:     expectedEventClients,
 		monitorConfig: &haproxy.Config{
 			MonitorConfig: config.MonitorConfig{
 				Type:                "haproxy",
@@ -76,15 +76,14 @@ func TestLoadConfig(t *testing.T) {
 	}, haproxyCfg)
 	require.NoError(t, haproxyCfg.validate())
 
-	var nilClients []string
 	redisCfg := cfg.Receivers["smartagent/redis"].(*Config)
 	require.Equal(t, &Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
 			TypeVal: typeStr,
 			NameVal: typeStr + "/redis",
 		},
-		DimensionClients: &nilClients,
-		EventClients:     &nilClients,
+		DimensionClients: []string{},
+		EventClients:     []string{},
 		monitorConfig: &redis.Config{
 			MonitorConfig: config.MonitorConfig{
 				Type:                "collectd/redis",

--- a/internal/receiver/smartagentreceiver/config_test.go
+++ b/internal/receiver/smartagentreceiver/config_test.go
@@ -52,13 +52,15 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, len(cfg.Receivers), 5)
 
 	haproxyCfg := cfg.Receivers["smartagent/haproxy"].(*Config)
-	expectedMetadataClients := []string{"exampleexporter/one", "exampleexporter/two"}
+	expectedDimensionClients := []string{"exampleexporter/one", "exampleexporter/two"}
+	expectedEventClients := []string{"exampleexporter/two", "exampleexporter/three"}
 	require.Equal(t, &Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
 			TypeVal: typeStr,
 			NameVal: typeStr + "/haproxy",
 		},
-		MetadataClients: &expectedMetadataClients,
+		DimensionClients: &expectedDimensionClients,
+		EventClients:     &expectedEventClients,
 		monitorConfig: &haproxy.Config{
 			MonitorConfig: config.MonitorConfig{
 				Type:                "haproxy",
@@ -74,14 +76,15 @@ func TestLoadConfig(t *testing.T) {
 	}, haproxyCfg)
 	require.NoError(t, haproxyCfg.validate())
 
-	var nilMetadataClients []string
+	var nilClients []string
 	redisCfg := cfg.Receivers["smartagent/redis"].(*Config)
 	require.Equal(t, &Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
 			TypeVal: typeStr,
 			NameVal: typeStr + "/redis",
 		},
-		MetadataClients: &nilMetadataClients,
+		DimensionClients: &nilClients,
+		EventClients:     &nilClients,
 		monitorConfig: &redis.Config{
 			MonitorConfig: config.MonitorConfig{
 				Type:                "collectd/redis",
@@ -385,32 +388,32 @@ func TestLoadInvalidConfigWithUnsupportedEndpoint(t *testing.T) {
 	require.Nil(t, cfg)
 }
 
-func TestLoadInvalidConfigWithNonArrayMetadataClients(t *testing.T) {
+func TestLoadInvalidConfigWithNonArrayEventClients(t *testing.T) {
 	factories, err := componenttest.ExampleComponents()
 	assert.Nil(t, err)
 
 	factory := NewFactory()
 	factories.Receivers[configmodels.Type(typeStr)] = factory
 	cfg, err := configtest.LoadConfigFile(
-		t, path.Join(".", "testdata", "invalid_nonarray_metadata_clients.yaml"), factories,
+		t, path.Join(".", "testdata", "invalid_nonarray_event_clients.yaml"), factories,
 	)
 	require.Error(t, err)
 	require.EqualError(t, err,
-		"error reading receivers configuration for smartagent/haproxy: metadataClients must be an array of compatible exporter names")
+		"error reading receivers configuration for smartagent/haproxy: eventClients must be an array of compatible exporter names")
 	require.Nil(t, cfg)
 }
 
-func TestLoadInvalidConfigWithNonStringArrayMetadataClients(t *testing.T) {
+func TestLoadInvalidConfigWithNonStringArrayDimensionClients(t *testing.T) {
 	factories, err := componenttest.ExampleComponents()
 	assert.Nil(t, err)
 
 	factory := NewFactory()
 	factories.Receivers[configmodels.Type(typeStr)] = factory
 	cfg, err := configtest.LoadConfigFile(
-		t, path.Join(".", "testdata", "invalid_float_metadata_clients.yaml"), factories,
+		t, path.Join(".", "testdata", "invalid_float_dimension_clients.yaml"), factories,
 	)
 	require.Error(t, err)
 	require.EqualError(t, err,
-		"error reading receivers configuration for smartagent/haproxy: metadataClients must be an array of compatible exporter names")
+		"error reading receivers configuration for smartagent/haproxy: dimensionClients must be an array of compatible exporter names")
 	require.Nil(t, cfg)
 }

--- a/internal/receiver/smartagentreceiver/output.go
+++ b/internal/receiver/smartagentreceiver/output.go
@@ -117,7 +117,7 @@ func getLogsConsumers(
 // MetricsExporters, the only truly supported component type.
 // If config.MetadataClients is nil, it will return a slice with nextConsumer if it's a MetricsExporter.
 func getClientsFromMetricsExporters(
-	specifiedClients *[]string, host component.Host, nextConsumer *consumer.MetricsConsumer, fieldName string, logger *zap.Logger,
+	specifiedClients []string, host component.Host, nextConsumer *consumer.MetricsConsumer, fieldName string, logger *zap.Logger,
 ) (clients []*interface{}) {
 	if specifiedClients == nil {
 		// default to nextConsumer if no clients have been provided
@@ -127,7 +127,7 @@ func getClientsFromMetricsExporters(
 	}
 
 	builtExporters := host.GetExporters()[configmodels.MetricsDataType]
-	for _, client := range *specifiedClients {
+	for _, client := range specifiedClients {
 		var found bool
 		for exporterConfig, exporter := range builtExporters {
 			if exporterConfig.Name() == client {

--- a/internal/receiver/smartagentreceiver/output.go
+++ b/internal/receiver/smartagentreceiver/output.go
@@ -34,58 +34,51 @@ import (
 
 const internalTransport = "internal"
 
-// Output is an implementation of a Smart Agent FilteringOutput that receives datapoints from a configured monitor.
-// It is what provides metrics to the next MetricsConsumer (to be implemented later).  At this stage it is only
-// a logging instance.
+// Output is an implementation of a Smart Agent FilteringOutput that receives datapoints, events, and dimension updates
+// from a configured monitor.  It will forward all datapoints to the nextConsumer, all dimension updates to the
+// nextMetricMetadataClients, and all events to the nextLogMetadataClients as determined by the associated
+// items in Config.MetadataClients.
 type Output struct {
-	receiverName          string
-	nextConsumer          consumer.MetricsConsumer
-	nextMetadataConsumers []*metadata.MetadataExporter
-	logger                *zap.Logger
-	converter             Converter
-	extraDimensions       map[string]string
+	receiverName              string
+	nextConsumer              consumer.MetricsConsumer
+	nextMetricMetadataClients []*metadata.MetadataExporter
+	nextLogMetadataClients    []*consumer.LogsConsumer
+	logger                    *zap.Logger
+	converter                 Converter
+	extraDimensions           map[string]string
 }
 
 var _ types.Output = (*Output)(nil)
 var _ types.FilteringOutput = (*Output)(nil)
 
 func NewOutput(config Config, nextConsumer consumer.MetricsConsumer, host component.Host, logger *zap.Logger) *Output {
-	metadataExporters := getMetadataExporters(config, host, nextConsumer, logger)
+	metadataExporters := getMetadataExporters(config, host, &nextConsumer, logger)
+	logConsumers := getLogsConsumers(config, host, &nextConsumer, logger)
 	return &Output{
-		receiverName:          config.Name(),
-		nextConsumer:          nextConsumer,
-		nextMetadataConsumers: metadataExporters,
-		logger:                logger,
-		converter:             Converter{logger: logger},
-		extraDimensions:       map[string]string{},
+		receiverName:              config.Name(),
+		nextConsumer:              nextConsumer,
+		nextMetricMetadataClients: metadataExporters,
+		nextLogMetadataClients:    logConsumers,
+		logger:                    logger,
+		converter:                 Converter{logger: logger},
+		extraDimensions:           map[string]string{},
 	}
 }
 
-func getMetadataExporters(config Config, host component.Host, nextConsumer consumer.MetricsConsumer, logger *zap.Logger) []*metadata.MetadataExporter {
+// getMetadataExporters walks through obtained Config.MetadataClients and returns all matching registered MetadataExporters,
+// if any.  At this time the SignalFx exporter is the only supported use case and adopter of this type.
+func getMetadataExporters(
+	config Config, host component.Host, nextConsumer *consumer.MetricsConsumer, logger *zap.Logger,
+) []*metadata.MetadataExporter {
 	var exporters []*metadata.MetadataExporter
 
-	if config.MetadataClients != nil {
-		builtExporters := host.GetExporters()[configmodels.MetricsDataType]
-		for _, client := range *config.MetadataClients {
-			var exporter component.Exporter
-			for k, v := range builtExporters {
-				if k.Name() == client {
-					exporter = v
-					break
-				}
-			}
-			if metadataExporter, ok := exporter.(metadata.MetadataExporter); ok {
-				exporters = append(exporters, &metadataExporter)
-			} else {
-				logger.Warn(
-					"provided metadataClients item not a MetadataExporter.  cannot send dimension updates",
-					zap.String("client", client),
-				)
-			}
+	metadataClients := getMetadataClients(config, host, nextConsumer, logger)
+	for _, client := range metadataClients {
+		if metadataExporter, ok := (*client).(metadata.MetadataExporter); ok {
+			exporters = append(exporters, &metadataExporter)
+		} else {
+			logger.Info("cannot send dimension updates to metadataClient", zap.Any("client", *client))
 		}
-		// Only if no metadataClients have been provided do we default to nextConsumer, if possible
-	} else if exporter, ok := nextConsumer.(metadata.MetadataExporter); ok {
-		exporters = append(exporters, &exporter)
 	}
 
 	if len(exporters) == 0 {
@@ -93,6 +86,69 @@ func getMetadataExporters(config Config, host component.Host, nextConsumer consu
 	}
 
 	return exporters
+}
+
+// getLogsConsumers walks through obtained Config.MetadataClients and returns all matching registered LogsConsumers,
+// if any.  At this time the SignalFx exporter is the only real target use case, but it's unexported and
+// as implemented all specified combination MetricsExporters and LogsConsumers will be returned.
+func getLogsConsumers(
+	config Config, host component.Host, nextConsumer *consumer.MetricsConsumer, logger *zap.Logger,
+) []*consumer.LogsConsumer {
+	var consumers []*consumer.LogsConsumer
+
+	metadataClients := getMetadataClients(config, host, nextConsumer, logger)
+	for _, client := range metadataClients {
+		if logsExporter, ok := (*client).(consumer.LogsConsumer); ok {
+			consumers = append(consumers, &logsExporter)
+		} else {
+			logger.Info("cannot send events to metadataClient", zap.Any("client", *client))
+		}
+	}
+
+	if len(consumers) == 0 {
+		logger.Debug("no SFx events are possible as no valid metadataClients have been provided and next pipeline component isn't a LogsConsumer")
+	}
+
+	return consumers
+}
+
+// getMetadataClients will walk through all provided config.MetadataClients and retrieve matching registered
+// MetricsExporters, the only truly supported component type.
+// If config.MetadataClients is nil, it will return a slice with nextConsumer if it's a MetricsExporter.
+func getMetadataClients(
+	config Config, host component.Host, nextConsumer *consumer.MetricsConsumer, logger *zap.Logger,
+) []*component.MetricsExporter {
+	var clients []*component.MetricsExporter
+	if config.MetadataClients == nil {
+		// default to nextConsumer if no metadata clients have been provided
+		if metricsExporter, ok := (*nextConsumer).(component.MetricsExporter); ok {
+			clients = append(clients, &metricsExporter)
+		}
+		return clients
+	}
+
+	builtExporters := host.GetExporters()[configmodels.MetricsDataType]
+	for _, client := range *config.MetadataClients {
+		var found bool
+		for exporterConfig, exporter := range builtExporters {
+			if exporterConfig.Name() == client {
+				if metricsExporter, ok := exporter.(component.MetricsExporter); ok {
+					clients = append(clients, &metricsExporter)
+					found = true
+					break
+				} else {
+					logger.Info(
+						"specified metadataClient is not a valid MetricsConsumer",
+						zap.String("client", client),
+					)
+				}
+			}
+		}
+		if !found {
+			logger.Info("specified metadataClient is not an available exporter", zap.String("client", client))
+		}
+	}
+	return clients
 }
 
 func (output *Output) AddDatapointExclusionFilter(filter dpfilters.DatapointFilter) {
@@ -142,7 +198,17 @@ func (output *Output) SendDatapoints(datapoints ...*datapoint.Datapoint) {
 }
 
 func (output *Output) SendEvent(event *event.Event) {
-	output.logger.Debug("SendEvent has been called.", zap.Any("event", event))
+	if len(output.nextLogMetadataClients) == 0 {
+		return
+	}
+
+	logRecord := eventToLog(event, output.logger)
+	for _, logsConsumer := range output.nextLogMetadataClients {
+		err := (*logsConsumer).ConsumeLogs(context.Background(), logRecord)
+		if err != nil {
+			output.logger.Debug("SendEvent has failed", zap.Error(err))
+		}
+	}
 }
 
 func (output *Output) SendSpans(spans ...*trace.Span) {
@@ -150,12 +216,12 @@ func (output *Output) SendSpans(spans ...*trace.Span) {
 }
 
 func (output *Output) SendDimensionUpdate(dimension *types.Dimension) {
-	if len(output.nextMetadataConsumers) == 0 {
+	if len(output.nextMetricMetadataClients) == 0 {
 		return
 	}
 
 	metadataUpdate := dimensionToMetadataUpdate(*dimension)
-	for _, consumer := range output.nextMetadataConsumers {
+	for _, consumer := range output.nextMetricMetadataClients {
 		exporter := *consumer
 		err := exporter.ConsumeMetadata([]*metadata.MetadataUpdate{&metadataUpdate})
 		if err != nil {

--- a/internal/receiver/smartagentreceiver/output_test.go
+++ b/internal/receiver/smartagentreceiver/output_test.go
@@ -107,7 +107,7 @@ func TestSendDimensionUpdateFromConfigMetadataExporters(t *testing.T) {
 	me := mockMetadataClient{name: "mockmetadataexporter"}
 	output := NewOutput(
 		Config{
-			MetadataClients: &[]string{"mockmetadataexporter", "exampleexporter", "metricsreceiver", "notareceiver", "notreal"},
+			DimensionClients: &[]string{"mockmetadataexporter", "exampleexporter", "metricsreceiver", "notareceiver", "notreal"},
 		}, &componenttest.ExampleExporterConsumer{},
 		&hostWithExporters{exporter: &me},
 		zap.NewNop(),
@@ -172,7 +172,7 @@ func TestSendEventWithInvalidExporter(t *testing.T) {
 
 func TestSendEventWithoutMetadataClients(t *testing.T) {
 	output := NewOutput(Config{
-		MetadataClients: &[]string{},
+		EventClients: &[]string{},
 	}, consumertest.NewMetricsNop(),
 		componenttest.NewNopHost(),
 		zap.NewNop(),
@@ -185,7 +185,7 @@ func TestSendEventFromConfigMetadataExporters(t *testing.T) {
 	me := mockMetadataClient{name: "mockmetadataexporter"}
 	output := NewOutput(
 		Config{
-			MetadataClients: &[]string{"mockmetadataexporter", "exampleexporter", "notareceiver", "notreal"},
+			EventClients: &[]string{"mockmetadataexporter", "exampleexporter", "notareceiver", "notreal"},
 		}, &componenttest.ExampleExporterConsumer{},
 		&hostWithExporters{exporter: &me},
 		zap.NewNop(),

--- a/internal/receiver/smartagentreceiver/output_test.go
+++ b/internal/receiver/smartagentreceiver/output_test.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
 )
 
@@ -74,7 +75,7 @@ func TestExtraDimensions(t *testing.T) {
 }
 
 func TestSendDimensionUpdate(t *testing.T) {
-	me := mockMetadataExporter{}
+	me := mockMetadataClient{}
 
 	output := NewOutput(Config{}, &me, componenttest.NewNopHost(), zap.NewNop())
 
@@ -86,7 +87,7 @@ func TestSendDimensionUpdate(t *testing.T) {
 		},
 	}
 	output.SendDimensionUpdate(&dim)
-	received := me.received
+	received := me.receivedMetadataUpdates
 	assert.Equal(t, 1, len(received))
 	update := *(received[0])
 	assert.Equal(t, "my_dimension", update.ResourceIDKey)
@@ -103,10 +104,10 @@ func TestSendDimensionUpdateWithInvalidExporter(t *testing.T) {
 }
 
 func TestSendDimensionUpdateFromConfigMetadataExporters(t *testing.T) {
-	me := mockMetadataExporter{name: "mockmetadataexporter"}
+	me := mockMetadataClient{name: "mockmetadataexporter"}
 	output := NewOutput(
 		Config{
-			MetadataClients: &[]string{"mockmetadataexporter", "exampleexporter"},
+			MetadataClients: &[]string{"mockmetadataexporter", "exampleexporter", "metricsreceiver", "notareceiver", "notreal"},
 		}, &componenttest.ExampleExporterConsumer{},
 		&hostWithExporters{exporter: &me},
 		zap.NewNop(),
@@ -116,34 +117,100 @@ func TestSendDimensionUpdateFromConfigMetadataExporters(t *testing.T) {
 		Name: "error",
 	}
 	output.SendDimensionUpdate(&dim)
-	received := me.received
+	received := me.receivedMetadataUpdates
 	require.Equal(t, 1, len(received))
 	update := *(received[0])
 	assert.Equal(t, "has_errored", update.ResourceIDKey)
 }
 
 func TestSendDimensionUpdateFromNextConsumerMetadataExporters(t *testing.T) {
-	me := mockMetadataExporter{}
+	me := mockMetadataClient{}
 	output := NewOutput(Config{}, &me, componenttest.NewNopHost(), zap.NewNop())
 
 	dim := types.Dimension{
 		Name: "error",
 	}
 	output.SendDimensionUpdate(&dim)
-	received := me.received
+	received := me.receivedMetadataUpdates
 	require.Equal(t, 1, len(received))
 	update := *(received[0])
 	assert.Equal(t, "has_errored", update.ResourceIDKey)
 }
 
-type mockMetadataExporter struct {
-	name     string
-	received []*metadata.MetadataUpdate
+func TestSendEvent(t *testing.T) {
+	me := mockMetadataClient{}
+
+	output := NewOutput(Config{}, &me, componenttest.NewNopHost(), zap.NewNop())
+
+	event := event.Event{
+		EventType: "my_event",
+		Properties: map[string]interface{}{
+			"property": "property_value",
+		},
+	}
+	output.SendEvent(&event)
+	received := me.receivedLogs
+	require.Equal(t, 1, len(received))
+	log := received[0]
+	logRecord := log.ResourceLogs().At(0).InstrumentationLibraryLogs().At(0).Logs().At(0)
+	assert.Equal(t, "my_event", logRecord.Name())
+	attributes := logRecord.Attributes()
+	eventProperties, ok := attributes.Get("com.splunk.signalfx.event_properties")
+	require.True(t, ok)
+	val, ok := eventProperties.MapVal().Get("property")
+	require.True(t, ok)
+	assert.Equal(t, "property_value", val.StringVal())
+}
+
+func TestSendEventWithInvalidExporter(t *testing.T) {
+	output := NewOutput(Config{}, &metricsReceiver{}, componenttest.NewNopHost(), zap.NewNop())
+	event := event.Event{EventType: "error"}
+
+	// doesn't panic
+	output.SendEvent(&event)
+}
+
+func TestSendEventWithoutMetadataClients(t *testing.T) {
+	output := NewOutput(Config{
+		MetadataClients: &[]string{},
+	}, consumertest.NewMetricsNop(),
+		componenttest.NewNopHost(),
+		zap.NewNop(),
+	)
+	// doesn't panic
+	output.SendEvent(&event.Event{})
+}
+
+func TestSendEventFromConfigMetadataExporters(t *testing.T) {
+	me := mockMetadataClient{name: "mockmetadataexporter"}
+	output := NewOutput(
+		Config{
+			MetadataClients: &[]string{"mockmetadataexporter", "exampleexporter", "notareceiver", "notreal"},
+		}, &componenttest.ExampleExporterConsumer{},
+		&hostWithExporters{exporter: &me},
+		zap.NewNop(),
+	)
+
+	event := event.Event{
+		EventType: "error",
+	}
+	output.SendEvent(&event)
+	received := me.receivedLogs
+	require.Equal(t, 1, len(received))
+	log := received[0]
+	logRecord := log.ResourceLogs().At(0).InstrumentationLibraryLogs().At(0).Logs().At(0)
+	assert.Equal(t, "has_errored", logRecord.Name())
+}
+
+type mockMetadataClient struct {
+	name                    string
+	receivedMetadataUpdates []*metadata.MetadataUpdate
+	receivedLogs            []pdata.Logs
 	componenttest.ExampleExporterConsumer
 }
 
-func (me *mockMetadataExporter) ConsumeMetadata(updates []*metadata.MetadataUpdate) error {
-	me.received = append(me.received, updates...)
+func (me *mockMetadataClient) ConsumeMetadata(updates []*metadata.MetadataUpdate) error {
+	me.receivedMetadataUpdates = append(me.receivedMetadataUpdates, updates...)
 
 	if updates[0].ResourceIDKey == "error" {
 		updates[0].ResourceIDKey = "has_errored"
@@ -152,8 +219,25 @@ func (me *mockMetadataExporter) ConsumeMetadata(updates []*metadata.MetadataUpda
 	return nil
 }
 
+func (me *mockMetadataClient) ConsumeLogs(ctx context.Context, logs pdata.Logs) error {
+	me.receivedLogs = append(me.receivedLogs, logs)
+
+	logRecord := logs.ResourceLogs().At(0).InstrumentationLibraryLogs().At(0).Logs().At(0)
+	if logRecord.Name() == "error" {
+		logRecord.SetName("has_errored")
+		return fmt.Errorf("some error")
+	}
+	return nil
+}
+
+type notAReceiver struct{ component.Component }
+
+type metricsReceiver struct{ component.Component }
+
+func (mr *metricsReceiver) ConsumeMetrics(context.Context, pdata.Metrics) error { return nil }
+
 type hostWithExporters struct {
-	exporter *mockMetadataExporter
+	exporter *mockMetadataClient
 	componenttest.NopHost
 }
 
@@ -170,6 +254,12 @@ func (h *hostWithExporters) GetExporters() map[configmodels.DataType]map[configm
 		context.Background(), component.ExporterCreateParams{}, nil,
 	)
 	exporterMap[exampleExporterFactory.CreateDefaultConfig()] = exampleExporter
+
+	receiver := namedEntity{name: "metricsreceiver"}
+	exporterMap[&receiver] = &metricsReceiver{}
+
+	notReceiver := namedEntity{name: "notareceiver"}
+	exporterMap[&notReceiver] = &notAReceiver{}
 
 	return exporters
 }

--- a/internal/receiver/smartagentreceiver/output_test.go
+++ b/internal/receiver/smartagentreceiver/output_test.go
@@ -107,7 +107,7 @@ func TestSendDimensionUpdateFromConfigMetadataExporters(t *testing.T) {
 	me := mockMetadataClient{name: "mockmetadataexporter"}
 	output := NewOutput(
 		Config{
-			DimensionClients: &[]string{"mockmetadataexporter", "exampleexporter", "metricsreceiver", "notareceiver", "notreal"},
+			DimensionClients: []string{"mockmetadataexporter", "exampleexporter", "metricsreceiver", "notareceiver", "notreal"},
 		}, &componenttest.ExampleExporterConsumer{},
 		&hostWithExporters{exporter: &me},
 		zap.NewNop(),
@@ -172,7 +172,7 @@ func TestSendEventWithInvalidExporter(t *testing.T) {
 
 func TestSendEventWithoutMetadataClients(t *testing.T) {
 	output := NewOutput(Config{
-		EventClients: &[]string{},
+		EventClients: []string{},
 	}, consumertest.NewMetricsNop(),
 		componenttest.NewNopHost(),
 		zap.NewNop(),
@@ -185,7 +185,7 @@ func TestSendEventFromConfigMetadataExporters(t *testing.T) {
 	me := mockMetadataClient{name: "mockmetadataexporter"}
 	output := NewOutput(
 		Config{
-			EventClients: &[]string{"mockmetadataexporter", "exampleexporter", "notareceiver", "notreal"},
+			EventClients: []string{"mockmetadataexporter", "exampleexporter", "notareceiver", "notreal"},
 		}, &componenttest.ExampleExporterConsumer{},
 		&hostWithExporters{exporter: &me},
 		zap.NewNop(),

--- a/internal/receiver/smartagentreceiver/testdata/config.yaml
+++ b/internal/receiver/smartagentreceiver/testdata/config.yaml
@@ -1,12 +1,14 @@
 receivers:
   smartagent/haproxy:
-    metadataClients: [exampleexporter/one, exampleexporter/two]
+    dimensionClients: [exampleexporter/one, exampleexporter/two]
+    eventClients: [exampleexporter/two, exampleexporter/three]
     type: haproxy
     intervalSeconds: 123
     username: SomeUser
     password: secret
   smartagent/redis:
-    metadataClients: []
+    dimensionClients: []
+    eventClients: []
     type: collectd/redis
     host: localhost
     port: 6379

--- a/internal/receiver/smartagentreceiver/testdata/invalid_float_dimension_clients.yaml
+++ b/internal/receiver/smartagentreceiver/testdata/invalid_float_dimension_clients.yaml
@@ -1,6 +1,6 @@
 receivers:
   smartagent/haproxy:
-    metadataClients: notanarray
+    dimensionClients: [1234.45, 2345.56]
     type: haproxy
     intervalSeconds: 123
     username: SomeUser

--- a/internal/receiver/smartagentreceiver/testdata/invalid_nonarray_event_clients.yaml
+++ b/internal/receiver/smartagentreceiver/testdata/invalid_nonarray_event_clients.yaml
@@ -1,6 +1,6 @@
 receivers:
   smartagent/haproxy:
-    metadataClients: [1234.45, 2345.56]
+    eventClients: notanarray
     type: haproxy
     intervalSeconds: 123
     username: SomeUser


### PR DESCRIPTION
These changes adopt SignalFx Event support using the same `MetadataClients` mechanism provided by https://github.com/signalfx/splunk-otel-collector/pull/124 but with the conversion provided by https://github.com/signalfx/splunk-otel-collector/pull/130.  The consumer selection logic is effectively the same as that of the metadata exporter path, but checking for `LogsConsumer` implementors and still defaulting to the next consumer if applicable.  **edit: Now these changes split dimension clients from event clients, but have the same functionality as described**

Not included, but associated with these changes will be a future PR proposing to default to any lone SignalFx exporter if no MetadataClients are specified to avoid the edge cases with processor usage and not requiring users specify metadata clients for each Smart Agent receiver instance.

edit: forgot to mention if not clear, this is designed to work w/ the SFx exporter's log to SFx event api feature without requiring standing up superfluous logging pipeline (after conversation w/ @jrcamp and @flands): https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/signalfxexporter/exporter.go#L193

additional edit: These changes split the proposal for a unified metadata client into dimension and event clients, but the functionality is unchanged.