### PR TITLE
Add six to pip requirements for tests

### DIFF
--- a/internal/buildscripts/packaging/tests/requirements.txt
+++ b/internal/buildscripts/packaging/tests/requirements.txt
@@ -2,3 +2,4 @@ docker==5.0.0
 pytest==6.2.4
 pytest-html==3.1.1
 pytest-xdist==2.2.1
+six==1.16.0


### PR DESCRIPTION
Explicitly add `six` as a requirement for pytest dependencies as a workaround for https://github.com/docker/docker-py/issues/2807.