### PR TITLE
Adopt 0.24.0 changes in tests

### DIFF
--- a/cmd/otelcol/Dockerfile
+++ b/cmd/otelcol/Dockerfile
@@ -34,4 +34,4 @@ COPY config/collector/gateway_config.yaml    /etc/otel/collector/gateway_config.
 COPY config/collector/otlp_config_linux.yaml /etc/otel/collector/otlp_config_linux.yaml
 COPY config/collector/agent_config.yaml      /etc/otel/collector/agent_config.yaml
 ENTRYPOINT ["/otelcol"]
-EXPOSE 13133 14250 14268 55680 4317 6060 7276 8888 9411 9443
+EXPOSE 13133 14250 14268 55680 4317 6060 7276 8888 9411 9443 9080

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -827,8 +827,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.10.2 h1:aY/nuoWlKJud2J6U0E3NWsjlg+0GtwXxgEqthRdzlcs=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
-github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.24.0 h1:lepRkNbEJDWuH1neuc+qPqPh1ys6QSVAMZiKne5tvrk=
-github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.24.0/go.mod h1:tR/dOYoq6Uky6SYCcqAHA/dZU4savuTNRnXpZ4pWMlQ=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.24.1-0.20210409203624-f1ee616c4d90 h1:cUViOe5xsV7GyGwkU1adx+Vt7T89ygduCcM6Fij5L/U=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.24.1-0.20210409203624-f1ee616c4d90/go.mod h1:tR/dOYoq6Uky6SYCcqAHA/dZU4savuTNRnXpZ4pWMlQ=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/tests/testutils/otlp_receiver_sink_test.go
+++ b/tests/testutils/otlp_receiver_sink_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
@@ -99,7 +100,9 @@ func TestReceiverMethodsWithoutBuildingDisallowed(t *testing.T) {
 }
 
 func otlpExporter(t *testing.T) component.MetricsExporter {
-	exporterCfg := otlpexporter.Config{GRPCClientSettings: configgrpc.GRPCClientSettings{
+	exporterCfg := otlpexporter.Config{
+		ExporterSettings: &config.ExporterSettings{NameVal: "otlp", TypeVal: "otlp"},
+		GRPCClientSettings: configgrpc.GRPCClientSettings{
 		Endpoint: "localhost:4317",
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,

--- a/tests/testutils/pdata_to_resource_metrics.go
+++ b/tests/testutils/pdata_to_resource_metrics.go
@@ -43,10 +43,10 @@ func PDataToResourceMetrics(pdataMetrics ...pdata.Metrics) (ResourceMetrics, err
 						addDoubleSum(&ilms, pdataMetric)
 					case pdata.MetricDataTypeIntHistogram:
 						panic(fmt.Sprintf("%s not yet supported", pdata.MetricDataTypeIntHistogram))
-					case pdata.MetricDataTypeDoubleHistogram:
-						panic(fmt.Sprintf("%s not yet supported", pdata.MetricDataTypeDoubleHistogram))
-					case pdata.MetricDataTypeDoubleSummary:
-						panic(fmt.Sprintf("%s not yet supported", pdata.MetricDataTypeDoubleSummary))
+					case pdata.MetricDataTypeHistogram:
+						panic(fmt.Sprintf("%s not yet supported", pdata.MetricDataTypeHistogram))
+					case pdata.MetricDataTypeSummary:
+						panic(fmt.Sprintf("%s not yet supported", pdata.MetricDataTypeSummary))
 					default:
 						panic(fmt.Sprintf("unexpected data type: %s", pdataMetric.DataType()))
 					}


### PR DESCRIPTION
Also exposes port 9080 for signalfx-forwarder monitor in docker image.