### PR TITLE
Avoid using type casting on Config, otel core guarantees access to instances

### DIFF
--- a/internal/extension/smartagentextension/config.go
+++ b/internal/extension/smartagentextension/config.go
@@ -27,12 +27,6 @@ import (
 	"github.com/signalfx/splunk-otel-collector/internal/utils"
 )
 
-// SmartAgentConfigProvider exposes global saconfig.Config to other components
-type SmartAgentConfigProvider interface {
-	SmartAgentConfig() *saconfig.Config
-}
-
-var _ SmartAgentConfigProvider = (*Config)(nil)
 var _ config.CustomUnmarshable = (*Config)(nil)
 
 type Config struct {
@@ -40,10 +34,6 @@ type Config struct {
 	// Agent uses yaml, which mapstructure doesn't support.
 	// Custom unmarshaller required for yaml and SFx defaults usage.
 	saconfig.Config `mapstructure:"-,squash"`
-}
-
-func (cfg Config) SmartAgentConfig() *saconfig.Config {
-	return &cfg.Config
 }
 
 func (cfg *Config) Unmarshal(componentParser *config.Parser) error {

--- a/internal/extension/smartagentextension/config_linux_test.go
+++ b/internal/extension/smartagentextension/config_linux_test.go
@@ -16,10 +16,12 @@
 package smartagentextension
 
 import (
+	"context"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configtest"
 )
@@ -42,7 +44,11 @@ func TestBundleDirDefault(t *testing.T) {
 	allSettingsConfig := cfg.Extensions["smartagent/default_settings"]
 	require.NotNil(t, allSettingsConfig)
 
-	saConfigProvider, ok := allSettingsConfig.(SmartAgentConfigProvider)
+	ext, err := factory.CreateExtension(context.Background(), component.ExtensionCreateParams{}, allSettingsConfig)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+
+	saConfigProvider, ok := ext.(SmartAgentConfigProvider)
 	require.True(t, ok)
 
 	require.Equal(t, "/usr/lib/splunk-otel-collector/agent-bundle", saConfigProvider.SmartAgentConfig().BundleDir)

--- a/internal/extension/smartagentextension/config_test.go
+++ b/internal/extension/smartagentextension/config_test.go
@@ -123,6 +123,9 @@ func TestSmartAgentConfigProvider(t *testing.T) {
 	require.NotNil(t, allSettingsConfig)
 
 	ext, err := factory.CreateExtension(context.Background(), component.ExtensionCreateParams{}, allSettingsConfig)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+
 	saConfigProvider, ok := ext.(SmartAgentConfigProvider)
 	require.True(t, ok)
 

--- a/internal/extension/smartagentextension/config_test.go
+++ b/internal/extension/smartagentextension/config_test.go
@@ -15,6 +15,7 @@
 package smartagentextension
 
 import (
+	"context"
 	"path"
 	"path/filepath"
 	"testing"
@@ -25,6 +26,7 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/core/config/sources/file"
 	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcheck"
@@ -120,7 +122,8 @@ func TestSmartAgentConfigProvider(t *testing.T) {
 	allSettingsConfig := cfg.Extensions["smartagent/all_settings"]
 	require.NotNil(t, allSettingsConfig)
 
-	saConfigProvider, ok := allSettingsConfig.(SmartAgentConfigProvider)
+	ext, err := factory.CreateExtension(context.Background(), component.ExtensionCreateParams{}, allSettingsConfig)
+	saConfigProvider, ok := ext.(SmartAgentConfigProvider)
 	require.True(t, ok)
 
 	require.Equal(t, func() saconfig.CollectdConfig {

--- a/internal/extension/smartagentextension/config_windows_test.go
+++ b/internal/extension/smartagentextension/config_windows_test.go
@@ -16,10 +16,12 @@
 package smartagentextension
 
 import (
+	"context"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configtest"
 )
@@ -42,7 +44,11 @@ func TestBundleDirDefault(t *testing.T) {
 	allSettingsConfig := cfg.Extensions["smartagent/default_settings"]
 	require.NotNil(t, allSettingsConfig)
 
-	saConfigProvider, ok := allSettingsConfig.(SmartAgentConfigProvider)
+	ext, err := factory.CreateExtension(context.Background(), component.ExtensionCreateParams{}, allSettingsConfig)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+
+	saConfigProvider, ok := ext.(SmartAgentConfigProvider)
 	require.True(t, ok)
 
 	require.Equal(t, "C:\\Program Files\\Splunk\\OpenTelemetry Collector\\agent-bundle", saConfigProvider.SmartAgentConfig().BundleDir)

--- a/internal/extension/smartagentextension/extension.go
+++ b/internal/extension/smartagentextension/extension.go
@@ -17,14 +17,20 @@ package smartagentextension
 import (
 	"context"
 
+	saconfig "github.com/signalfx/signalfx-agent/pkg/core/config"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config"
 )
 
-type smartAgentConfigExtension struct {
+// SmartAgentConfigProvider exposes global saconfig.Config to other components
+type SmartAgentConfigProvider interface {
+	SmartAgentConfig() *saconfig.Config
 }
 
-var _ component.Extension = (*smartAgentConfigExtension)(nil)
+type smartAgentConfigExtension struct {
+	saCfg *saconfig.Config
+}
+
+var _ SmartAgentConfigProvider = (*smartAgentConfigExtension)(nil)
 
 func (sae *smartAgentConfigExtension) Start(_ context.Context, _ component.Host) error {
 	return nil
@@ -34,6 +40,10 @@ func (sae *smartAgentConfigExtension) Shutdown(_ context.Context) error {
 	return nil
 }
 
-func newSmartAgentConfigExtension(_ config.Extension) (*smartAgentConfigExtension, error) {
-	return &smartAgentConfigExtension{}, nil
+func (sae *smartAgentConfigExtension) SmartAgentConfig() *saconfig.Config {
+	return sae.saCfg
+}
+
+func newSmartAgentConfigExtension(cfg *Config) (component.Extension, error) {
+	return &smartAgentConfigExtension{saCfg: &cfg.Config}, nil
 }

--- a/internal/extension/smartagentextension/factory.go
+++ b/internal/extension/smartagentextension/factory.go
@@ -88,5 +88,5 @@ func createExtension(
 	_ component.ExtensionCreateParams,
 	cfg config.Extension,
 ) (component.Extension, error) {
-	return newSmartAgentConfigExtension(cfg)
+	return newSmartAgentConfigExtension(cfg.(*Config))
 }

--- a/internal/receiver/smartagentreceiver/receiver_test.go
+++ b/internal/receiver/smartagentreceiver/receiver_test.go
@@ -323,7 +323,7 @@ func TestSmartAgentConfigProviderOverrides(t *testing.T) {
 		HasGenericJMXMonitor: false,
 		InstanceName:         "",
 		WriteServerQuery:     "",
-	}, saConfigProvider.SmartAgentConfig().Collectd)
+	}, saConfig.Collectd)
 
 	// Ensure envs are setup.
 	require.Equal(t, "/opt/", os.Getenv("SIGNALFX_BUNDLE_DIR"))
@@ -384,7 +384,7 @@ func (m *mockHost) GetExtensions() map[config.NamedEntity]component.Extension {
 	return map[config.NamedEntity]component.Extension{
 		m.smartagentextensionConfig:      getExtension(smartagentextension.NewFactory(), m.smartagentextensionConfig),
 		randomExtensionConfig:            getExtension(exampleFactory, randomExtensionConfig),
-		m.smartagentextensionConfigExtra: nil,
+		m.smartagentextensionConfigExtra: getExtension(smartagentextension.NewFactory(), m.smartagentextensionConfigExtra),
 	}
 }
 


### PR DESCRIPTION
OpenTelemetry collector core in the Host interface does not guarantee access to the Config as a Key in the map (which is NamedInstance and not config.Extension).

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>