### PR TITLE
Update sizing guidelines

### DIFF
--- a/docs/sizing.md
+++ b/docs/sizing.md
@@ -3,11 +3,15 @@
 The OpenTelemetry Collector can be scaled up or out as needed. Sizing is based
 on the amount of data per data source and requires 1 CPU core per:
 
-- Traces: 10,000 spans per second
+- Traces: 15,000 spans per second
 - Metrics: 20,000 data points per second
+- Logs: 10,000 log records per second
+
+Note: The sizing recommendation for logs also account for `td-agent` (`fluentd`),
+that forwards logs to the [`fluentforward` receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/fluentforwardreceiver) in the Collector.
 
 If a Collector handles both trace and metric data then both must be accounted
-for when sizing. For example, 5K spans per second plus 10K data points per
+for when sizing. For example, 7.5K spans per second plus 10K data points per
 second would require 1 CPU core.
 
 The recommendation is to use a ratio of 1 CPU to 2 GB of memory. By default, the


### PR DESCRIPTION
Existing tests in the [testbed](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/testbed/tests) were used to validate/determine sizing information. The specific tests used -

1. SAPM for traces
2. SignalFx for metrics
3. FluentForward-SplunkHEC for logs (yet to be merged https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2924)

Each of these tests were run separately. Slight code modifications were made to testbed code to test various loads and also include default processors included by this distribution. For example, for the logs test, the used config was the following - 

```yaml
receivers:
  prometheus:
    config:
      scrape_configs:
        - job_name: 'otel-collector'
          scrape_interval: 10s
          static_configs:
            - targets: [ '0.0.0.0:8888' ]
          metric_relabel_configs:
            - source_labels: [ __name__ ]
              regex: '.*grpc_io.*'
              action: drop

  fluentforward:
    endpoint: localhost:8006
exporters:
    signalfx/self:
      access_token: "${SPLUNK_HEC_TOKEN}"
      realm: us0
      exclude_metrics: []
      translation_rules: []
    splunk_hec:
      endpoint: "http://localhost:38271"
      token: "token"

processors:
  batch:
  memory_limiter:
    ballast_size_mib: 2048
    check_interval: 2s
    limit_mib: 683
  resourcedetection:
    detectors: [system]
    override: true

extensions:
  pprof:
    save_to_file: /home/ubuntu/opentelemetry-collector-contrib/testbed/tests/results/TestLog10kDPS/FluentForward-SplunkHEC/cpu.prof

service:
  extensions: [pprof, ]
  pipelines:
    metrics/self:
      receivers: [prometheus]
      exporters: [signalfx/self]
    logs:
      receivers: [fluentforward]
      processors: [batch,memory_limiter,resourcedetection]
      exporters: [splunk_hec]
``` 

The same processor configs and self reporting configs were used for traces and metrics tests.

The tests were run on AWS `c4.2xlarge` instances. The CPU consumption per core was 25-30% (overall CPU used on instances ~3.5% of total CPU) (inclusive of `td-agent` for logs) for each of these tests. Memory consumption was well within the default of 512 MB.

