### PR TITLE
Include SA bundle in msi

### DIFF
--- a/docs/getting-started/windows-installer.md
+++ b/docs/getting-started/windows-installer.md
@@ -65,6 +65,7 @@ key and passed to the Collector service:
 - `SPLUNK_INGEST_URL`: The Splunk ingest URL, e.g. `https://ingest.us0.signalfx.com`
 - `SPLUNK_MEMORY_TOTAL_MIB`: Total memory in MiB allocated to the collector, e.g. `512`
 - `SPLUNK_TRACE_URL`: The Splunk trace endpoint URL, e.g. `https://ingest.us0.signalfx.com/v2/trace`
+- `SPLUNK_BUNDLE_DIR`: The location of your Smart Agent bundle for monitor functionality, e.g. `C:\Program Files\Splunk\OpenTelemetry Collector\agent-bundle`
 
 To modify these values, run `regdit` and browse to the path, or run the
 following PowerShell command (replace `ENV_VAR` and `VALUE` for the desired

--- a/docs/getting-started/windows-standalone.md
+++ b/docs/getting-started/windows-standalone.md
@@ -42,6 +42,7 @@ your environment:
 - `${SPLUNK_HEC_URL}`: The Splunk HEC endpoint URL, e.g. `https://ingest.us0.signalfx.com/v1/log`
 - `${SPLUNK_INGEST_URL}`: The Splunk ingest URL, e.g. `https://ingest.us0.signalfx.com`
 - `${SPLUNK_TRACE_URL}`: The Splunk trace endpoint URL, e.g. `https://ingest.us0.signalfx.com/v2/trace`
+- `${SPLUNK_BUNDLE_DIR}`: The location of your Smart Agent bundle for monitor functionality, e.g. `C:\Program Files\Splunk\OpenTelemetry Collector\agent-bundle`
 
 After updating all variables in the config file, start the
 `splunk-otel-collector` service by rebooting the system or running the

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -60,6 +60,10 @@
     (OPTIONAL) Whether to install and configure fluentd to forward log events to the collector (default: $true)
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -with_fluentd $false
+.PARAMETER bundle_dir
+    (OPTIONAL) The location of your Smart Agent bundle for monitor functionality (default: C:\Program Files\Splunk\OpenTelemetry Collector\agent-bundle)
+    .EXAMPLE
+    .\install.ps1 -access_token "ACCESSTOKEN" -bundle_dir "C:\Program Files\Splunk\OpenTelemetry Collector\agent-bundle"
 .PARAMETER insecure
     (OPTIONAL) If true then certificates will not be checked when downloading resources. Defaults to '$false'.
     .EXAMPLE
@@ -91,6 +95,7 @@ param (
     [bool]$insecure = $false,
     [string]$collector_version = "",
     [bool]$with_fluentd = $true,
+    [string]$bundle_dir = "",
     [ValidateSet('test','beta','release')][string]$stage = "release",
     [string]$msi_path = "",
     [bool]$UNIT_TEST = $false
@@ -351,6 +356,10 @@ if ($hec_token -eq "") {
     $hec_token = "$access_token"
 }
 
+if ($bundle_dir -eq "") {
+    $bundle_dir = "C:\Program Files\Splunk\OpenTelemetry Collector\agent-bundle"
+}
+
 if ("$env:VERIFY_ACCESS_TOKEN" -ne "false") {
     # verify access token
     echo 'Verifying Access Token...'
@@ -404,6 +413,7 @@ update_registry -path "$regkey" -name "SPLUNK_HEC_URL" -value "$hec_url"
 update_registry -path "$regkey" -name "SPLUNK_INGEST_URL" -value "$ingest_url"
 update_registry -path "$regkey" -name "SPLUNK_MEMORY_TOTAL_MIB" -value "$memory"
 update_registry -path "$regkey" -name "SPLUNK_TRACE_URL" -value "$trace_url"
+update_registry -path "$regkey" -name "SPLUNK_BUNDLE_DIR" -value "$bundle_dir"
 
 echo "Starting $service_name service..."
 start_service -name "$service_name" -config_path "$config_path"

--- a/internal/buildscripts/packaging/msi/make.ps1
+++ b/internal/buildscripts/packaging/msi/make.ps1
@@ -84,6 +84,7 @@ function Confirm-MSI {
     ((Get-Content -path "$configpath" -Raw) -Replace '\${SPLUNK_HEC_TOKEN}', 'testing456') | Set-Content -Path "$configpath"
     ((Get-Content -path "$configpath" -Raw) -Replace '\${SPLUNK_INGEST_URL}', 'https://ingest.us0.signalfx.com') | Set-Content -Path "$configpath"
     ((Get-Content -path "$configpath" -Raw) -Replace '\${SPLUNK_TRACE_URL}', 'https://ingest.us0.signalfx.com/v2/trace') | Set-Content -Path "$configpath"
+    ((Get-Content -path "$configpath" -Raw) -Replace '\${SPLUNK_BUNDLE_DIR}', 'C:\Program Files\Splunk\OpenTelemetry Collector\agent-bundle') | Set-Content -Path "$configpath"
 
     # start service
     echo "Starting service ..."

--- a/internal/buildscripts/packaging/msi/msi-builder/Dockerfile
+++ b/internal/buildscripts/packaging/msi/msi-builder/Dockerfile
@@ -1,8 +1,15 @@
 FROM felfert/wix:latest
 
+USER root
+RUN apt-get update -y
+RUN apt-get install -y curl unzip
+
+USER wix
+
 COPY ./build.sh /work/build.sh
 
 ENV OUTPUT_DIR=project/dist
+ENV SMART_AGENT_RELEASE=5.9.1
 
 # `wix` user cannot write to anything outside /work, so run w/ `-u 0` if necessary (circle configuration)
-ENTRYPOINT ["bash", "-c", "su wix -c \"/work/build.sh $0 $@ --output /work/build/stage \" && cp /work/build/stage/*.msi $OUTPUT_DIR/"]
+ENTRYPOINT ["bash", "-c", "su wix -c \"/work/build.sh $0 $@ --output /work/build/stage --smart-agent $SMART_AGENT_RELEASE \" && cp /work/build/stage/*.msi $OUTPUT_DIR/"]

--- a/internal/buildscripts/packaging/msi/msi-builder/build.sh
+++ b/internal/buildscripts/packaging/msi/msi-builder/build.sh
@@ -21,6 +21,7 @@ OTELCOL="/project/bin/otelcol_windows_amd64.exe"
 CONFIG="/project/cmd/otelcol/config/collector/agent_config.yaml"
 FLUENTD_CONFIG="/project/internal/buildscripts/packaging/fpm/etc/otel/collector/fluentd/fluent.conf"
 FLUENTD_CONFD="/project/internal/buildscripts/packaging/msi/fluentd/conf.d"
+SMART_AGENT_RELEASE="latest"
 SPLUNK_ICON="/project/internal/buildscripts/packaging/msi/splunk.ico"
 OUTPUT_DIR="/project/dist"
 
@@ -41,6 +42,8 @@ OPTIONS:
                              Defaults to '$FLUENTD_CONFIG'.
     --fluentd-confd PATH:    Absolute path to the conf.d.
                              Defaults to '$FLUENTD_CONFD'.
+    --smart-agent VERSION:   The released version of the Smart Agent bundle to include (will be downloaded).
+                             Defaults to '$SMART_AGENT_RELEASE'.
     --splunk-icon PATH:      Absolute path to the splunk.ico.
                              Defaults to '$SPLUNK_ICON'.
     --output DIR:            Directory to save the MSI.
@@ -54,8 +57,9 @@ parse_args_and_build() {
     local config="$CONFIG"
     local fluentd_config="$FLUENTD_CONFIG"
     local fluentd_confd="$FLUENTD_CONFD"
-    local output="$OUTPUT_DIR"
+    local smart_agent_release="$SMART_AGENT_RELEASE"
     local splunk_icon="$SPLUNK_ICON"
+    local output="$OUTPUT_DIR"
     local version=
 
     while [ -n "${1-}" ]; do
@@ -74,6 +78,10 @@ parse_args_and_build() {
                 ;;
             --fluentd-confd)
                 fluentd_confd="$2"
+                shift 1
+                ;;
+            --smart-agent)
+                smart_agent_release="$2"
                 shift 1
                 ;;
             --splunk-icon)
@@ -122,6 +130,8 @@ parse_args_and_build() {
     cp "$fluentd_config" "${files_dir}/fluentd/td-agent.conf"
     cp "${fluentd_confd}"/*.conf "${files_dir}/fluentd/conf.d/"
 
+    download_and_extract_smart_agent "$smart_agent_release" "$build_dir" "$files_dir"
+
     # kludge to satisfy relative path in splunk-otel-collector.wxs
     mkdir -p /work/internal/buildscripts/packaging/msi
     cp "${splunk_icon}" "/work/internal/buildscripts/packaging/msi/splunk.ico"
@@ -144,6 +154,38 @@ parse_args_and_build() {
     { set +x; } 2>/dev/null
 
     echo "MSI saved to ${output}/${msi_name}"
+}
+
+download_and_extract_smart_agent() {
+    SMART_AGENT_RELEASE_URL="https://dl.signalfx.com/windows/release/zip"
+    SMART_AGENT_LATEST_URL="${SMART_AGENT_RELEASE_URL}/latest/latest.txt"
+    local version="$1"
+    local build_dir="$2"
+    local output_dir="$3/agent-bundle"
+
+    if [ "$version" = "latest" ]; then
+        version=$( curl -sL "$SMART_AGENT_LATEST_URL" )
+        if [ -z "$version" ]; then
+            echo "Failed to get version for latest release from ${SMART_AGENT_LATEST_URL}" >&2
+            exit 1
+        fi
+    fi
+
+    dl_url="$SMART_AGENT_RELEASE_URL/SignalFxAgent-$version-win64.zip"
+    echo "Downloading ${dl_url}..."
+    curl -sL "$dl_url" -o "${build_dir}/signalfx-agent.zip"
+
+    unzip -d "$build_dir" "${build_dir}/signalfx-agent.zip"
+    mv "${build_dir}/SignalFxAgent" "$output_dir"
+    rm -rf "${output_dir}/bin"
+
+    # Delete unnecessary files.
+    find "$output_dir" -type d -name __pycache__ | xargs rm -rf {} \;
+    find "$output_dir" -regextype sed -regex ".*py[co]" -delete
+    # This defers resolving https://github.com/wixtoolset/issues/issues/5314, which appears to require building on windows.
+    # Check if test file content's path is >= 126 (128 w/ 'Z:' in wine).
+    find "$output_dir" -wholename "*/tests/*" -exec bash -c 'if [ `echo "{}" | wc -c` -ge 126 ]; then rm -f {}; fi' \;
+    rm -f "${build_dir}/signalfx-agent.zip"
 }
 
 parse_args_and_build $@

--- a/internal/buildscripts/packaging/msi/msi-builder/build.sh
+++ b/internal/buildscripts/packaging/msi/msi-builder/build.sh
@@ -177,13 +177,14 @@ download_and_extract_smart_agent() {
 
     unzip -d "$build_dir" "${build_dir}/signalfx-agent.zip"
     mv "${build_dir}/SignalFxAgent" "$output_dir"
-    rm -rf "${output_dir}/bin"
 
     # Delete unnecessary files.
+    rm -rf "${output_dir}/bin"
+    rm -rf "${output_dir}/etc"
     find "$output_dir" -type d -name __pycache__ | xargs rm -rf {} \;
     find "$output_dir" -regextype sed -regex ".*py[co]" -delete
     # This defers resolving https://github.com/wixtoolset/issues/issues/5314, which appears to require building on windows.
-    # Check if test file content's path is >= 126 (128 w/ 'Z:' in wine).
+    # Check if test file content's path is >= 126 (128 w/ 'Z:' prefix in wine).
     find "$output_dir" -wholename "*/tests/*" -exec bash -c 'if [ `echo "{}" | wc -c` -ge 126 ]; then rm -f {}; fi' \;
     rm -f "${build_dir}/signalfx-agent.zip"
 }


### PR DESCRIPTION
requires https://github.com/signalfx/splunk-otel-collector/pull/210

These changes add a slightly modified Smart Agent bundle to msi installations.  There is a path length limitation w/ WiX and Wine that prevents copying it completely that I wasn't able to find a workaround to while preserving signed builds in linux.