### PR TITLE
Explicitly define receivers endpoints

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -13,7 +13,10 @@
 
 extensions:
   health_check:
+    endpoint: 0.0.0.0:13133
   http_forwarder:
+    ingress:
+      endpoint: 0.0.0.0:6060
     egress:
       endpoint: "${SPLUNK_API_URL}"
       # Use instead when sending to gateway
@@ -47,13 +50,19 @@ receivers:
   jaeger:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:14250
       thrift_binary:
+        endpoint: 0.0.0.0:6832
       thrift_compact:
+        endpoint: 0.0.0.0:6831
       thrift_http:
+        endpoint: 0.0.0.0:14268
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:55681
   # This section is used to collect the OpenTelemetry Collector metrics
   # Even if just a Splunk APM customer, these metrics are included
   prometheus:
@@ -68,11 +77,14 @@ receivers:
             regex: '.*grpc_io.*'
             action: drop
   sapm:
+    endpoint: 0.0.0.0:7276
   smartagent/signalfx-forwarder:
     type: signalfx-forwarder
     listenAddress: 0.0.0.0:9080
   signalfx:
+    endpoint: 0.0.0.0:9943
   zipkin:
+    endpoint: 0.0.0.0:9411
 
 processors:
   batch:

--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -38,7 +38,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:55681
 
   #############################################################################
   # Traces
@@ -53,9 +55,13 @@ receivers:
   jaeger:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:14250
       thrift_binary:
+        endpoint: 0.0.0.0:6832
       thrift_compact:
+        endpoint: 0.0.0.0:6831
       thrift_http:
+        endpoint: 0.0.0.0:14268
 
   # Enables the kafka receiver with default settings
   #  - brokers = localhost:9092
@@ -68,6 +74,7 @@ receivers:
   #  - grpc (default endpoint = 0.0.0.0:7276)
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sapmreceiver
   sapm:
+    endpoint: 0.0.0.0:7276
     #access_token_passthrough: true
 
   # Enables the Smart Agent's SignalFx Forwarder with default settings
@@ -80,6 +87,7 @@ receivers:
   #  - grpc (default endpoint = 0.0.0.0:9411)
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/zipkinreceiver
   zipkin:
+    endpoint: 0.0.0.0:9411
 
   #############################################################################
   # Metrics
@@ -141,6 +149,7 @@ receivers:
   #  - grpc (default endpoint = 0.0.0.0:9943)
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/signalfxreceiver
   signalfx:
+    endpoint: 0.0.0.0:9943
     #access_token_passthrough: true
 
   #############################################################################
@@ -489,13 +498,14 @@ extensions:
   # Enables the health check extension
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/healthcheckextension
   health_check:
+    endpoint: 0.0.0.0:13133
 
   # Enables the http forwarder extension
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/httpforwarder
   # TODO: Add realm
   http_forwarder:
-    #ingress:
-    #  endpoint: 0.0.0.0:6060
+    ingress:
+      endpoint: 0.0.0.0:6060
     egress:
       endpoint: "https://api.${SPLUNK_REALM}.signalfx.com"
 

--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -3,23 +3,32 @@
 
 extensions:
   health_check:
+    endpoint: 0.0.0.0:13133
   http_forwarder:
+    ingress:
+      endpoint: 0.0.0.0:6060
     egress:
       endpoint: "https://api.${SPLUNK_REALM}.signalfx.com"
   zpages:
-    #endpoint: 0.0.0.0:55679
+    endpoint: 0.0.0.0:55679
 
 receivers:
   jaeger:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:14250
       thrift_binary:
+        endpoint: 0.0.0.0:6832
       thrift_compact:
+        endpoint: 0.0.0.0:6831
       thrift_http:
+        endpoint: 0.0.0.0:14268
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:55681
   # This section is used to collect the OpenTelemetry Collector metrics
   # Even if just a Splunk APM customer, these metrics are included
   prometheus:
@@ -34,8 +43,11 @@ receivers:
             regex: '.*grpc_io.*'
             action: drop
   sapm:
+    endpoint: 0.0.0.0:7276
   signalfx:
+    endpoint: 0.0.0.0:9943
   zipkin:
+    endpoint: 0.0.0.0:9411
 
 processors:
   batch:

--- a/cmd/otelcol/config/collector/otlp_config_linux.yaml
+++ b/cmd/otelcol/config/collector/otlp_config_linux.yaml
@@ -5,13 +5,19 @@ receivers:
   jaeger:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:14250
       thrift_binary:
+        endpoint: 0.0.0.0:6832
       thrift_compact:
+        endpoint: 0.0.0.0:6831
       thrift_http:
+        endpoint: 0.0.0.0:14268
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:55681
   # This section is used to collect the OpenTelemetry Collector metrics
   # Even if just a Splunk APM customer, these metrics are included
   prometheus:
@@ -26,11 +32,14 @@ receivers:
             regex: '.*grpc_io.*'
             action: drop
   sapm:
+    endpoint: 0.0.0.0:7276
   signalfx:
+    endpoint: 0.0.0.0:9943
   smartagent/signalfx-forwarder:
     type: signalfx-forwarder
     listenAddress: 0.0.0.0:9080
   zipkin:
+    endpoint: 0.0.0.0:9411
 
 processors:
   batch:
@@ -73,11 +82,14 @@ exporters:
 
 extensions:
   health_check:
+    endpoint: 0.0.0.0:13133
   http_forwarder:
+    ingress:
+      endpoint: 0.0.0.0:6060
     egress:
       endpoint: "https://api.${SPLUNK_REALM}.signalfx.com"
   zpages:
-    #endpoint: 0.0.0.0:55679
+    endpoint: 0.0.0.0:55679
 
 service:
   extensions: [health_check, http_forwarder, zpages]

--- a/examples/kubernetes-yaml/splunk-otel-collector-agent.yaml
+++ b/examples/kubernetes-yaml/splunk-otel-collector-agent.yaml
@@ -10,7 +10,10 @@ data:
   otel-collector-config: |
     extensions:
       health_check:
+        endpoint: 0.0.0.0:13133
       http_forwarder:
+        ingress:
+          endpoint: 0.0.0.0:6060
         egress:
           # TODO: Ensure this is set properly
           endpoint: "https://api.${SPLUNK_REALM}.signalfx.com"
@@ -35,15 +38,23 @@ data:
       jaeger:
         protocols:
           grpc:
+            endpoint: 0.0.0.0:14250
           thrift_binary:
+            endpoint: 0.0.0.0:6832
           thrift_compact:
+            endpoint: 0.0.0.0:6831
           thrift_http:
+            endpoint: 0.0.0.0:14268
       otlp:
         protocols:
           grpc:
+            endpoint: 0.0.0.0:4317
           http:
+            endpoint: 0.0.0.0:55681
       sapm:
+        endpoint: 0.0.0.0:7276
       signalfx:
+        endpoint: 0.0.0.0:9943
       # This section is used to collect OpenTelemetry metrics
       # Even if just a SignalFx µAPM customer, these metrics are included
       prometheus:
@@ -64,6 +75,7 @@ data:
       # Enable Zipkin to support Istio Mixer Adapter
       # https://github.com/signalfx/signalfx-istio-adapter
       zipkin:
+        endpoint: 0.0.0.0:9411
     processors:
       batch:
       # Optional: If you have a different environment tag name

--- a/examples/kubernetes-yaml/splunk-otel-collector-gateway.yaml
+++ b/examples/kubernetes-yaml/splunk-otel-collector-gateway.yaml
@@ -10,7 +10,10 @@ data:
   otel-collector-config: |
     extensions:
       health_check:
+        endpoint: 0.0.0.0:13133
       http_forwarder:
+        ingress:
+          endpoint: 0.0.0.0:6060
         egress:
           # TODO: Ensure this is set properly
           endpoint: "https://api.${SPLUNK_REALM}.signalfx.com"
@@ -35,15 +38,23 @@ data:
       jaeger:
         protocols:
           grpc:
+            endpoint: 0.0.0.0:14250
           thrift_binary:
+            endpoint: 0.0.0.0:6832
           thrift_compact:
+            endpoint: 0.0.0.0:6831
           thrift_http:
+            endpoint: 0.0.0.0:14268
       otlp:
         protocols:
           grpc:
+            endpoint: 0.0.0.0:4317
           http:
+            endpoint: 0.0.0.0:55681
       sapm:
+        endpoint: 0.0.0.0:7276
       signalfx:
+        endpoint: 0.0.0.0:9943
       # This section is used to collect OpenTelemetry metrics
       # Even if just a SignalFx µAPM customer, these metrics are included
       prometheus:
@@ -64,6 +75,7 @@ data:
       # Enable Zipkin to support Istio Mixer Adapter
       # https://github.com/signalfx/signalfx-istio-adapter
       zipkin:
+        endpoint: 0.0.0.0:9411
     processors:
       batch:
       # Optional: If you have a different environment tag name

--- a/examples/prometheus-federation/otel-collector-config.yml
+++ b/examples/prometheus-federation/otel-collector-config.yml
@@ -11,6 +11,7 @@ receivers:
     otlp:
         protocols:
             grpc:
+              endpoint: 0.0.0.0:4317
 
 exporters:
     splunk_hec/metrics:
@@ -39,6 +40,7 @@ processors:
 
 extensions:
     health_check:
+      endpoint: 0.0.0.0:13133
     pprof:
       endpoint: :1888
     zpages:

--- a/examples/splunk-hec-metrics/otel-collector-config.yml
+++ b/examples/splunk-hec-metrics/otel-collector-config.yml
@@ -28,6 +28,7 @@ processors:
 
 extensions:
     health_check:
+      endpoint: 0.0.0.0:13133
     pprof:
       endpoint: :1888
     zpages:

--- a/examples/splunk-hec/otel-collector-config.yml
+++ b/examples/splunk-hec/otel-collector-config.yml
@@ -28,6 +28,7 @@ processors:
 
 extensions:
     health_check:
+      endpoint: 0.0.0.0:13133
     pprof:
       endpoint: :1888
     zpages:


### PR DESCRIPTION
For better user experience, we want to have default endpoint values always to be explicitly set in the configs, so user don't have to check receiver docs in order to find out which port data should be sent to.