### PR TITLE
Initial version of HTTP sink exporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,12 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-zookeeper/zk v1.0.2
+	github.com/gogo/protobuf v1.3.2
 	github.com/hashicorp/vault v1.7.0
 	github.com/hashicorp/vault-plugin-auth-gcp v0.9.0
 	github.com/hashicorp/vault/api v1.1.0
 	github.com/hashicorp/vault/sdk v0.2.1 // indirect
+	github.com/jaegertracing/jaeger v1.26.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.36.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.36.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.36.0
@@ -28,6 +30,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.36.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.36.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.36.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.36.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.36.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.36.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.36.0
@@ -149,7 +152,6 @@ require (
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/gobwas/glob v0.2.4-0.20181002190808-e7a84e9525fe // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -201,7 +203,6 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20200307190119-3430c5407db8 // indirect
 	github.com/jackc/pgtype v1.3.0 // indirect
 	github.com/jackc/pgx/v4 v4.6.0 // indirect
-	github.com/jaegertracing/jaeger v1.26.0 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
 	github.com/jcmturner/gofork v1.0.0 // indirect
@@ -257,7 +258,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.36.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza v0.36.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr v0.36.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.36.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.36.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/scraperhelper v0.36.0 // indirect
 	github.com/open-telemetry/opentelemetry-log-collection v0.20.0 // indirect

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -67,6 +67,7 @@ import (
 	"go.opentelemetry.io/collector/processor/memorylimiterprocessor"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
 
+	"github.com/signalfx/splunk-otel-collector/internal/exporter/httpsinkexporter"
 	"github.com/signalfx/splunk-otel-collector/internal/extension/smartagentextension"
 	"github.com/signalfx/splunk-otel-collector/internal/receiver/smartagentreceiver"
 )
@@ -125,6 +126,7 @@ func Get() (component.Factories, error) {
 		sapmexporter.NewFactory(),
 		signalfxexporter.NewFactory(),
 		splunkhecexporter.NewFactory(),
+		httpsinkexporter.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -81,6 +81,7 @@ func TestDefaultComponents(t *testing.T) {
 		"sapm",
 		"signalfx",
 		"splunk_hec",
+		"httpsink",
 	}
 
 	factories, err := Get()

--- a/internal/exporter/httpsinkexporter/README.md
+++ b/internal/exporter/httpsinkexporter/README.md
@@ -1,0 +1,28 @@
+# HTTP Sink Exporter
+
+This exporter makes span data available via a HTTP endpoint. The endpoint
+accepts requests for spans with specific characteristics and blocks until the exporter
+receives such spans or the request times out. Once the requested spans are detected, they're
+returned back to the client as JSON. 
+
+This exporter returns data as [JSON encoding](https://developers.google.com/protocol-buffers/docs/proto3#json)
+using [Jaeger protocol](https://github.com/jaegertracing/jaeger-idl/tree/master/proto/api_v2).
+
+Please note that there is no guarantee that exact field names will remain stable.
+This intended for primarily for testing observability pipelines without setting up backends.
+
+Supported pipeline types: traces.
+
+## Getting Started
+
+The following settings are required:
+
+- `endpoint` (defaults to `0.0.0.0:8378`).
+
+Example:
+
+```yaml
+exporters:
+  httpsink:
+    endpoint: "0.0.0.0:8378"
+```

--- a/internal/exporter/httpsinkexporter/client.go
+++ b/internal/exporter/httpsinkexporter/client.go
@@ -1,0 +1,119 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpsinkexporter
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jaegertracing/jaeger/model"
+)
+
+type options struct {
+	attrs   map[string]string
+	names   []string
+	count   int
+	timeout time.Duration
+}
+
+func parseOptions(r *http.Request) (options, error) {
+	opts := options{
+		count:   1,
+		timeout: time.Second * 10,
+		names:   []string{},
+		attrs:   map[string]string{},
+	}
+
+	q := r.URL.Query()
+
+	for _, attr := range q["attr"] {
+		parts := strings.SplitN(attr, "=", 2)
+		if len(parts) != 2 {
+			return opts, fmt.Errorf("attr query string parameter is not formatted correctly")
+		}
+		opts.attrs[parts[0]] = parts[1]
+	}
+
+	opts.names = q["name"]
+
+	if timeout, ok := q["timeout"]; ok {
+		timeoutNum, err := strconv.Atoi(timeout[0])
+		if err != nil {
+			return opts, err
+		}
+		opts.timeout = time.Second * time.Duration(timeoutNum)
+	}
+
+	if count, ok := q["count"]; ok {
+		countNum, err := strconv.Atoi(count[0])
+		if err != nil {
+			return opts, err
+		}
+		opts.count = countNum
+	}
+
+	return opts, nil
+}
+
+type client struct {
+	ch      chan *model.Batch
+	opts    options
+	stopped bool
+}
+
+func newClient(opts options) *client {
+	return &client{
+		ch:   make(chan *model.Batch),
+		opts: opts,
+	}
+}
+
+func (c *client) response() ([]byte, error) {
+	// TODO: add support to filter by attributes and names
+	defer func() {
+		c.stopped = true
+	}()
+
+	spans := []string{}
+	received := 0
+
+	done := make(chan struct{})
+	for {
+		select {
+		case batch := <-c.ch:
+			for _, span := range batch.Spans {
+				json, err := marshaler.MarshalToString(span)
+				if err != nil {
+					return nil, err
+				}
+				spans = append(spans, json)
+				received++
+				if received == c.opts.count {
+					close(done)
+				}
+			}
+		case <-time.After(c.opts.timeout):
+			return nil, fmt.Errorf("timed out while waiting for spans")
+
+		case <-done:
+			result := "[" + strings.Join(spans, ",") + "]"
+			return []byte(result), nil
+		}
+	}
+}

--- a/internal/exporter/httpsinkexporter/config.go
+++ b/internal/exporter/httpsinkexporter/config.go
@@ -1,0 +1,40 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpsinkexporter
+
+import (
+	"errors"
+
+	"go.opentelemetry.io/collector/config"
+)
+
+// Config defines configuration for file exporter.
+type Config struct {
+	config.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+
+	Endpoint string `mapstructure:"endpoint"`
+}
+
+var _ config.Exporter = (*Config)(nil)
+
+// Validate checks if the exporter configuration is valid
+func (cfg *Config) Validate() error {
+	if cfg.Endpoint == "" {
+		return errors.New("endpoint must not be empty")
+	}
+
+	return nil
+}

--- a/internal/exporter/httpsinkexporter/config_test.go
+++ b/internal/exporter/httpsinkexporter/config_test.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpsinkexporter
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configtest"
+)
+
+func TestLoadConfig(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Exporters[typeStr] = factory
+	cfg, err := configtest.LoadConfigAndValidate(path.Join(".", "testdata", "config.yaml"), factories)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	e0 := cfg.Exporters[config.NewID(typeStr)]
+	assert.Equal(t, e0, factory.CreateDefaultConfig())
+
+	e1 := cfg.Exporters[config.NewIDWithName(typeStr, "2")]
+	assert.Equal(t, e1,
+		&Config{
+			ExporterSettings: config.NewExporterSettings(config.NewIDWithName(typeStr, "2")),
+			Endpoint:         "localhost:3333",
+		})
+}

--- a/internal/exporter/httpsinkexporter/factory.go
+++ b/internal/exporter/httpsinkexporter/factory.go
@@ -1,0 +1,61 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpsinkexporter
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+)
+
+const (
+	// The value of "type" key in configuration.
+	typeStr         = "httpsink"
+	defaultEndpoint = "localhost:8378"
+)
+
+// NewFactory creates a factory for httpsink exporter.
+func NewFactory() component.ExporterFactory {
+	return exporterhelper.NewFactory(
+		typeStr,
+		createDefaultConfig,
+		exporterhelper.WithTraces(createTracesExporter),
+	)
+}
+
+func createDefaultConfig() config.Exporter {
+	return &Config{
+		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		Endpoint:         defaultEndpoint,
+	}
+}
+
+func createTracesExporter(
+	_ context.Context,
+	set component.ExporterCreateSettings,
+	cfg config.Exporter,
+) (component.TracesExporter, error) {
+	exp := &httpSinkExporter{endpoint: cfg.(*Config).Endpoint}
+	return exporterhelper.NewTracesExporter(
+		cfg,
+		set,
+		exp.ConsumeTraces,
+		exporterhelper.WithStart(exp.Start),
+		exporterhelper.WithShutdown(exp.Shutdown),
+	)
+}

--- a/internal/exporter/httpsinkexporter/factory_test.go
+++ b/internal/exporter/httpsinkexporter/factory_test.go
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpsinkexporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configtest"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configtest.CheckConfigStruct(cfg))
+}
+
+func TestCreateTracesExporter(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	te, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, te)
+}

--- a/internal/exporter/httpsinkexporter/httpsink_exporter.go
+++ b/internal/exporter/httpsinkexporter/httpsink_exporter.go
@@ -1,0 +1,129 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpsinkexporter
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/jaegertracing/jaeger/model"
+	jaegertranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+var marshaler = &jsonpb.Marshaler{}
+
+// httpSinkExporter ...
+type httpSinkExporter struct {
+	endpoint string
+
+	ch      chan *model.Batch
+	clients []*client
+	mu      sync.Mutex
+}
+
+func (e *httpSinkExporter) ConsumeTraces(_ context.Context, td pdata.Traces) error {
+	batches, err := jaegertranslator.InternalTracesToJaegerProto(td)
+	if err != nil {
+		return err
+	}
+	for _, batch := range batches {
+		go func(b *model.Batch) {
+			e.ch <- b
+		}(batch)
+	}
+	return nil
+}
+
+func (e *httpSinkExporter) addClient(c *client) {
+	e.mu.Lock()
+	e.clients = append(e.clients, c)
+	e.mu.Unlock()
+}
+
+func (e *httpSinkExporter) removeClient(c *client) {
+	e.mu.Lock()
+	index := -1
+	for i, v := range e.clients {
+		if v == c {
+			index = i
+			break
+		}
+	}
+	if index != -1 {
+		e.clients = append(e.clients[:index], e.clients[index+1:]...)
+	}
+	e.mu.Unlock()
+}
+
+func (e *httpSinkExporter) handler(w http.ResponseWriter, r *http.Request) {
+	opts, err := parseOptions(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	c := newClient(opts)
+	e.addClient(c)
+	defer e.removeClient(c)
+
+	result, err := c.response()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(result)
+}
+
+func (e *httpSinkExporter) Start(ctx context.Context, _ component.Host) error {
+	go e.startServer(ctx)
+	go e.fanOut()
+	return nil
+}
+
+func (e *httpSinkExporter) fanOut() error {
+	e.ch = make(chan *model.Batch)
+	for {
+		batch := <-e.ch
+		e.mu.Lock()
+		clients := e.clients
+		e.mu.Unlock()
+		for _, c := range clients {
+			if !c.stopped {
+				go func(c *client) {
+					c.ch <- batch
+				}(c)
+			}
+		}
+	}
+}
+
+// Shutdown stops the exporter and is invoked during shutdown.
+func (e *httpSinkExporter) Shutdown(context.Context) error {
+	// shutdown http server
+	return nil
+
+}
+
+func (e *httpSinkExporter) startServer(context.Context) {
+	http.HandleFunc("/", e.handler)
+	http.ListenAndServe(e.endpoint, nil)
+}

--- a/internal/exporter/httpsinkexporter/testdata/config.yaml
+++ b/internal/exporter/httpsinkexporter/testdata/config.yaml
@@ -1,0 +1,17 @@
+receivers:
+  nop:
+
+processors:
+  nop:
+
+exporters:
+  httpsink:
+  httpsink/2:
+    endpoint: localhost:3333
+
+service:
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [httpsink]


### PR DESCRIPTION
This is a test exporter that allows clients to "watch" for spans they might be interested in. This is very useful for end-to-end tests where we want to test real world applications and ensure data reaches the collector as expected.

The exporter exposes a HTTP endpoint. Clients can make GET requests to this endpoint and specify the characteristics of spans they are interested in using URL query params. Collector will then block the request until it detects the specified spans. Once the spans are detected, they are serialized to JSON (using jaeger proto) and returned back to the client. Multiple clients can watch for the same spans at the same time. The export does not hold anything in memory before a watch is started or after a watch ends. Clients must start the watch first, generate spans and assert the watch result.

All this can be done with the file or logging exporter as well but this dramatically simplifies writing such tests especially when this needs to be done for multiple libraries across different languages.

Example test that leverages this to test a simple but real app instrumented with otel: https://github.com/signalfx/splunk-otel-python/blob/main/tests/integration/test_simple.py#L24-L47 

The implementation is very basic, code is rough and a lot of tests are lacking. I'll improve this over time and if it makes sense, try to migrate it to Otel Contrib but for now this would make life a lot easier for at least a couple of our (instrumentals) projects.

Perhaps down the line, we can permanently host a collector in Splunk lab with this exporter enabled to allow very quick and easy manual and automated testing (even from CI). May be I'll try this for the upcoming hackathon. 

### Example and explanation 
Recorded an example here: https://www.loom.com/share/16256b778d9a40a297a2212692422d0b