### PR TITLE
Avoid using removed functionality (Parser.Viper) from otel core

### DIFF
--- a/internal/configprovider/manager.go
+++ b/internal/configprovider/manager.go
@@ -514,12 +514,11 @@ func parseCfgSrc(s string) (cfgSrcName, selector string, params interface{}, err
 		selector = strings.Trim(parts[0], " ")
 
 		if len(parts) > 1 && len(parts[1]) > 0 {
-			v := config.NewParser().Viper()
-			v.SetConfigType("yaml")
-			if err = v.ReadConfig(bytes.NewReader([]byte(parts[1]))); err != nil {
+			var p *config.Parser
+			if p, err = config.NewParserFromBuffer(bytes.NewReader([]byte(parts[1]))); err != nil {
 				return
 			}
-			params = v.AllSettings()
+			params = p.ToStringMap()
 		}
 
 	default:

--- a/internal/configprovider/manager_test.go
+++ b/internal/configprovider/manager_test.go
@@ -106,8 +106,7 @@ func TestConfigSourceManager_Simple(t *testing.T) {
 
 	res, err := manager.Resolve(ctx, cp)
 	require.NoError(t, err)
-	actualCfg := res.Viper().AllSettings()
-	assert.Equal(t, expectedCfg, actualCfg)
+	assert.Equal(t, expectedCfg, res.ToStringMap())
 
 	doneCh := make(chan struct{})
 	var errWatcher error
@@ -141,7 +140,7 @@ func TestConfigSourceManager_ResolveRemoveConfigSourceSection(t *testing.T) {
 	require.NotNil(t, res)
 
 	delete(cfg, "config_sources")
-	assert.Equal(t, cfg, res.Viper().AllSettings())
+	assert.Equal(t, cfg, res.ToStringMap())
 }
 
 func TestConfigSourceManager_ResolveErrors(t *testing.T) {
@@ -227,12 +226,10 @@ func TestConfigSourceManager_ArraysAndMaps(t *testing.T) {
 	expectedFile := path.Join("testdata", "arrays_and_maps_expected.yaml")
 	expectedParser, err := config.NewParserFromFile(expectedFile)
 	require.NoError(t, err)
-	expectedCfg := expectedParser.Viper().AllSettings()
 
 	res, err := manager.Resolve(ctx, cp)
 	require.NoError(t, err)
-	actualCfg := res.Viper().AllSettings()
-	assert.Equal(t, expectedCfg, actualCfg)
+	assert.Equal(t, expectedParser.ToStringMap(), res.ToStringMap())
 	assert.NoError(t, manager.Close(ctx))
 }
 
@@ -279,12 +276,10 @@ func TestConfigSourceManager_ParamsHandling(t *testing.T) {
 	expectedFile := path.Join("testdata", "params_handling_expected.yaml")
 	expectedParser, err := config.NewParserFromFile(expectedFile)
 	require.NoError(t, err)
-	expectedCfg := expectedParser.Viper().AllSettings()
 
 	res, err := manager.Resolve(ctx, cp)
 	require.NoError(t, err)
-	actualCfg := res.Viper().AllSettings()
-	assert.Equal(t, expectedCfg, actualCfg)
+	assert.Equal(t, expectedParser.ToStringMap(), res.ToStringMap())
 	assert.NoError(t, manager.Close(ctx))
 }
 
@@ -420,12 +415,10 @@ func TestConfigSourceManager_EnvVarHandling(t *testing.T) {
 	expectedFile := path.Join("testdata", "envvar_cfgsrc_mix_expected.yaml")
 	expectedParser, err := config.NewParserFromFile(expectedFile)
 	require.NoError(t, err)
-	expectedCfg := expectedParser.Viper().AllSettings()
 
 	res, err := manager.Resolve(ctx, cp)
 	require.NoError(t, err)
-	actualCfg := res.Viper().AllSettings()
-	assert.Equal(t, expectedCfg, actualCfg)
+	assert.Equal(t, expectedParser.ToStringMap(), res.ToStringMap())
 	assert.NoError(t, manager.Close(ctx))
 }
 

--- a/internal/extension/smartagentextension/config.go
+++ b/internal/extension/smartagentextension/config.go
@@ -47,7 +47,7 @@ func (cfg Config) SmartAgentConfig() *saconfig.Config {
 }
 
 func (cfg *Config) Unmarshal(componentParser *config.Parser) error {
-	allSettings := componentParser.Viper().AllSettings()
+	allSettings := componentParser.ToStringMap()
 
 	configDirSet := false
 	if collectd, ok := allSettings["collectd"]; ok {

--- a/internal/receiver/smartagentreceiver/config.go
+++ b/internal/receiver/smartagentreceiver/config.go
@@ -70,7 +70,7 @@ func (cfg *Config) Unmarshal(componentParser *config.Parser) error {
 	// AllSettings() is the user provided config and intoCfg is the default Config instance we populate to
 	// form the final desired version. To do so, we manually obtain all Config items, leaving only Smart Agent
 	// monitor config settings to be unmarshalled to their respective custom monitor config types.
-	allSettings := componentParser.Viper().AllSettings()
+	allSettings := componentParser.ToStringMap()
 	monitorType, ok := allSettings["type"].(string)
 	if !ok || monitorType == "" {
 		return fmt.Errorf("you must specify a \"type\" for a smartagent receiver")


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>