### PR TITLE
Add SignalFx forwarder to default configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,6 +369,7 @@ jobs:
   build-package:
     machine:
       image: ubuntu-1604:202007-01
+      docker_layer_caching: true
     parameters:
       package_type:
         type: enum

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -66,6 +66,9 @@ receivers:
             regex: '.*grpc_io.*'
             action: drop
   sapm:
+  smartagent/signalfx-forwarder:
+    type: signalfx-forwarder
+    listenAddress: 0.0.0.0:9080
   signalfx:
   zipkin:
 
@@ -120,7 +123,7 @@ service:
   extensions: [health_check, http_forwarder, zpages]
   pipelines:
     traces:
-      receivers: [jaeger, otlp, sapm, zipkin]
+      receivers: [jaeger, otlp, sapm, smartagent/signalfx-forwarder, zipkin]
       processors:
       - memory_limiter
       - batch
@@ -128,7 +131,7 @@ service:
       #- resource/add_environment
       exporters: [sapm, signalfx]
     metrics:
-      receivers: [otlp, signalfx, prometheus, hostmetrics]
+      receivers: [hostmetrics, otlp, prometheus, signalfx, smartagent/signalfx-forwarder]
       processors: [memory_limiter, batch, resourcedetection]
       exporters: [signalfx]
     logs/signalfx:

--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -76,6 +76,12 @@ receivers:
   sapm:
     #access_token_passthrough: true
 
+  # Enables the Smart Agent's SignalFx Forwarder with default settings
+  # - listenAddress: 127.0.0.1:9080
+  # - serverTimeout: 5 (seconds)
+  smartagent/signalfx-forwarder:
+    type: signalfx-forwarder
+
   # Enables the zipkin receiver with default settings
   #  - grpc (default endpoint = 0.0.0.0:9411)
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/zipkinreceiver
@@ -533,14 +539,14 @@ service:
   # NOTE: Receivers expose ports so ensure no other application uses the same ports
   pipelines:
     traces:
-      receivers: [jaeger, otlp, sapm, zipkin]
+      receivers: [jaeger, otlp, sapm, smartagent/signalfx-forwarder, zipkin]
       processors: 
       - memory_limiter
       - batch
       #- resource/add_environment
       exporters: [sapm, signalfx]
     metrics:
-      receivers: [otlp, signalfx, prometheus]
+      receivers: [otlp, prometheus, signalfx, smartagent/signalfx-forwarder]
       processors: [memory_limiter, batch]
       exporters: [signalfx]
     logs:

--- a/cmd/otelcol/config/collector/otlp_config_linux.yaml
+++ b/cmd/otelcol/config/collector/otlp_config_linux.yaml
@@ -28,6 +28,9 @@ receivers:
             action: drop
   sapm:
   signalfx:
+  smartagent/signalfx-forwarder:
+    type: signalfx-forwarder
+    listenAddress: 0.0.0.0:9080
   zipkin:
 
 processors:
@@ -80,14 +83,14 @@ service:
   extensions: [health_check, http_forwarder, zpages]
   pipelines:
     traces:
-      receivers: [jaeger, otlp, sapm, zipkin]
+      receivers: [jaeger, otlp, sapm, smartagent/signalfx-forwarder, zipkin]
       processors:
       - memory_limiter
       - batch
       #- resource/add_environment
       exporters: [otlphttp, signalfx]
     metrics:
-      receivers: [otlp, signalfx, prometheus]
+      receivers: [otlp, prometheus, signalfx, smartagent/signalfx-forwarder]
       processors: [memory_limiter, batch]
       exporters: [signalfx]
     logs:

--- a/docs/signalfx-smart-agent-migration.md
+++ b/docs/signalfx-smart-agent-migration.md
@@ -6,8 +6,8 @@ for the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent).
 This distribution provides helpful components to assist current Smart Agent
 users in their transition to OpenTelemetry Collector and ensure no functionality
 loss.  The [Smart Agent
-Receiver](./internal/receiver/smartagentreceiver/README.md), its associated
-[extension](./internal/extension/smartagentextension/README.md), and other
+Receiver](../internal/receiver/smartagentreceiver/README.md), its associated
+[extension](../internal/extension/smartagentextension/README.md), and other
 Collector components provide a means of integrating all Smart Agent metric
 monitors into your Collector pipelines.
 
@@ -57,8 +57,8 @@ monitors:
 
 Below is an equivalent, recommended Collector configuration.  Notice that the
 `signalfx-forwarder` monitor's associated `smartagent/signalfx-forwarder` receiver instance
-is part of a `traces` pipeline using the `sapm` exporter.  The additional metric
-monitors utilize the
+is part of both `metrics` and `traces` pipelines using the `signalfx` and `sapm` exporters,
+respectively. The additional metric monitors utilize the
 [Receiver Creator](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/master/receiver/receivercreator/README.md):
 
 ```yaml
@@ -134,6 +134,7 @@ service:
     metrics:
       receivers:
         - receivor_creator
+        - smartagent/signalfx-forwarder
       processors:
         - resourcedetection
       exporters:

--- a/internal/receiver/smartagentreceiver/README.md
+++ b/internal/receiver/smartagentreceiver/README.md
@@ -16,8 +16,9 @@ Each `smartagent` receiver configuration acts a drop-in replacement for each sup
 and associated [Observer extensions](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/extension/observer/README.md)
 should be used.
 1. The [`signalfx-forwarder`](https://github.com/signalfx/signalfx-agent/blob/master/docs/monitors/signalfx-forwarder.md)
-monitor should be made part of a `traces` pipeline utilizing the [`sapm`
-exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/sapmexporter/README.md)
+monitor should be made part of both `metrics` and `traces` pipelines utilizing the
+[`signalfx`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/signalfxexporter/README.md)
+and [`sapm`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/sapmexporter/README.md) exporters, respectively.
 1. All metric content replacement and transformation rules should utilize existing
 [Collector processors](https://github.com/open-telemetry/opentelemetry-collector/blob/master/processor/README.md).
 1. Monitors with [dimension property and tag update
@@ -76,6 +77,7 @@ service:
       receivers:
         - smartagent/postgresql
         - smartagent/kafka
+        - smartagent/signalfx-forwarder
       processors:
         - resourcedetection
       exporters:


### PR DESCRIPTION
This will allow existing tracing library users to not need to update their instrumented deployments' configurations when using the Collector.

Also pork-barrelling layer caching on fpm image builds.