### PR TITLE
Remove year from Splunk copyright

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test-with-cover:
 
 .PHONY: addlicense
 addlicense:
-	$(ADDLICENSE) -c 'Splunk, Inc.' $(ALL_SRC)
+	$(ADDLICENSE) -y "" -c 'Splunk, Inc.' $(ALL_SRC)
 
 .PHONY: checklicense
 checklicense:

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/otelcol/main_others.go
+++ b/cmd/otelcol/main_others.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/otelcol/main_test.go
+++ b/cmd/otelcol/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/otelcol/main_windows.go
+++ b/cmd/otelcol/main_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/etcd2configsource/config.go
+++ b/internal/configsource/etcd2configsource/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/etcd2configsource/config_test.go
+++ b/internal/configsource/etcd2configsource/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/etcd2configsource/configsource.go
+++ b/internal/configsource/etcd2configsource/configsource.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/etcd2configsource/configsource_test.go
+++ b/internal/configsource/etcd2configsource/configsource_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/etcd2configsource/factory_test.go
+++ b/internal/configsource/etcd2configsource/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/etcd2configsource/mocks_test.go
+++ b/internal/configsource/etcd2configsource/mocks_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/etcd2configsource/session.go
+++ b/internal/configsource/etcd2configsource/session.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/etcd2configsource/session_test.go
+++ b/internal/configsource/etcd2configsource/session_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/vaultconfigsource/config.go
+++ b/internal/configsource/vaultconfigsource/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/vaultconfigsource/config_test.go
+++ b/internal/configsource/vaultconfigsource/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/vaultconfigsource/configsource.go
+++ b/internal/configsource/vaultconfigsource/configsource.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/vaultconfigsource/configsource_test.go
+++ b/internal/configsource/vaultconfigsource/configsource_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/vaultconfigsource/factory_test.go
+++ b/internal/configsource/vaultconfigsource/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/vaultconfigsource/gcp_authentication.go
+++ b/internal/configsource/vaultconfigsource/gcp_authentication.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/vaultconfigsource/iam_authentication.go
+++ b/internal/configsource/vaultconfigsource/iam_authentication.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/vaultconfigsource/session.go
+++ b/internal/configsource/vaultconfigsource/session.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/vaultconfigsource/session_test.go
+++ b/internal/configsource/vaultconfigsource/session_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/zookeeperconfigsource/config.go
+++ b/internal/configsource/zookeeperconfigsource/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/zookeeperconfigsource/config_test.go
+++ b/internal/configsource/zookeeperconfigsource/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/zookeeperconfigsource/configsource.go
+++ b/internal/configsource/zookeeperconfigsource/configsource.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/zookeeperconfigsource/connection.go
+++ b/internal/configsource/zookeeperconfigsource/connection.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/zookeeperconfigsource/factory_test.go
+++ b/internal/configsource/zookeeperconfigsource/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/zookeeperconfigsource/mocks_test.go
+++ b/internal/configsource/zookeeperconfigsource/mocks_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/zookeeperconfigsource/session.go
+++ b/internal/configsource/zookeeperconfigsource/session.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsource/zookeeperconfigsource/session_test.go
+++ b/internal/configsource/zookeeperconfigsource/session_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsources/configsources.go
+++ b/internal/configsources/configsources.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/configsources/configsources_test.go
+++ b/internal/configsources/configsources_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/empty_test.go
+++ b/internal/empty_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/extension/smartagentextension/config.go
+++ b/internal/extension/smartagentextension/config.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/extension/smartagentextension/config_linux_test.go
+++ b/internal/extension/smartagentextension/config_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/extension/smartagentextension/config_test.go
+++ b/internal/extension/smartagentextension/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/extension/smartagentextension/config_windows_test.go
+++ b/internal/extension/smartagentextension/config_windows_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/extension/smartagentextension/extension.go
+++ b/internal/extension/smartagentextension/extension.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/extension/smartagentextension/extension_test.go
+++ b/internal/extension/smartagentextension/extension_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/extension/smartagentextension/factory.go
+++ b/internal/extension/smartagentextension/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/extension/smartagentextension/factory_test.go
+++ b/internal/extension/smartagentextension/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/config.go
+++ b/internal/receiver/smartagentreceiver/config.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/config_linux_test.go
+++ b/internal/receiver/smartagentreceiver/config_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/config_test.go
+++ b/internal/receiver/smartagentreceiver/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/converter/converter.go
+++ b/internal/receiver/smartagentreceiver/converter/converter.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/converter/converter_test.go
+++ b/internal/receiver/smartagentreceiver/converter/converter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/converter/event.go
+++ b/internal/receiver/smartagentreceiver/converter/event.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/converter/event_test.go
+++ b/internal/receiver/smartagentreceiver/converter/event_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/converter/metrics.go
+++ b/internal/receiver/smartagentreceiver/converter/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/converter/metrics_test.go
+++ b/internal/receiver/smartagentreceiver/converter/metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/converter/traces.go
+++ b/internal/receiver/smartagentreceiver/converter/traces.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/converter/traces_test.go
+++ b/internal/receiver/smartagentreceiver/converter/traces_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/dimension.go
+++ b/internal/receiver/smartagentreceiver/dimension.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/dimension_test.go
+++ b/internal/receiver/smartagentreceiver/dimension_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/factory.go
+++ b/internal/receiver/smartagentreceiver/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/factory_test.go
+++ b/internal/receiver/smartagentreceiver/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/filtering.go
+++ b/internal/receiver/smartagentreceiver/filtering.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/filtering_test.go
+++ b/internal/receiver/smartagentreceiver/filtering_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/log.go
+++ b/internal/receiver/smartagentreceiver/log.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/log_test.go
+++ b/internal/receiver/smartagentreceiver/log_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/output.go
+++ b/internal/receiver/smartagentreceiver/output.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/output_test.go
+++ b/internal/receiver/smartagentreceiver/output_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/output_traces_test.go
+++ b/internal/receiver/smartagentreceiver/output_traces_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/receiver.go
+++ b/internal/receiver/smartagentreceiver/receiver.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/receiver_test.go
+++ b/internal/receiver/smartagentreceiver/receiver_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/reflect.go
+++ b/internal/receiver/smartagentreceiver/reflect.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/receiver/smartagentreceiver/reflect_test.go
+++ b/internal/receiver/smartagentreceiver/reflect_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Splunk, Inc.
+// Copyright Splunk, Inc.
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/receivers/smartagent/collectd-activemq/collectd_activemq_test.go
+++ b/tests/receivers/smartagent/collectd-activemq/collectd_activemq_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/receivers/smartagent/collectd-apache/collectd_apache_test.go
+++ b/tests/receivers/smartagent/collectd-apache/collectd_apache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/receivers/smartagent/collectd-cassandra/collectd_cassandra_test.go
+++ b/tests/receivers/smartagent/collectd-cassandra/collectd_cassandra_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/receivers/smartagent/collectd-couchbase/collectd_couchbase_test.go
+++ b/tests/receivers/smartagent/collectd-couchbase/collectd_couchbase_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/receivers/smartagent/collectd-elasticsearch/collectd_elasticsearch_test.go
+++ b/tests/receivers/smartagent/collectd-elasticsearch/collectd_elasticsearch_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/receivers/smartagent/collectd-hadoop/collectd_hadoop_test.go
+++ b/tests/receivers/smartagent/collectd-hadoop/collectd_hadoop_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/receivers/smartagent/collectd-kafka/collectd_kafka_test.go
+++ b/tests/receivers/smartagent/collectd-kafka/collectd_kafka_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/receivers/smartagent/collectd-nginx/collectd_nginx_test.go
+++ b/tests/receivers/smartagent/collectd-nginx/collectd_nginx_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/receivers/smartagent/collectd-postgresql/collectd_postgresql_test.go
+++ b/tests/receivers/smartagent/collectd-postgresql/collectd_postgresql_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/receivers/smartagent/collectd-solr/collectd_solr_test.go
+++ b/tests/receivers/smartagent/collectd-solr/collectd_solr_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/receivers/smartagent/collectd-spark/collectd_spark_test.go
+++ b/tests/receivers/smartagent/collectd-spark/collectd_spark_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/receivers/smartagent/haproxy/haproxy_test.go
+++ b/tests/receivers/smartagent/haproxy/haproxy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/receivers/smartagent/postgresql/postgresql_test.go
+++ b/tests/receivers/smartagent/postgresql/postgresql_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/testutils/collector_process.go
+++ b/tests/testutils/collector_process.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/testutils/collector_process_integration_test.go
+++ b/tests/testutils/collector_process_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/testutils/collector_process_test.go
+++ b/tests/testutils/collector_process_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/testutils/container.go
+++ b/tests/testutils/container.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/testutils/container_test.go
+++ b/tests/testutils/container_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/testutils/otlp_receiver_sink.go
+++ b/tests/testutils/otlp_receiver_sink.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/testutils/otlp_receiver_sink_test.go
+++ b/tests/testutils/otlp_receiver_sink_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/testutils/resource_metrics.go
+++ b/tests/testutils/resource_metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/testutils/resource_metrics_test.go
+++ b/tests/testutils/resource_metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/testutils/testcase.go
+++ b/tests/testutils/testcase.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Splunk, Inc.
+// Copyright Splunk, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
1. Follow same practice of removing the year as OTel core, change via https://github.com/signalfx/splunk-otel-collector/commit/f265a082eea6e7b9755bde3cc8f09a5aa2b481e2
2. Removed year from all copyright notices on golang file headers:
```shell
$ find . -name '*.go' | xargs sed -i -r 's/^(\/\/.*Copyright.[^0-9]*)([0-9]+[, ]*)(.*)$/\1\3/g'
```
