### PR TITLE
Support gateway mode for linux installer

### DIFF
--- a/internal/buildscripts/packaging/fpm/common.sh
+++ b/internal/buildscripts/packaging/fpm/common.sh
@@ -29,8 +29,10 @@ SERVICE_USER="splunk-otel-collector"
 SERVICE_GROUP="splunk-otel-collector"
 
 OTELCOL_INSTALL_PATH="/usr/bin/otelcol"
-CONFIG_REPO_PATH="$REPO_DIR/cmd/otelcol/config/collector/agent_config.yaml"
-CONFIG_INSTALL_PATH="/etc/otel/collector/agent_config.yaml"
+AGENT_CONFIG_REPO_PATH="$REPO_DIR/cmd/otelcol/config/collector/agent_config.yaml"
+AGENT_CONFIG_INSTALL_PATH="/etc/otel/collector/agent_config.yaml"
+GATEWAY_CONFIG_REPO_PATH="$REPO_DIR/cmd/otelcol/config/collector/gateway_config.yaml"
+GATEWAY_CONFIG_INSTALL_PATH="/etc/otel/collector/gateway_config.yaml"
 SERVICE_REPO_PATH="$FPM_DIR/$SERVICE_NAME.service"
 SERVICE_INSTALL_PATH="/lib/systemd/system/$SERVICE_NAME.service"
 
@@ -107,7 +109,8 @@ setup_files_and_permissions() {
     sudo chmod 755 "$buildroot/$OTELCOL_INSTALL_PATH"
 
     cp -r "$FPM_DIR/etc" "$buildroot/etc"
-    cp -f "$CONFIG_REPO_PATH" "$buildroot/$CONFIG_INSTALL_PATH"
+    cp -f "$AGENT_CONFIG_REPO_PATH" "$buildroot/$AGENT_CONFIG_INSTALL_PATH"
+    cp -f "$GATEWAY_CONFIG_REPO_PATH" "$buildroot/$GATEWAY_CONFIG_INSTALL_PATH"
     sudo chown -R $SERVICE_USER:$SERVICE_GROUP "$buildroot/etc/otel"
     sudo chmod -R 755 "$buildroot/etc/otel"
     sudo chmod 600 "$buildroot/etc/otel/collector/$SERVICE_NAME.conf.example"

--- a/internal/buildscripts/packaging/fpm/deb/build.sh
+++ b/internal/buildscripts/packaging/fpm/deb/build.sh
@@ -54,7 +54,8 @@ sudo fpm -s dir -t deb -n "$PKG_NAME" -v "$VERSION" -f -p "$OUTPUT_DIR" \
     --after-install "$POSTINSTALL_PATH" \
     --before-remove "$PREUNINSTALL_PATH" \
     --deb-no-default-config-files \
-    --config-files "$CONFIG_INSTALL_PATH" \
+    --config-files "$AGENT_CONFIG_INSTALL_PATH" \
+    --config-files "$GATEWAY_CONFIG_INSTALL_PATH" \
     --config-files "$FLUENTD_CONFIG_INSTALL_DIR" \
     "$buildroot/"=/
 

--- a/internal/buildscripts/packaging/fpm/rpm/build.sh
+++ b/internal/buildscripts/packaging/fpm/rpm/build.sh
@@ -58,7 +58,8 @@ sudo fpm -s dir -t rpm -n "$PKG_NAME" -v "$VERSION" -f -p "$OUTPUT_DIR" \
     --before-install "$PREINSTALL_PATH" \
     --after-install "$POSTINSTALL_PATH" \
     --before-remove "$PREUNINSTALL_PATH" \
-    --config-files "$CONFIG_INSTALL_PATH" \
+    --config-files "$AGENT_CONFIG_INSTALL_PATH" \
+    --config-files "$GATEWAY_CONFIG_INSTALL_PATH" \
     --config-files "$FLUENTD_CONFIG_INSTALL_DIR" \
     "$buildroot/"=/
 

--- a/internal/buildscripts/packaging/tests/installer_test.py
+++ b/internal/buildscripts/packaging/tests/installer_test.py
@@ -39,8 +39,12 @@ VERSIONS = os.environ.get("VERSIONS", "latest").split(",")
 
 SPLUNK_ENV_PATH = "/etc/otel/collector/splunk-otel-collector.conf"
 OLD_SPLUNK_ENV_PATH = "/etc/otel/collector/splunk_env"
+AGENT_CONFIG_PATH = "/etc/otel/collector/agent_config.yaml"
+GATEWAY_CONFIG_PATH = "/etc/otel/collector/gateway_config.yaml"
+OLD_CONFIG_PATH = "/etc/otel/collector/splunk_config_linux.yaml"
 TOTAL_MEMORY = "256"
 BALLAST = "128"
+
 
 @pytest.mark.installer
 @pytest.mark.parametrize(
@@ -49,14 +53,9 @@ BALLAST = "128"
     + [pytest.param(distro, marks=pytest.mark.rpm) for distro in RPM_DISTROS],
     )
 @pytest.mark.parametrize("version", VERSIONS)
-@pytest.mark.parametrize("memory_option", ["memory", "ballast"])
-def test_installer(distro, version, memory_option):
-    install_cmd = f"sh -x /test/install.sh -- testing123 --realm us0"
-
-    if memory_option == "memory":
-        install_cmd = f"{install_cmd} --{memory_option} {TOTAL_MEMORY}"
-    elif memory_option == "ballast":
-        install_cmd = f"{install_cmd} --{memory_option} {BALLAST}"
+@pytest.mark.parametrize("mode", ["agent", "gateway"])
+def test_installer_mode(distro, version, mode):
+    install_cmd = f"sh -x /test/install.sh -- testing123 --realm us0 --memory {TOTAL_MEMORY} --mode {mode}"
 
     if version != "latest":
         install_cmd = f"{install_cmd} --collector-version {version.lstrip('v')}"
@@ -74,16 +73,20 @@ def test_installer(distro, version, memory_option):
             run_container_cmd(container, install_cmd, env={"VERIFY_ACCESS_TOKEN": "false"})
             time.sleep(5)
 
+            config_path = AGENT_CONFIG_PATH if mode == "agent" else GATEWAY_CONFIG_PATH
+            if container.exec_run(f"test -f {OLD_CONFIG_PATH}").exit_code == 0:
+                config_path = OLD_CONFIG_PATH
+            elif mode == "gateway" and container.exec_run(f"test -f {GATEWAY_CONFIG_PATH}").exit_code != 0:
+                config_path = AGENT_CONFIG_PATH
+
             # verify env file created with configured parameters
             splunk_env_path = SPLUNK_ENV_PATH
             if container.exec_run(f"test -f {OLD_SPLUNK_ENV_PATH}").exit_code == 0:
                 splunk_env_path = OLD_SPLUNK_ENV_PATH
+            run_container_cmd(container, f"grep '^SPLUNK_CONFIG={config_path}$' {splunk_env_path}")
             run_container_cmd(container, f"grep '^SPLUNK_ACCESS_TOKEN=testing123$' {splunk_env_path}")
             run_container_cmd(container, f"grep '^SPLUNK_REALM=us0$' {splunk_env_path}")
-            if memory_option == "memory":
-                run_container_cmd(container, f"grep '^SPLUNK_MEMORY_TOTAL_MIB={TOTAL_MEMORY}$' {splunk_env_path}")
-            elif memory_option == "ballast":
-                run_container_cmd(container, f"grep '^SPLUNK_BALLAST_SIZE_MIB={BALLAST}$' {splunk_env_path}")
+            run_container_cmd(container, f"grep '^SPLUNK_MEMORY_TOTAL_MIB={TOTAL_MEMORY}$' {splunk_env_path}")
 
             # verify collector service status
             assert wait_for(lambda: service_is_running(container, service_owner=SERVICE_OWNER))
@@ -96,6 +99,66 @@ def test_installer(distro, version, memory_option):
                 assert container.exec_run("systemctl status td-agent").exit_code != 0
 
             run_container_cmd(container, "sh -x /test/install.sh --uninstall")
+
+        finally:
+            run_container_cmd(container, "journalctl -u td-agent --no-pager")
+            if container.exec_run("test -f /var/log/td-agent/td-agent.log").exit_code == 0:
+                run_container_cmd(container, "cat /var/log/td-agent/td-agent.log")
+            run_container_cmd(container, f"journalctl -u {SERVICE_NAME} --no-pager")
+
+
+@pytest.mark.installer
+@pytest.mark.parametrize(
+    "distro",
+    [pytest.param(distro, marks=pytest.mark.deb) for distro in DEB_DISTROS]
+    + [pytest.param(distro, marks=pytest.mark.rpm) for distro in RPM_DISTROS],
+    )
+@pytest.mark.parametrize("version", VERSIONS)
+def test_installer_ballast(distro, version):
+    install_cmd = f"sh -x /test/install.sh -- testing123 --realm us0 --ballast {BALLAST}"
+
+    if version != "latest":
+        install_cmd = f"{install_cmd} --collector-version {version.lstrip('v')}"
+
+    if STAGE != "release":
+        assert STAGE in ("test", "beta"), f"Unsupported stage '{STAGE}'!"
+        install_cmd = f"{install_cmd} --{STAGE}"
+
+    print(f"Testing installation on {distro} from {STAGE} stage ...")
+    with run_distro_container(distro) as container:
+        # run installer script
+        copy_file_into_container(container, INSTALLER_PATH, "/test/install.sh")
+
+        try:
+            run_container_cmd(container, install_cmd, env={"VERIFY_ACCESS_TOKEN": "false"})
+            time.sleep(5)
+
+            config_path = AGENT_CONFIG_PATH
+            if container.exec_run(f"test -f {OLD_CONFIG_PATH}").exit_code == 0:
+                config_path = OLD_CONFIG_PATH
+
+            splunk_env_path = SPLUNK_ENV_PATH
+            if container.exec_run(f"test -f {OLD_SPLUNK_ENV_PATH}").exit_code == 0:
+                splunk_env_path = OLD_SPLUNK_ENV_PATH
+
+            # verify env file created with configured parameters
+            run_container_cmd(container, f"grep '^SPLUNK_CONFIG={config_path}$' {splunk_env_path}")
+            run_container_cmd(container, f"grep '^SPLUNK_ACCESS_TOKEN=testing123$' {splunk_env_path}")
+            run_container_cmd(container, f"grep '^SPLUNK_REALM=us0$' {splunk_env_path}")
+            run_container_cmd(container, f"grep '^SPLUNK_BALLAST_SIZE_MIB={BALLAST}$' {splunk_env_path}")
+
+            # verify collector service status
+            assert wait_for(lambda: service_is_running(container, service_owner=SERVICE_OWNER))
+
+            # the td-agent service should only be running when installing
+            # collector packages that have our custom fluent config
+            if container.exec_run("test -f /etc/otel/collector/fluentd/fluent.conf").exit_code == 0:
+                assert container.exec_run("systemctl status td-agent").exit_code == 0
+            else:
+                assert container.exec_run("systemctl status td-agent").exit_code != 0
+
+            run_container_cmd(container, "sh -x /test/install.sh --uninstall")
+
         finally:
             run_container_cmd(container, "journalctl -u td-agent --no-pager")
             if container.exec_run("test -f /var/log/td-agent/td-agent.log").exit_code == 0:
@@ -124,16 +187,23 @@ def test_installer_service_owner(distro, version):
 
     print(f"Testing installation on {distro} from {STAGE} stage ...")
     with run_distro_container(distro) as container:
-        # run installer script
         copy_file_into_container(container, INSTALLER_PATH, "/test/install.sh")
-        run_container_cmd(container, install_cmd, env={"VERIFY_ACCESS_TOKEN": "false"})
-        time.sleep(5)
 
         try:
-            # verify env file created with configured parameters
+            # run installer script
+            run_container_cmd(container, install_cmd, env={"VERIFY_ACCESS_TOKEN": "false"})
+            time.sleep(5)
+
+            config_path = AGENT_CONFIG_PATH
+            if container.exec_run(f"test -f {OLD_CONFIG_PATH}").exit_code == 0:
+                config_path = OLD_CONFIG_PATH
+
             splunk_env_path = SPLUNK_ENV_PATH
             if container.exec_run(f"test -f {OLD_SPLUNK_ENV_PATH}").exit_code == 0:
                 splunk_env_path = OLD_SPLUNK_ENV_PATH
+
+            # verify env file created with configured parameters
+            run_container_cmd(container, f"grep '^SPLUNK_CONFIG={config_path}$' {splunk_env_path}")
             run_container_cmd(container, f"grep '^SPLUNK_ACCESS_TOKEN=testing123$' {splunk_env_path}")
             run_container_cmd(container, f"grep '^SPLUNK_REALM=us0$' {splunk_env_path}")
             run_container_cmd(container, f"grep '^SPLUNK_MEMORY_TOTAL_MIB={TOTAL_MEMORY}$' {splunk_env_path}")
@@ -150,4 +220,58 @@ def test_installer_service_owner(distro, version):
 
         finally:
             run_container_cmd(container, "journalctl -u td-agent --no-pager")
+            run_container_cmd(container, f"journalctl -u {SERVICE_NAME} --no-pager")
+
+
+@pytest.mark.installer
+@pytest.mark.parametrize(
+    "distro",
+    [pytest.param(distro, marks=pytest.mark.deb) for distro in DEB_DISTROS]
+    + [pytest.param(distro, marks=pytest.mark.rpm) for distro in RPM_DISTROS],
+    )
+@pytest.mark.parametrize("version", VERSIONS)
+def test_installer_without_fluentd(distro, version):
+    install_cmd = f"sh -x /test/install.sh -- testing123 --realm us0 --memory {TOTAL_MEMORY} --without-fluentd"
+
+    if version != "latest":
+        install_cmd = f"{install_cmd} --collector-version {version.lstrip('v')}"
+
+    if STAGE != "release":
+        assert STAGE in ("test", "beta"), f"Unsupported stage '{STAGE}'!"
+        install_cmd = f"{install_cmd} --{STAGE}"
+
+    print(f"Testing installation on {distro} from {STAGE} stage ...")
+    with run_distro_container(distro) as container:
+        copy_file_into_container(container, INSTALLER_PATH, "/test/install.sh")
+
+        try:
+            # run installer script
+            run_container_cmd(container, install_cmd, env={"VERIFY_ACCESS_TOKEN": "false"})
+            time.sleep(5)
+
+            config_path = AGENT_CONFIG_PATH
+            if container.exec_run(f"test -f {OLD_CONFIG_PATH}").exit_code == 0:
+                config_path = OLD_CONFIG_PATH
+
+            splunk_env_path = SPLUNK_ENV_PATH
+            if container.exec_run(f"test -f {OLD_SPLUNK_ENV_PATH}").exit_code == 0:
+                splunk_env_path = OLD_SPLUNK_ENV_PATH
+
+            # verify env file created with configured parameters
+            run_container_cmd(container, f"grep '^SPLUNK_CONFIG={config_path}$' {splunk_env_path}")
+            run_container_cmd(container, f"grep '^SPLUNK_ACCESS_TOKEN=testing123$' {splunk_env_path}")
+            run_container_cmd(container, f"grep '^SPLUNK_REALM=us0$' {splunk_env_path}")
+            run_container_cmd(container, f"grep '^SPLUNK_MEMORY_TOTAL_MIB={TOTAL_MEMORY}$' {splunk_env_path}")
+
+            # verify collector service status
+            assert wait_for(lambda: service_is_running(container, service_owner=SERVICE_OWNER))
+
+            if distro in DEB_DISTROS:
+                assert container.exec_run("dpkg -s td-agent").exit_code != 0
+            else:
+                assert container.exec_run("rpm -q td-agent").exit_code != 0
+
+            run_container_cmd(container, "sh -x /test/install.sh --uninstall")
+
+        finally:
             run_container_cmd(container, f"journalctl -u {SERVICE_NAME} --no-pager")

--- a/internal/buildscripts/packaging/tests/package_test.py
+++ b/internal/buildscripts/packaging/tests/package_test.py
@@ -54,7 +54,9 @@ def test_collector_package_install(distro):
     service_name = "splunk-otel-collector"
     service_owner = "splunk-otel-collector"
     service_proc = "otelcol"
-    config_path = "/etc/otel/collector/splunk-otel-collector.conf"
+    env_path = "/etc/otel/collector/splunk-otel-collector.conf"
+    agent_config_path = "/etc/otel/collector/agent_config.yaml"
+    gateway_config_path = "/etc/otel/collector/gateway_config.yaml"
     bundle_dir = "/usr/lib/splunk-otel-collector/agent-bundle"
 
     pkg_path = get_package(distro, pkg_name, pkg_dir)
@@ -75,12 +77,15 @@ def test_collector_package_install(distro):
             run_container_cmd(container, f"test -d {bundle_dir}")
             run_container_cmd(container, f"test -d {bundle_dir}/run/collectd")
 
+            run_container_cmd(container, f"test -f {agent_config_path}")
+            run_container_cmd(container, f"test -f {gateway_config_path}")
+
             # verify service is not running after install without config file
             time.sleep(5)
             assert not service_is_running(container, service_name, service_owner, service_proc)
 
             # verify service starts with config file
-            run_container_cmd(container, f"cp -f {config_path}.example {config_path}")
+            run_container_cmd(container, f"cp -f {env_path}.example {env_path}")
             run_container_cmd(container, f"systemctl start {service_name}")
             time.sleep(5)
             assert wait_for(lambda: service_is_running(container, service_name, service_owner, service_proc))
@@ -111,4 +116,4 @@ def test_collector_package_install(distro):
         assert not service_is_running(container, service_name, service_owner, service_proc)
 
         # verify config file is not removed
-        run_container_cmd(container, f"test -f {config_path}")
+        run_container_cmd(container, f"test -f {env_path}")


### PR DESCRIPTION
- Updated installer script for the `--mode <agent|gateway>` option (defaults to agent)
- Sets the `SPLUNK_CONFIG` env var for the collector service to `agent_config.yaml` if running the installer script with `--mode agent`, or `gateway_config.yaml` if `--mode gateway`
- Updated the installer test for the `--mode` and `--without-fluentd` options