### PR TITLE
Smart Agent log receiver

### DIFF
--- a/internal/receiver/smartagentreceiver/README.md
+++ b/internal/receiver/smartagentreceiver/README.md
@@ -19,30 +19,54 @@ should be used.
 [Collector processors](https://github.com/open-telemetry/opentelemetry-collector/blob/master/processor/README.md).
 1. Monitors with [dimension property and tag update
 functionality](https://dev.splunk.com/observability/docs/datamodel#Creating-or-updating-custom-properties-and-tags)
-require an associated `dimensionClients` field that references the name of the SignalFx exporter you are using in your
-pipeline.
+allow an associated `dimensionClients` field that references the name of the SignalFx exporter you are using in your
+pipeline.  If you do not specify any exporters via this field, the receiver will attempt to use the associated
+pipeline.  If the next element of the pipeline isn't compatible with dimension update behavior, if a lone SignalFx
+exporter was configured for your deployment, it will be selected.  If no dimension update behavior is desired,
+you can specify the empty array `[]` to disable.
 1. Monitors with [event-sending
-functionality](https://dev.splunk.com/observability/docs/datamodel/ingest#Send-custom-events)
-require an associated `eventClients` field that references the name of the SignalFx exporter you are using in your
-pipeline.
+functionality](https://dev.splunk.com/observability/docs/datamodel/ingest#Send-custom-events) should be made members of
+a `logs` pipeline that utilizes a [SignalFx
+exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/signalfxexporter/README.md)
+that will make the event submission requests.  It's recommended, and in the case of the Processlist monitor required,
+to use a Resource Detection to ensure that host identity and other useful information is made available as event
+dimensions.
 
 Example:
 
 ```yaml
-exporters:
-  signalfx:
-
 receivers:
-  smartagent/haproxy:
-    type: haproxy
-    host: myhaproxyinstance
-    port: 8080
   smartagent/postgresql:
     type: postgresql
     host: mypostgresinstance
     port: 5432
     dimensionClients: [signalfx]
-    eventClients: [signalfx]
+  smartagent/processlist:
+    type: processlist
+  smartagent/kafka:
+    type: collectd/kafka
+    host: mykafkabroker
+    port: 7099
+    clusterName: mykafkacluster
+    intervalSeconds: 1
+
+processors:
+  resourcedetection:
+    detectors: [system]
+
+exporters:
+  signalfx:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [smartagent/postgresql, smartagent/kafka]
+      processors: [resourcedetection]
+      exporters: [signalfx]
+    logs:
+      receivers: [smartagent/processlist]
+      processors: [resourcedetection]
+      exporters: [signalfx]
 ```
 
 The full list of settings exposed for this receiver are documented for

--- a/internal/receiver/smartagentreceiver/config.go
+++ b/internal/receiver/smartagentreceiver/config.go
@@ -33,7 +33,6 @@ import (
 const defaultIntervalSeconds = 10
 
 var errDimensionClientValue = fmt.Errorf("dimensionClients must be an array of compatible exporter names")
-var errEventClientValue = fmt.Errorf("eventClients must be an array of compatible exporter names")
 
 type Config struct {
 	monitorConfig                 config.MonitorCustomConfig
@@ -42,7 +41,6 @@ type Config struct {
 	// Will expand to MonitorCustomConfig Host and Port values if unset.
 	Endpoint         string   `mapstructure:"endpoint"`
 	DimensionClients []string `mapstructure:"dimensionclients"`
-	EventClients     []string `mapstructure:"eventclients"`
 }
 
 func (rCfg *Config) validate() error {
@@ -84,10 +82,6 @@ func mergeConfigs(componentViperSection *viper.Viper, intoCfg interface{}) error
 
 	var err error
 	receiverCfg.DimensionClients, err = getStringSliceFromAllSettings(allSettings, "dimensionclients", errDimensionClientValue)
-	if err != nil {
-		return err
-	}
-	receiverCfg.EventClients, err = getStringSliceFromAllSettings(allSettings, "eventclients", errEventClientValue)
 	if err != nil {
 		return err
 	}

--- a/internal/receiver/smartagentreceiver/config_test.go
+++ b/internal/receiver/smartagentreceiver/config_test.go
@@ -54,14 +54,12 @@ func TestLoadConfig(t *testing.T) {
 
 	haproxyCfg := cfg.Receivers["smartagent/haproxy"].(*Config)
 	expectedDimensionClients := []string{"exampleexporter/one", "exampleexporter/two"}
-	expectedEventClients := []string{"exampleexporter/two", "exampleexporter/three"}
 	require.Equal(t, &Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
 			TypeVal: typeStr,
 			NameVal: typeStr + "/haproxy",
 		},
 		DimensionClients: expectedDimensionClients,
-		EventClients:     expectedEventClients,
 		monitorConfig: &haproxy.Config{
 			MonitorConfig: config.MonitorConfig{
 				Type:                "haproxy",
@@ -84,7 +82,6 @@ func TestLoadConfig(t *testing.T) {
 			NameVal: typeStr + "/redis",
 		},
 		DimensionClients: []string{},
-		EventClients:     []string{},
 		monitorConfig: &redis.Config{
 			MonitorConfig: config.MonitorConfig{
 				Type:                "collectd/redis",
@@ -388,18 +385,18 @@ func TestLoadInvalidConfigWithUnsupportedEndpoint(t *testing.T) {
 	require.Nil(t, cfg)
 }
 
-func TestLoadInvalidConfigWithNonArrayEventClients(t *testing.T) {
+func TestLoadInvalidConfigWithNonArrayDimensionClients(t *testing.T) {
 	factories, err := componenttest.ExampleComponents()
 	assert.Nil(t, err)
 
 	factory := NewFactory()
 	factories.Receivers[configmodels.Type(typeStr)] = factory
 	cfg, err := configtest.LoadConfigFile(
-		t, path.Join(".", "testdata", "invalid_nonarray_event_clients.yaml"), factories,
+		t, path.Join(".", "testdata", "invalid_nonarray_dimension_clients.yaml"), factories,
 	)
 	require.Error(t, err)
 	require.EqualError(t, err,
-		"error reading receivers configuration for smartagent/haproxy: eventClients must be an array of compatible exporter names")
+		"error reading receivers configuration for smartagent/haproxy: dimensionClients must be an array of compatible exporter names")
 	require.Nil(t, cfg)
 }
 

--- a/internal/receiver/smartagentreceiver/testdata/config.yaml
+++ b/internal/receiver/smartagentreceiver/testdata/config.yaml
@@ -1,14 +1,12 @@
 receivers:
   smartagent/haproxy:
     dimensionClients: [exampleexporter/one, exampleexporter/two]
-    eventClients: [exampleexporter/two, exampleexporter/three]
     type: haproxy
     intervalSeconds: 123
     username: SomeUser
     password: secret
   smartagent/redis:
     dimensionClients: []
-    eventClients: []
     type: collectd/redis
     host: localhost
     port: 6379

--- a/internal/receiver/smartagentreceiver/testdata/invalid_nonarray_dimension_clients.yaml
+++ b/internal/receiver/smartagentreceiver/testdata/invalid_nonarray_dimension_clients.yaml
@@ -1,6 +1,6 @@
 receivers:
   smartagent/haproxy:
-    eventClients: notanarray
+    dimensionClients: notanarray
     type: haproxy
     intervalSeconds: 123
     username: SomeUser


### PR DESCRIPTION
(In lieu of https://github.com/signalfx/splunk-otel-collector/pull/149)

These changes allow the Smart Agent receiver to act as both a metrics and logs receiver, as well as removing the notion of an event client in config and Output functionality.  Instead they use standard log pipelines after I discovered that the main user of events in the agent, the processlist monitor, requires a host dimension that must be added via processor in a log pipeline unless hardcoded in agent config (https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2631 is necessary in SFx exporter for this to take effect).

Also includes the basic SFx exporter dimension client defaulting logic, which is simpler without event clients.