### PR TITLE
Enable capabilities in deb/rpm postinstall

### DIFF
--- a/internal/buildscripts/packaging/fpm/deb/build.sh
+++ b/internal/buildscripts/packaging/fpm/deb/build.sh
@@ -50,6 +50,7 @@ sudo fpm -s dir -t deb -n "$PKG_NAME" -v "$VERSION" -f -p "$OUTPUT_DIR" \
     --architecture "$ARCH" \
     --deb-dist "stable" \
     --deb-use-file-permissions \
+    --depends libcap2-bin \
     --before-install "$PREINSTALL_PATH" \
     --after-install "$POSTINSTALL_PATH" \
     --before-remove "$PREUNINSTALL_PATH" \

--- a/internal/buildscripts/packaging/fpm/postinstall.sh
+++ b/internal/buildscripts/packaging/fpm/postinstall.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+setcap CAP_SYS_PTRACE,CAP_DAC_READ_SEARCH=+eip /usr/bin/otelcol
+
 if [ -f /usr/lib/splunk-otel-collector/agent-bundle/bin/patch-interpreter ]; then
     /usr/lib/splunk-otel-collector/agent-bundle/bin/patch-interpreter /usr/lib/splunk-otel-collector/agent-bundle
 fi

--- a/internal/buildscripts/packaging/fpm/rpm/build.sh
+++ b/internal/buildscripts/packaging/fpm/rpm/build.sh
@@ -55,6 +55,7 @@ sudo fpm -s dir -t rpm -n "$PKG_NAME" -v "$VERSION" -f -p "$OUTPUT_DIR" \
     --architecture "$ARCH" \
     --rpm-summary "$PKG_DESCRIPTION" \
     --rpm-use-file-permissions \
+    --depends libcap \
     --before-install "$PREINSTALL_PATH" \
     --after-install "$POSTINSTALL_PATH" \
     --before-remove "$PREUNINSTALL_PATH" \

--- a/internal/buildscripts/packaging/tests/package_test.py
+++ b/internal/buildscripts/packaging/tests/package_test.py
@@ -65,6 +65,16 @@ def test_collector_package_install(distro):
     pkg_base = os.path.basename(pkg_path)
 
     with run_distro_container(distro) as container:
+        # install setcap dependency
+        if distro in RPM_DISTROS:
+            if container.exec_run("command -v yum").exit_code == 0:
+                run_container_cmd(container, "yum install -y libcap")
+            else:
+                run_container_cmd(container, "dnf install -y libcap")
+        else:
+            run_container_cmd(container, "apt-get update")
+            run_container_cmd(container, "apt-get install -y libcap2-bin")
+
         copy_file_into_container(container, pkg_path, f"/test/{pkg_base}")
 
         try:


### PR DESCRIPTION
- Set the `CAP_SYS_PTRACE` and `CAP_DAC_READ_SEARCH` capabilities for `/usr/bin/otelcol` during deb/rpm postinstall (similar to the smart agent)
- Add the `setcap` package dependency