### PR TITLE
Correctly handle nil value on the config provider

### DIFF
--- a/internal/configprovider/manager.go
+++ b/internal/configprovider/manager.go
@@ -473,8 +473,13 @@ func (m *Manager) expandString(ctx context.Context, s string) (interface{}, erro
 					return retrieved, nil
 				}
 
-				// Either there was a prefix already or there are still
-				// characters to be processed.
+				// Either there was a prefix already or there are still characters to be processed.
+				if retrieved == nil {
+					// Since this is going to be concatenated to a string use "" instead of nil,
+					// otherwise the string will end up with "<nil>".
+					retrieved = ""
+				}
+
 				buf = append(buf, fmt.Sprintf("%v", retrieved)...)
 			}
 

--- a/internal/configprovider/manager_test.go
+++ b/internal/configprovider/manager_test.go
@@ -472,6 +472,7 @@ func TestManager_expandString(t *testing.T) {
 			ValueMap: map[string]valueEntry{
 				"str_key": {Value: "test_value"},
 				"int_key": {Value: 1},
+				"nil_key": {Value: nil},
 			},
 		},
 		"tstcfgsrc/named": &testConfigSource{
@@ -585,6 +586,15 @@ func TestManager_expandString(t *testing.T) {
 			name:    "envvar_treated_as_cfgsrc",
 			input:   "$envvar/test:test",
 			wantErr: &errUnknownConfigSource{},
+		},
+		{
+			name:  "retrieved_nil",
+			input: "${tstcfgsrc:nil_key}",
+		},
+		{
+			name:  "retrieved_nil_on_string",
+			input: "prefix-${tstcfgsrc:nil_key}-suffix",
+			want:  "prefix--suffix",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/configsource/envvarconfigsource/session.go
+++ b/internal/configsource/envvarconfigsource/session.go
@@ -68,9 +68,6 @@ func (e *envVarSession) Retrieve(_ context.Context, selector string, params inte
 		if !actualParams.Optional {
 			return nil, &errMissingRequiredEnvVar{fmt.Errorf("env var %q is required but not defined and not present on defaults", selector)}
 		}
-
-		// To keep with default behavior for env vars not defined set the value to empty string
-		defaultValue = ""
 	}
 
 	return configprovider.NewRetrieved(defaultValue, configprovider.WatcherNotSupported), nil

--- a/internal/configsource/envvarconfigsource/session_test.go
+++ b/internal/configsource/envvarconfigsource/session_test.go
@@ -48,7 +48,7 @@ func TestEnvVarConfigSource_Session(t *testing.T) {
 			params: map[string]interface{}{
 				"optional": true,
 			},
-			expected: "", // The default behavior for undefined env var is empty string.
+			expected: nil,
 		},
 		{
 			name: "invalid_param",


### PR DESCRIPTION
Handling of nil retrieved values by the config provider manager was causing the string "<nil>" to be used. Fixed the handling on the manager and removed the special case on the env variable.