### PR TITLE
Expose initial and effective config for debugging purposes

### DIFF
--- a/internal/configprovider/config_server.go
+++ b/internal/configprovider/config_server.go
@@ -152,6 +152,7 @@ func shouldRedactKey(k string) bool {
 		"login",
 		"password",
 		"pwd",
+		"token",
 		"user",
 	}
 

--- a/internal/configprovider/config_server.go
+++ b/internal/configprovider/config_server.go
@@ -1,0 +1,145 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configprovider
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"strings"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	defaultEndpoint = "localhost:5555"
+)
+
+type configServer struct {
+	logger    *zap.Logger
+	initial   map[string]interface{}
+	effective map[string]interface{}
+	server    *http.Server
+	doneCh    chan struct{}
+}
+
+func newConfigServer(logger *zap.Logger, initial, effective map[string]interface{}) *configServer {
+	return &configServer{
+		logger:    logger,
+		initial:   initial,
+		effective: effective,
+	}
+}
+
+func (cs *configServer) start() error {
+	endpoint := defaultEndpoint
+	if portOverride, ok := os.LookupEnv("SPLUNK_CONFIG_SERVER_PORT"); ok {
+		if portOverride == "" {
+			// If explicitly set to empty do not start the server.
+			return nil
+		}
+
+		endpoint = "localhost:" + portOverride
+	}
+
+	listener, err := net.Listen("tcp", endpoint)
+	if err != nil {
+		return err
+	}
+
+	mux := http.NewServeMux()
+
+	initialHandleFunc, err := cs.muxHandleFunc(cs.initial)
+	if err != nil {
+		return err
+	}
+	mux.HandleFunc("/debug/configz/initial", initialHandleFunc)
+
+	effectiveHandleFunc, err := cs.muxHandleFunc(simpleRedact(cs.effective))
+	if err != nil {
+		return err
+	}
+	mux.HandleFunc("/debug/configz/effective", effectiveHandleFunc)
+
+	cs.server = &http.Server{
+		Handler: mux,
+	}
+	cs.doneCh = make(chan struct{})
+	go func() {
+		defer close(cs.doneCh)
+
+		if httpErr := cs.server.Serve(listener); httpErr != http.ErrServerClosed {
+			cs.logger.Error("config server error", zap.Error(err))
+		}
+	}()
+
+	return nil
+}
+
+func (cs *configServer) shutdown() error {
+	var err error
+	if cs.server != nil {
+		err = cs.server.Close()
+		// If launched wait for Serve goroutine exit.
+		<-cs.doneCh
+	}
+
+	return err
+}
+
+func (cs *configServer) muxHandleFunc(config map[string]interface{}) (func(http.ResponseWriter, *http.Request), error) {
+	configYAML, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write(configYAML)
+	}, nil
+}
+
+func simpleRedact(config map[string]interface{}) map[string]interface{} {
+	redactedConfig := make(map[string]interface{})
+	for k, v := range config {
+		switch value := v.(type) {
+		case string:
+			if shouldRedactKey(k) {
+				v = "<redacted>"
+			}
+		case map[string]interface{}:
+			v = simpleRedact(value)
+		}
+
+		redactedConfig[k] = v
+	}
+
+	return redactedConfig
+}
+
+// shouldRedactKey applies a simple check to see if the contents of the given key
+// should be redacted or not.
+func shouldRedactKey(k string) bool {
+	fragments := []string{"access", "auth", "credential", "creds", "login", "password", "pwd", "user"}
+
+	for _, fragment := range fragments {
+		if strings.Contains(k, fragment) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/configprovider/config_server.go
+++ b/internal/configprovider/config_server.go
@@ -27,8 +27,10 @@ import (
 )
 
 const (
-	defaultConfigServerEndpoint   = "localhost:55555"
-	defaultConfigServerPortEnvVar = "SPLUNK_CONFIG_SERVER_PORT"
+	configServerEnabledEnvVar = "SPLUNK_DEBUG_CONFIG_SERVER"
+	configServerPortEnvVar    = "SPLUNK_DEBUG_CONFIG_SERVER_PORT"
+
+	defaultConfigServerEndpoint = "localhost:55555"
 )
 
 type configServer struct {
@@ -48,8 +50,13 @@ func newConfigServer(logger *zap.Logger, initial, effective map[string]interface
 }
 
 func (cs *configServer) start() error {
+	if enabled := os.Getenv(configServerEnabledEnvVar); enabled != "true" {
+		// The config server needs to be explicitly enabled for the time being.
+		return nil
+	}
+
 	endpoint := defaultConfigServerEndpoint
-	if portOverride, ok := os.LookupEnv(defaultConfigServerPortEnvVar); ok {
+	if portOverride, ok := os.LookupEnv(configServerPortEnvVar); ok {
 		if portOverride == "" {
 			// If explicitly set to empty do not start the server.
 			return nil

--- a/internal/configprovider/config_server_test.go
+++ b/internal/configprovider/config_server_test.go
@@ -151,8 +151,6 @@ func assertValidYAMLPages(t *testing.T, expected map[string]interface{}, path st
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	// Use viper to unmarshal to the more friendly instead of yaml internal maps get unmarshalled
-	// as map[string]interface{} instead of map[interface{}]interface{}.
 	var unmarshalled map[string]interface{}
 	require.NoError(t, yaml.Unmarshal(respBytes, &unmarshalled))
 

--- a/internal/configprovider/config_server_test.go
+++ b/internal/configprovider/config_server_test.go
@@ -1,0 +1,160 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configprovider
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/testutil"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
+)
+
+func TestConfigServer_EnvVar(t *testing.T) {
+	alternativePort := strconv.FormatUint(uint64(testutil.GetAvailablePort(t)), 10)
+	tests := []struct {
+		name       string
+		envVar     string
+		endpoint   string
+		setEnvVar  bool
+		serverDown bool
+	}{
+		{
+			name: "default",
+		},
+		{
+			name:       "disable_server",
+			setEnvVar:  true, // Explicitly setting it to empty to disable the server.
+			serverDown: true,
+		},
+		{
+			name:     "change_port",
+			envVar:   alternativePort,
+			endpoint: "http://localhost:" + alternativePort,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initial := map[string]interface{}{
+				"key": "value",
+			}
+
+			if tt.envVar != "" || tt.setEnvVar {
+				require.NoError(t, os.Setenv(defaultConfigServerPortEnvVar, tt.envVar))
+				defer func() {
+					assert.NoError(t, os.Unsetenv(defaultConfigServerPortEnvVar))
+				}()
+			}
+
+			cs := newConfigServer(zap.NewNop(), initial, initial)
+			require.NoError(t, cs.start())
+			defer func() {
+				assert.NoError(t, cs.shutdown())
+			}()
+
+			endpoint := tt.endpoint
+			if endpoint == "" {
+				endpoint = "http://" + defaultConfigServerEndpoint
+			}
+
+			path := "/debug/configz/initial"
+			if tt.serverDown {
+				client := &http.Client{}
+				_, err := client.Get(endpoint + path)
+				assert.Error(t, err)
+				return
+			}
+
+			client := &http.Client{}
+			resp, err := client.Get(endpoint + path)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode, "unsuccessful zpage %q GET", path)
+		})
+	}
+}
+
+func TestConfigServer_Serve(t *testing.T) {
+	initial := map[string]interface{}{
+		"field":   "not_redacted",
+		"api_key": "not_redacted_on_initial",
+		"int":     42,
+		"map": map[interface{}]interface{}{
+			"k0":       true,
+			"k1":       -1,
+			"password": "$ENV_VAR",
+		},
+	}
+	effective := map[string]interface{}{
+		"field":   "not_redacted",
+		"api_key": "<redacted>",
+		"int":     42,
+		"map": map[interface{}]interface{}{
+			"k0":       true,
+			"k1":       -1,
+			"password": "<redacted>",
+		},
+	}
+
+	cs := newConfigServer(zap.NewNop(), initial, initial)
+	require.NotNil(t, cs)
+
+	require.NoError(t, cs.start())
+	t.Cleanup(func() {
+		require.NoError(t, cs.shutdown())
+	})
+
+	// Test for the pages to be actually valid YAML files.
+	assertValidYAMLPages(t, initial, "/debug/configz/initial")
+	assertValidYAMLPages(t, effective, "/debug/configz/effective")
+}
+
+func assertValidYAMLPages(t *testing.T, expected map[string]interface{}, path string) {
+	url := "http://" + defaultConfigServerEndpoint + path
+
+	client := &http.Client{}
+
+	// Anything other the GET should return 405.
+	resp, err := client.Head(url)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	assert.NoError(t, resp.Body.Close())
+
+	resp, err = client.Get(url)
+	if !assert.NoError(t, err, "error retrieving zpage at %q", path) {
+		return
+	}
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "unsuccessful zpage %q GET", path)
+	t.Cleanup(func() {
+		assert.NoError(t, resp.Body.Close())
+	})
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// Use viper to unmarshal to the more friendly instead of yaml internal maps get unmarshalled
+	// as map[string]interface{} instead of map[interface{}]interface{}.
+	var unmarshalled map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(respBytes, &unmarshalled))
+
+	assert.Equal(t, expected, unmarshalled)
+}


### PR DESCRIPTION
Exposes config via an HTTP server at localhost if explicitly requested. Expose the config by setting the environment variable "SPLUNK_DEBUG_CONFIG_SERVER" to "true" (it won't work for any other value). By default it exposes the HTTP server at localhost:55555 with the following paths:

- /debug/configz/initial
- /debug/configz/effective

The first shows the initial configuration used by the collector the second the configuration actually in use by the collector. If the configuration is reloaded due to some update triggered by a config source the endpoint is briefly unavailable until the updated configuration is reloaded.

The exposed port is controlled by the env var "SPLUNK_CONFIG_SERVER_PORT" - if it is explicitly set to the empty string, e.g. SPLUNK_DEBUG_CONFIG_SERVER_PORT="" it disables the HTTP server.

On the effective configuration, it performs a simple attempt to redact all string values for which the key contains strings like "token", "secret", etc. This covers all components currently in use by the collector a more generic solution is desirable.