### PR TITLE
Remove host mapping in fluentd configs

### DIFF
--- a/internal/buildscripts/packaging/fpm/etc/otel/collector/fluentd/conf.d/journald.conf
+++ b/internal/buildscripts/packaging/fpm/etc/otel/collector/fluentd/conf.d/journald.conf
@@ -58,7 +58,6 @@
     path /var/log/td-agent/journald.pos.json
   </storage>
   <entry>
-    field_map {"_HOSTNAME": "host.name"}
     fields_strip_underscores true
     fields_lowercase true
   </entry>

--- a/internal/buildscripts/packaging/msi/fluentd/conf.d/eventlog.conf
+++ b/internal/buildscripts/packaging/msi/fluentd/conf.d/eventlog.conf
@@ -14,7 +14,6 @@
 <filter winevt.raw>
   @type record_transformer
   <record>
-    host ${hostname}
     log ${record["Description"]}
   </record>
 </filter>


### PR DESCRIPTION
No longer required with the latest collector release.