### PR TITLE
Create default config sources

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/signalfx/splunk-otel-collector/internal/components"
 	"github.com/signalfx/splunk-otel-collector/internal/configprovider"
+	"github.com/signalfx/splunk-otel-collector/internal/configsources"
 	"github.com/signalfx/splunk-otel-collector/internal/version"
 )
 
@@ -75,7 +76,7 @@ func main() {
 	parserProvider := configprovider.NewConfigSourceParserProvider(
 		zap.NewNop(), // The service logger is not available yet, setting it to NoP.
 		info,
-		// TODO: Add config source factories.
+		configsources.Get()...,
 	)
 	serviceParams := service.Parameters{
 		ApplicationStartInfo: info,

--- a/internal/configsources/configsources.go
+++ b/internal/configsources/configsources.go
@@ -1,0 +1,29 @@
+// Copyright 2020 Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configsources lists all config sources that can be used in the configuration.
+package configsources
+
+import (
+	"github.com/signalfx/splunk-otel-collector/internal/configprovider"
+	"github.com/signalfx/splunk-otel-collector/internal/configsource/vaultconfigsource"
+)
+
+// Get returns the factories to all config sources available to the user.
+func Get() []configprovider.Factory {
+	return []configprovider.Factory{
+		vaultconfigsource.NewFactory(),
+	}
+}

--- a/internal/configsources/configsources_test.go
+++ b/internal/configsources/configsources_test.go
@@ -1,0 +1,57 @@
+// Copyright 2020 Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configsources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config"
+
+	"github.com/signalfx/splunk-otel-collector/internal/configprovider"
+)
+
+func TestConfigSourcesGet(t *testing.T) {
+	tests := []struct {
+		configSourceType config.Type
+	}{
+		{"vault"},
+	}
+
+	defaultCfgSrcFactories := Get()
+	require.Equal(t, len(tests), len(defaultCfgSrcFactories))
+
+	cfgSrcFactoryMap := make(map[config.Type]struct{})
+	for _, tt := range tests {
+		t.Run(string(tt.configSourceType), func(t *testing.T) {
+			var factory configprovider.Factory
+			for _, f := range defaultCfgSrcFactories {
+				if f.Type() == tt.configSourceType {
+					// Ensure no duplicated factories.
+					if _, ok := cfgSrcFactoryMap[tt.configSourceType]; ok {
+						assert.Fail(t, "duplicated config source factory")
+					}
+					cfgSrcFactoryMap[f.Type()] = struct{}{}
+					factory = f
+					break
+				}
+			}
+
+			require.NotNil(t, factory, "missing or nil config source factory")
+		})
+	}
+}


### PR DESCRIPTION
Similar to components a set of default config sources needs to be defined. Since config sources are still experimental they are not being added to the components package. To avoid circular dependencies a dedicated package, configsources, was created since config source implementations depend on the configprovider package for configuration load and related interfaces.