### PR TITLE
Don't override system resource attrs in default config

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -87,7 +87,7 @@ processors:
     limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
   resourcedetection:
     detectors: [system]
-    override: true
+    override: false
 
   # Optional: The following processor can be used to add a default "deployment.environment" attribute to the logs and 
   # traces when it's not populated by instrumentation libraries.


### PR DESCRIPTION
Any `host.name` and `os.type` resource attributes that have been set should be respected instead of overridden by our provided resource detection processor instance.  Otherwise there is the potential for masking the actual data source.