### PR TITLE
Add minimal lifecycle tests for distro components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ dist/
 *.iml
 
 # VS Code
-.vscode
+.vscode/
+.devcontainer/
 
 # Emacs
 *~

--- a/internal/components/componenttest/assert_no_error_host.go
+++ b/internal/components/componenttest/assert_no_error_host.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package componenttest is a temporary addition while related changes are not made on core.
+package componenttest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configmodels"
+)
+
+// assertNoErrorHost implements a component.Host that asserts that
+// there were no errors.
+type assertNoErrorHost struct {
+	t *testing.T
+}
+
+var _ component.Host = (*assertNoErrorHost)(nil)
+
+// NewAssertNoError returns a new instance of a component.Host. This instance
+// asserts if an error is received.
+// TODO: Remove this package when equivalent is available from OpenTelemetry Collector repo.
+func NewAssertNoError(t *testing.T) component.Host {
+	return &assertNoErrorHost{
+		t: t,
+	}
+}
+
+func (aneh *assertNoErrorHost) ReportFatalError(err error) {
+	assert.NoError(aneh.t, err)
+}
+
+func (aneh *assertNoErrorHost) GetFactory(kind component.Kind, componentType configmodels.Type) component.Factory {
+	return nil
+}
+
+func (aneh *assertNoErrorHost) GetExtensions() map[configmodels.NamedEntity]component.Extension {
+	return nil
+}
+
+func (aneh *assertNoErrorHost) GetExporters() map[configmodels.DataType]map[configmodels.NamedEntity]component.Exporter {
+	return nil
+}

--- a/internal/components/componenttest/assert_no_error_host.go
+++ b/internal/components/componenttest/assert_no_error_host.go
@@ -31,10 +31,10 @@ type assertNoErrorHost struct {
 
 var _ component.Host = (*assertNoErrorHost)(nil)
 
-// NewAssertNoError returns a new instance of a component.Host. This instance
+// NewAssertNoErrorHost returns a new instance of a component.Host. This instance
 // asserts if an error is received.
 // TODO: Remove this package when equivalent is available from OpenTelemetry Collector repo.
-func NewAssertNoError(t *testing.T) component.Host {
+func NewAssertNoErrorHost(t *testing.T) component.Host {
 	return &assertNoErrorHost{
 		t: t,
 	}

--- a/internal/components/componenttest/assert_no_error_host.go
+++ b/internal/components/componenttest/assert_no_error_host.go
@@ -20,12 +20,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/component/componenttest"
 )
 
 // assertNoErrorHost implements a component.Host that asserts that
 // there were no errors.
 type assertNoErrorHost struct {
+	component.Host
 	t *testing.T
 }
 
@@ -36,22 +37,11 @@ var _ component.Host = (*assertNoErrorHost)(nil)
 // TODO: Remove this package when equivalent is available from OpenTelemetry Collector repo.
 func NewAssertNoErrorHost(t *testing.T) component.Host {
 	return &assertNoErrorHost{
-		t: t,
+		componenttest.NewNopHost(),
+		t,
 	}
 }
 
 func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh.t, err)
-}
-
-func (aneh *assertNoErrorHost) GetFactory(kind component.Kind, componentType configmodels.Type) component.Factory {
-	return nil
-}
-
-func (aneh *assertNoErrorHost) GetExtensions() map[configmodels.NamedEntity]component.Extension {
-	return nil
-}
-
-func (aneh *assertNoErrorHost) GetExporters() map[configmodels.DataType]map[configmodels.NamedEntity]component.Exporter {
-	return nil
 }

--- a/internal/extension/smartagentextension/extension_test.go
+++ b/internal/extension/smartagentextension/extension_test.go
@@ -32,10 +32,12 @@ func TestExtensionLifecycle(t *testing.T) {
 		Logger: zap.NewNop(),
 	}
 	cfg := &Config{
-		bundleDir: "/bundle/",
-		collectdConfig: config.CollectdConfig{
-			Timeout:   10,
-			ConfigDir: "/config/",
+		Config: config.Config{
+			BundleDir: "/bundle/",
+			Collectd: config.CollectdConfig{
+				Timeout:   10,
+				ConfigDir: "/config/",
+			},
 		},
 	}
 

--- a/internal/extension/smartagentextension/extension_test.go
+++ b/internal/extension/smartagentextension/extension_test.go
@@ -45,7 +45,7 @@ func TestExtensionLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, fstExt)
 
-	mh := componenttest.NewAssertNoError(t)
+	mh := componenttest.NewAssertNoErrorHost(t)
 	require.NoError(t, fstExt.Start(ctx, mh))
 
 	sndExt, err := f.CreateExtension(ctx, createParams, cfg)

--- a/internal/extension/smartagentextension/extension_test.go
+++ b/internal/extension/smartagentextension/extension_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
@@ -47,13 +46,11 @@ func TestExtensionLifecycle(t *testing.T) {
 
 	mh := componenttest.NewAssertNoErrorHost(t)
 	require.NoError(t, fstExt.Start(ctx, mh))
-
-	sndExt, err := f.CreateExtension(ctx, createParams, cfg)
-	assert.NoError(t, err)
-	assert.NotNil(t, sndExt)
-
 	require.NoError(t, fstExt.Shutdown(ctx))
 
+	sndExt, err := f.CreateExtension(ctx, createParams, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, sndExt)
 	require.NoError(t, sndExt.Start(ctx, mh))
 	require.NoError(t, sndExt.Shutdown(ctx))
 }

--- a/internal/extension/smartagentextension/extension_test.go
+++ b/internal/extension/smartagentextension/extension_test.go
@@ -19,32 +19,41 @@ import (
 	"testing"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.uber.org/zap"
+
+	"github.com/signalfx/splunk-otel-collector/internal/components/componenttest"
 )
 
-func TestExtension(t *testing.T) {
-	f := NewFactory()
-	e, err := f.CreateExtension(
-		context.Background(),
-		component.ExtensionCreateParams{
-			Logger: zap.NewNop(),
+func TestExtensionLifecycle(t *testing.T) {
+	ctx := context.Background()
+	createParams := component.ExtensionCreateParams{
+		Logger: zap.NewNop(),
+	}
+	cfg := &Config{
+		bundleDir: "/bundle/",
+		collectdConfig: config.CollectdConfig{
+			Timeout:   10,
+			ConfigDir: "/config/",
 		},
-		&Config{
-			Config: config.Config{
-				BundleDir: "/bundle/",
-				Collectd: config.CollectdConfig{
-					Timeout:   10,
-					ConfigDir: "/config/",
-				},
-			},
-		},
-	)
-	require.NoError(t, err)
-	require.NotNil(t, e)
+	}
 
-	require.NoError(t, e.Start(context.Background(), componenttest.NewNopHost()))
-	require.NoError(t, e.Shutdown(context.Background()))
+	f := NewFactory()
+	fstExt, err := f.CreateExtension(ctx, createParams, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, fstExt)
+
+	mh := componenttest.NewAssertNoError(t)
+	require.NoError(t, fstExt.Start(ctx, mh))
+
+	sndExt, err := f.CreateExtension(ctx, createParams, cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, sndExt)
+
+	require.NoError(t, fstExt.Shutdown(ctx))
+
+	require.NoError(t, sndExt.Start(ctx, mh))
+	require.NoError(t, sndExt.Shutdown(ctx))
 }

--- a/internal/receiver/smartagentreceiver/receiver_test.go
+++ b/internal/receiver/smartagentreceiver/receiver_test.go
@@ -234,7 +234,7 @@ func TestMultipleInstacesOfSameMonitorType(t *testing.T) {
 	fstRcvr := NewReceiver(zap.NewNop(), cfg)
 
 	ctx := context.Background()
-	mh := internaltest.NewAssertNoError(t)
+	mh := internaltest.NewAssertNoErrorHost(t)
 	require.NoError(t, fstRcvr.Start(ctx, mh))
 
 	sndRcvr := NewReceiver(zap.NewNop(), cfg)

--- a/internal/receiver/smartagentreceiver/receiver_test.go
+++ b/internal/receiver/smartagentreceiver/receiver_test.go
@@ -236,11 +236,9 @@ func TestMultipleInstacesOfSameMonitorType(t *testing.T) {
 	ctx := context.Background()
 	mh := internaltest.NewAssertNoErrorHost(t)
 	require.NoError(t, fstRcvr.Start(ctx, mh))
-
-	sndRcvr := NewReceiver(zap.NewNop(), cfg)
-
 	require.NoError(t, fstRcvr.Shutdown(ctx))
 
+	sndRcvr := NewReceiver(zap.NewNop(), cfg)
 	assert.NoError(t, sndRcvr.Start(ctx, mh))
 	assert.NoError(t, sndRcvr.Shutdown(ctx))
 }

--- a/internal/receiver/smartagentreceiver/receiver_test.go
+++ b/internal/receiver/smartagentreceiver/receiver_test.go
@@ -228,6 +228,23 @@ func TestOutOfOrderShutdownInvocations(t *testing.T) {
 	)
 }
 
+func TestMultipleInstacesOfSameMonitorType(t *testing.T) {
+	t.Cleanup(cleanUp)
+	cfg := newConfig("valid", "cpu", 1)
+	fstRcvr := NewReceiver(zap.NewNop(), cfg)
+
+	ctx := context.Background()
+	mh := internaltest.NewAssertNoError(t)
+	require.NoError(t, fstRcvr.Start(ctx, mh))
+
+	sndRcvr := NewReceiver(zap.NewNop(), cfg)
+
+	require.NoError(t, fstRcvr.Shutdown(ctx))
+
+	assert.NoError(t, sndRcvr.Start(ctx, mh))
+	assert.NoError(t, sndRcvr.Shutdown(ctx))
+}
+
 func TestInvalidMonitorStateAtShutdown(t *testing.T) {
 	t.Cleanup(cleanUp)
 	cfg := newConfig("valid", "cpu", 1)
@@ -333,23 +350,6 @@ func TestSmartAgentConfigProviderOverrides(t *testing.T) {
 	require.Equal(t, "/run", os.Getenv("HOST_RUN"))
 	require.Equal(t, "/var", os.Getenv("HOST_VAR"))
 	require.Equal(t, "/etc", os.Getenv("HOST_ETC"))
-}
-
-func TestReceiverLifecycle(t *testing.T) {
-	t.Cleanup(cleanUp)
-	cfg := newConfig("valid", "cpu", 1)
-	fstRcvr := NewReceiver(zap.NewNop(), cfg)
-
-	ctx := context.Background()
-	mh := internaltest.NewAssertNoError(t)
-	require.NoError(t, fstRcvr.Start(ctx, mh))
-
-	sndRcvr := NewReceiver(zap.NewNop(), cfg)
-
-	require.NoError(t, fstRcvr.Shutdown(ctx))
-
-	assert.NoError(t, sndRcvr.Start(ctx, mh))
-	assert.NoError(t, sndRcvr.Shutdown(ctx))
 }
 
 func getSmartAgentExtensionConfig(t *testing.T) []*smartagentextension.Config {

--- a/internal/receiver/smartagentreceiver/receiver_test.go
+++ b/internal/receiver/smartagentreceiver/receiver_test.go
@@ -42,6 +42,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
+	internaltest "github.com/signalfx/splunk-otel-collector/internal/components/componenttest"
 	"github.com/signalfx/splunk-otel-collector/internal/extension/smartagentextension"
 )
 
@@ -332,6 +333,23 @@ func TestSmartAgentConfigProviderOverrides(t *testing.T) {
 	require.Equal(t, "/run", os.Getenv("HOST_RUN"))
 	require.Equal(t, "/var", os.Getenv("HOST_VAR"))
 	require.Equal(t, "/etc", os.Getenv("HOST_ETC"))
+}
+
+func TestReceiverLifecycle(t *testing.T) {
+	t.Cleanup(cleanUp)
+	cfg := newConfig("valid", "cpu", 1)
+	fstRcvr := NewReceiver(zap.NewNop(), cfg)
+
+	ctx := context.Background()
+	mh := internaltest.NewAssertNoError(t)
+	require.NoError(t, fstRcvr.Start(ctx, mh))
+
+	sndRcvr := NewReceiver(zap.NewNop(), cfg)
+
+	require.NoError(t, fstRcvr.Shutdown(ctx))
+
+	assert.NoError(t, sndRcvr.Start(ctx, mh))
+	assert.NoError(t, sndRcvr.Shutdown(ctx))
 }
 
 func getSmartAgentExtensionConfig(t *testing.T) []*smartagentextension.Config {


### PR DESCRIPTION
## Why
In the near future components need to support the cycle of creation/start/stop multiple times inside the same process.

## What
Adding minimal tests to ensure that the components defined on the repo are at least supporting the most trivial lifecycle. Ideally, the testing code for components will be provided by packages from the core repo until that happens these minimal tests ensure the basic behavior is not broken. The tests don't cover the case when the components are actively receiving or sending data that will be added later when the collector can recycle components.