### PR TITLE
Allow running integration tests against Collector images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,13 @@ BUILD_INFO=-ldflags "${BUILD_X1}"
 SMART_AGENT_RELEASE=v5.10.2
 SKIP_COMPILE=false
 
+# For integration testing against local changes you can run
+# SPLUNK_OTEL_COLLECTOR_IMAGE='otelcol:latest' make -e docker-otelcol integration-test
+# for local docker build testing or
+# SPLUNK_OTEL_COLLECTOR_IMAGE='' make -e otelcol integration-test
+# for local binary testing (agent-bundle configuration required)
+export SPLUNK_OTEL_COLLECTOR_IMAGE?=quay.io/signalfx/splunk-otel-collector-dev:latest
+
 ### FUNCTIONS
 
 # Function to execute a command. Note the empty line before endef to make sure each command
@@ -81,7 +88,6 @@ integration-test:
 	  (cd "$${dir}" && \
 	   $(GOTEST) -v -timeout 5m -count 1 ./... ); \
 	done
-
 
 .PHONY: test-with-cover
 test-with-cover:

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,7 +9,7 @@ is:
 ([see example](./testutils/testdata/resourceMetrics.yaml))
 1. Spin up your target resources as [docker containers](./testutils/README.md#test-containers).
 1. Stand up an in-memory [OTLP metrics receiver and sink](./testutils/README.md#otlp-metrics-receiver-sink) capable of detecting if/when desired data are received.
-1. Spin up your [Collector as a subprocess](./testutils/README.md#collector-process) configured to report to this OTLP receiver.
+1. Spin up your Collector [as a subprocess](./testutils/README.md#collector-process) or [as a container](./testutils/README.md#collector-container) configured to report to this OTLP receiver.
   
 ...but if you are interested in something else enhancements and contributions are a great way to ensure this library
 is more useful overall.

--- a/tests/receivers/smartagent/collectd-activemq/testdata/all_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-activemq/testdata/all_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_activemq:
     type: collectd/activemq
@@ -20,7 +14,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-activemq/testdata/default_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-activemq/testdata/default_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_activemq:
     type: collectd/activemq
@@ -19,7 +13,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-apache/testdata/all_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-apache/testdata/all_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_apache:
     type: collectd/apache
@@ -18,7 +12,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-apache/testdata/default_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-apache/testdata/default_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_apache:
     type: collectd/apache
@@ -17,7 +11,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-cassandra/testdata/all_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-cassandra/testdata/all_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_cassandra:
     type: collectd/cassandra
@@ -20,7 +14,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-cassandra/testdata/default_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-cassandra/testdata/default_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_cassandra:
     type: collectd/cassandra
@@ -19,7 +13,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-couchbase/testdata/all_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-couchbase/testdata/all_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_couchbase:
     type: collectd/couchbase
@@ -21,7 +15,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-elasticsearch/testdata/all_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-elasticsearch/testdata/all_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_elasticsearch:
     type: collectd/elasticsearch
@@ -20,7 +14,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-hadoop/testdata/all_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-hadoop/testdata/all_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_hadoop:
     type: collectd/hadoop
@@ -19,7 +13,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-kafka/testdata/all_broker_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-kafka/testdata/all_broker_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_kafka:
     type: collectd/kafka
@@ -19,7 +13,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-kafka/testdata/all_consumer_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-kafka/testdata/all_consumer_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_kafka_consumer:
     type: collectd/kafka_consumer
@@ -18,7 +12,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-kafka/testdata/all_producer_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-kafka/testdata/all_producer_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_kafka_producer:
     type: collectd/kafka_producer
@@ -18,7 +12,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-nginx/testdata/all_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-nginx/testdata/all_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_nginx:
     type: collectd/nginx
@@ -18,7 +12,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-postgresql/testdata/all_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-postgresql/testdata/all_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_postgresql:
     type: collectd/postgresql
@@ -23,7 +17,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-solr/testdata/all_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-solr/testdata/all_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_solr:
     type: collectd/solr
@@ -20,7 +14,6 @@ exporters:
   logging:
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-spark/testdata/all_master_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-spark/testdata/all_master_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_spark_master:
     type: collectd/spark
@@ -22,7 +16,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/receivers/smartagent/collectd-spark/testdata/all_worker_metrics_config.yaml
+++ b/tests/receivers/smartagent/collectd-spark/testdata/all_worker_metrics_config.yaml
@@ -1,9 +1,3 @@
-extensions:
-  smartagent:
-    bundleDir: /opt/bundle
-    collectd:
-      configDir: /tmp/collectd/config
-
 receivers:
   smartagent/collectd_spark_worker:
     type: collectd/spark
@@ -21,7 +15,6 @@ exporters:
     insecure: true
 
 service:
-  extensions: [smartagent]
   pipelines:
     metrics:
       receivers:

--- a/tests/testutils/README.md
+++ b/tests/testutils/README.md
@@ -140,6 +140,23 @@ defer func() { require.NoError(t, collector.Shutdown()) }()
 collector, err = testutils.NewCollectorProcess().WithArgs("--tested-feature", "--etc").Build()
 ```
 
+### Collector Container
+
+The `CollectorContainer` is an equivalent helper type to the `CollectorProcess` but will run a container in host network
+mode for an arbitrary Collector image and tag using the config you provide.  If an image is not specified it will use a default
+of `"quay.io/signalfx/splunk-otel-collector-dev:latest"`.
+
+```go
+import "github.com/signafx/splunk-otel-collector/tests/testutils"
+
+collector, err := testutils.NewCollectorContainer().WithImage("quay.io/signalfx/splunk-otel-collector:latest",
+).WithConfigPath("my_config_path").Build()
+
+err = collector.Start()
+require.NoError(t, err)
+defer func() { require.NoError(t, collector.Shutdown()) }()
+```
+
 ### Testcase
 
 All the above test utilities can be easily configured by the `Testcase` helper to avoid unnecessary boilerplate in
@@ -147,6 +164,9 @@ resource creation and cleanup.  The associated OTLPMetricsReceiverSink for each 
 endpoint that can be rendered via the `"${OTLP_ENDPOINT}"` environment variable in your tested config. `testutils`
 provides a general `AssertAllMetricsReceived()` function that utilizes this type to stand up all the necessary resources
 associated with a test and assert that all expected metrics are received:
+
+If the `SPLUNK_OTEL_COLLECTOR_IMAGE` environment variable is set and not empty its value will be used to start a
+`CollectorContainer` instead of a subprocess.
 
 ```go
 import "github.com/signafx/splunk-otel-collector/tests/testutils"

--- a/tests/testutils/collector.go
+++ b/tests/testutils/collector.go
@@ -1,0 +1,30 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"go.uber.org/zap"
+)
+
+type Collector interface {
+	WithConfigPath(path string) Collector
+	WithArgs(args ...string) Collector
+	WithEnv(env map[string]string) Collector
+	WithLogger(logger *zap.Logger) Collector
+	WithLogLevel(level string) Collector
+	Build() (Collector, error)
+	Start() error
+	Shutdown() error
+}

--- a/tests/testutils/collector_container.go
+++ b/tests/testutils/collector_container.go
@@ -1,0 +1,199 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/testcontainers/testcontainers-go"
+	"go.uber.org/zap"
+)
+
+var _ Collector = (*CollectorContainer)(nil)
+var _ testcontainers.LogConsumer = (*collectorLogConsumer)(nil)
+
+type CollectorContainer struct {
+	Image          string
+	ConfigPath     string
+	Args           []string
+	Logger         *zap.Logger
+	LogLevel       string
+	Container      Container
+	contextArchive io.Reader
+	logConsumer    collectorLogConsumer
+}
+
+// To be used as a builder whose Build() method provides the actual instance capable of launching the process.
+func NewCollectorContainer() CollectorContainer {
+	return CollectorContainer{Args: []string{}, Container: NewContainer()}
+}
+
+// quay.io/signalfx/splunk-otel-collector:latest by default
+func (collector CollectorContainer) WithImage(image string) CollectorContainer {
+	collector.Image = image
+	return collector
+}
+
+// Will use bundled config by default
+func (collector CollectorContainer) WithConfigPath(path string) Collector {
+	collector.ConfigPath = path
+	return &collector
+}
+
+// []string{} by default, but currently a noop
+func (collector CollectorContainer) WithArgs(args ...string) Collector {
+	collector.Args = args
+	return &collector
+}
+
+// empty by default
+func (collector CollectorContainer) WithEnv(env map[string]string) Collector {
+	collector.Container = collector.Container.WithEnv(env)
+	return &collector
+}
+
+// Nop logger by default
+func (collector CollectorContainer) WithLogger(logger *zap.Logger) Collector {
+	collector.Logger = logger
+	return &collector
+}
+
+// "info" by default, but currently a noop
+func (collector CollectorContainer) WithLogLevel(level string) Collector {
+	collector.LogLevel = level
+	return &collector
+}
+
+func (collector CollectorContainer) Build() (Collector, error) {
+	if collector.Image == "" {
+		collector.Image = "quay.io/signalfx/splunk-otel-collector:latest"
+	}
+	if collector.Logger == nil {
+		collector.Logger = zap.NewNop()
+	}
+	if collector.LogLevel == "" {
+		collector.LogLevel = "info"
+	}
+
+	collector.logConsumer = newCollectorLogConsumer(collector.Logger)
+
+	var err error
+	collector.contextArchive, err = collector.buildContextArchive()
+	if err != nil {
+		return nil, err
+	}
+	collector.Container = collector.Container.WithContextArchive(
+		collector.contextArchive,
+	).WithNetworkMode("host").WillWaitForLogs("Everything is ready. Begin running and processing data.")
+	collector.Container = *(collector.Container.Build())
+
+	return &collector, nil
+}
+
+func (collector *CollectorContainer) Start() error {
+	if collector.contextArchive == nil {
+		return fmt.Errorf("cannot Start a CollectorContainer that hasn't been successfully built")
+	}
+
+	err := collector.Container.Start(context.Background())
+	if err != nil {
+		return err
+	}
+	collector.Container.FollowOutput(collector.logConsumer)
+	return collector.Container.StartLogProducer(context.Background())
+}
+
+func (collector *CollectorContainer) Shutdown() error {
+	if collector.contextArchive == nil {
+		return fmt.Errorf("cannot Shutdown a CollectorContainer that hasn't been successfully built")
+	}
+	defer collector.Container.StopLogProducer()
+	return collector.Container.Terminate(context.Background())
+}
+
+func (collector CollectorContainer) buildContextArchive() (io.Reader, error) {
+	var buf bytes.Buffer
+	tarWriter := tar.NewWriter(&buf)
+
+	dockerfile := fmt.Sprintf("FROM %s\n", collector.Image)
+	if collector.ConfigPath != "" {
+		config, err := os.ReadFile(collector.ConfigPath)
+		if err != nil {
+			return nil, err
+		}
+		header := tar.Header{
+			Name:     "config.yaml",
+			Mode:     0777,
+			Size:     int64(len(config)),
+			Typeflag: tar.TypeReg,
+			Format:   tar.FormatGNU,
+		}
+		if err := tarWriter.WriteHeader(&header); err != nil {
+			return nil, err
+		}
+		if _, err := tarWriter.Write(config); err != nil {
+			return nil, err
+		}
+
+		dockerfile += `
+COPY config.yaml /etc/config.yaml
+ENV SPLUNK_CONFIG=/etc/config.yaml
+
+ENV SPLUNK_ACCESS_TOKEN=12345
+ENV SPLUNK_REALM=us0
+`
+	}
+
+	header := tar.Header{
+		Name:     "Dockerfile",
+		Mode:     0777,
+		Size:     int64(len(dockerfile)),
+		Typeflag: tar.TypeReg,
+		Format:   tar.FormatGNU,
+	}
+	if err := tarWriter.WriteHeader(&header); err != nil {
+		return nil, err
+	}
+	if _, err := tarWriter.Write([]byte(dockerfile)); err != nil {
+		return nil, err
+	}
+	if err := tarWriter.Close(); err != nil {
+		return nil, err
+	}
+	reader := bytes.NewReader(buf.Bytes())
+	return reader, nil
+}
+
+type collectorLogConsumer struct {
+	logger *zap.Logger
+}
+
+func newCollectorLogConsumer(logger *zap.Logger) collectorLogConsumer {
+	return collectorLogConsumer{logger: logger}
+}
+
+func (l collectorLogConsumer) Accept(log testcontainers.Log) {
+	msg := string(log.Content)
+	if log.LogType == testcontainers.StderrLog {
+		l.logger.Info(msg)
+	} else {
+		l.logger.Debug(msg)
+	}
+}

--- a/tests/testutils/collector_container_test.go
+++ b/tests/testutils/collector_container_test.go
@@ -1,0 +1,128 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestCollectorContainerBuilders(t *testing.T) {
+	builder := NewCollectorContainer()
+	require.NotNil(t, builder)
+
+	assert.Empty(t, builder.Image)
+	assert.Empty(t, builder.ConfigPath)
+
+	withImage := builder.WithImage("someimage")
+	assert.Equal(t, "someimage", withImage.Image)
+	assert.Empty(t, builder.Image)
+
+	withConfigPath, ok := builder.WithConfigPath("someconfigpath").(*CollectorContainer)
+	require.True(t, ok)
+	assert.Equal(t, "someconfigpath", withConfigPath.ConfigPath)
+	assert.Empty(t, builder.ConfigPath)
+
+	withArgs, ok := builder.WithArgs("arg_one", "arg_two", "arg_three").(*CollectorContainer)
+	require.True(t, ok)
+	assert.Equal(t, []string{"arg_one", "arg_two", "arg_three"}, withArgs.Args)
+	assert.Empty(t, builder.Args)
+
+	logger := zap.NewNop()
+	withLogger, ok := builder.WithLogger(logger).(*CollectorContainer)
+	require.True(t, ok)
+	assert.Same(t, logger, withLogger.Logger)
+	assert.Nil(t, builder.Logger)
+
+	withLogLevel, ok := builder.WithLogLevel("someloglevel").(*CollectorContainer)
+	require.True(t, ok)
+	assert.Equal(t, "someloglevel", withLogLevel.LogLevel)
+	assert.Empty(t, builder.LogLevel)
+}
+
+func TestContainerConfigPathNotRequiredUponBuildWithArgs(t *testing.T) {
+	withArgs := NewCollectorContainer().WithArgs("arg_one", "arg_two")
+
+	collector, err := withArgs.Build()
+	require.NoError(t, err)
+	require.NotNil(t, collector)
+}
+
+func TestCollectorContainerBuildDefaults(t *testing.T) {
+	builder := NewCollectorContainer()
+
+	c, err := builder.Build()
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	collector, ok := c.(*CollectorContainer)
+	require.True(t, ok)
+
+	assert.Equal(t, "quay.io/signalfx/splunk-otel-collector:latest", collector.Image)
+	assert.Equal(t, "", collector.ConfigPath)
+	assert.NotNil(t, collector.Logger)
+	assert.Equal(t, "info", collector.LogLevel)
+	assert.Equal(t, []string{}, collector.Args)
+}
+
+func TestStartAndShutdownInvalidWithoutBuildingContainer(t *testing.T) {
+	builder := NewCollectorContainer()
+
+	err := builder.Start()
+	require.Error(t, err)
+	require.EqualError(t, err, "cannot Start a CollectorContainer that hasn't been successfully built")
+
+	err = builder.Shutdown()
+	require.Error(t, err)
+	require.EqualError(t, err, "cannot Shutdown a CollectorContainer that hasn't been successfully built")
+}
+
+func TestCollectorContainerWithInvalidImage(t *testing.T) {
+	collector, err := NewCollectorContainer().WithImage("&%notanimage%&:latest").Build()
+	require.NotNil(t, collector)
+	require.NoError(t, err)
+
+	err = collector.Start()
+	require.Contains(t, err.Error(), "failed to create container: Error response from daemon: No such image")
+
+	err = collector.Shutdown()
+	require.EqualError(t, err, "cannot invoke Terminate() on unstarted container")
+}
+
+func TestCollectorContainerWithInvalidConfigPath(t *testing.T) {
+	collector, err := NewCollectorContainer().WithConfigPath("notaconfig").Build()
+	require.Nil(t, collector)
+	require.EqualError(t, err, "open notaconfig: no such file or directory")
+}
+
+func TestCollectorContainerLogging(t *testing.T) {
+	builder := NewCollectorContainer()
+
+	c, err := builder.Build()
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	collector, ok := c.(*CollectorContainer)
+	require.True(t, ok)
+
+	assert.Equal(t, "quay.io/signalfx/splunk-otel-collector:latest", collector.Image)
+	assert.Equal(t, "", collector.ConfigPath)
+	assert.NotNil(t, collector.Logger)
+	assert.Equal(t, "info", collector.LogLevel)
+	assert.Equal(t, []string{}, collector.Args)
+}

--- a/tests/testutils/collector_process.go
+++ b/tests/testutils/collector_process.go
@@ -27,6 +27,8 @@ import (
 const binaryPathSuffix = "/bin/otelcol"
 const findExecutableErrorMsg = "unable to find collector executable path.  Be sure to run `make otelcol`"
 
+var _ Collector = (*CollectorProcess)(nil)
+
 type CollectorProcess struct {
 	Path             string
 	ConfigPath       string
@@ -50,36 +52,36 @@ func (collector CollectorProcess) WithPath(path string) CollectorProcess {
 }
 
 // Required
-func (collector CollectorProcess) WithConfigPath(path string) CollectorProcess {
+func (collector CollectorProcess) WithConfigPath(path string) Collector {
 	collector.ConfigPath = path
-	return collector
+	return &collector
 }
 
 // []string{"--log-level", collector.LogLevel, "--config", collector.ConfigPath, "--metrics-level", "none"} by default
-func (collector CollectorProcess) WithArgs(args ...string) CollectorProcess {
+func (collector CollectorProcess) WithArgs(args ...string) Collector {
 	collector.Args = args
-	return collector
+	return &collector
 }
 
 // empty by default
-func (collector CollectorProcess) WithEnv(env map[string]string) CollectorProcess {
+func (collector CollectorProcess) WithEnv(env map[string]string) Collector {
 	collector.Env = env
-	return collector
+	return &collector
 }
 
 // Nop logger by default
-func (collector CollectorProcess) WithLogger(logger *zap.Logger) CollectorProcess {
+func (collector CollectorProcess) WithLogger(logger *zap.Logger) Collector {
 	collector.Logger = logger
-	return collector
+	return &collector
 }
 
 // info by default
-func (collector CollectorProcess) WithLogLevel(level string) CollectorProcess {
+func (collector CollectorProcess) WithLogLevel(level string) Collector {
 	collector.LogLevel = level
-	return collector
+	return &collector
 }
 
-func (collector CollectorProcess) Build() (*CollectorProcess, error) {
+func (collector CollectorProcess) Build() (Collector, error) {
 	if collector.ConfigPath == "" && collector.Args == nil {
 		return nil, fmt.Errorf("you must specify a ConfigPath for your CollectorProcess before building")
 	}

--- a/tests/testutils/otlp_receiver_sink_test.go
+++ b/tests/testutils/otlp_receiver_sink_test.go
@@ -103,11 +103,11 @@ func otlpExporter(t *testing.T) component.MetricsExporter {
 	exporterCfg := otlpexporter.Config{
 		ExporterSettings: &config.ExporterSettings{NameVal: "otlp", TypeVal: "otlp"},
 		GRPCClientSettings: configgrpc.GRPCClientSettings{
-		Endpoint: "localhost:4317",
-		TLSSetting: configtls.TLSClientSetting{
-			Insecure: true,
-		},
-	}}
+			Endpoint: "localhost:4317",
+			TLSSetting: configtls.TLSClientSetting{
+				Insecure: true,
+			},
+		}}
 	otlpExporterFactory := otlpexporter.NewFactory()
 	ctx := context.Background()
 	createParams := component.ExporterCreateParams{Logger: zap.NewNop()}


### PR DESCRIPTION
These changes allow running the existing integration tests against* an arbitrary collector container.  They add a new `CollectorContainer` type that implements the now unified `Collector` interface broken out from the previously lone `CollectorProcess`.   The `make integration-test` target uses this collector type by default to run against `quay.io/signalfx/splunk-otel-collector-dev:latest`.

Also updates the integration test configs to not use the agent extension.  These are breaking changes that require running against a collector binary with a properly configured agent bundle.  An easy way to avoid this and still test local changes is to run:

```bash
SPLUNK_OTEL_COLLECTOR_IMAGE='otelcol:latest' make -e docker-otelcol integration-test
```

Running Collector containers with command line arguments is not currently provided.  This should be added shortly in a follow-up PR.
