### PR TITLE
Added path for jaeger thrift http and zipkin 

### DIFF
--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -48,7 +48,7 @@ receivers:
   #  - grpc (default endpoint = 0.0.0.0:14250)
   #  - thrift_binary (default endpoint = 0.0.0.0:6832/udp)
   #  - thrift_compact (default endpoint = 0.0.0.0:6831/udp)
-  #  - thrift_http (default endpoint = 0.0.0.0:14268)
+  #  - thrift_http (default endpoint = 0.0.0.0:14268/api/traces)
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/jaegerreceiver
   jaeger:
     protocols:
@@ -77,7 +77,7 @@ receivers:
     type: signalfx-forwarder
 
   # Enables the zipkin receiver with default settings
-  #  - grpc (default endpoint = 0.0.0.0:9411)
+  #  - grpc (default endpoint = 0.0.0.0:9411/api/[v1|v2]/spans)
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/zipkinreceiver
   zipkin:
 


### PR DESCRIPTION
to make it easier for pe…ople to know what the correct URL/path is

Also I suggest you add the path in for the other protocols such as sapm, etc.

Per  https://github.com/signalfx/splunk-otel-collector/blob/main/docs/security.md:
- I'd have expected the paths for the jaeger grpc, thrift_binary, and thrift_compact to be /api/traces also and not /udp.  You should probably review them and determine what the correct path is.
- The referenced security.md file does not have splunk_hec. If that is used, it should probably be included in security.md.  Also the path should be referenced here.
- otlp. Port 55681 is not listed in security.md. Not sure if that is an error or not.  Path is not listed in either document. Should be added.
- sapm on port 7276. Neither this document nor security.md indicates the path
- all other receivers ports listed here and in security.md should have the path specified to help users configure the file appropriately.