### PR TITLE
Create registry key for collector service events

### DIFF
--- a/internal/buildscripts/packaging/msi/splunk-otel-collector.wxs
+++ b/internal/buildscripts/packaging/msi/splunk-otel-collector.wxs
@@ -19,7 +19,7 @@
                      <File Id="ExecutableFile" Name="otelcol.exe" KeyPath="yes" Source="$(var.Otelcol)"/>
                      <!-- Install the collector service with the config file in ProgramData -->
                      <ServiceInstall
-                        Id="Sevice"
+                        Id="Service"
                         Name="splunk-otel-collector"
                         DisplayName="Splunk OpenTelemetry Collector"
                         Description="Splunk OpenTelemetry Collector"
@@ -36,6 +36,9 @@
                         Stop="both"
                         Remove="uninstall"
                         Wait="yes" />
+                     <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\EventLog\Application\splunk-otel-collector">
+                        <RegistryValue Type="expandable" Name="EventMessageFile" Value="%SystemRoot%\System32\EventCreate.exe"/>
+                     </RegistryKey>
                   </Component>
                </Directory>
             </Directory>


### PR DESCRIPTION
- Workaround for #153 
- The registry key is created on MSI installation and removed on uninstall
- Adding the registry key changes the events to:
![Screen Shot 2021-03-19 at 5 10 38 PM](https://user-images.githubusercontent.com/36963516/111844512-8f656600-88d9-11eb-92f9-2fd0ad738a54.png)
