### PR TITLE
Fix API breakage

### DIFF
--- a/examples/prometheus-federation/prom-counter/go.sum
+++ b/examples/prometheus-federation/prom-counter/go.sum
@@ -277,6 +277,7 @@ go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mI
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.opentelemetry.io v0.1.0 h1:EANZoRCOP+A3faIlw/iN6YEWoYb1vleZRKm1EvH8T48=
 go.opentelemetry.io/otel v0.17.0 h1:6MKOu8WY4hmfpQ4oQn34u6rYhnf2sWf1LXYO/UFm71U=
 go.opentelemetry.io/otel v0.17.0/go.mod h1:Oqtdxmf7UtEvL037ohlgnaYa1h7GtMh0NcSd9eqkC9s=
 go.opentelemetry.io/otel v0.18.0 h1:d5Of7+Zw4ANFOJB+TIn2K3QWsgS2Ht7OU9DqZHI6qu8=

--- a/examples/prometheus-federation/prom-counter/main.go
+++ b/examples/prometheus-federation/prom-counter/main.go
@@ -9,10 +9,10 @@ import (
 	"syscall"
 	"time"
 
-	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/metric/prometheus"
-	"go.opentelemetry.io/otel/label"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/global"
 	"go.uber.org/zap"
 )
 
@@ -34,11 +34,11 @@ func main() {
 	logger, _ := zap.NewProduction()
 	defer logger.Sync()
 	logger.Info("Start Prometheus metrics app")
-	meter := otel.Meter("counter")
+	meter := global.Meter("counter")
 	valueRecorder := metric.Must(meter).NewInt64ValueRecorder("prom_counter")
 	ctx := context.Background()
 	valueRecorder.Measurement(0)
-	commonLabels := []label.KeyValue{label.String("A", "1"), label.String("B", "2"), label.String("C", "3")}
+	commonLabels := []attribute.KeyValue{attribute.String("A", "1"), attribute.String("B", "2"), attribute.String("C", "3")}
 	counter := int64(0)
 	meter.RecordBatch(ctx,
 		commonLabels,


### PR DESCRIPTION
#146 and #147 impacted the code as some API renames were done in the opentelemetry go SDK. Apologies for catching this late.