### PR TITLE
smartagent extension: ensure propagation of collectd bundle dir

### DIFF
--- a/internal/extension/smartagentextension/config.go
+++ b/internal/extension/smartagentextension/config.go
@@ -62,9 +62,9 @@ func customUnmarshaller(componentViperSection *viper.Viper, intoCfg interface{})
 	var collectdSettings map[string]interface{}
 	var ok bool
 	if collectdSettings, ok = allSettings["collectd"].(map[string]interface{}); !ok {
-		// Nothing to do if user specified collectd settings do not exist.
-		// Defaults will be picked up.
-		return nil
+		// We must set the BundleDir field on the resulting CollectdConfig
+		// so we use an empty instance.  Defaults will be picked up.
+		collectdSettings = map[string]interface{}{}
 	}
 
 	var collectdConfig config.CollectdConfig

--- a/internal/extension/smartagentextension/config_test.go
+++ b/internal/extension/smartagentextension/config_test.go
@@ -62,6 +62,7 @@ func TestLoadConfig(t *testing.T) {
 				WriteServerIPAddr:    "127.9.8.7",
 				WriteServerPort:      0,
 				ConfigDir:            "/var/run/signalfx-agent/collectd",
+				BundleDir:            bundleDir,
 				HasGenericJMXMonitor: false,
 			},
 		}


### PR DESCRIPTION
These changes fix a bug in the SA Extension that leaves* the default collectd config partially populated and doesn't* respect the desired executable location, which is what the agent [actually uses](https://github.com/signalfx/signalfx-agent/blob/c295133b4a52b2fff071c8070536183a48e403fc/pkg/monitors/collectd/collectd.go#L469).

I've corrected the relevant unit test with the desired value.  The integration tests missed this since they set a temporary collectd configDir option, which I'm not able to bypass at this time due to resulting permission errors w/ the default.