### PR TITLE
Workaround ansible.builtin.apt_key module bug in ansible 4.0.0

### DIFF
--- a/deployments/ansible/roles/collector/tasks/apt_install_otel_collector.yml
+++ b/deployments/ansible/roles/collector/tasks/apt_install_otel_collector.yml
@@ -10,9 +10,15 @@
     update_cache: yes
 
 - name: Add an apt signing key for Splunk OpenTelemetry Collector
-  ansible.builtin.apt_key:
+  # TODO: Uncomment once ansible-core 4.0.1 released.
+  #       Using ansible.builtin.get_url for now due to bug in ansible-core 4.0.0
+  #       https://github.com/ansible/ansible/issues/74424
+  # ansible.builtin.apt_key:
+  #   url: "{{ splunk_repo_base_url }}/otel-collector-deb/splunk-B3CD4420.gpg"
+  #   keyring: /etc/apt/trusted.gpg.d/splunk.gpg
+  ansible.builtin.get_url:
     url: "{{ splunk_repo_base_url }}/otel-collector-deb/splunk-B3CD4420.gpg"
-    keyring: /etc/apt/trusted.gpg.d/splunk.gpg
+    dest: /etc/apt/trusted.gpg.d/splunk.gpg
 
 - name: Add Splunk OpenTelemetry Collector repo to apt source list
   ansible.builtin.apt_repository:

--- a/deployments/ansible/roles/collector/tasks/apt_install_otel_collector.yml
+++ b/deployments/ansible/roles/collector/tasks/apt_install_otel_collector.yml
@@ -10,15 +10,18 @@
     update_cache: yes
 
 - name: Add an apt signing key for Splunk OpenTelemetry Collector
-  # TODO: Uncomment once ansible-core 4.0.1 released.
-  #       Using ansible.builtin.get_url for now due to bug in ansible-core 4.0.0
-  #       https://github.com/ansible/ansible/issues/74424
-  # ansible.builtin.apt_key:
-  #   url: "{{ splunk_repo_base_url }}/otel-collector-deb/splunk-B3CD4420.gpg"
-  #   keyring: /etc/apt/trusted.gpg.d/splunk.gpg
+  ansible.builtin.apt_key:
+    url: "{{ splunk_repo_base_url }}/otel-collector-deb/splunk-B3CD4420.gpg"
+    keyring: /etc/apt/trusted.gpg.d/splunk.gpg
+  when: ansible_version.full != '2.11.0'
+
+# NOTE: Using ansible.builtin.get_url instead of ansible.builtin.apt_key due to a bug
+#       in ansible-core 2.11.0 https://github.com/ansible/ansible/issues/74424
+- name: Download an apt signing key for Splunk OpenTelemetry Collector
   ansible.builtin.get_url:
     url: "{{ splunk_repo_base_url }}/otel-collector-deb/splunk-B3CD4420.gpg"
     dest: /etc/apt/trusted.gpg.d/splunk.gpg
+  when: ansible_version.full == '2.11.0'
 
 - name: Add Splunk OpenTelemetry Collector repo to apt source list
   ansible.builtin.apt_repository:

--- a/deployments/ansible/roles/collector/tasks/apt_install_otel_collector.yml
+++ b/deployments/ansible/roles/collector/tasks/apt_install_otel_collector.yml
@@ -13,7 +13,7 @@
   ansible.builtin.apt_key:
     url: "{{ splunk_repo_base_url }}/otel-collector-deb/splunk-B3CD4420.gpg"
     keyring: /etc/apt/trusted.gpg.d/splunk.gpg
-  when: ansible_version.full != '2.11.0'
+  when: ansible_version.full is version('2.11.0', '!=') 
 
 # NOTE: Using ansible.builtin.get_url instead of ansible.builtin.apt_key due to a bug
 #       in ansible-core 2.11.0 https://github.com/ansible/ansible/issues/74424
@@ -21,7 +21,7 @@
   ansible.builtin.get_url:
     url: "{{ splunk_repo_base_url }}/otel-collector-deb/splunk-B3CD4420.gpg"
     dest: /etc/apt/trusted.gpg.d/splunk.gpg
-  when: ansible_version.full == '2.11.0'
+  when: ansible_version.full is version('2.11.0', '==') 
 
 - name: Add Splunk OpenTelemetry Collector repo to apt source list
   ansible.builtin.apt_repository:

--- a/deployments/ansible/roles/collector/tasks/apt_install_otel_collector.yml
+++ b/deployments/ansible/roles/collector/tasks/apt_install_otel_collector.yml
@@ -13,7 +13,7 @@
   ansible.builtin.apt_key:
     url: "{{ splunk_repo_base_url }}/otel-collector-deb/splunk-B3CD4420.gpg"
     keyring: /etc/apt/trusted.gpg.d/splunk.gpg
-  when: ansible_version.full is version('2.11.0', '!=') 
+  when: ansible_version.full is version('2.11.0', '!=')
 
 # NOTE: Using ansible.builtin.get_url instead of ansible.builtin.apt_key due to a bug
 #       in ansible-core 2.11.0 https://github.com/ansible/ansible/issues/74424
@@ -21,7 +21,7 @@
   ansible.builtin.get_url:
     url: "{{ splunk_repo_base_url }}/otel-collector-deb/splunk-B3CD4420.gpg"
     dest: /etc/apt/trusted.gpg.d/splunk.gpg
-  when: ansible_version.full is version('2.11.0', '==') 
+  when: ansible_version.full is version('2.11.0', '==')
 
 - name: Add Splunk OpenTelemetry Collector repo to apt source list
   ansible.builtin.apt_repository:


### PR DESCRIPTION
`ansible.builtin.apt_key` module has a know bug in ansible v4.0.0 https://github.com/ansible/ansible/issues/74424 which is fixed in the version 4.0.1 that will be released on May 24. Until that use `ansible.builtin.get_url` module instead