### PR TITLE
Add comments on how to setup optional "environment" attribute

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -81,6 +81,15 @@ processors:
     detectors: [system]
     override: true
 
+  # Optional: The following processor can be used to add a default "deployment.environment" attribute to the logs and 
+  # traces when it's not populated by instrumentation libraries.
+  # If enabled, make sure to enable this processor in the pipeline below.
+  #resource/add_environment:
+    #attributes:
+      #- action: insert
+        #value: staging/production/...
+        #key: deployment.environment
+
 exporters:
   # Traces
   sapm:
@@ -103,7 +112,11 @@ service:
   pipelines:
     traces:
       receivers: [jaeger, otlp, sapm, zipkin]
-      processors: [memory_limiter, batch, resourcedetection]
+      processors: 
+      - memory_limiter
+      - batch
+      - resourcedetection
+      #- resource/add_environment
       exporters: [sapm, signalfx]
     metrics:
       receivers: [otlp, signalfx, prometheus, hostmetrics]
@@ -115,5 +128,9 @@ service:
       exporters: [signalfx]
     logs:
       receivers: [fluentforward]
-      processors: [memory_limiter, batch, resourcedetection]
+      processors: 
+      - memory_limiter
+      - batch
+      - resourcedetection
+      #- resource/add_environment
       exporters: [splunk_hec]

--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -257,6 +257,15 @@ processors:
         rules:
           - ^\/api\/v1\/document\/(?P<documentId>.*)\/update$
 
+  # Optional: The following processor can be used to add a default "deployment.environment" attribute to the traces
+  # when it's not populated by instrumentation libraries.
+  # If enabled, make sure to enable this processor in the pipeline below.
+  #resource/add_environment:
+    #attributes:
+      #- action: insert
+        #value: staging/production/...
+        #key: deployment.environment
+
   #############################################################################
   # Metrics
   #############################################################################
@@ -525,7 +534,10 @@ service:
   pipelines:
     traces:
       receivers: [jaeger, otlp, sapm, zipkin]
-      processors: [memory_limiter, batch]
+      processors: 
+      - memory_limiter
+      - batch
+      #- resource/add_environment
       exporters: [sapm, signalfx]
     metrics:
       receivers: [otlp, signalfx, prometheus]

--- a/cmd/otelcol/config/collector/otlp_config_linux.yaml
+++ b/cmd/otelcol/config/collector/otlp_config_linux.yaml
@@ -45,6 +45,15 @@ processors:
     check_interval: 2s
     limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
 
+  # Optional: The following processor can be used to add a default "deployment.environment" attribute to the traces
+  # when it's not populated by instrumentation libraries.
+  # If enabled, make sure to enable this processor in the pipeline below.
+  #resource/add_environment:
+    #attributes:
+      #- action: insert
+        #value: staging/production/...
+        #key: deployment.environment
+
 exporters:
   # Traces
   otlphttp:
@@ -72,7 +81,10 @@ service:
   pipelines:
     traces:
       receivers: [jaeger, otlp, sapm, zipkin]
-      processors: [memory_limiter, batch]
+      processors: 
+      - memory_limiter
+      - batch
+      #- resource/add_environment
       exporters: [otlphttp, signalfx]
     metrics:
       receivers: [otlp, signalfx, prometheus]

--- a/cmd/otelcol/config/collector/splunk_config_linux.yaml
+++ b/cmd/otelcol/config/collector/splunk_config_linux.yaml
@@ -45,6 +45,15 @@ processors:
     check_interval: 2s
     limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
 
+  # Optional: The following processor can be used to add a default "deployment.environment" attribute to the traces
+  # when it's not populated by instrumentation libraries.
+  # If enabled, make sure to enable this processor in the pipeline below.
+  #resource/add_environment:
+    #attributes:
+      #- action: insert
+        #value: staging/production/...
+        #key: deployment.environment
+
 exporters:
   # Traces
   sapm:
@@ -71,7 +80,10 @@ service:
   pipelines:
     traces:
       receivers: [jaeger, otlp, sapm, zipkin]
-      processors: [memory_limiter, batch]
+      processors: 
+      - memory_limiter
+      - batch
+      #- resource/add_environment
       exporters: [sapm, signalfx]
     metrics:
       receivers: [otlp, signalfx, prometheus]


### PR DESCRIPTION
"deployment.environment" supposed to be set by OTel instrumentation libraries, but when it's missing we want to provide an easy option to specify a default value in collector.