### PR TITLE
Smart Agent: Default to lone SFx Exporter for dimension/event client if applicable

### DIFF
--- a/internal/receiver/smartagentreceiver/README.md
+++ b/internal/receiver/smartagentreceiver/README.md
@@ -19,12 +19,18 @@ should be used.
 [Collector processors](https://github.com/open-telemetry/opentelemetry-collector/blob/master/processor/README.md).
 1. Monitors with [dimension property and tag update
 functionality](https://dev.splunk.com/observability/docs/datamodel#Creating-or-updating-custom-properties-and-tags)
-require an associated `dimensionClients` field that references the name of the SignalFx exporter you are using in your
-pipeline.
+allow an associated `dimensionClients` field that references the name of the SignalFx exporter you are using in your
+pipeline.  If you do not specify any exporters via this field, the receiver will attempt to use the associated
+pipeline.  If the next element of the pipeline isn't compatible with dimension update behavior, if a lone SignalFx
+exporter was configured for your deployment, it will be selected.  If no dimension update behavior is desired,
+you can specify the empty array `[]` to disable.
 1. Monitors with [event-sending
 functionality](https://dev.splunk.com/observability/docs/datamodel/ingest#Send-custom-events)
-require an associated `eventClients` field that references the name of the SignalFx exporter you are using in your
-pipeline.
+allow an associated `eventClients` field that references the name of the SignalFx exporter you are using in your
+pipeline.  If you do not specify any exporters via this field, the receiver will attempt to use the associated pipeline.
+If the next element of the pipeline isn't compatible with event reporting behavior, if a lone SignalFx exporter was
+configured for your deployment, it will be selected.  If no event-sending behavior is desired, you can specify the
+empty array `[]` to disable.
 
 Example:
 

--- a/internal/receiver/smartagentreceiver/output_test.go
+++ b/internal/receiver/smartagentreceiver/output_test.go
@@ -312,20 +312,23 @@ type hostWithExporters struct {
 
 func getExporters() map[configmodels.DataType]map[configmodels.Exporter]component.Exporter {
 	exporters := map[configmodels.DataType]map[configmodels.Exporter]component.Exporter{}
-	exporterMap := map[configmodels.Exporter]component.Exporter{}
-	exporters[configmodels.MetricsDataType] = exporterMap
+	logExporterMap := map[configmodels.Exporter]component.Exporter{}
+	exporters[configmodels.LogsDataType] = logExporterMap
+
+	metricExporterMap := map[configmodels.Exporter]component.Exporter{}
+	exporters[configmodels.MetricsDataType] = metricExporterMap
 
 	exampleExporterFactory := componenttest.ExampleExporterFactory{}
 	exampleExporter, _ := exampleExporterFactory.CreateMetricsExporter(
 		context.Background(), component.ExporterCreateParams{}, nil,
 	)
-	exporterMap[exampleExporterFactory.CreateDefaultConfig()] = exampleExporter
+	metricExporterMap[exampleExporterFactory.CreateDefaultConfig()] = exampleExporter
 
 	receiver := namedEntity{name: "metricsreceiver"}
-	exporterMap[&receiver] = &metricsReceiver{}
+	metricExporterMap[&receiver] = &metricsReceiver{}
 
 	notReceiver := namedEntity{name: "notareceiver"}
-	exporterMap[&notReceiver] = &notAReceiver{}
+	metricExporterMap[&notReceiver] = &notAReceiver{}
 
 	return exporters
 }
@@ -336,6 +339,9 @@ func (h *hostWithExporters) GetExporters() map[configmodels.DataType]map[configm
 
 	me := namedEntity{name: h.exporter.name, _type: h.exporter.name}
 	exporterMap[&me] = component.MetricsExporter(h.exporter)
+
+	exporterMap = exporters[configmodels.LogsDataType]
+	exporterMap[&me] = component.LogsExporter(h.exporter)
 	return exporters
 }
 
@@ -353,6 +359,11 @@ func (h *hostWithTwoSFxExporters) GetExporters() map[configmodels.DataType]map[c
 
 	meTwo := namedEntity{name: "sfx2", _type: "signalfx"}
 	exporterMap[&meTwo] = component.MetricsExporter(h.sfxExporter)
+
+	exporterMap = exporters[configmodels.LogsDataType]
+	exporterMap[&meOne] = component.LogsExporter(h.sfxExporter)
+	exporterMap[&meTwo] = component.LogsExporter(h.sfxExporter)
+
 	return exporters
 }
 


### PR DESCRIPTION
These changes add an additional path for default dimension and event client selection in the Smart Agent receiver.  The final proposed behavior is:

1.  If dimension/event clients config field is not null, try to use all specified exporters.  If it is not null, but empty don't use any exporters. (already the case)
2. If dimension/event clients is null, try to use the next consumer for the associated pipeline. (already the case)
3. If dimension/event clients is null but the next consumer is not compatible, use the lone SFx exporter on the host. (this PR)
4. If there is more than one configured SFx exporter, don't use any exporters. (this PR)

edit: To clarify, the aim of these changes is to not require specifying a value for this field for most usages, but to not interfere with or prevent any desired configuration.