### PR TITLE
Config sources: handle strings and byte slices as YAML

### DIFF
--- a/internal/configprovider/manager_test.go
+++ b/internal/configprovider/manager_test.go
@@ -240,11 +240,11 @@ map:
 	expectedFile := path.Join("testdata", "yaml_injection_expected.yaml")
 	expectedParser, err := config.NewParserFromFile(expectedFile)
 	require.NoError(t, err)
-	expectedCfg := expectedParser.Viper().AllSettings()
+	expectedCfg := expectedParser.ToStringMap()
 
 	res, err := manager.Resolve(ctx, cp)
 	require.NoError(t, err)
-	actualCfg := res.Viper().AllSettings()
+	actualCfg := res.ToStringMap()
 	assert.Equal(t, expectedCfg, actualCfg)
 	assert.NoError(t, manager.Close(ctx))
 }

--- a/internal/configprovider/testdata/yaml_injection.yaml
+++ b/internal/configprovider/testdata/yaml_injection.yaml
@@ -1,0 +1,3 @@
+yaml_00: $tstcfgsrc:valid_yaml_str
+yaml_01: $tstcfgsrc:invalid_yaml_str
+yaml_02: $tstcfgsrc:valid_yaml_byte_slice

--- a/internal/configprovider/testdata/yaml_injection_expected.yaml
+++ b/internal/configprovider/testdata/yaml_injection_expected.yaml
@@ -1,0 +1,15 @@
+yaml_00:
+  bool: true
+  int: 42
+  source: string
+  map:
+    k0: v0
+    k1: v1
+yaml_01: ":"
+yaml_02:
+  bool: true
+  int: 42
+  source: "[]byte"
+  map:
+    k0: v0
+    k1: v1


### PR DESCRIPTION
This keeps parity with SA functionality: config sources can return fragments of YAML to be injected in the configuration. Usage of it will appear on the README for env var config sources.

/cc @owais 