### PR TITLE
Enable primary cloud resource detection

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -88,8 +88,10 @@ processors:
     ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     check_interval: 2s
     limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+  ## detect if the collector is running on a cloud system
+  ## important for creating unique cloud provider dimensions
   resourcedetection:
-    detectors: [system]
+    detectors: [system, gce, ecs, ec2, azure]
     override: false
 
   # Optional: The following processor can be used to add a default "deployment.environment" attribute to the logs and 


### PR DESCRIPTION
This is important to create the unique cloud dimensions,
such as `AWSUniqueId`, `gcp_id`, or `azure_resource_id`,
which our built-in content heavily relies on.

Ordering taken from https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#ordering