### PR TITLE
Add support of env vars on config_sources section

### DIFF
--- a/internal/configprovider/testdata/cfgsrc_load_use_cfgsrc.yaml
+++ b/internal/configprovider/testdata/cfgsrc_load_use_cfgsrc.yaml
@@ -1,0 +1,5 @@
+config_sources:
+  tstcfgsrc:
+  tstcfgsrc/named:
+    # It is not valid to use a dynamic config source when defining other one.
+    endpoint: $tstcfgsrc:str_value

--- a/internal/configprovider/testdata/env_var_on_load.yaml
+++ b/internal/configprovider/testdata/env_var_on_load.yaml
@@ -1,0 +1,6 @@
+config_sources:
+  tstcfgsrc:
+    endpoint: https://${ENV_VAR_ENDPOINT}:8200
+    token: $ENV_VAR_TOKEN
+ignored_by_parser:
+  some_field: $ENV_VAR_TOKEN


### PR DESCRIPTION
The YAML section config_sources was missing the environment variables. This PR adds that support by processing the config.Parser passed to load.

/cc @Owais