### PR TITLE
Add and adopt unified integration test helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ ALL_SRC := $(shell find . -name '*.go' \
 # ALL_PKGS is the list of all packages where ALL_SRC files reside.
 ALL_PKGS := $(shell go list $(sort $(dir $(ALL_SRC))))
 
+ALL_TESTS_DIRS := $(shell find tests -name *_test.go | xargs dirname | uniq | sort -r)
+
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release
 
@@ -69,6 +71,15 @@ all: checklicense impi lint misspell test otelcol
 .PHONY: test
 test:
 	$(GOTEST) $(GOTEST_OPT) $(ALL_PKGS)
+
+.PHONY: integration-test
+integration-test:
+	@set -e; for dir in $(ALL_TESTS_DIRS); do \
+	  echo "go test ./... in $${dir}"; \
+	  (cd "$${dir}" && \
+	   $(GOTEST) -v -timeout 5m -count 1 ./... ); \
+	done
+
 
 .PHONY: test-with-cover
 test-with-cover:

--- a/tests/receivers/smartagent/postgresql/postgresql_test.go
+++ b/tests/receivers/smartagent/postgresql/postgresql_test.go
@@ -15,117 +15,37 @@
 package tests
 
 import (
-	"context"
-	"fmt"
 	"path"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/signalfx/splunk-otel-collector/tests/testutils"
 )
 
 func TestPostgresReceiverProvidesAllMetrics(t *testing.T) {
-	tc := newTestcase(t)
-	defer tc.printLogsOnFailure()
-	defer func() { require.NoError(t, tc.otlp.Shutdown()) }()
+	containers := []testutils.Container{
+		testutils.NewContainer().WithContext(
+			path.Join(".", "testdata", "server"),
+		).WithEnv(map[string]string{
+			"POSTGRES_DB":       "test_db",
+			"POSTGRES_USER":     "postgres",
+			"POSTGRES_PASSWORD": "postgres",
+		}).WithExposedPorts(
+			"5432:5432",
+		).WithName("postgres-server").WithNetworks(
+			"postgres",
+		).WillWaitForPorts("5432").WillWaitForLogs(
+			"database system is ready to accept connections",
+		),
+		testutils.NewContainer().WithContext(
+			path.Join(".", "testdata", "client"),
+		).WithEnv(map[string]string{
+			"POSTGRES_SERVER": "postgres-server",
+		}).WithName("postgres-client").WithNetworks(
+			"postgres",
+		).WillWaitForLogs("Beginning psql requests"),
+	}
 
-	expectedResourceMetrics := tc.resourceMetrics("all.yaml")
-
-	server, client := tc.postgresContainers()
-	defer func() {
-		require.NoError(t, server.Stop(context.Background()))
-		require.NoError(t, client.Stop(context.Background()))
-	}()
-
-	collector := tc.splunkOtelCollector("all_metrics_config.yaml")
-	defer func() { require.NoError(tc, collector.Shutdown()) }()
-
-	require.NoError(t, tc.otlp.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
-}
-
-// While overkill for these test purposes, as a repeated pattern these should eventually be moved to testutils.
-type testcase struct {
-	*testing.T
-	logger       *zap.Logger
-	observedLogs *observer.ObservedLogs
-	otlp         *testutils.OTLPMetricsReceiverSink
-}
-
-func newTestcase(t *testing.T) *testcase {
-	tc := testcase{T: t}
-	var logCore zapcore.Core
-	logCore, tc.observedLogs = observer.New(zap.DebugLevel)
-	tc.logger = zap.New(logCore)
-
-	var err error
-	tc.otlp, err = testutils.NewOTLPMetricsReceiverSink().WithEndpoint("localhost:23456").WithLogger(tc.logger).Build()
-	require.NoError(tc, err)
-	require.NoError(tc, tc.otlp.Start())
-	return &tc
-}
-
-func (t *testcase) resourceMetrics(filename string) *testutils.ResourceMetrics {
-	expectedResourceMetrics, err := testutils.LoadResourceMetrics(
-		path.Join(".", "testdata", "resource_metrics", filename),
+	testutils.AssertAllMetricsReceived(
+		t, "all.yaml", "all_metrics_config.yaml", containers,
 	)
-	require.NoError(t, err)
-	require.NotNil(t, expectedResourceMetrics)
-	return expectedResourceMetrics
 }
-
-func (t *testcase) postgresContainers() (server, client *testutils.Container) {
-	server = testutils.NewContainer().WithContext(
-		path.Join(".", "testdata", "server"),
-	).WithEnv(map[string]string{
-		"POSTGRES_DB":       "test_db",
-		"POSTGRES_USER":     "postgres",
-		"POSTGRES_PASSWORD": "postgres",
-	}).WithExposedPorts(
-		"5432:5432",
-	).WithName("postgres-server").WithNetworks(
-		"postgres",
-	).WillWaitForPorts("5432").WillWaitForLogs(
-		"database system is ready to accept connections",
-	).Build()
-
-	require.NoError(t, server.Start(context.Background()))
-
-	client = testutils.NewContainer().WithContext(
-		path.Join(".", "testdata", "client"),
-	).WithEnv(map[string]string{
-		"POSTGRES_SERVER": "postgres-server",
-	}).WithName("postgres-client").WithNetworks(
-		"postgres",
-	).WillWaitForLogs("Beginning psql requests").Build()
-
-	require.NoError(t, client.Start(context.Background()))
-
-	return server, client
-}
-
-func (t *testcase) splunkOtelCollector(configFilename string) *testutils.CollectorProcess {
-	collector, err := testutils.NewCollectorProcess().WithConfigPath(
-		path.Join(".", "testdata", configFilename),
-	).WithLogLevel("debug").WithLogger(t.logger).Build()
-
-	require.NoError(t, err)
-	require.NotNil(t, collector)
-	require.NoError(t, collector.Start())
-	return collector
-}
-
-func (t *testcase) printLogsOnFailure() {
-	if !t.Failed() {
-		return
-	}
-	fmt.Printf("Logs: \n")
-	for _, statement := range t.observedLogs.All() {
-		fmt.Printf("%v\n", statement)
-	}
-}
-

--- a/tests/receivers/smartagent/postgresql/testdata/all_metrics_config.yaml
+++ b/tests/receivers/smartagent/postgresql/testdata/all_metrics_config.yaml
@@ -12,17 +12,12 @@ receivers:
 
 exporters:
   otlp:
-    endpoint: localhost:23456
+    endpoint: "${OTLP_ENDPOINT}"
     insecure: true
-
-  logging:
-    loglevel: debug
-    sampling_initial: 1
-    sampling_thereafter: 10
 
 service:
   pipelines:
     metrics:
       receivers:
         - smartagent/postgresql
-      exporters: [otlp, logging]
+      exporters: [otlp]

--- a/tests/testutils/collector_process.go
+++ b/tests/testutils/collector_process.go
@@ -31,6 +31,7 @@ type CollectorProcess struct {
 	Path             string
 	ConfigPath       string
 	Args             []string
+	Env              map[string]string
 	Logger           *zap.Logger
 	LogLevel         string
 	Process          *subprocess.Subprocess
@@ -54,9 +55,15 @@ func (collector CollectorProcess) WithConfigPath(path string) CollectorProcess {
 	return collector
 }
 
-// []string{"--log-level", collector.LogLevel, "--config", collector.ConfigPath} by default
+// []string{"--log-level", collector.LogLevel, "--config", collector.ConfigPath, "--metrics-level", "none"} by default
 func (collector CollectorProcess) WithArgs(args ...string) CollectorProcess {
 	collector.Args = args
+	return collector
+}
+
+// empty by default
+func (collector CollectorProcess) WithEnv(env map[string]string) CollectorProcess {
+	collector.Env = env
 	return collector
 }
 
@@ -90,11 +97,15 @@ func (collector CollectorProcess) Build() (*CollectorProcess, error) {
 		collector.LogLevel = "info"
 	}
 	if collector.Args == nil {
-		collector.Args = []string{"--log-level", collector.LogLevel, "--config", collector.ConfigPath}
+		collector.Args = []string{
+			"--log-level", collector.LogLevel, "--config", collector.ConfigPath, "--metrics-level", "none",
+		}
 	}
+
 	collector.subprocessConfig = &subprocess.Config{
-		ExecutablePath: collector.Path,
-		Args:           collector.Args,
+		ExecutablePath:       collector.Path,
+		Args:                 collector.Args,
+		EnvironmentVariables: collector.Env,
 	}
 	collector.Process = subprocess.NewSubprocess(collector.subprocessConfig, collector.Logger)
 	return &collector, nil

--- a/tests/testutils/collector_process_test.go
+++ b/tests/testutils/collector_process_test.go
@@ -85,7 +85,7 @@ func TestCollectorProcessBuildDefaults(t *testing.T) {
 	assert.Equal(t, "someconfigpath", collector.ConfigPath)
 	assert.NotNil(t, collector.Logger)
 	assert.Equal(t, "info", collector.LogLevel)
-	assert.Equal(t, []string{"--log-level", "info", "--config", "someconfigpath"}, collector.Args)
+	assert.Equal(t, []string{"--log-level", "info", "--config", "someconfigpath", "--metrics-level", "none"}, collector.Args)
 }
 
 func TestStartAndShutdownInvalidWithoutBuilding(t *testing.T) {

--- a/tests/testutils/testcase.go
+++ b/tests/testutils/testcase.go
@@ -1,0 +1,123 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/testutil"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+type Testcase struct {
+	*testing.T
+	Logger                  *zap.Logger
+	ObservedLogs            *observer.ObservedLogs
+	OTLPMetricsReceiverSink *OTLPMetricsReceiverSink
+	OTLPEndpoint            string
+}
+
+func NewTestcase(t *testing.T) *Testcase {
+	tc := Testcase{T: t}
+	var logCore zapcore.Core
+	logCore, tc.ObservedLogs = observer.New(zap.DebugLevel)
+	tc.Logger = zap.New(logCore)
+
+	tc.OTLPEndpoint = testutil.GetAvailableLocalAddress(t)
+
+	var err error
+	tc.OTLPMetricsReceiverSink, err = NewOTLPMetricsReceiverSink().WithEndpoint(tc.OTLPEndpoint).WithLogger(tc.Logger).Build()
+	require.NoError(tc, err)
+	require.NoError(tc, tc.OTLPMetricsReceiverSink.Start())
+	return &tc
+}
+
+func (t *Testcase) ResourceMetrics(filename string) *ResourceMetrics {
+	expectedResourceMetrics, err := LoadResourceMetrics(
+		path.Join(".", "testdata", "resource_metrics", filename),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, expectedResourceMetrics)
+	return expectedResourceMetrics
+}
+
+func (t *Testcase) Containers(builders ...Container) (containers []*Container, stop func()) {
+	for _, builder := range builders {
+		containers = append(containers, builder.Build())
+	}
+
+	for _, container := range containers {
+		require.NoError(t, container.Start(context.Background()))
+	}
+
+	stop = func() {
+		for _, container := range containers {
+			require.NoError(t, container.Stop(context.Background()))
+		}
+	}
+
+	return
+}
+
+func (t *Testcase) SplunkOtelCollector(configFilename string) (*CollectorProcess, func()) {
+	collector, err := NewCollectorProcess().WithConfigPath(
+		path.Join(".", "testdata", configFilename),
+	).WithEnv(map[string]string{
+		"OTLP_ENDPOINT": t.OTLPEndpoint,
+	}).WithLogLevel("debug").WithLogger(t.Logger).Build()
+
+	require.NoError(t, err)
+	require.NotNil(t, collector)
+	require.NoError(t, collector.Start())
+
+	return collector, func() { require.NoError(t, collector.Shutdown()) }
+}
+
+func (t *Testcase) PrintLogsOnFailure() {
+	if !t.Failed() {
+		return
+	}
+	fmt.Printf("Logs: \n")
+	for _, statement := range t.ObservedLogs.All() {
+		fmt.Printf("%v\n", statement)
+	}
+}
+
+func (t *Testcase) ShutdownOTLPMetricsReceiverSink() {
+	require.NoError(t, t.OTLPMetricsReceiverSink.Shutdown())
+}
+
+func AssertAllMetricsReceived(t *testing.T, resourceMetricsFilename, collectorConfigFilename string, containers []Container) {
+	tc := NewTestcase(t)
+	defer tc.PrintLogsOnFailure()
+	defer tc.ShutdownOTLPMetricsReceiverSink()
+
+	expectedResourceMetrics := tc.ResourceMetrics(resourceMetricsFilename)
+
+	_, stop := tc.Containers(containers...)
+	defer stop()
+
+	_, shutdown := tc.SplunkOtelCollector(collectorConfigFilename)
+	defer shutdown()
+
+	require.NoError(t, tc.OTLPMetricsReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
+}


### PR DESCRIPTION
These changes introduce and source a new `testutils.AssertAllMetricsReceived()` helper to remove unnecessary boilerplate in integration tests, which is largely relocated from the existing postgresql monitor test.  The major change is that they enable a random OTLP receiver address to be used for each case and disable internal telemetry to avoid port conflicts.

Also adds a new `integration-test` make target to be utilized in future Circle CI change.