### PR TITLE
Add Trace support to SA Receiver

### DIFF
--- a/internal/receiver/smartagentreceiver/factory.go
+++ b/internal/receiver/smartagentreceiver/factory.go
@@ -62,6 +62,7 @@ func NewFactory() component.ReceiverFactory {
 		receiverhelper.WithCustomUnmarshaler(mergeConfigs),
 		receiverhelper.WithMetrics(createMetricsReceiver),
 		receiverhelper.WithLogs(createLogsReceiver),
+		receiverhelper.WithTraces(createTracesReceiver),
 	)
 }
 
@@ -78,14 +79,14 @@ func createMetricsReceiver(
 	_ context.Context,
 	params component.ReceiverCreateParams,
 	cfg configmodels.Receiver,
-	consumer consumer.MetricsConsumer,
+	metricsConsumer consumer.MetricsConsumer,
 ) (component.MetricsReceiver, error) {
 	receiver, err := getOrCreateReceiver(cfg, params.Logger)
 	if err != nil {
 		return nil, err
 	}
 
-	receiver.registerMetricsConsumer(consumer)
+	receiver.registerMetricsConsumer(metricsConsumer)
 	return receiver, nil
 }
 
@@ -93,13 +94,28 @@ func createLogsReceiver(
 	_ context.Context,
 	params component.ReceiverCreateParams,
 	cfg configmodels.Receiver,
-	consumer consumer.LogsConsumer,
+	logsConsumer consumer.LogsConsumer,
 ) (component.LogsReceiver, error) {
 	receiver, err := getOrCreateReceiver(cfg, params.Logger)
 	if err != nil {
 		return nil, err
 	}
 
-	receiver.registerLogsConsumer(consumer)
+	receiver.registerLogsConsumer(logsConsumer)
+	return receiver, nil
+}
+
+func createTracesReceiver(
+	_ context.Context,
+	params component.ReceiverCreateParams,
+	cfg configmodels.Receiver,
+	tracesConsumer consumer.TracesConsumer,
+) (component.TracesReceiver, error) {
+	receiver, err := getOrCreateReceiver(cfg, params.Logger)
+	if err != nil {
+		return nil, err
+	}
+
+	receiver.registerTracesConsumer(tracesConsumer)
 	return receiver, nil
 }

--- a/internal/receiver/smartagentreceiver/output.go
+++ b/internal/receiver/smartagentreceiver/output.go
@@ -237,15 +237,17 @@ func (output *Output) SendSpans(spans ...*trace.Span) {
 	}
 
 	for _, span := range spans {
+		if span.Tags == nil {
+			span.Tags = map[string]string{}
+		}
+
 		for name, value := range output.defaultSpanTags {
-			if span.Tags == nil {
-				span.Tags = map[string]string{}
-			}
 			// If the tags are already set, don't override
 			if _, ok := span.Tags[name]; !ok {
 				span.Tags[name] = value
 			}
 		}
+
 		span.Tags = utils.MergeStringMaps(span.Tags, output.extraSpanTags)
 	}
 

--- a/internal/receiver/smartagentreceiver/output_test.go
+++ b/internal/receiver/smartagentreceiver/output_test.go
@@ -38,7 +38,11 @@ import (
 )
 
 func TestOutput(t *testing.T) {
-	output := NewOutput(Config{}, fakeMonitorFiltering(), consumertest.NewMetricsNop(), consumertest.NewLogsNop(), componenttest.NewNopHost(), zap.NewNop())
+	output := NewOutput(
+		Config{}, fakeMonitorFiltering(), consumertest.NewMetricsNop(),
+		consumertest.NewLogsNop(), consumertest.NewTracesNop(),
+		componenttest.NewNopHost(), zap.NewNop(),
+	)
 	output.AddDatapointExclusionFilter(dpfilters.DatapointFilter(nil))
 	assert.False(t, output.HasAnyExtraMetrics())
 	assert.NotSame(t, &output, output.Copy())
@@ -64,13 +68,19 @@ func TestHasEnabledMetric(t *testing.T) {
 		Groups: utils.StringSet("mem"),
 	}, zap.NewNop())
 	require.NoError(t, err)
-	output := NewOutput(Config{}, monitorFiltering, consumertest.NewMetricsNop(), consumertest.NewLogsNop(), componenttest.NewNopHost(), zap.NewNop())
+	output := NewOutput(
+		Config{}, monitorFiltering, consumertest.NewMetricsNop(), consumertest.NewLogsNop(),
+		consumertest.NewTracesNop(), componenttest.NewNopHost(), zap.NewNop(),
+	)
 	assert.Equal(t, []string{"mem.used"}, output.EnabledMetrics())
 
 	// Empty metadata
 	monitorFiltering, err = newMonitorFiltering(&config.MonitorConfig{}, nil, zap.NewNop())
 	require.NoError(t, err)
-	output = NewOutput(Config{}, monitorFiltering, consumertest.NewMetricsNop(), consumertest.NewLogsNop(), componenttest.NewNopHost(), zap.NewNop())
+	output = NewOutput(
+		Config{}, monitorFiltering, consumertest.NewMetricsNop(), consumertest.NewLogsNop(),
+		consumertest.NewTracesNop(), componenttest.NewNopHost(), zap.NewNop(),
+	)
 	assert.Empty(t, output.EnabledMetrics())
 }
 
@@ -90,19 +100,28 @@ func TestHasEnabledMetricInGroup(t *testing.T) {
 		},
 	}, zap.NewNop())
 	require.NoError(t, err)
-	output := NewOutput(Config{}, monitorFiltering, consumertest.NewMetricsNop(), consumertest.NewLogsNop(), componenttest.NewNopHost(), zap.NewNop())
+	output := NewOutput(
+		Config{}, monitorFiltering, consumertest.NewMetricsNop(), consumertest.NewLogsNop(),
+		consumertest.NewTracesNop(), componenttest.NewNopHost(), zap.NewNop(),
+	)
 	assert.True(t, output.HasEnabledMetricInGroup("mem"))
 	assert.False(t, output.HasEnabledMetricInGroup("cpu"))
 
 	// Empty metadata
 	monitorFiltering, err = newMonitorFiltering(&config.MonitorConfig{}, nil, zap.NewNop())
 	require.NoError(t, err)
-	output = NewOutput(Config{}, monitorFiltering, consumertest.NewMetricsNop(), consumertest.NewLogsNop(), componenttest.NewNopHost(), zap.NewNop())
+	output = NewOutput(
+		Config{}, monitorFiltering, consumertest.NewMetricsNop(), consumertest.NewLogsNop(),
+		consumertest.NewTracesNop(), componenttest.NewNopHost(), zap.NewNop(),
+	)
 	assert.False(t, output.HasEnabledMetricInGroup("any"))
 }
 
 func TestExtraDimensions(t *testing.T) {
-	output := NewOutput(Config{}, fakeMonitorFiltering(), consumertest.NewMetricsNop(), consumertest.NewLogsNop(), componenttest.NewNopHost(), zap.NewNop())
+	output := NewOutput(
+		Config{}, fakeMonitorFiltering(), consumertest.NewMetricsNop(), consumertest.NewLogsNop(),
+		consumertest.NewTracesNop(), componenttest.NewNopHost(), zap.NewNop(),
+	)
 	assert.Empty(t, output.extraDimensions)
 
 	output.RemoveExtraDimension("not_a_known_dimension_name")
@@ -125,7 +144,10 @@ func TestExtraDimensions(t *testing.T) {
 
 func TestSendDimensionUpdate(t *testing.T) {
 	me := mockMetadataClient{}
-	output := NewOutput(Config{}, fakeMonitorFiltering(), &me, consumertest.NewLogsNop(), componenttest.NewNopHost(), zap.NewNop())
+	output := NewOutput(
+		Config{}, fakeMonitorFiltering(), &me, consumertest.NewLogsNop(), consumertest.NewTracesNop(),
+		componenttest.NewNopHost(), zap.NewNop(),
+	)
 
 	dim := types.Dimension{
 		Name:  "my_dimension",
@@ -144,7 +166,10 @@ func TestSendDimensionUpdate(t *testing.T) {
 }
 
 func TestSendDimensionUpdateWithInvalidExporter(t *testing.T) {
-	output := NewOutput(Config{}, fakeMonitorFiltering(), consumertest.NewMetricsNop(), consumertest.NewLogsNop(), componenttest.NewNopHost(), zap.NewNop())
+	output := NewOutput(
+		Config{}, fakeMonitorFiltering(), consumertest.NewMetricsNop(), consumertest.NewLogsNop(),
+		consumertest.NewTracesNop(), componenttest.NewNopHost(), zap.NewNop(),
+	)
 	dim := types.Dimension{Name: "error"}
 
 	// doesn't panic
@@ -160,6 +185,7 @@ func TestSendDimensionUpdateFromConfigMetadataExporters(t *testing.T) {
 		fakeMonitorFiltering(),
 		consumertest.NewMetricsNop(),
 		consumertest.NewLogsNop(),
+		consumertest.NewTracesNop(),
 		&hostWithExporters{exporter: &me},
 		zap.NewNop(),
 	)
@@ -176,7 +202,10 @@ func TestSendDimensionUpdateFromConfigMetadataExporters(t *testing.T) {
 
 func TestSendDimensionUpdateFromNextConsumerMetadataExporters(t *testing.T) {
 	me := mockMetadataClient{}
-	output := NewOutput(Config{}, fakeMonitorFiltering(), &me, consumertest.NewLogsNop(), componenttest.NewNopHost(), zap.NewNop())
+	output := NewOutput(
+		Config{}, fakeMonitorFiltering(), &me, consumertest.NewLogsNop(),
+		consumertest.NewTracesNop(), componenttest.NewNopHost(), zap.NewNop(),
+	)
 
 	dim := types.Dimension{
 		Name: "error",
@@ -190,7 +219,10 @@ func TestSendDimensionUpdateFromNextConsumerMetadataExporters(t *testing.T) {
 
 func TestSendEvent(t *testing.T) {
 	me := mockMetadataClient{}
-	output := NewOutput(Config{}, fakeMonitorFiltering(), consumertest.NewMetricsNop(), &me, componenttest.NewNopHost(), zap.NewNop())
+	output := NewOutput(
+		Config{}, fakeMonitorFiltering(), consumertest.NewMetricsNop(), &me,
+		consumertest.NewTracesNop(), componenttest.NewNopHost(), zap.NewNop(),
+	)
 
 	event := event.Event{
 		EventType: "my_event",
@@ -219,6 +251,7 @@ func TestDimensionClientDefaultsToSFxExporter(t *testing.T) {
 		fakeMonitorFiltering(),
 		consumertest.NewMetricsNop(),
 		consumertest.NewLogsNop(),
+		consumertest.NewTracesNop(),
 		&hostWithExporters{exporter: &me},
 		zap.NewNop(),
 	)
@@ -240,6 +273,7 @@ func TestDimensionClientDefaultsRequiresLoneSFxExporter(t *testing.T) {
 		fakeMonitorFiltering(),
 		consumertest.NewMetricsNop(),
 		consumertest.NewLogsNop(),
+		consumertest.NewTracesNop(),
 		&hostWithTwoSFxExporters{sfxExporter: &me},
 		zap.NewNop(),
 	)

--- a/internal/receiver/smartagentreceiver/output_traces_test.go
+++ b/internal/receiver/smartagentreceiver/output_traces_test.go
@@ -1,0 +1,194 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smartagentreceiver
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/signalfx/golib/v3/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestSendSpansWithoutNextTracesConsumer(t *testing.T) {
+	output := NewOutput(
+		Config{}, fakeMonitorFiltering(), consumertest.NewMetricsNop(), consumertest.NewLogsNop(),
+		nil, componenttest.NewNopHost(), zap.NewNop(),
+	)
+
+	output.SendSpans(&trace.Span{TraceID: "12345678", ID: "23456789"}) // doesn't panic
+}
+
+func TestExtraSpanTags(t *testing.T) {
+	output := NewOutput(
+		Config{}, fakeMonitorFiltering(), consumertest.NewMetricsNop(), consumertest.NewLogsNop(),
+		consumertest.NewTracesNop(), componenttest.NewNopHost(), zap.NewNop(),
+	)
+	assert.Empty(t, output.extraSpanTags)
+
+	output.RemoveExtraSpanTag("not_a_known_tag")
+
+	output.AddExtraSpanTag("a_tag", "a_value")
+	assert.Equal(t, "a_value", output.extraSpanTags["a_tag"])
+
+	cp, ok := output.Copy().(*Output)
+	require.True(t, ok)
+	assert.Equal(t, "a_value", cp.extraSpanTags["a_tag"])
+
+	cp.RemoveExtraSpanTag("a_tag")
+	assert.Empty(t, cp.extraSpanTags["a_tag"])
+	assert.Equal(t, "a_value", output.extraSpanTags["a_tag"])
+
+	cp.AddExtraSpanTag("another_tag", "another_tag_value")
+	assert.Equal(t, "another_tag_value", cp.extraSpanTags["another_tag"])
+	assert.Empty(t, output.extraSpanTags["another_tag"])
+}
+
+func TestDefaultSpanTags(t *testing.T) {
+	output := NewOutput(
+		Config{}, fakeMonitorFiltering(), consumertest.NewMetricsNop(), consumertest.NewLogsNop(),
+		consumertest.NewTracesNop(), componenttest.NewNopHost(), zap.NewNop(),
+	)
+	assert.Empty(t, output.defaultSpanTags)
+
+	output.RemoveDefaultSpanTag("not_a_known_tag")
+
+	output.AddDefaultSpanTag("a_tag", "a_value")
+	assert.Equal(t, "a_value", output.defaultSpanTags["a_tag"])
+
+	cp, ok := output.Copy().(*Output)
+	require.True(t, ok)
+	assert.Equal(t, "a_value", cp.defaultSpanTags["a_tag"])
+
+	cp.RemoveDefaultSpanTag("a_tag")
+	assert.Empty(t, cp.defaultSpanTags["a_tag"])
+	assert.Equal(t, "a_value", output.defaultSpanTags["a_tag"])
+
+	cp.AddDefaultSpanTag("another_tag", "another_tag_value")
+	assert.Equal(t, "another_tag_value", cp.defaultSpanTags["another_tag"])
+	assert.Empty(t, output.defaultSpanTags["another_tag"])
+}
+
+func TestSendSpansWithDefaultAndExtraSpanTags(t *testing.T) {
+	tracesSink := consumertest.TracesSink{}
+	output := NewOutput(
+		Config{}, fakeMonitorFiltering(), consumertest.NewMetricsNop(), consumertest.NewLogsNop(),
+		&tracesSink, componenttest.NewNopHost(), zap.NewNop(),
+	)
+	output.AddExtraSpanTag("will_be_overridden", "added extra value (want)")
+	output.AddDefaultSpanTag("wont_be_overridden", "added default value")
+
+	sfxSpan0 := trace.Span{
+		TraceID: "12345678",
+		ID:      "23456789",
+		Tags: map[string]string{
+			"will_be_overridden": "span-provided value (don't want)",
+			"some_tag":           "some_value",
+		},
+	}
+
+	sfxSpan1 := trace.Span{
+		TraceID: "34567890",
+		ID:      "45678901",
+		Tags: map[string]string{
+			"wont_be_overridden": "span-provided value (want)",
+		},
+	}
+
+	sfxSpan2 := trace.Span{
+		TraceID: "56789012",
+		ID:      "67890123",
+	}
+
+	// core zipkin pdata translation reverses span order
+	output.SendSpans(&sfxSpan2, &sfxSpan1, &sfxSpan0)
+
+	received := tracesSink.AllTraces()
+	require.Equal(t, 1, len(received))
+	trace := received[0]
+	assert.Equal(t, 3, trace.SpanCount())
+	resourceSpans := trace.ResourceSpans()
+	require.Equal(t, 1, resourceSpans.Len())
+	illSpansSlice := resourceSpans.At(0).InstrumentationLibrarySpans()
+	require.Equal(t, 1, illSpansSlice.Len())
+	illSpans := illSpansSlice.At(0).Spans()
+	require.Equal(t, 3, illSpans.Len())
+
+	span0 := illSpans.At(0)
+	require.Equal(t, "00000000000000000000000012345678", span0.TraceID().HexString())
+	require.Equal(t, "0000000023456789", span0.SpanID().HexString())
+
+	extraValue, containsExtraValue := span0.Attributes().Get("will_be_overridden")
+	require.True(t, containsExtraValue)
+	assert.Equal(t, "added extra value (want)", extraValue.StringVal())
+
+	defaultValue, containsDefaultValue := span0.Attributes().Get("wont_be_overridden")
+	require.True(t, containsDefaultValue)
+	assert.Equal(t, "added default value", defaultValue.StringVal())
+
+	value, containsValue := span0.Attributes().Get("some_tag")
+	require.True(t, containsValue)
+	assert.Equal(t, "some_value", value.StringVal())
+
+	span1 := illSpans.At(1)
+	require.Equal(t, "00000000000000000000000034567890", span1.TraceID().HexString())
+	require.Equal(t, "0000000045678901", span1.SpanID().HexString())
+
+	extraValue, containsExtraValue = span1.Attributes().Get("will_be_overridden")
+	require.True(t, containsExtraValue)
+	assert.Equal(t, "added extra value (want)", extraValue.StringVal())
+
+	defaultValue, containsDefaultValue = span1.Attributes().Get("wont_be_overridden")
+	require.True(t, containsDefaultValue)
+	assert.Equal(t, "span-provided value (want)", defaultValue.StringVal())
+
+	span2 := illSpans.At(2)
+	require.Equal(t, "00000000000000000000000056789012", span2.TraceID().HexString())
+	require.Equal(t, "0000000067890123", span2.SpanID().HexString())
+
+	extraValue, containsExtraValue = span2.Attributes().Get("will_be_overridden")
+	require.True(t, containsExtraValue)
+	assert.Equal(t, "added extra value (want)", extraValue.StringVal())
+
+	defaultValue, containsDefaultValue = span2.Attributes().Get("wont_be_overridden")
+	require.True(t, containsDefaultValue)
+	assert.Equal(t, "added default value", defaultValue.StringVal())
+}
+
+func TestSendSpansWithConsumerError(t *testing.T) {
+
+	obs, logs := observer.New(zap.DebugLevel)
+	logger := zap.New(obs)
+
+	err := fmt.Errorf("desired error")
+	tracesConsumer := consumertest.NewTracesErr(err)
+	output := NewOutput(
+		Config{}, fakeMonitorFiltering(), consumertest.NewMetricsNop(), consumertest.NewLogsNop(),
+		tracesConsumer, componenttest.NewNopHost(), logger,
+	)
+
+	output.SendSpans(&trace.Span{TraceID: "12345678", ID: "23456789"})
+
+	// first log will be about lack of dimension client
+	require.Equal(t, 2, logs.Len())
+	entry := logs.All()[1]
+	assert.Equal(t, "SendSpans has failed", entry.Message)
+	assert.Equal(t, "desired error", entry.ContextMap()["error"])
+}


### PR DESCRIPTION
These changes adopt the converter introduced in https://github.com/signalfx/splunk-otel-collector/pull/178 and add trace receiver support to the Smart Agent Receiver.  They also port the extra and default span tags functionality from the SA codebase.

This is largely done to support the signalfx-forwarder monitor, whose documentation I will add in a subsequent PR once https://github.com/signalfx/splunk-otel-collector/pull/167 has landed.