### PR TITLE
Env variable NO_WINDOWS_SERVICE to force interactive mode on Windows

### DIFF
--- a/cmd/otelcol/main_windows.go
+++ b/cmd/otelcol/main_windows.go
@@ -19,28 +19,42 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"go.opentelemetry.io/collector/service"
 	"golang.org/x/sys/windows/svc"
 )
 
 func run(params service.Parameters) error {
-	isInteractive, err := svc.IsAnInteractiveSession()
-	if err != nil {
-		return fmt.Errorf("failed to determine if we are running in an interactive session %w", err)
-	}
-
-	if isInteractive {
+	if useInteractiveMode, err := checkUseInteractiveMode(); err != nil {
+		return err
+	} else if useInteractiveMode {
 		return runInteractive(params)
 	} else {
 		return runService(params)
 	}
 }
 
+func checkUseInteractiveMode() (bool, error) {
+	// If environment variable NO_WINDOWS_SERVICE is set with any value other
+	// than 0, use interactive mode instead of running as a service. This should
+	// be set in case running as a service is not possible or desired even
+	// though the current session is not detected to be interactive
+	if value, present := os.LookupEnv("NO_WINDOWS_SERVICE"); present && value != "0" {
+		return true, nil
+	}
+
+	if isInteractiveSession, err := svc.IsAnInteractiveSession(); err != nil {
+		return false, fmt.Errorf("failed to determine if we are running in an interactive session %w", err)
+	} else {
+		return isInteractiveSession, nil
+	}
+}
+
 func runService(params service.Parameters) error {
 	// do not need to supply service name when startup is invoked through Service Control Manager directly
 	if err := svc.Run("", service.NewWindowsService(params)); err != nil {
-		return fmt.Errorf("failed to start service %w", err)
+		return fmt.Errorf("failed to start service: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
This is a copy of the main repo PR: open-telemetry/opentelemetry-collector#2272 that enables running the collector inside Windows Docker containers.

Main repo PR description:

> Adding a feature - adds a check for NO_WINDOWS_SERVICE environment variable on Windows to allow forcing interactive mode instead of running as a service.
>
> This is required for using the collector in Windows Docker containers, as at least some of the Windows base images do not support services (fails with "The service process could not connect to the service controller"). Environment variable is used instead of automatic detection of Docker as it is uncertain if images that support services are possible and/or desired.
>
>Running collector in Windows Docker containers is required to perform containerized integration tests of agents on Windows.

We want to use splunk-otel-collector in our splunk-otel-java smoke-tests, and that includes Windows tests. This change is required to make Windows containers work.