### PR TITLE
nit: >, not >=

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -271,7 +271,7 @@ func setMemoryLimit(memTotalSizeMiB int) {
 	args := os.Args[1:]
 	b := getKeyValue(args, "--mem-ballast-size-mib")
 	ballastSize, _ := strconv.Atoi(b)
-	if (ballastSize * 2) >= memLimit {
+	if (ballastSize * 2) > memLimit {
 		log.Fatalf("Memory limit (%v) is less than 2x ballast (%v). Increase memory limit or decrease ballast size.", memLimit, ballastSize)
 	}
 


### PR DESCRIPTION
Use a strict greater than so folks can set ballast as exactly 2x the memory limit.

Right now, we get this message:
```
2021/05/06 00:44:51 main.go:276: Memory limit (512) is less than 2x ballast (256). Increase memory limit or decrease ballast size.
```