### PR TITLE
Support gateway mode for windows installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,6 +240,16 @@ workflows:
       - windows-msi-validation:
           requires:
             - windows-msi
+          name: windows-msi-agent-test
+          mode: agent
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+      - windows-msi-validation:
+          requires:
+            - windows-msi
+          name: windows-msi-gateway-test
+          mode: gateway
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
@@ -465,11 +475,16 @@ jobs:
     executor:
       name: win/default
       shell: powershell.exe
+    parameters:
+      mode:
+        type: enum
+        enum: ["agent", "gateway"]
     steps:
       - attach_to_workspace
       - run:
           name: Installation test
           command: |
+            Set-PSDebug -Trace 1
             $msi_path = Resolve-Path .\dist\splunk-otel-collector*.msi
             $env:VERIFY_ACCESS_TOKEN = "false"
-            .\internal\buildscripts\packaging\installer\install.ps1 -access_token "testing123" -msi_path "$msi_path"
+            .\internal\buildscripts\packaging\installer\install.ps1 -access_token "testing123" -msi_path "$msi_path" -mode "<< parameters.mode >>"

--- a/docs/getting-started/windows-installer.md
+++ b/docs/getting-started/windows-installer.md
@@ -46,7 +46,7 @@ Replace the `SPLUNK_MEMORY_TOTAL_MIB` variable with the desired value.
 ### Collector Configuration
 
 The Collector comes with a default configuration which can be found at
-`\ProgramData\Splunk\OpenTelemetry Collector\config.yaml`. This configuration
+`\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml`. This configuration
 can be modified as needed. Possible configuration options can be found in the
 `receivers`, `processors`, `exporters`, and `extensions` folders of either:
 
@@ -60,12 +60,14 @@ key and passed to the Collector service:
 
 - `SPLUNK_ACCESS_TOKEN`: The Splunk access token to authenticate requests
 - `SPLUNK_API_URL`: The Splunk API URL, e.g. `https://api.us0.signalfx.com`
+- `SPLUNK_BUNDLE_DIR`: The location of your Smart Agent bundle for monitor functionality, e.g. `C:\Program Files\Splunk\OpenTelemetry Collector\agent-bundle`
+- `SPLUNK_CONFIG`: The path to the collector config file, e.g. `C:\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml`
 - `SPLUNK_HEC_TOKEN`: The Splunk HEC authentication token
 - `SPLUNK_HEC_URL`: The Splunk HEC endpoint URL, e.g. `https://ingest.us0.signalfx.com/v1/log`
 - `SPLUNK_INGEST_URL`: The Splunk ingest URL, e.g. `https://ingest.us0.signalfx.com`
 - `SPLUNK_MEMORY_TOTAL_MIB`: Total memory in MiB allocated to the collector, e.g. `512`
+- `SPLUNK_REALM`: The Splunk realm to send the data to, e.g. `us0`
 - `SPLUNK_TRACE_URL`: The Splunk trace endpoint URL, e.g. `https://ingest.us0.signalfx.com/v2/trace`
-- `SPLUNK_BUNDLE_DIR`: The location of your Smart Agent bundle for monitor functionality, e.g. `C:\Program Files\Splunk\OpenTelemetry Collector\agent-bundle`
 
 To modify these values, run `regdit` and browse to the path, or run the
 following PowerShell command (replace `ENV_VAR` and `VALUE` for the desired

--- a/docs/getting-started/windows-standalone.md
+++ b/docs/getting-started/windows-standalone.md
@@ -11,7 +11,7 @@ The collector will be installed to
 `splunk-otel-collector` service will be created but not started.
 
 A default config file will be copied to
-`\ProgramData\Splunk\OpenTelemetry Collector\config.yaml` if it does not
+`\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml` if it does not
 already exist.  This file is required to start the `splunk-otel-collector`
 service.
 
@@ -50,6 +50,25 @@ following command in a PowerShell terminal:
 
 ```sh
 PS> Start-Service splunk-otel-collector
+```
+
+To modify the default path to the configuration file for the
+`splunk-otel-collector` service, run `regdit` and modify the `SPLUNK_CONFIG`
+value in the
+`HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment`
+registry key, or run the following PowerShell command (replace `PATH` with the
+full path to the new configuration file):
+
+```powershell
+Set-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" -name "SPLUNK_CONFIG" -value "PATH"
+```
+
+After modifying the configuration file or registry key, apply the changes by
+restarting the system or running the following PowerShell commands:
+
+```powershell
+Stop-Service splunk-otel-collector
+Start-Service splunk-otel-collector
 ```
 
 The collector logs and errors can be viewed in the Windows Event Viewer.

--- a/internal/buildscripts/packaging/msi/msi-builder/build.sh
+++ b/internal/buildscripts/packaging/msi/msi-builder/build.sh
@@ -18,7 +18,8 @@ set -euo pipefail
 
 WXS_PATH="/project/internal/buildscripts/packaging/msi/splunk-otel-collector.wxs"
 OTELCOL="/project/bin/otelcol_windows_amd64.exe"
-CONFIG="/project/cmd/otelcol/config/collector/agent_config.yaml"
+AGENT_CONFIG="/project/cmd/otelcol/config/collector/agent_config.yaml"
+GATEWAY_CONFIG="/project/cmd/otelcol/config/collector/gateway_config.yaml"
 FLUENTD_CONFIG="/project/internal/buildscripts/packaging/fpm/etc/otel/collector/fluentd/fluent.conf"
 FLUENTD_CONFD="/project/internal/buildscripts/packaging/msi/fluentd/conf.d"
 SMART_AGENT_RELEASE="latest"
@@ -36,8 +37,10 @@ Description:
 OPTIONS:
     --otelcol PATH:          Absolute path to the otelcol exe.
                              Defaults to '$OTELCOL'.
-    --config PATH:           Absolute path to the agent config.
-                             Defaults to '$CONFIG'.
+    --agent-config PATH:     Absolute path to the agent config.
+                             Defaults to '$AGENT_CONFIG'.
+    --gateway-config PATH:   Absolute path to the gateway config.
+                             Defaults to '$GATEWAY_CONFIG'.
     --fluentd PATH:          Absolute path to the fluentd config.
                              Defaults to '$FLUENTD_CONFIG'.
     --fluentd-confd PATH:    Absolute path to the conf.d.
@@ -54,7 +57,8 @@ EOH
 
 parse_args_and_build() {
     local otelcol="$OTELCOL"
-    local config="$CONFIG"
+    local agent_config="$AGENT_CONFIG"
+    local gateway_config="$GATEWAY_CONFIG"
     local fluentd_config="$FLUENTD_CONFIG"
     local fluentd_confd="$FLUENTD_CONFD"
     local smart_agent_release="$SMART_AGENT_RELEASE"
@@ -68,8 +72,12 @@ parse_args_and_build() {
                 otelcol="$2"
                 shift 1
                 ;;
-            --config)
-                config="$2"
+            --agent-config)
+                agent_config="$2"
+                shift 1
+                ;;
+            --gateway-config)
+                gateway_config="$2"
                 shift 1
                 ;;
             --fluentd)
@@ -126,7 +134,8 @@ parse_args_and_build() {
     fi
 
     mkdir -p "${files_dir}/fluentd/conf.d"
-    cp "$config" "${files_dir}/config.yaml"
+    cp "$agent_config" "${files_dir}/agent_config.yaml"
+    cp "$gateway_config" "${files_dir}/gateway_config.yaml"
     cp "$fluentd_config" "${files_dir}/fluentd/td-agent.conf"
     cp "${fluentd_confd}"/*.conf "${files_dir}/fluentd/conf.d/"
 

--- a/internal/buildscripts/packaging/msi/splunk-otel-collector.wxs
+++ b/internal/buildscripts/packaging/msi/splunk-otel-collector.wxs
@@ -28,7 +28,6 @@
                         Start="auto"
                         Account="LocalSystem"
                         ErrorControl="normal"
-                        Arguments=" --config=&quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\config.yaml&quot;"
                         Interactive="no" />
                      <ServiceControl
                         Id="StartStopRemoveService"
@@ -38,6 +37,9 @@
                         Wait="yes" />
                      <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\EventLog\Application\splunk-otel-collector">
                         <RegistryValue Type="expandable" Name="EventMessageFile" Value="%SystemRoot%\System32\EventCreate.exe"/>
+                     </RegistryKey>
+                     <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Control\Session Manager\Environment">
+                        <RegistryValue Type="string" Name="SPLUNK_CONFIG" Value="[CommonAppDataFolder]Splunk\OpenTelemetry Collector\agent_config.yaml"/>
                      </RegistryKey>
                   </Component>
                </Directory>
@@ -56,14 +58,14 @@
          <DirectorySearch Id="AppDataFolderSearch" Path="[CommonAppDataFolder]">
             <DirectorySearch Id="SplunkSearch" Path="Splunk">
                <DirectorySearch Id="OpenTelemetryCollectorSearch" Path="OpenTelemetry Collector">
-                  <FileSearch Id="ConfigSearch" Name="config.yaml" />
+                  <FileSearch Id="ConfigSearch" Name="agent_config.yaml" />
                </DirectorySearch>
             </DirectorySearch>
          </DirectorySearch>
       </Property>
 
-      <!-- Copy the default config file to ProgramData if it does not already exist -->
-      <CustomAction Id="CopyConfig" ExeCommand="xcopy /y &quot;[INSTALLDIR]config.yaml&quot; &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\config.yaml*&quot;" Directory="INSTALLDIR" Impersonate="no" Execute="deferred" Return="check" />
+      <!-- Copy the default agent config file to ProgramData if it does not already exist -->
+      <CustomAction Id="CopyConfig" ExeCommand="xcopy /y &quot;[INSTALLDIR]agent_config.yaml&quot; &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\agent_config.yaml*&quot;" Directory="INSTALLDIR" Impersonate="no" Execute="deferred" Return="check" />
       <InstallExecuteSequence>
          <Custom Action="CopyConfig" After="InstallFiles">NOT CONFIG_FILE_EXISTS AND NOT Installed</Custom>
       </InstallExecuteSequence>


### PR DESCRIPTION
- Add `gateway_config.yaml` to the MSI
- Add `--mode <agent|gateway>` option to the installer script (defaults to `agent`)
- Set and use the `SPLUNK_CONFIG` env var in the registry instead of the `--config` argument for the collector service
- Update msi/installer test in circleci for agent and gateway modes