### PR TITLE
Unset exclusion and translations by default in gateway config

### DIFF
--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -70,10 +70,10 @@ exporters:
   signalfx:
     access_token: "${SPLUNK_ACCESS_TOKEN}"
     realm: "${SPLUNK_REALM}"
-    # no need to translate/exclude metrics when using as a gateway
-    # metrics should be translated at agent
-    translation_rules: []
-    exclude_metrics: []
+    ## Uncomment below if your agents are sending via signalfx exporter
+    ## to avoid double translations and exclusions.
+    #translation_rules: []
+    #exclude_metrics: []
   # Debug
   #logging:
     #loglevel: debug


### PR DESCRIPTION
In our other default agent config, we are recommending sending
to the gateway via OTLP. If agents are sending OTLP to the gateway,
we need to do exclusions and translations at the gateway, as these
would only occur if they were using the signalfx exporter.