### PR TITLE
Correct invalid monitor ID encoding

### DIFF
--- a/internal/receiver/smartagentreceiver/receiver.go
+++ b/internal/receiver/smartagentreceiver/receiver.go
@@ -17,10 +17,10 @@ package smartagentreceiver
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"sync"
 
@@ -62,6 +62,7 @@ var (
 	configureEnvironmentOnce sync.Once
 	saConfigProvider         smartagentextension.SmartAgentConfigProvider
 	configureRusToZapOnce    sync.Once
+	nonWordCharacters        = regexp.MustCompile(`[^\w]+`)
 )
 
 func NewReceiver(logger *zap.Logger, config Config) *Receiver {
@@ -97,7 +98,7 @@ func (r *Receiver) Start(_ context.Context, host component.Host) error {
 
 	configCore := r.config.monitorConfig.MonitorConfigCore()
 	monitorType := configCore.Type
-	monitorName := url.PathEscape(r.config.Name())
+	monitorName := nonWordCharacters.ReplaceAllString(r.config.Name(), "")
 	configCore.MonitorID = types.MonitorID(monitorName)
 
 	configureRusToZapOnce.Do(func() {

--- a/internal/receiver/smartagentreceiver/receiver_test.go
+++ b/internal/receiver/smartagentreceiver/receiver_test.go
@@ -93,7 +93,7 @@ func TestSmartAgentReceiver(t *testing.T) {
 	err := receiver.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 
-	assert.EqualValues(t, "smartagent%2Fvalid", cfg.monitorConfig.MonitorConfigCore().MonitorID)
+	assert.EqualValues(t, "smartagentvalid", cfg.monitorConfig.MonitorConfigCore().MonitorID)
 	monitor, isMonitor := receiver.monitor.(*cpu.Monitor)
 	require.True(t, isMonitor)
 


### PR DESCRIPTION
https://github.com/signalfx/splunk-otel-collector/pull/266 introduced a regression where monitor ids with unsupported characters are not used as monitorID dimension values, causing the collectd write server to drop points.  Instead of url encoding these changes strip all non-word characters.