### PR TITLE
Better document and test SA Extension config

### DIFF
--- a/docs/signalfx-smart-agent-migration.md
+++ b/docs/signalfx-smart-agent-migration.md
@@ -32,6 +32,12 @@ apiUrl: https://api.us1.signalfx.com
 
 bundleDir: /opt/my-smart-agent-bundle
 
+procPath: /my_custom_proc
+etcPath: /my_custom_etc
+varPath: /my_custom_var
+runPath: /my_custom_run
+sysPath: /my_custom_sys
+
 observers:
   - type: k8s-api
 
@@ -39,6 +45,7 @@ collectd:
   readThreads: 10
   writeQueueLimitHigh: 1000000
   writeQueueLimitLow: 600000
+  configDir: "/tmp/signalfx-agent/collectd"
 
 monitors:
   - type: signalfx-forwarder
@@ -68,10 +75,16 @@ extensions:
     node: ${K8S_NODE_NAME}
   smartagent:
     bundleDir: /opt/my-smart-agent-bundle
+    procPath: /my_custom_proc
+    etcPath: /my_custom_etc
+    varPath: /my_custom_var
+    runPath: /my_custom_run
+    sysPath: /my_custom_sys
     collectd:
       readThreads: 10
       writeQueueLimitHigh: 1000000
       writeQueueLimitLow: 600000
+      configDir: "/tmp/signalfx-agent/collectd"
 
 receivers:
   smartagent/signalfx-forwarder:

--- a/internal/extension/smartagentextension/README.md
+++ b/internal/extension/smartagentextension/README.md
@@ -1,13 +1,27 @@
 # SignalFx Smart Agent Extension
 
 The `smartagent` extension provides a mechanism to specify config options that are not
-just specific to a single instance of the [`smartagent` receiver](../../receiver/smartagentreceiver/README.md) but are applicable to
-all instances of the `smartagent` receiver.
+just specific to a single instance of the [Smart Agent Receiver](../../receiver/smartagentreceiver/README.md) but are applicable to
+all instances.  This component provides a means of migrating your existing
+[Smart Agent configuration](https://docs.signalfx.com/en/latest/integrations/agent/config-schema.html#config-schema)
+to the Splunk Distribution of OpenTelemetry Collector.
 
-To begin with, this extension will provide a mechanism to specify config options to configure
-collectd. These options are mapped to the [collectd config options](https://docs.signalfx.com/en/latest/integrations/agent/config-schema.html#collectd)
-in the SignalFx Agent. Note that if this extension is not configured, the defaults in `smartagent`
-receiver will be used.
+As the Smart Agent Receiver doesn't provide 1:1 functional parity with the SignalFx Smart Agent in itself,
+only a subset of existing configuration fields are supported by the Smart Agent Extension at this time:
+
+1. The [bundleDir] field refers to the path of a supported Smart Agent release bundle.  All provided
+Splunk Distribution of OpenTelemetry Collector packages include the agent bundle, and their installers
+source its value via the `SPLUNK_BUNDLE_DIR` environment variable by default.
+1. The [collectd](https://docs.signalfx.com/en/latest/integrations/agent/config-schema.html#collectd)
+field refers to performance and debugging configurables for the collectd subprocess and associated mechanisms.
+If the Smart Agent Extension or this field are not configured, the Agent defaults will be inherited.
+This configuration object's `configDir` refers to the location for internal configuration files and is set to the value
+of the `SPLUNK_COLLECTD_DIR` environment variable by the default agent deployment mode config.
+1. `procPath` for host or mounted container procfs access (default `/proc`)
+1. `etcPath` for host or mounted container volume/filesystem etc content (default `/etc`)
+1. `varPath` for host or mounted container volume/filesystem var content (default `/var`)
+1. `runPath` for host or mounted container volume/filesystem run content (default `/run`)
+1. `sysPath` for host or mounted container sysfs access (default `/sys`)
 
 In the below example configuration, `configDir` and `bundleDir` will be used for all instances
 of the `smartagent` receiver that wrap around a collectd based monitor.
@@ -16,9 +30,7 @@ of the `smartagent` receiver that wrap around a collectd based monitor.
 extensions:
   smartagent:
     bundleDir: /bundle/
+    procPath: /custom/proc
     collectd:
-      configDir: /etc/collectd/
+      configDir: /tmp/collectd/config
 ```
-
-The full list of settings exposed for this receiver are documented [here](./config.go)
-with detailed sample configurations [here](./testdata/config.yaml).

--- a/internal/extension/smartagentextension/config_test.go
+++ b/internal/extension/smartagentextension/config_test.go
@@ -64,6 +64,11 @@ func TestLoadConfig(t *testing.T) {
 		cfg := defaultConfig()
 		cfg.ExtensionSettings.NameVal = "smartagent/all_settings"
 		cfg.BundleDir = "/opt/bin/collectd/"
+		cfg.ProcPath = "/my_proc"
+		cfg.EtcPath = "/my_etc"
+		cfg.VarPath = "/my_var"
+		cfg.RunPath = "/my_run"
+		cfg.SysPath = "/my_sys"
 		cfg.Collectd.Timeout = 10
 		cfg.Collectd.ReadThreads = 1
 		cfg.Collectd.WriteThreads = 4

--- a/internal/extension/smartagentextension/testdata/config.yaml
+++ b/internal/extension/smartagentextension/testdata/config.yaml
@@ -2,6 +2,11 @@ extensions:
   smartagent/default_settings:
   smartagent/all_settings:
     bundleDir: /opt/bin/collectd/
+    procPath: /my_proc
+    etcPath: /my_etc
+    varPath: /my_var
+    runPath: /my_run
+    sysPath: /my_sys
     collectd:
       timeout: 10
       readThreads: 1

--- a/internal/receiver/smartagentreceiver/README.md
+++ b/internal/receiver/smartagentreceiver/README.md
@@ -2,15 +2,19 @@
 
 The Smart Agent Receiver allows you to utilize existing [SignalFx Smart Agent monitors](https://github.com/signalfx/signalfx-agent#monitors)
 as OpenTelemetry Collector metric receivers.  It assumes that you have a properly configured environment with a
-functional [Smart Agent release bundle](https://github.com/signalfx/signalfx-agent/releases/latest) on your system.
+functional [Smart Agent release bundle](https://github.com/signalfx/signalfx-agent/releases/latest) on your system,
+which is already provided for supported Splunk Distribution of OpenTelemetry Collector
+[installation paths](https://github.com/signalfx/splunk-otel-collector#getting-started).
 
-**Beta: No stability or functional guarantees are made at this time.  Configuration and behavior may change without notice.**
+**Beta: All Smart Agent monitors are supported at this time.  Configuration and behavior may change without notice.**
 
 ## Configuration
 
 Each `smartagent` receiver configuration acts a drop-in replacement for each supported Smart Agent Monitor
 [configuration](https://github.com/signalfx/signalfx-agent/blob/master/docs/monitor-config.md) with some exceptions:
 
+1. Any Agent global or collectd desired configuration should be performed via the
+[Smart Agent Extension](../../extension/smartagentextension/README.md).
 1. In lieu of `discoveryRule` support, the Collector's
 [`receivercreator`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/master/receiver/receivercreator/README.md)
 and associated [Observer extensions](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/extension/observer/README.md)


### PR DESCRIPTION
These changes update the supported global/collectd config fields and descriptions and add a reference to the extension from the receiver readme.  Also includes a minor unit test update to vet fs fields.

These changes also expand the beta disclaimer for the SA receiver.