### PR TITLE
Adopt single msi-builder in circle and release script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,12 @@ workflows:
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+      - windows-msi-validation:
+          requires:
+            - windows-msi
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
 
 jobs:
   setup-environment:
@@ -404,6 +410,7 @@ jobs:
   installer-script-test:
     machine:
       image: ubuntu-1604:202007-01
+      docker_layer_caching: true
     parallelism: 2
     steps:
       - checkout
@@ -433,30 +440,35 @@ jobs:
       - save_pytest_results
 
   windows-msi:
+    machine:
+      image: ubuntu-1604:202007-01
+      docker_layer_caching: true
+    steps:
+      - attach_to_workspace
+      - run:
+          name: Build msi-builder image
+          command: docker build -t msi-builder internal/buildscripts/packaging/msi/msi-builder
+      - run:
+          name: Build MSI
+          command: |
+            mkdir dist
+            export VERSION_TAG="${CIRCLE_TAG/v/}"
+            docker run --rm -v $(pwd):/project -u 0 msi-builder "${VERSION_TAG:-0.0.1.$CIRCLE_BUILD_NUM}"
+      - persist_to_workspace:
+          root: ~/
+          paths: project/dist/*.msi
+      - store_artifacts:
+          path: dist
+
+  windows-msi-validation:
     executor:
       name: win/default
       shell: powershell.exe
     steps:
       - attach_to_workspace
       - run:
-          command: mkdir -p dist
-      - run:
-          name: Install Wix Toolset
-          command: .\internal\buildscripts\packaging\msi\make.ps1 Install-Tools
-      - run:
-          name: Build MSI
-          command: |
-            $Version = if ($env:CIRCLE_TAG -match '^v(\d+\.\d+\.\d+)') { $Matches[1] } else { "0.0.1.$env:CIRCLE_BUILD_NUM" }
-            .\internal\buildscripts\packaging\msi\make.ps1 New-MSI -Version $Version
-            Remove-Item -Force -Recurse .\dist -Exclude *.msi
-      - run:
           name: Installation test
           command: |
             $msi_path = Resolve-Path .\dist\splunk-otel-collector*.msi
             $env:VERIFY_ACCESS_TOKEN = "false"
             .\internal\buildscripts\packaging\installer\install.ps1 -access_token "testing123" -msi_path "$msi_path"
-      - persist_to_workspace:
-          root: ~/
-          paths: project/dist/*.msi
-      - store_artifacts:
-          path: dist

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ bin/
 dist/
 
 # GoLand IDEA
-/.idea/
+.idea
 *.iml
 
 # VS Code

--- a/internal/buildscripts/packaging/msi/msi-builder/Dockerfile
+++ b/internal/buildscripts/packaging/msi/msi-builder/Dockerfile
@@ -1,0 +1,8 @@
+FROM felfert/wix:latest
+
+COPY ./build.sh /work/build.sh
+
+ENV OUTPUT_DIR=project/dist
+
+# `wix` user cannot write to anything outside /work, so run w/ `-u 0` if necessary (circle configuration)
+ENTRYPOINT ["bash", "-c", "su wix -c \"/work/build.sh $0 $@ --output /work/build/stage \" && cp /work/build/stage/*.msi $OUTPUT_DIR/"]


### PR DESCRIPTION
requires: https://github.com/signalfx/splunk-otel-collector/pull/202

These changes migrate the circle ci and release job msi builders to a shared docker image, with build script based on the currently unused local development script and the python `build_msi()` helper.  This way any required changes to the msi build process (like SA bundling support) only need to be made once*, as opposed to in 3 places* (circle's make.ps1, utils.py, build.sh).

Given the restrictions and requirements for the `felfert/wix` image's wix user, the msi-builder image is intended to be run as user root.  This way only wix user read access to the `/project` directory is required, and any desired `OUTPUT_DIR`** writes are guaranteed to be the resulting msi.