### PR TITLE
Update splunk-forwarder-integration.md

### DIFF
--- a/docs/experimental/splunk-forwarder-integration.md
+++ b/docs/experimental/splunk-forwarder-integration.md
@@ -63,13 +63,12 @@ monitors. For example, `tcp.conf` could be added with the following:
 <source>
    @type tcp
    @label @SPLUNK
-   tag "tcp.events"
+   tag tcp.events
    port 20001
-   bind "0.0.0.0"
+   bind 0.0.0.0
    delimiter "\n"
    <parse>
      @type "none"
-     message_key "_raw"
    </parse>
  </source>
 ```


### PR DESCRIPTION
Removed _raw field from parsing that was present during testing - This will not work with log observer as it isn't present. - @flands