### PR TITLE
Add a parser provider that allows config sources

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -26,8 +26,10 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/service"
+	"go.uber.org/zap"
 
 	"github.com/signalfx/splunk-otel-collector/internal/components"
+	"github.com/signalfx/splunk-otel-collector/internal/configprovider"
 	"github.com/signalfx/splunk-otel-collector/internal/version"
 )
 
@@ -70,7 +72,18 @@ func main() {
 		GitHash:  version.GitHash,
 	}
 
-	if err := run(service.Parameters{ApplicationStartInfo: info, Factories: factories}); err != nil {
+	parserProvider := configprovider.NewConfigSourceParserProvider(
+		zap.NewNop(), // The service logger is not available yet, setting it to NoP.
+		info,
+		configprovider.DefaultConfigSources()...,
+	)
+	serviceParams := service.Parameters{
+		ApplicationStartInfo: info,
+		Factories:            factories,
+		ParserProvider:       parserProvider,
+	}
+
+	if err := run(serviceParams); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -75,7 +75,7 @@ func main() {
 	parserProvider := configprovider.NewConfigSourceParserProvider(
 		zap.NewNop(), // The service logger is not available yet, setting it to NoP.
 		info,
-		configprovider.DefaultConfigSources()...,
+		// TODO: Add config source factories.
 	)
 	serviceParams := service.Parameters{
 		ApplicationStartInfo: info,

--- a/internal/configprovider/config_source_provider.go
+++ b/internal/configprovider/config_source_provider.go
@@ -1,0 +1,97 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configprovider
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/service/parserprovider"
+	"go.uber.org/zap"
+)
+
+type errDuplicatedConfigSourceFactory struct { error }
+
+type configSourceParserProvider struct {
+	logger       *zap.Logger
+	csm          *Manager
+	pp           parserprovider.ParserProvider
+	appStartInfo component.ApplicationStartInfo
+	factories    []Factory
+}
+
+// DefaultConfigSources return the default config sources available.
+func DefaultConfigSources() []Factory {
+	return []Factory{
+		// TODO: Initially empty, will add Vault, etcd, Zookeeper, etc.
+	}
+}
+
+// NewConfigSourceParserProvider creates a ParserProvider that uses config sources.
+func NewConfigSourceParserProvider(logger *zap.Logger, appStartInfo component.ApplicationStartInfo, factories ...Factory) parserprovider.ParserProvider {
+	return &configSourceParserProvider{
+		pp:           parserprovider.Default(),
+		logger:       logger,
+		factories:    factories,
+		appStartInfo: appStartInfo,
+	}
+}
+
+func (c *configSourceParserProvider) Get() (*config.Parser, error) {
+	defaultParser, err := c.pp.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	factories, err := makeFactoryMap(c.factories)
+	if err != nil {
+		return nil, err
+	}
+
+	csm, err := NewManager(defaultParser, c.logger, c.appStartInfo, factories)
+	if err != nil {
+		return nil, err
+	}
+
+	parser, err := csm.Resolve(context.Background(), defaultParser)
+	if err != nil {
+		return nil, err
+	}
+
+	c.csm = csm
+	return parser, nil
+}
+
+func (c *configSourceParserProvider) WatchForUpdate() error {
+	return c.csm.WatchForUpdate()
+}
+
+func (c *configSourceParserProvider) Close(ctx context.Context) error {
+	return c.csm.Close(ctx)
+}
+
+func makeFactoryMap(factories []Factory) (Factories, error) {
+	fMap := make(Factories)
+	for _, f := range factories {
+		if _, ok := fMap[f.Type()]; ok {
+			return nil, &errDuplicatedConfigSourceFactory{fmt.Errorf("duplicate config source factory %q", f.Type())}
+		}
+		fMap[f.Type()] = f
+	}
+	return fMap, nil
+}

--- a/internal/configprovider/config_source_provider.go
+++ b/internal/configprovider/config_source_provider.go
@@ -35,13 +35,6 @@ type configSourceParserProvider struct {
 	factories    []Factory
 }
 
-// DefaultConfigSources return the default config sources available.
-func DefaultConfigSources() []Factory {
-	return []Factory{
-		// TODO: Initially empty, will add Vault, etcd, Zookeeper, etc.
-	}
-}
-
 // NewConfigSourceParserProvider creates a ParserProvider that uses config sources.
 func NewConfigSourceParserProvider(logger *zap.Logger, appStartInfo component.ApplicationStartInfo, factories ...Factory) parserprovider.ParserProvider {
 	return &configSourceParserProvider{

--- a/internal/configprovider/config_source_provider.go
+++ b/internal/configprovider/config_source_provider.go
@@ -52,6 +52,9 @@ func NewConfigSourceParserProvider(logger *zap.Logger, appStartInfo component.Ap
 	}
 }
 
+// Get returns a config.Parser that wraps the parserprovider.Default() with a parser
+// that can load and inject data from config sources. If there are no config sources
+// in the configuration the returned parser behaves like the parserprovider.Default().
 func (c *configSourceParserProvider) Get() (*config.Parser, error) {
 	defaultParser, err := c.pp.Get()
 	if err != nil {
@@ -77,10 +80,14 @@ func (c *configSourceParserProvider) Get() (*config.Parser, error) {
 	return parser, nil
 }
 
+// WatchForUpdate is used to monitor for updates on configuration values that
+// were retrieved from config sources.
 func (c *configSourceParserProvider) WatchForUpdate() error {
 	return c.csm.WatchForUpdate()
 }
 
+// Close ends the watch for updates and closes the parser provider and respective
+// config sources.
 func (c *configSourceParserProvider) Close(ctx context.Context) error {
 	return c.csm.Close(ctx)
 }

--- a/internal/configprovider/config_source_provider.go
+++ b/internal/configprovider/config_source_provider.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/zap"
 )
 
-type errDuplicatedConfigSourceFactory struct { error }
+type errDuplicatedConfigSourceFactory struct{ error }
 
 type configSourceParserProvider struct {
 	logger       *zap.Logger

--- a/internal/configprovider/config_source_provider_test.go
+++ b/internal/configprovider/config_source_provider_test.go
@@ -71,9 +71,6 @@ func TestConfigSourceParserProvider(t *testing.T) {
 		},
 		{
 			name: "manager_resolve_error",
-			factories: []Factory{
-				&mockCfgSrcFactory{},
-			},
 			parserProvider: &fileParserProvider{
 				FileName: path.Join("testdata", "manager_resolve_error.yaml"),
 			},
@@ -85,7 +82,9 @@ func TestConfigSourceParserProvider(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			factories := tt.factories
 			if factories == nil {
-				factories = DefaultConfigSources()
+				factories = []Factory{
+					&mockCfgSrcFactory{},
+				}
 			}
 
 			pp := NewConfigSourceParserProvider(

--- a/internal/configprovider/config_source_provider_test.go
+++ b/internal/configprovider/config_source_provider_test.go
@@ -33,11 +33,11 @@ import (
 )
 
 func TestConfigSourceParserProvider(t *testing.T) {
-	tests := []struct{
-		factories []Factory
+	tests := []struct {
+		factories      []Factory
 		parserProvider parserprovider.ParserProvider
-		wantErr error
-		name string
+		wantErr        error
+		name           string
 	}{
 		{
 			name: "success",
@@ -82,7 +82,7 @@ func TestConfigSourceParserProvider(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func (t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			factories := tt.factories
 			if factories == nil {
 				factories = DefaultConfigSources()
@@ -143,7 +143,7 @@ func (mpp *mockParserProvider) Get() (*config.Parser, error) {
 	return config.NewParser(), nil
 }
 
-type errOnParserProviderGet struct {error}
+type errOnParserProviderGet struct{ error }
 
 type fileParserProvider struct {
 	FileName string

--- a/internal/configprovider/config_source_provider_test.go
+++ b/internal/configprovider/config_source_provider_test.go
@@ -34,10 +34,10 @@ import (
 
 func TestConfigSourceParserProvider(t *testing.T) {
 	tests := []struct {
-		factories      []Factory
 		parserProvider parserprovider.ParserProvider
 		wantErr        error
 		name           string
+		factories      []Factory
 	}{
 		{
 			name: "success",

--- a/internal/configprovider/config_source_provider_test.go
+++ b/internal/configprovider/config_source_provider_test.go
@@ -1,0 +1,156 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/experimental/configsource"
+	"go.opentelemetry.io/collector/service/parserprovider"
+	"go.uber.org/zap"
+)
+
+func TestConfigSourceParserProvider(t *testing.T) {
+	tests := []struct{
+		factories []Factory
+		parserProvider parserprovider.ParserProvider
+		wantErr error
+		name string
+	}{
+		{
+			name: "success",
+		},
+		{
+			name: "wrapped_parser_provider_get_error",
+			parserProvider: &mockParserProvider{
+				ErrOnGet: true,
+			},
+			wantErr: &errOnParserProviderGet{},
+		},
+		{
+			name: "duplicated_factory_type",
+			factories: []Factory{
+				&mockCfgSrcFactory{},
+				&mockCfgSrcFactory{},
+			},
+			wantErr: &errDuplicatedConfigSourceFactory{},
+		},
+		{
+			name: "new_manager_builder_error",
+			factories: []Factory{
+				&mockCfgSrcFactory{
+					ErrOnCreateConfigSource: errors.New("new_manager_builder_error forced error"),
+				},
+			},
+			parserProvider: &fileParserProvider{
+				FileName: path.Join("testdata", "basic_config.yaml"),
+			},
+			wantErr: &errConfigSourceCreation{},
+		},
+		{
+			name: "manager_resolve_error",
+			factories: []Factory{
+				&mockCfgSrcFactory{},
+			},
+			parserProvider: &fileParserProvider{
+				FileName: path.Join("testdata", "manager_resolve_error.yaml"),
+			},
+			wantErr: fmt.Errorf("error not wrapped by specific error type: %w", configsource.ErrSessionClosed),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func (t *testing.T) {
+			factories := tt.factories
+			if factories == nil {
+				factories = DefaultConfigSources()
+			}
+
+			pp := NewConfigSourceParserProvider(
+				zap.NewNop(),
+				component.DefaultApplicationStartInfo(),
+				factories...,
+			)
+			require.NotNil(t, pp)
+
+			// Do not use the parserprovider.Default() to simplify the test setup.
+			cspp := pp.(*configSourceParserProvider)
+			cspp.pp = tt.parserProvider
+			if cspp.pp == nil {
+				cspp.pp = &mockParserProvider{}
+			}
+
+			cp, err := pp.Get()
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				require.NotNil(t, cp)
+			} else {
+				assert.IsType(t, tt.wantErr, err)
+				assert.Nil(t, cp)
+				return
+			}
+
+			var watchForUpdatedError error
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				watchForUpdatedError = pp.(parserprovider.Watchable).WatchForUpdate()
+			}()
+			cspp.csm.WaitForWatcher()
+
+			closeErr := pp.(parserprovider.Closeable).Close(context.Background())
+			assert.NoError(t, closeErr)
+
+			wg.Wait()
+			assert.Equal(t, configsource.ErrSessionClosed, watchForUpdatedError)
+		})
+	}
+}
+
+type mockParserProvider struct {
+	ErrOnGet bool
+}
+
+var _ (parserprovider.ParserProvider) = (*mockParserProvider)(nil)
+
+func (mpp *mockParserProvider) Get() (*config.Parser, error) {
+	if mpp.ErrOnGet {
+		return nil, &errOnParserProviderGet{errors.New("mockParserProvider.Get() forced test error")}
+	}
+	return config.NewParser(), nil
+}
+
+type errOnParserProviderGet struct {error}
+
+type fileParserProvider struct {
+	FileName string
+}
+
+var _ (parserprovider.ParserProvider) = (*fileParserProvider)(nil)
+
+func (fpp *fileParserProvider) Get() (*config.Parser, error) {
+	return config.NewParserFromFile(fpp.FileName)
+}

--- a/internal/configprovider/testdata/manager_resolve_error.yaml
+++ b/internal/configprovider/testdata/manager_resolve_error.yaml
@@ -1,0 +1,4 @@
+config_sources:
+  tstcfgsrc:
+
+cfgsrc: $tstcfgsrc:selector?{invalid}


### PR DESCRIPTION
Adds a parser provider that can understand config sources. At this moment no config sources were added yet so none can be used but it works as the default parser provider in this case - manually verified.