### PR TITLE
Use agent bundle-relative Collectd ConfigDir default

### DIFF
--- a/internal/extension/smartagentextension/config.go
+++ b/internal/extension/smartagentextension/config.go
@@ -16,6 +16,7 @@ package smartagentextension
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -48,6 +49,15 @@ func customUnmarshaller(componentViperSection *viper.Viper, intoCfg interface{})
 	allSettings := componentViperSection.AllSettings()
 	extensionCfg := intoCfg.(*Config)
 
+	configDirSet := false
+	if collectd, ok := allSettings["collectd"]; ok {
+		if collectdBlock, ok := collectd.(map[string]interface{}); ok {
+			if _, ok := collectdBlock["configdir"]; ok {
+				configDirSet = true
+			}
+		}
+	}
+
 	config, err := smartAgentConfigFromSettingsMap(allSettings)
 	if err != nil {
 		return err
@@ -57,6 +67,10 @@ func customUnmarshaller(componentViperSection *viper.Viper, intoCfg interface{})
 		config.BundleDir = extensionCfg.Config.BundleDir
 	}
 	config.Collectd.BundleDir = config.BundleDir
+
+	if !configDirSet {
+		config.Collectd.ConfigDir = filepath.Join(config.Collectd.BundleDir, "run", "collectd")
+	}
 
 	extensionCfg.Config = *config
 	return nil

--- a/internal/extension/smartagentextension/config_test.go
+++ b/internal/extension/smartagentextension/config_test.go
@@ -16,6 +16,7 @@ package smartagentextension
 
 import (
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -95,7 +96,7 @@ func TestLoadConfig(t *testing.T) {
 		cfg.Collectd.ReadThreads = 1
 		cfg.Collectd.WriteThreads = 4
 		cfg.Collectd.WriteQueueLimitHigh = 5
-		cfg.Collectd.ConfigDir = "/etc/"
+		cfg.Collectd.ConfigDir = "/var/run/signalfx-agent/collectd"
 		cfg.Collectd.BundleDir = "/opt/"
 		return &cfg
 	}(), partialSettingsConfig)
@@ -191,7 +192,7 @@ func defaultConfig() Config {
 				IntervalSeconds:      10,
 				WriteServerIPAddr:    "127.9.8.7",
 				WriteServerPort:      0,
-				ConfigDir:            "/var/run/signalfx-agent/collectd",
+				ConfigDir:            filepath.Join(bundleDir, "run", "collectd"),
 				BundleDir:            bundleDir,
 				HasGenericJMXMonitor: false,
 			},

--- a/internal/extension/smartagentextension/testdata/config.yaml
+++ b/internal/extension/smartagentextension/testdata/config.yaml
@@ -25,7 +25,7 @@ extensions:
       readThreads: 1
       writeThreads: 4
       writeQueueLimitHigh: 5
-      configDir: /etc/
+      configDir: /var/run/signalfx-agent/collectd
 
 receivers:
   nop:


### PR DESCRIPTION
Instead of using the [Smart Agent default](https://github.com/signalfx/signalfx-agent/blob/master/pkg/core/config/config.go#L387) for the collectd config directory setting value, these changes introduce an agent-bundle relative location (~`${bundleDir}/run/collectd`) for more intuitive organization.

Thanks to @bjsignalfx for initial leg work in https://github.com/signalfx/splunk-otel-collector/pull/241