### PR TITLE
Fix MSI release build for signed exe

### DIFF
--- a/internal/buildscripts/packaging/msi/msi-builder/Dockerfile
+++ b/internal/buildscripts/packaging/msi/msi-builder/Dockerfile
@@ -4,12 +4,11 @@ USER root
 RUN apt-get update -y
 RUN apt-get install -y curl unzip
 
-USER wix
-
 COPY ./build.sh /work/build.sh
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod a+x /work/build.sh /docker-entrypoint.sh
 
 ENV OUTPUT_DIR=project/dist
 ENV SMART_AGENT_RELEASE=5.9.1
 
-# `wix` user cannot write to anything outside /work, so run w/ `-u 0` if necessary (circle configuration)
-ENTRYPOINT ["bash", "-c", "su wix -c \"/work/build.sh $0 $@ --output /work/build/stage --smart-agent $SMART_AGENT_RELEASE \" && cp /work/build/stage/*.msi $OUTPUT_DIR/"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/internal/buildscripts/packaging/msi/msi-builder/docker-entrypoint.sh
+++ b/internal/buildscripts/packaging/msi/msi-builder/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SMART_AGENT_RELEASE="${SMART_AGENT_RELEASE:-}"
+OUTPUT_DIR="${OUTPUT_DIR:-}"
+
+if [ -z "$SMART_AGENT_RELEASE" ]; then
+    echo "SMART_AGENT_RELEASE env var not set!" >&2
+    exit 1
+fi
+
+if [ -z "$OUTPUT_DIR" ]; then
+    echo "OUTPUT_DIR env var not set!" >&2
+    exit 1
+fi
+
+if [ $# -eq 0 ]; then
+    echo "Required version argument not specified!" >&2
+    exit 1
+fi
+
+buildargs="--output /work/build/stage --smart-agent $SMART_AGENT_RELEASE $@"
+su wix -c "/work/build.sh $buildargs"
+
+cp /work/build/stage/*.msi $OUTPUT_DIR/

--- a/internal/buildscripts/packaging/release/helpers/util.py
+++ b/internal/buildscripts/packaging/release/helpers/util.py
@@ -445,6 +445,7 @@ def build_msi(exe_path, args):
     msi_builder_image, _ = client.images.build(path=msi_builder_path)
 
     with tempfile.TemporaryDirectory(dir=str(REPO_DIR)) as build_dir:
+        shutil.copy(exe_path, os.path.join(build_dir, "otelcol.exe"))
         container_options = {
             "remove": True,
             "volumes": {
@@ -454,7 +455,7 @@ def build_msi(exe_path, args):
             "user": 0,
             "working_dir": "/work",
             "environment": {'OUTPUT_DIR': "/work/stage"},
-            "command": f"{msi_version}",
+            "command": [f"--otelcol /work/stage/otelcol.exe {msi_version}"],
         }
         output = client.containers.run(msi_builder_image, **container_options)
         print(output.decode("utf-8"))


### PR DESCRIPTION
- Move Dockerfile entrypoint command to `docker-entrypoint.sh`
- Copy the signed exe before the MSI release build to the staging directory and pass the `--otelcol` option to the build script