### PR TITLE
Fully adopt default collectd config directory

### DIFF
--- a/cmd/otelcol/Dockerfile
+++ b/cmd/otelcol/Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir -p "$(dirname "/usr/lib/splunk-otel-collector/agent-bundle")" && \
 
 FROM scratch
 ENV SPLUNK_BUNDLE_DIR=/usr/lib/splunk-otel-collector/agent-bundle
-ENV SPLUNK_COLLECTD_DIR=$SIGNALFX_BUNDLE_DIR/run/collectd
+ENV SPLUNK_COLLECTD_DIR=${SPLUNK_BUNDLE_DIR}/run/collectd
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=otelcol /otelcol /
 # Maintaining interpreter location as required.

--- a/internal/extension/smartagentextension/factory.go
+++ b/internal/extension/smartagentextension/factory.go
@@ -73,6 +73,8 @@ func createDefaultConfig() config.Extension {
 	}
 	cfg.BundleDir = bundleDir
 	cfg.Collectd.BundleDir = bundleDir
+	cfg.Collectd.ConfigDir = filepath.Join(bundleDir, "run", "collectd")
+
 	return &Config{
 		ExtensionSettings: config.ExtensionSettings{
 			TypeVal: typeStr,

--- a/internal/receiver/smartagentreceiver/receiver_test.go
+++ b/internal/receiver/smartagentreceiver/receiver_test.go
@@ -327,7 +327,7 @@ func TestSmartAgentConfigProviderOverrides(t *testing.T) {
 		IntervalSeconds:      10,
 		WriteServerIPAddr:    "127.9.8.7",
 		WriteServerPort:      0,
-		ConfigDir:            "/etc/",
+		ConfigDir:            filepath.Join("/opt", "run", "collectd"),
 		BundleDir:            "/opt/",
 		HasGenericJMXMonitor: false,
 		InstanceName:         "",

--- a/internal/receiver/smartagentreceiver/testdata/extension_config.yaml
+++ b/internal/receiver/smartagentreceiver/testdata/extension_config.yaml
@@ -6,7 +6,6 @@ extensions:
       readThreads: 1
       writeThreads: 4
       writeQueueLimitHigh: 5
-      configDir: /etc/
   smartagent/extra:
     bundleDir: /opt/
     collectd:
@@ -14,7 +13,6 @@ extensions:
       readThreads: 1
       writeThreads: 4
       writeQueueLimitHigh: 5
-      configDir: /etc/
 
 receivers:
   nop:


### PR DESCRIPTION
These changes ensure that if the SA extension isn't used, a bundleDir-relative configDir is still used.  Also corrects a typo in the dockerfile for this config field.