### PR TITLE
SA Extension: Set platform specific bundleDir default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,9 +377,14 @@ jobs:
             choco upgrade golang --version=1.15
             refreshenv
             go env -w CGO_ENABLED=0
+            go install github.com/ory/go-acc
+            (New-Object System.Net.WebClient).DownloadFile("https://codecov.io/bash", "C:\Users\circleci\project\codecov.sh")
       - run:
-          name: Unit tests
-          command: go test ./...
+          name: Unit tests with coverage
+          command: go-acc ./...
+      - run:
+          name: Upload coverage
+          command: bash codecov.sh -f coverage.txt
       - save_module_cache
 
   build-package:

--- a/internal/extension/smartagentextension/config_linux_test.go
+++ b/internal/extension/smartagentextension/config_linux_test.go
@@ -1,0 +1,49 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// +build !windows
+
+package smartagentextension
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configtest"
+)
+
+func TestBundleDirDefault(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	require.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Extensions[typeStr] = factory
+	cfg, err := configtest.LoadConfigFile(
+		t, path.Join(".", "testdata", "config.yaml"), factories,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	require.GreaterOrEqual(t, len(cfg.Extensions), 1)
+
+	allSettingsConfig := cfg.Extensions["smartagent/default_settings"]
+	require.NotNil(t, allSettingsConfig)
+
+	saConfigProvider, ok := allSettingsConfig.(SmartAgentConfigProvider)
+	require.True(t, ok)
+
+	require.Equal(t, "/usr/lib/splunk-otel-collector/agent-bundle", saConfigProvider.SmartAgentConfig().BundleDir)
+}

--- a/internal/extension/smartagentextension/config_windows_test.go
+++ b/internal/extension/smartagentextension/config_windows_test.go
@@ -1,0 +1,49 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// +build windows
+
+package smartagentextension
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configtest"
+)
+
+func TestBundleDirDefault(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	require.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Extensions[typeStr] = factory
+	cfg, err := configtest.LoadConfigFile(
+		t, path.Join(".", "testdata", "config.yaml"), factories,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	require.GreaterOrEqual(t, len(cfg.Extensions), 1)
+
+	allSettingsConfig := cfg.Extensions["smartagent/default_settings"]
+	require.NotNil(t, allSettingsConfig)
+
+	saConfigProvider, ok := allSettingsConfig.(SmartAgentConfigProvider)
+	require.True(t, ok)
+
+	require.Equal(t, "C:\\Program Files\\Splunk\\OpenTelemetry Collector\\agent-bundle", saConfigProvider.SmartAgentConfig().BundleDir)
+}


### PR DESCRIPTION
These changes use saner defaults for the agent bundle path, which should match standard installation paths.  For windows, since the bundle is adjacent to the executable in standard installation we check for it and source it if found.

edit: I've also added uploading a windows run coverage report, but don't think I'll be hitting the requirement for this PR since one diff path requires running from an installed msi's perspective.

The significant drop in project coverage w/ these changes results from the windows build files now revealing they are without coverage.  The actual missing coverage from the diff is from a runtime only path, and one where a critical env var has been cleared (both relative edge cases).