### PR TITLE
Add the config source manager

### DIFF
--- a/internal/configprovider/manager.go
+++ b/internal/configprovider/manager.go
@@ -1,0 +1,650 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configsource
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	// expandPrefixChar is the char used to prefix strings that can be expanded,
+	// either environment variables or config sources.
+	expandPrefixChar = '$'
+	// configSourceNameDelimChar is the char used to terminate the name of config source
+	// when it is used to retrieve values to inject in the configuration
+	configSourceNameDelimChar = ':'
+)
+
+// private error types to help with testability
+type (
+	errUnknownConfigSource struct{ error }
+)
+
+// Manager is used to inject data from config sources into a configuration and also
+// to monitor for updates on the items injected into the configuration.  All methods
+// of a Manager must be called only once and have a expected sequence:
+//
+// 1. NewManager to create a new instance;
+// 2. Resolve to inject the data from config sources into a configuration;
+// 3. WatchForUpdate in a goroutine to wait for configuration updates;
+// 4. WaitForWatcher to wait until the watchers are in place;
+// 5. Close to close the instance;
+//
+// The current syntax to reference a config source in a YAML is provisional. Currently
+// single-line:
+//
+//    param_to_be_retrieved: $<cfgSrcName>:<selector>[?<params_url_query_format>]
+//
+// bracketed single-line:
+//
+//    param_to_be_retrieved: ${<cfgSrcName>:<selector>[?<params_url_query_format>]}
+//
+// and multi-line are supported:
+//
+//    param_to_be_retrieved: |
+//      $<cfgSrcName>: <selector>
+//      [<params_multi_line_YAML>]
+//
+// The <cfgSrcName> is a name string used to identify the config source instance to be used
+// to retrieve the value.
+//
+// The <selector> is the mandatory parameter required when retrieving data from a config source.
+//
+// Not all config sources need the optional parameters, they are used to provide extra control when
+// retrieving and preparing the data to be injected into the configuration.
+//
+// For single-line format <params_url_query_format> uses the same syntax as URL query parameters.
+// Hypothetical example in a YAML file:
+//
+// component:
+//   config_field: $file:/etc/secret.bin?binary=true
+//
+// For multi-line format <params_multi_line_YAML> uses syntax as a YAML inside YAML. Possible usage
+// example in a YAML file:
+//
+// component:
+//   config_field: |
+//     $yamltemplate: /etc/log_template.yaml
+//     logs_path: /var/logs/
+//     timeout: 10s
+//
+// Not all config sources need these optional parameters, they are used to provide extra control when
+// retrieving and data to be injected into the configuration.
+//
+// Assuming a config source named "env" that retrieve environment variables and one named "file" that
+// retrieves contents from individual files, here are some examples:
+//
+//    component:
+//      # Retrieves the value of the environment variable LOGS_DIR.
+//      logs_dir: $env:LOGS_DIR
+//
+//      # Retrieves the value from the file /etc/secret.bin and injects its contents as a []byte.
+//      bytes_from_file: $file:/etc/secret.bin?binary=true
+//
+//      # Retrieves the value from the file /etc/text.txt and injects its contents as a string.
+//      # Hypothetically the "file" config source by default tries to inject the file contents
+//      # as a string if params doesn't specify that "binary" is true.
+//      text_from_file: $file:/etc/text.txt
+//
+// Bracketed single-line should be used when concatenating a suffix to the value retrieved by
+// the config source. Example:
+//
+//    component:
+//      # Retrieves the value of the environment variable LOGS_DIR and appends /component.log to it.
+//      log_file_fullname: ${env:LOGS_DIR}/component.log
+//
+// Environment variables are expanded before passed to the config source when used in the selector or
+// the optional parameters. Example:
+//
+//    component:
+//      # Retrieves the value from the file text.txt located on the path specified by the environment
+//      # variable DATA_PATH. The name of the environment variable is the string after the delimiter
+//      # until the first character different than '_' and non-alpha-numeric.
+//      text_from_file: $file:$DATA_PATH/text.txt
+//
+// Since environment variables and config sources both use the '$', with or without brackets, as a prefix
+// for their expansion it is necessary to have a way to distinguish between them. For the non-bracketed
+// syntax the code will peek at the first character other than alpha-numeric and '_' after the '$'. If
+// that character is a ':' it will treat it as a config source and as environment variable otherwise.
+// For example:
+//
+//    component:
+//      field_0: $PATH:/etc/logs # Injects the data from a config sourced named "PATH" using the selector "/etc/logs".
+//      field_1: $PATH/etc/logs  # Expands the environment variable "PATH" and adds the suffix "/etc/logs" to it.
+//
+// So if you need to include an environment followed by ':' the bracketed syntax must be used instead:
+//
+//    component:
+//      field_0: ${PATH}:/etc/logs # Expands the environment variable "PATH" and adds the suffix ":/etc/logs" to it.
+//
+// For the bracketed syntax the presence of ':' inside the brackets indicates that code will treat the bracketed
+// contents as a config source. For example:
+//
+//    component:
+//      field_0: ${file:/var/secret.txt} # Injects the data from a config sourced named "file" using the selector "/var/secret.txt".
+//      field_1: ${file}:/var/secret.txt # Expands the environment variable "file" and adds the suffix ":/var/secret.txt" to it.
+//
+// If the the character following the '$' is in the set {'*', '#', '$', '@', '!', '?', '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
+// the code will consider it to be the name of an environment variable to expand, or config source if followed by ':'. Do not use any of these
+// characters as the first char on the name of a config source or an environment variable (even if allowed by the system) to avoid unexpected
+// results.
+type Manager struct {
+	// configSources is map from ConfigSource names (as defined in the configuration)
+	// and the respective instances.
+	configSources map[string]ConfigSource
+	// sessions track all the Session objects used to retrieve values to be injected
+	// into the configuration.
+	sessions map[string]Session
+	// watchingCh is used to notify users of the Manager that the WatchForUpdate function
+	// is ready and waiting for notifications.
+	watchingCh chan struct{}
+	// closeCh is used to notify the Manager WatchForUpdate function that the manager
+	// is being closed.
+	closeCh chan struct{}
+	// watchers keeps track of all WatchForUpdate functions for retrieved values.
+	watchers []func() error
+	// watchersWG is used to ensure that Close waits for all WatchForUpdate calls
+	// to complete.
+	watchersWG sync.WaitGroup
+}
+
+// NewManager creates a new instance of a Manager to be used to inject data from
+// ConfigSource objects into a configuration and watch for updates on the injected
+// data.
+func NewManager(parser *config.Parser, logger *zap.Logger, appStartInfo component.ApplicationStartInfo, factories Factories) (*Manager, error) {
+	configSourcesSettings, err := Load(context.Background(), parser, factories)
+	if err != nil {
+		return nil, err
+	}
+
+	params := CreateParams{
+		Logger:               logger,
+		ApplicationStartInfo: appStartInfo,
+	}
+	cfgSources, err := Build(context.Background(), configSourcesSettings, params, factories)
+	if err != nil {
+		return nil, err
+	}
+
+	return newManager(cfgSources), nil
+}
+
+// Resolve inspects the given config.Parser and resolves all config sources referenced
+// in the configuration, returning a config.Parser fully resolved. This must be called only
+// once per lifetime of a Manager object.
+func (m *Manager) Resolve(ctx context.Context, parser *config.Parser) (*config.Parser, error) {
+	res := config.NewParser()
+	allKeys := parser.AllKeys()
+	for _, k := range allKeys {
+		if strings.HasPrefix(k, configSourcesKey) {
+			// Remove everything under config_sources
+			continue
+		}
+
+		value, err := m.expandStringValues(ctx, parser.Get(k))
+		if err != nil {
+			// Call RetrieveEnd for all sessions used so far but don't record any errors.
+			_ = m.retrieveEndAllSessions(ctx)
+			return nil, err
+		}
+		res.Set(k, value)
+	}
+
+	if errs := m.retrieveEndAllSessions(ctx); len(errs) > 0 {
+		return nil, consumererror.Combine(errs)
+	}
+
+	return res, nil
+}
+
+// WatchForUpdate must watch for updates on any of the values retrieved from config sources
+// and injected into the configuration. Typically this method is launched in a goroutine, the
+// method WaitForWatcher blocks until the WatchForUpdate goroutine is running and ready.
+func (m *Manager) WatchForUpdate() error {
+	// Use a channel to capture the first error returned by any watcher and another one
+	// to ensure completion of any remaining watcher also trying to report an error.
+	errChannel := make(chan error, 1)
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+
+	for _, watcher := range m.watchers {
+		m.watchersWG.Add(1)
+		watcherFn := watcher
+		go func() {
+			defer m.watchersWG.Done()
+
+			err := watcherFn()
+			switch {
+			case errors.Is(err, ErrWatcherNotSupported):
+				// The watcher for the retrieved value is not supported, nothing to
+				// do, just exit from the goroutine.
+				return
+			case errors.Is(err, ErrSessionClosed):
+				// The Session from which this watcher was retrieved is being closed.
+				// There is no error to report, just exit from the goroutine.
+				return
+			default:
+				select {
+				case errChannel <- err:
+					// Try to report any other error.
+				case <-doneCh:
+					// There was either one error published or the watcher was closed.
+					// This channel was closed and any goroutines waiting on these
+					// should simply close.
+				}
+			}
+		}()
+	}
+
+	// All goroutines were created, they may not be running yet, but the manager WatchForUpdate
+	// is only waiting for any of the watchers to terminate.
+	close(m.watchingCh)
+
+	select {
+	case err := <-errChannel:
+		// Return the first error that reaches the channel and ignore any other error.
+		return err
+	case <-m.closeCh:
+		// This covers the case that all watchers returned ErrWatcherNotSupported.
+		return ErrSessionClosed
+	}
+}
+
+// WaitForWatcher blocks until the watchers used by WatchForUpdate are all ready.
+// This is used to ensure that the watchers are in place before proceeding.
+func (m *Manager) WaitForWatcher() {
+	<-m.watchingCh
+}
+
+// Close terminates the WatchForUpdate function and closes all Session objects used
+// in the configuration. It should be called
+func (m *Manager) Close(ctx context.Context) error {
+	var errs []error
+	for _, session := range m.sessions {
+		if err := session.Close(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	close(m.closeCh)
+	m.watchersWG.Wait()
+
+	return consumererror.Combine(errs)
+}
+
+func newManager(configSources map[string]ConfigSource) *Manager {
+	return &Manager{
+		configSources: configSources,
+		sessions:      make(map[string]Session),
+		watchingCh:    make(chan struct{}),
+		closeCh:       make(chan struct{}),
+	}
+}
+func (m *Manager) retrieveEndAllSessions(ctx context.Context) []error {
+	var errs []error
+	for _, session := range m.sessions {
+		if err := session.RetrieveEnd(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+func (m *Manager) expandStringValues(ctx context.Context, value interface{}) (interface{}, error) {
+	switch v := value.(type) {
+	case string:
+		return m.expandString(ctx, v)
+	case []interface{}:
+		nslice := make([]interface{}, 0, len(v))
+		for _, vint := range v {
+			value, err := m.expandStringValues(ctx, vint)
+			if err != nil {
+				return nil, err
+			}
+			nslice = append(nslice, value)
+		}
+		return nslice, nil
+	case map[interface{}]interface{}:
+		nmap := make(map[interface{}]interface{}, len(v))
+		for k, vint := range v {
+			value, err := m.expandStringValues(ctx, vint)
+			if err != nil {
+				return nil, err
+			}
+			nmap[k] = value
+		}
+		return nmap, nil
+	default:
+		return v, nil
+	}
+}
+
+// expandConfigSource retrieve data from the specified config source and injects them into
+// the configuration. The Manager tracks sessions and watcher objects as needed.
+func (m *Manager) expandConfigSource(ctx context.Context, cfgSrc ConfigSource, s string) (interface{}, error) {
+	cfgSrcName, selector, params, err := parseCfgSrc(s)
+	if err != nil {
+		return nil, err
+	}
+
+	session, ok := m.sessions[cfgSrcName]
+	if !ok {
+		session, err = cfgSrc.NewSession(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create session for config source %q: %w", cfgSrcName, err)
+		}
+		m.sessions[cfgSrcName] = session
+	}
+
+	retrieved, err := session.Retrieve(ctx, selector, params)
+	if err != nil {
+		return nil, fmt.Errorf("config source %q failed to retrieve value: %w", cfgSrcName, err)
+	}
+
+	m.watchers = append(m.watchers, retrieved.WatchForUpdate)
+
+	return retrieved.Value(), nil
+}
+
+// expandString expands environment variables and config sources that are specified on the string.
+func (m *Manager) expandString(ctx context.Context, s string) (interface{}, error) {
+	// Code based on os.Expand function. All delimiters that are checked against are
+	// ASCII so bytes are fine for this operation.
+	var buf []byte
+
+	// Using i, j, and w variables to keep correspondence with os.Expand code.
+	// i tracks the index in s from which a slice to be appended to buf should start.
+	// j tracks the char being currently checked and also the end of the slice to be appended to buf.
+	// w tracks the number of characters being consumed after a prefix identifying env vars or config sources.
+	i := 0
+	for j := 0; j < len(s); j++ {
+		if s[j] == expandPrefixChar && j+1 < len(s) {
+			if buf == nil {
+				// Assuming that the length of the string will double after expansion of env vars and config sources.
+				buf = make([]byte, 0, 2*len(s))
+			}
+
+			// Append everything consumed up to the prefix char (but not including the prefix char) to the result.
+			buf = append(buf, s[i:j]...)
+
+			var expandableContent, cfgSrcName string
+			w := 0 // number of bytes consumed on this pass
+
+			switch {
+			case s[j+1] == expandPrefixChar:
+				// Escaping the prefix so $$ becomes a single $ without attempting
+				// to treat the string after it as a config source or env var.
+				expandableContent = string(expandPrefixChar)
+				w = 1 // consumed a single char
+
+			case s[j+1] == '{':
+				// Bracketed usage, consume everything until first '}' exactly as os.Expand.
+				expandableContent, w = getShellName(s[j+1:])
+				expandableContent = strings.Trim(expandableContent, " ") // Allow for some spaces.
+				if len(expandableContent) > 1 && strings.Contains(expandableContent, string(configSourceNameDelimChar)) {
+					// Bracket expandableContent contains ':' treating it as a config source.
+					cfgSrcName, _ = getShellName(expandableContent)
+				}
+
+			default:
+				// Non-bracketed usage, ie.: found the prefix char, it can be either a config
+				// source or an environment variable.
+				var name string
+				name, w = getShellName(s[j+1:])
+				expandableContent = name // Assume for now that it is an env var.
+
+				// Peek next char after name, if it is a config source name delimiter treat the remaining of the
+				// string as a config source.
+				if j+w+1 < len(s) && s[j+w+1] == configSourceNameDelimChar {
+					// This is a config source, since it is not delimited it will consume until end of the string.
+					cfgSrcName = name
+					expandableContent = s[j+1:]
+					w = len(expandableContent) // Set consumed bytes to the length of expandableContent
+				}
+			}
+
+			switch {
+			case cfgSrcName == "":
+				// Not a config source, expand as os.ExpandEnv
+				buf = osExpandEnv(buf, expandableContent, w)
+
+			default:
+				// A config source, retrieve and apply results.
+				retrieved, err := m.retrieveConfigSourceData(ctx, cfgSrcName, expandableContent)
+				if err != nil {
+					return nil, err
+				}
+
+				consumedAll := j+w+1 == len(s)
+				if consumedAll && len(buf) == 0 {
+					// This is the only expandableContent on the string, config
+					// source is free to return interface{}.
+					return retrieved, nil
+				}
+
+				// Either there was a prefix already or there are still
+				// characters to be processed.
+				buf = append(buf, fmt.Sprintf("%v", retrieved)...)
+			}
+
+			j += w    // move the index of the char being checked (j) by the number of characters consumed (w) on this iteration.
+			i = j + 1 // update start index (i) of next slice of bytes to be copied.
+		}
+	}
+
+	if buf == nil {
+		// No changes to original string, just return it.
+		return s, nil
+	}
+
+	// Return whatever was accumulated on the buffer plus the remaining of the original string.
+	return string(buf) + s[i:], nil
+}
+
+func (m *Manager) retrieveConfigSourceData(ctx context.Context, name, cfgSrcInvoke string) (interface{}, error) {
+	cfgSrc, ok := m.configSources[name]
+	if !ok {
+		return nil, newErrUnknownConfigSource(name)
+	}
+
+	// Expand any env vars on the selector and parameters. Nested config source usage
+	// is not supported.
+	cfgSrcInvoke = expandEnvVars(cfgSrcInvoke)
+	retrieved, err := m.expandConfigSource(ctx, cfgSrc, cfgSrcInvoke)
+	if err != nil {
+		return nil, err
+	}
+
+	return retrieved, nil
+}
+
+func newErrUnknownConfigSource(cfgSrcName string) error {
+	return &errUnknownConfigSource{
+		fmt.Errorf(`config source %q not found if this was intended to be an environment variable use "${%s}" instead"`, cfgSrcName, cfgSrcName),
+	}
+}
+
+// parseCfgSrc extracts the reference to a config source from a string value.
+// The caller should check for error explicitly since it is possible for the
+// other values to have been partially set.
+func parseCfgSrc(s string) (cfgSrcName, selector string, params interface{}, err error) {
+	parts := strings.SplitN(s, string(configSourceNameDelimChar), 2)
+	if len(parts) != 2 {
+		err = fmt.Errorf("invalid config source syntax at %q, it must have at least the config source name and a selector", s)
+		return
+	}
+	cfgSrcName = strings.Trim(parts[0], " ")
+
+	// Separate multi-line and single line case.
+	afterCfgSrcName := parts[1]
+	switch {
+	case strings.Contains(afterCfgSrcName, "\n"):
+		// Multi-line, until the first \n it is the selector, everything after as YAML.
+		parts = strings.SplitN(afterCfgSrcName, "\n", 2)
+		selector = strings.Trim(parts[0], " ")
+
+		if len(parts) > 1 && len(parts[1]) > 0 {
+			v := config.NewViper()
+			v.SetConfigType("yaml")
+			if err = v.ReadConfig(bytes.NewReader([]byte(parts[1]))); err != nil {
+				return
+			}
+			params = v.AllSettings()
+		}
+
+	default:
+		// Single line, and parameters as URL query.
+		const selectorDelim string = "?"
+		parts = strings.SplitN(parts[1], selectorDelim, 2)
+		selector = strings.Trim(parts[0], " ")
+
+		if len(parts) == 2 {
+			paramsPart := parts[1]
+			params, err = parseParamsAsURLQuery(paramsPart)
+			if err != nil {
+				err = fmt.Errorf("invalid parameters syntax at %q: %w", s, err)
+				return
+			}
+		}
+	}
+
+	return cfgSrcName, selector, params, err
+}
+
+func parseParamsAsURLQuery(s string) (interface{}, error) {
+	values, err := url.ParseQuery(s)
+	if err != nil {
+		return nil, err
+	}
+
+	// Transform single array values in scalars.
+	params := make(map[string]interface{})
+	for k, v := range values {
+		switch len(v) {
+		case 0:
+			params[k] = nil
+		case 1:
+			var iface interface{}
+			if err = yaml.Unmarshal([]byte(v[0]), &iface); err != nil {
+				return nil, err
+			}
+			params[k] = iface
+		default:
+			// It is a slice add element by element
+			elemSlice := make([]interface{}, 0, len(v))
+			for _, elem := range v {
+				var iface interface{}
+				if err = yaml.Unmarshal([]byte(elem), &iface); err != nil {
+					return nil, err
+				}
+				elemSlice = append(elemSlice, iface)
+			}
+			params[k] = elemSlice
+		}
+	}
+	return params, err
+}
+
+// expandEnvVars is used to expand environment variables with the same syntax used
+// by config.Parser.
+func expandEnvVars(s string) string {
+	return os.Expand(s, func(str string) string {
+		// This allows escaping environment variable substitution via $$, e.g.
+		// - $FOO will be substituted with env var FOO
+		// - $$FOO will be replaced with $FOO
+		// - $$$FOO will be replaced with $ + substituted env var FOO
+		if str == "$" {
+			return "$"
+		}
+		return os.Getenv(str)
+	})
+}
+
+// osExpandEnv replicate the internal behavior of os.ExpandEnv when handling env
+// vars updating the buffer accordingly.
+func osExpandEnv(buf []byte, name string, w int) []byte {
+	switch {
+	case name == "" && w > 0:
+		// Encountered invalid syntax; eat the
+		// characters.
+	case name == "" || name == "$":
+		// Valid syntax, but $ was not followed by a
+		// name. Leave the dollar character untouched.
+		buf = append(buf, expandPrefixChar)
+	default:
+		buf = append(buf, os.Getenv(name)...)
+	}
+
+	return buf
+}
+
+// Below are helper functions used by os.Expand, copied without changes from original sources (env.go).
+
+// isShellSpecialVar reports whether the character identifies a special
+// shell variable such as $*.
+func isShellSpecialVar(c uint8) bool {
+	switch c {
+	case '*', '#', '$', '@', '!', '?', '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		return true
+	}
+	return false
+}
+
+// isAlphaNum reports whether the byte is an ASCII letter, number, or underscore
+func isAlphaNum(c uint8) bool {
+	return c == '_' || '0' <= c && c <= '9' || 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z'
+}
+
+// getShellName returns the name that begins the string and the number of bytes
+// consumed to extract it. If the name is enclosed in {}, it's part of a ${}
+// expansion and two more bytes are needed than the length of the name.
+func getShellName(s string) (string, int) {
+	switch {
+	case s[0] == '{':
+		if len(s) > 2 && isShellSpecialVar(s[1]) && s[2] == '}' {
+			return s[1:2], 3
+		}
+		// Scan to closing brace
+		for i := 1; i < len(s); i++ {
+			if s[i] == '}' {
+				if i == 1 {
+					return "", 2 // Bad syntax; eat "${}"
+				}
+				return s[1:i], i + 1
+			}
+		}
+		return "", 1 // Bad syntax; eat "${"
+	case isShellSpecialVar(s[0]):
+		return s[0:1], 1
+	}
+	// Scan alphanumerics.
+	var i int
+	for i = 0; i < len(s) && isAlphaNum(s[i]); i++ {
+	}
+	return s[:i], i
+}

--- a/internal/configprovider/manager_test.go
+++ b/internal/configprovider/manager_test.go
@@ -1,0 +1,688 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configsource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.uber.org/zap"
+)
+
+func TestConfigSourceManager_NewManager(t *testing.T) {
+	tests := []struct {
+		factories Factories
+		wantErr   error
+		name      string
+		file      string
+	}{
+		{
+			name: "basic_config",
+			file: "basic_config",
+			factories: Factories{
+				"tstcfgsrc": &mockCfgSrcFactory{},
+			},
+		},
+		{
+			name:      "unknown_type",
+			file:      "basic_config",
+			factories: Factories{},
+			wantErr:   &errUnknownType{},
+		},
+		{
+			name: "build_error",
+			file: "basic_config",
+			factories: Factories{
+				"tstcfgsrc": &mockCfgSrcFactory{
+					ErrOnCreateConfigSource: errors.New("forced test error"),
+				},
+			},
+			wantErr: &errConfigSourceCreation{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filename := path.Join("testdata", tt.file+".yaml")
+			parser, err := config.NewParserFromFile(filename)
+			require.NoError(t, err)
+
+			manager, err := NewManager(parser, zap.NewNop(), component.DefaultApplicationStartInfo(), tt.factories)
+			require.IsType(t, tt.wantErr, err)
+			if tt.wantErr != nil {
+				require.Nil(t, manager)
+				return
+			}
+
+			require.NotNil(t, manager)
+		})
+	}
+}
+
+func TestConfigSourceManager_Simple(t *testing.T) {
+	ctx := context.Background()
+	manager := newManager(map[string]ConfigSource{
+		"tstcfgsrc": &testConfigSource{
+			ValueMap: map[string]valueEntry{
+				"test_selector": {Value: "test_value"},
+			},
+		},
+	})
+
+	originalCfg := map[string]interface{}{
+		"top0": map[string]interface{}{
+			"int":    1,
+			"cfgsrc": "$tstcfgsrc:test_selector",
+		},
+	}
+	expectedCfg := map[string]interface{}{
+		"top0": map[string]interface{}{
+			"int":    1,
+			"cfgsrc": "test_value",
+		},
+	}
+
+	cp := config.NewParserFromStringMap(originalCfg)
+
+	res, err := manager.Resolve(ctx, cp)
+	require.NoError(t, err)
+	actualCfg := res.Viper().AllSettings()
+	assert.Equal(t, expectedCfg, actualCfg)
+
+	doneCh := make(chan struct{})
+	var errWatcher error
+	go func() {
+		defer close(doneCh)
+		errWatcher = manager.WatchForUpdate()
+	}()
+
+	manager.WaitForWatcher()
+	assert.NoError(t, manager.Close(ctx))
+	<-doneCh
+	assert.ErrorIs(t, errWatcher, ErrSessionClosed)
+}
+
+func TestConfigSourceManager_ResolveRemoveConfigSourceSection(t *testing.T) {
+	cfg := map[string]interface{}{
+		"config_sources": map[string]interface{}{
+			"testcfgsrc": nil,
+		},
+		"another_section": map[string]interface{}{
+			"int": 42,
+		},
+	}
+
+	manager := newManager(map[string]ConfigSource{
+		"tstcfgsrc": &testConfigSource{},
+	})
+
+	res, err := manager.Resolve(context.Background(), config.NewParserFromStringMap(cfg))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	delete(cfg, "config_sources")
+	assert.Equal(t, cfg, res.Viper().AllSettings())
+}
+
+func TestConfigSourceManager_ResolveErrors(t *testing.T) {
+	ctx := context.Background()
+	testErr := errors.New("test error")
+
+	tests := []struct {
+		config          map[string]interface{}
+		configSourceMap map[string]ConfigSource
+		name            string
+	}{
+		{
+			name: "incorrect_cfgsrc_ref",
+			config: map[string]interface{}{
+				"cfgsrc": "$tstcfgsrc:selector?{invalid}",
+			},
+			configSourceMap: map[string]ConfigSource{
+				"tstcfgsrc": &testConfigSource{},
+			},
+		},
+		{
+			name: "error_on_new_session",
+			config: map[string]interface{}{
+				"cfgsrc": "$tstcfgsrc:selector",
+			},
+			configSourceMap: map[string]ConfigSource{
+				"tstcfgsrc": &testConfigSource{ErrOnNewSession: testErr},
+			},
+		},
+		{
+			name: "error_on_retrieve",
+			config: map[string]interface{}{
+				"cfgsrc": "$tstcfgsrc:selector",
+			},
+			configSourceMap: map[string]ConfigSource{
+				"tstcfgsrc": &testConfigSource{ErrOnRetrieve: testErr},
+			},
+		},
+		{
+			name: "error_on_retrieve_end",
+			config: map[string]interface{}{
+				"cfgsrc": "$tstcfgsrc:selector",
+			},
+			configSourceMap: map[string]ConfigSource{
+				"tstcfgsrc": &testConfigSource{
+					ErrOnRetrieveEnd: testErr,
+					ValueMap: map[string]valueEntry{
+						"selector": {Value: "test_value"},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := newManager(tt.configSourceMap)
+
+			res, err := manager.Resolve(ctx, config.NewParserFromStringMap(tt.config))
+			require.Error(t, err)
+			require.Nil(t, res)
+			require.NoError(t, manager.Close(ctx))
+		})
+	}
+}
+
+func TestConfigSourceManager_ArraysAndMaps(t *testing.T) {
+	ctx := context.Background()
+	manager := newManager(map[string]ConfigSource{
+		"tstcfgsrc": &testConfigSource{
+			ValueMap: map[string]valueEntry{
+				"elem0": {Value: "elem0_value"},
+				"elem1": {Value: "elem1_value"},
+				"k0":    {Value: "k0_value"},
+				"k1":    {Value: "k1_value"},
+			},
+		},
+	})
+
+	file := path.Join("testdata", "arrays_and_maps.yaml")
+	cp, err := config.NewParserFromFile(file)
+	require.NoError(t, err)
+
+	expectedFile := path.Join("testdata", "arrays_and_maps_expected.yaml")
+	expectedParser, err := config.NewParserFromFile(expectedFile)
+	require.NoError(t, err)
+	expectedCfg := expectedParser.Viper().AllSettings()
+
+	res, err := manager.Resolve(ctx, cp)
+	require.NoError(t, err)
+	actualCfg := res.Viper().AllSettings()
+	assert.Equal(t, expectedCfg, actualCfg)
+	assert.NoError(t, manager.Close(ctx))
+}
+
+func TestConfigSourceManager_ParamsHandling(t *testing.T) {
+	ctx := context.Background()
+	tstCfgSrc := testConfigSource{
+		ValueMap: map[string]valueEntry{
+			"elem0": {Value: nil},
+			"elem1": {
+				Value: map[string]interface{}{
+					"p0": true,
+					"p1": "a string with spaces",
+					"p3": 42,
+				},
+			},
+			"k0": {Value: nil},
+			"k1": {
+				Value: map[string]interface{}{
+					"p0": true,
+					"p1": "a string with spaces",
+					"p2": map[string]interface{}{
+						"p2_0": "a nested map0",
+						"p2_1": true,
+					},
+				},
+			},
+		},
+	}
+
+	// Set OnRetrieve to check if the parameters were parsed as expected.
+	tstCfgSrc.OnRetrieve = func(ctx context.Context, selector string, params interface{}) error {
+		assert.Equal(t, tstCfgSrc.ValueMap[selector].Value, params)
+		return nil
+	}
+
+	manager := newManager(map[string]ConfigSource{
+		"tstcfgsrc": &tstCfgSrc,
+	})
+
+	file := path.Join("testdata", "params_handling.yaml")
+	cp, err := config.NewParserFromFile(file)
+	require.NoError(t, err)
+
+	expectedFile := path.Join("testdata", "params_handling_expected.yaml")
+	expectedParser, err := config.NewParserFromFile(expectedFile)
+	require.NoError(t, err)
+	expectedCfg := expectedParser.Viper().AllSettings()
+
+	res, err := manager.Resolve(ctx, cp)
+	require.NoError(t, err)
+	actualCfg := res.Viper().AllSettings()
+	assert.Equal(t, expectedCfg, actualCfg)
+	assert.NoError(t, manager.Close(ctx))
+}
+
+func TestConfigSourceManager_WatchForUpdate(t *testing.T) {
+	ctx := context.Background()
+	watchForUpdateCh := make(chan error, 1)
+
+	manager := newManager(map[string]ConfigSource{
+		"tstcfgsrc": &testConfigSource{
+			ValueMap: map[string]valueEntry{
+				"test_selector": {
+					Value: "test_value",
+					WatchForUpdateFn: func() error {
+						return <-watchForUpdateCh
+					},
+				},
+			},
+		},
+	})
+
+	originalCfg := map[string]interface{}{
+		"top0": map[string]interface{}{
+			"var0": "$tstcfgsrc:test_selector",
+		},
+	}
+
+	cp := config.NewParserFromStringMap(originalCfg)
+	_, err := manager.Resolve(ctx, cp)
+	require.NoError(t, err)
+
+	doneCh := make(chan struct{})
+	var errWatcher error
+	go func() {
+		defer close(doneCh)
+		errWatcher = manager.WatchForUpdate()
+	}()
+
+	manager.WaitForWatcher()
+	watchForUpdateCh <- ErrValueUpdated
+
+	<-doneCh
+	assert.ErrorIs(t, errWatcher, ErrValueUpdated)
+	assert.NoError(t, manager.Close(ctx))
+}
+
+func TestConfigSourceManager_MultipleWatchForUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	watchDoneCh := make(chan struct{})
+	const watchForUpdateChSize int = 2
+	watchForUpdateCh := make(chan error, watchForUpdateChSize)
+	watchForUpdateFn := func() error {
+		select {
+		case errFromWatchForUpdate := <-watchForUpdateCh:
+			return errFromWatchForUpdate
+		case <-watchDoneCh:
+			return ErrSessionClosed
+		}
+	}
+
+	manager := newManager(map[string]ConfigSource{
+		"tstcfgsrc": &testConfigSource{
+			ValueMap: map[string]valueEntry{
+				"test_selector": {
+					Value:            "test_value",
+					WatchForUpdateFn: watchForUpdateFn,
+				},
+			},
+		},
+	})
+
+	originalCfg := map[string]interface{}{
+		"top0": map[string]interface{}{
+			"var0": "$tstcfgsrc:test_selector",
+			"var1": "$tstcfgsrc:test_selector",
+			"var2": "$tstcfgsrc:test_selector",
+			"var3": "$tstcfgsrc:test_selector",
+		},
+	}
+
+	cp := config.NewParserFromStringMap(originalCfg)
+	_, err := manager.Resolve(ctx, cp)
+	require.NoError(t, err)
+
+	doneCh := make(chan struct{})
+	var errWatcher error
+	go func() {
+		defer close(doneCh)
+		errWatcher = manager.WatchForUpdate()
+	}()
+
+	manager.WaitForWatcher()
+
+	for i := 0; i < watchForUpdateChSize; i++ {
+		watchForUpdateCh <- ErrValueUpdated
+	}
+
+	<-doneCh
+	assert.ErrorIs(t, errWatcher, ErrValueUpdated)
+	close(watchForUpdateCh)
+	assert.NoError(t, manager.Close(ctx))
+}
+
+func TestConfigSourceManager_EnvVarHandling(t *testing.T) {
+	require.NoError(t, os.Setenv("envvar", "envvar_value"))
+	defer func() {
+		assert.NoError(t, os.Unsetenv("envvar"))
+	}()
+
+	ctx := context.Background()
+	tstCfgSrc := testConfigSource{
+		ValueMap: map[string]valueEntry{
+			"int_key": {Value: 42},
+		},
+	}
+
+	// Intercept "params_key" and create an entry with the params themselves.
+	tstCfgSrc.OnRetrieve = func(ctx context.Context, selector string, params interface{}) error {
+		if selector == "params_key" {
+			tstCfgSrc.ValueMap[selector] = valueEntry{Value: params}
+		}
+		return nil
+	}
+
+	manager := newManager(map[string]ConfigSource{
+		"tstcfgsrc": &tstCfgSrc,
+	})
+
+	file := path.Join("testdata", "envvar_cfgsrc_mix.yaml")
+	cp, err := config.NewParserFromFile(file)
+	require.NoError(t, err)
+
+	expectedFile := path.Join("testdata", "envvar_cfgsrc_mix_expected.yaml")
+	expectedParser, err := config.NewParserFromFile(expectedFile)
+	require.NoError(t, err)
+	expectedCfg := expectedParser.Viper().AllSettings()
+
+	res, err := manager.Resolve(ctx, cp)
+	require.NoError(t, err)
+	actualCfg := res.Viper().AllSettings()
+	assert.Equal(t, expectedCfg, actualCfg)
+	assert.NoError(t, manager.Close(ctx))
+}
+
+func TestManager_expandString(t *testing.T) {
+	ctx := context.Background()
+	manager := newManager(map[string]ConfigSource{
+		"tstcfgsrc": &testConfigSource{
+			ValueMap: map[string]valueEntry{
+				"str_key": {Value: "test_value"},
+				"int_key": {Value: 1},
+			},
+		},
+	})
+
+	require.NoError(t, os.Setenv("envvar", "envvar_value"))
+	defer func() {
+		assert.NoError(t, os.Unsetenv("envvar"))
+	}()
+	require.NoError(t, os.Setenv("envvar_str_key", "str_key"))
+	defer func() {
+		assert.NoError(t, os.Unsetenv("envvar_str_key"))
+	}()
+
+	tests := []struct {
+		want    interface{}
+		wantErr error
+		name    string
+		input   string
+	}{
+		{
+			name:  "literal_string",
+			input: "literal_string",
+			want:  "literal_string",
+		},
+		{
+			name:  "escaped_$",
+			input: "$$tstcfgsrc:int_key$$envvar",
+			want:  "$tstcfgsrc:int_key$envvar",
+		},
+		{
+			name:  "cfgsrc_int",
+			input: "$tstcfgsrc:int_key",
+			want:  1,
+		},
+		{
+			name:  "concatenate_cfgsrc_string",
+			input: "prefix-$tstcfgsrc:str_key",
+			want:  "prefix-test_value",
+		},
+		{
+			name:  "concatenate_cfgsrc_non_string",
+			input: "prefix-$tstcfgsrc:int_key",
+			want:  "prefix-1",
+		},
+		{
+			name:  "envvar",
+			input: "$envvar",
+			want:  "envvar_value",
+		},
+		{
+			name:  "prefixed_envvar",
+			input: "prefix-$envvar",
+			want:  "prefix-envvar_value",
+		},
+		{
+			name:    "envvar_treated_as_cfgsrc",
+			input:   "$envvar:suffix",
+			wantErr: &errUnknownConfigSource{},
+		},
+		{
+			name:  "cfgsrc_using_envvar",
+			input: "$tstcfgsrc:$envvar_str_key",
+			want:  "test_value",
+		},
+		{
+			name:  "envvar_cfgsrc_using_envvar",
+			input: "$envvar/$tstcfgsrc:$envvar_str_key",
+			want:  "envvar_value/test_value",
+		},
+		{
+			name:  "delimited_cfgsrc",
+			input: "${tstcfgsrc:int_key}",
+			want:  1,
+		},
+		{
+			name:    "unknown_delimited_cfgsrc",
+			input:   "${cfgsrc:int_key}",
+			wantErr: &errUnknownConfigSource{},
+		},
+		{
+			name:  "delimited_cfgsrc_with_spaces",
+			input: "${ tstcfgsrc: int_key }",
+			want:  1,
+		},
+		{
+			name:  "interpolated_and_delimited_cfgsrc",
+			input: "0/${ tstcfgsrc: $envvar_str_key }/2/${tstcfgsrc:int_key}",
+			want:  "0/test_value/2/1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := manager.expandString(ctx, tt.input)
+			require.IsType(t, tt.wantErr, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_parseCfgSrc(t *testing.T) {
+	tests := []struct {
+		params     interface{}
+		name       string
+		str        string
+		cfgSrcName string
+		selector   string
+		wantErr    bool
+	}{
+		{
+			name:       "basic",
+			str:        "cfgsrc:selector",
+			cfgSrcName: "cfgsrc",
+			selector:   "selector",
+		},
+		{
+			name:    "missing_selector",
+			str:     "cfgsrc",
+			wantErr: true,
+		},
+		{
+			name:       "params",
+			str:        "cfgsrc:selector?p0=1&p1=a_string&p2=true",
+			cfgSrcName: "cfgsrc",
+			selector:   "selector",
+			params: map[string]interface{}{
+				"p0": 1,
+				"p1": "a_string",
+				"p2": true,
+			},
+		},
+		{
+			name:       "query_pass_nil",
+			str:        "cfgsrc:selector?p0&p1&p2",
+			cfgSrcName: "cfgsrc",
+			selector:   "selector",
+			params: map[string]interface{}{
+				"p0": nil,
+				"p1": nil,
+				"p2": nil,
+			},
+		},
+		{
+			name:       "array_in_params",
+			str:        "cfgsrc:selector?p0=0&p0=1&p0=2&p1=done",
+			cfgSrcName: "cfgsrc",
+			selector:   "selector",
+			params: map[string]interface{}{
+				"p0": []interface{}{0, 1, 2},
+				"p1": "done",
+			},
+		},
+		{
+			name:       "empty_param",
+			str:        "cfgsrc:selector?no_closing=",
+			cfgSrcName: "cfgsrc",
+			selector:   "selector",
+			params: map[string]interface{}{
+				"no_closing": interface{}(nil),
+			},
+		},
+		{
+			name:       "use_url_encode",
+			str:        "cfgsrc:selector?p0=contains+%3D+and+%26+too",
+			cfgSrcName: "cfgsrc",
+			selector:   "selector",
+			params: map[string]interface{}{
+				"p0": "contains = and & too",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgSrcName, selector, params, err := parseCfgSrc(tt.str)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.cfgSrcName, cfgSrcName)
+			assert.Equal(t, tt.selector, selector)
+			assert.Equal(t, tt.params, params)
+		})
+	}
+}
+
+// testConfigSource a ConfigSource to be used in tests.
+type testConfigSource struct {
+	ValueMap map[string]valueEntry
+
+	ErrOnNewSession  error
+	ErrOnRetrieve    error
+	ErrOnRetrieveEnd error
+	ErrOnClose       error
+
+	OnRetrieve func(ctx context.Context, selector string, params interface{}) error
+}
+
+type valueEntry struct {
+	Value            interface{}
+	WatchForUpdateFn func() error
+}
+
+var _ (ConfigSource) = (*testConfigSource)(nil)
+var _ (Session) = (*testConfigSource)(nil)
+
+func (t *testConfigSource) NewSession(context.Context) (Session, error) {
+	if t.ErrOnNewSession != nil {
+		return nil, t.ErrOnNewSession
+	}
+	return t, nil
+}
+
+func (t *testConfigSource) Retrieve(ctx context.Context, selector string, params interface{}) (Retrieved, error) {
+	if t.OnRetrieve != nil {
+		if err := t.OnRetrieve(ctx, selector, params); err != nil {
+			return nil, err
+		}
+	}
+
+	if t.ErrOnRetrieve != nil {
+		return nil, t.ErrOnRetrieve
+	}
+
+	entry, ok := t.ValueMap[selector]
+	if !ok {
+		return nil, fmt.Errorf("no value for selector %q", selector)
+	}
+
+	watchForUpdateFn := func() error {
+		return ErrWatcherNotSupported
+	}
+
+	if entry.WatchForUpdateFn != nil {
+		watchForUpdateFn = entry.WatchForUpdateFn
+	}
+
+	return &retrieved{
+		value:            entry.Value,
+		watchForUpdateFn: watchForUpdateFn,
+	}, nil
+}
+
+func (t *testConfigSource) RetrieveEnd(context.Context) error {
+	return t.ErrOnRetrieveEnd
+}
+
+func (t *testConfigSource) Close(context.Context) error {
+	return t.ErrOnClose
+}


### PR DESCRIPTION
A follow-up to #295 that superseded #277.

This brings the config source manager from the core repository that is not publicly exposed. The manager will be used to implement a provider that uses config sources to inject data in configuration. This code was originally reviewed on the collector core repository.

/cc @owais

