### PR TITLE
Enable etcd2 and zookeeper config sources

### DIFF
--- a/internal/configsources/configsources.go
+++ b/internal/configsources/configsources.go
@@ -18,12 +18,16 @@ package configsources
 
 import (
 	"github.com/signalfx/splunk-otel-collector/internal/configprovider"
+	"github.com/signalfx/splunk-otel-collector/internal/configsource/etcd2configsource"
 	"github.com/signalfx/splunk-otel-collector/internal/configsource/vaultconfigsource"
+	"github.com/signalfx/splunk-otel-collector/internal/configsource/zookeeperconfigsource"
 )
 
 // Get returns the factories to all config sources available to the user.
 func Get() []configprovider.Factory {
 	return []configprovider.Factory{
+		etcd2configsource.NewFactory(),
 		vaultconfigsource.NewFactory(),
+		zookeeperconfigsource.NewFactory(),
 	}
 }

--- a/internal/configsources/configsources_test.go
+++ b/internal/configsources/configsources_test.go
@@ -29,7 +29,9 @@ func TestConfigSourcesGet(t *testing.T) {
 	tests := []struct {
 		configSourceType config.Type
 	}{
+		{"etcd2"},
 		{"vault"},
+		{"zookeeper"},
 	}
 
 	defaultCfgSrcFactories := Get()


### PR DESCRIPTION
Enabling two more config sources: etcd2 and zookeeper.