### PR TITLE
Use same scrapers as OCK

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -24,13 +24,17 @@ receivers:
     scrapers:
       cpu:
       disk:
-      load:
       filesystem:
       memory:
       network:
-      process:
-      processes:
+      # System load average metrics https://en.wikipedia.org/wiki/Load_(computing)
+      load:
+      # Paging/Swap space utilization and I/O metrics
       paging:
+      # Aggregated system process count metrics
+      processes:
+      # System processes metrics, disabled by default
+      # process:
   jaeger:
     protocols:
       grpc:

--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -104,12 +104,17 @@ receivers:
     scrapers:
       cpu:
       disk:
-      load:
       filesystem:
       memory:
       network:
-      processes:
+      # System load average metrics https://en.wikipedia.org/wiki/Load_(computing)
+      load:
+      # Paging/Swap space utilization and I/O metrics
       paging:
+      # Aggregated system process count metrics
+      processes:
+      # System processes metrics, disabled by default
+      # process:
 
   # Enables the prometheus receiver -- should only be used for local metric collection
   # This section is used to collect the OpenTelemetry Collector metrics

--- a/examples/kubernetes-yaml/splunk-otel-collector-agent.yaml
+++ b/examples/kubernetes-yaml/splunk-otel-collector-agent.yaml
@@ -21,12 +21,17 @@ data:
         scrapers:
           cpu:
           disk:
-          load:
           filesystem:
           memory:
           network:
-          processes:
+          # System load average metrics https://en.wikipedia.org/wiki/Load_(computing)
+          load:
+          # Paging/Swap space utilization and I/O metrics
           paging:
+          # Aggregated system process count metrics
+          processes:
+          # System processes metrics, disabled by default
+          # process:
       jaeger:
         protocols:
           grpc:

--- a/examples/kubernetes-yaml/splunk-otel-collector-gateway.yaml
+++ b/examples/kubernetes-yaml/splunk-otel-collector-gateway.yaml
@@ -21,12 +21,17 @@ data:
         scrapers:
           cpu:
           disk:
-          load:
           filesystem:
           memory:
           network:
-          processes:
+          # System load average metrics https://en.wikipedia.org/wiki/Load_(computing)
+          load:
+          # Paging/Swap space utilization and I/O metrics
           paging:
+          # Aggregated system process count metrics
+          processes:
+          # System processes metrics, disabled by default
+          # process:
       jaeger:
         protocols:
           grpc:


### PR DESCRIPTION
Specifically don't need process scraper which doesn't collect default metrics.