### PR TITLE
url encode monitor IDs in SA receiver

### DIFF
--- a/internal/receiver/smartagentreceiver/receiver.go
+++ b/internal/receiver/smartagentreceiver/receiver.go
@@ -17,11 +17,11 @@ package smartagentreceiver
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
-	"strings"
 	"sync"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
@@ -97,7 +97,7 @@ func (r *Receiver) Start(_ context.Context, host component.Host) error {
 
 	configCore := r.config.monitorConfig.MonitorConfigCore()
 	monitorType := configCore.Type
-	monitorName := strings.ReplaceAll(r.config.Name(), "/", "")
+	monitorName := url.PathEscape(r.config.Name())
 	configCore.MonitorID = types.MonitorID(monitorName)
 
 	configureRusToZapOnce.Do(func() {

--- a/internal/receiver/smartagentreceiver/receiver_test.go
+++ b/internal/receiver/smartagentreceiver/receiver_test.go
@@ -93,7 +93,7 @@ func TestSmartAgentReceiver(t *testing.T) {
 	err := receiver.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 
-	assert.EqualValues(t, "smartagentvalid", cfg.monitorConfig.MonitorConfigCore().MonitorID)
+	assert.EqualValues(t, "smartagent%2Fvalid", cfg.monitorConfig.MonitorConfigCore().MonitorID)
 	monitor, isMonitor := receiver.monitor.(*cpu.Monitor)
 	require.True(t, isMonitor)
 


### PR DESCRIPTION
Receiver creator instantiated names have quotes in them, which breaks collectd instance templating:
```<Instance "[monitorID=receiver_creatorsmartagentnginx{endpoint="172.17.0.2:8080"}]">```

These changes url encode the monitor name for monitor id usage instead of simply removing forward slashes.