### PR TITLE
Allow setting both SPLUNK_CONFIG and --config with priority given to --config

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -127,14 +127,17 @@ func checkRuntimeParams() {
 	args := os.Args[1:]
 	config := ""
 
-	// Check if config flag was passed
-	// If so, ensure config env var is not set
-	// Then set config properly
+	// Check if config flag was passed and its value differs from config env var.
+	// If so, log that it will be used instead of env var value and set env var with that value.
+	// This allows users to set `--config` and have it take priority when running from most contexts.
 	cliConfig := getKeyValue(args, "--config")
 	if cliConfig != "" {
 		config = os.Getenv(configEnvVarName)
-		if config != "" {
-			log.Fatalf("Both %v and '--config' were specified, but only one is allowed", configEnvVarName)
+		if config != "" && config != cliConfig {
+			log.Printf(
+				"Both %v and '--config' were specified. Overriding %q environment variable value with %q for this session",
+				configEnvVarName, config, cliConfig,
+			)
 		}
 		os.Setenv(configEnvVarName, cliConfig)
 	}
@@ -210,7 +213,7 @@ func setConfig() {
 		for _, v := range requiredEnvVars {
 			if len(os.Getenv(v)) == 0 {
 				log.Printf("Usage: %s=12345 %s=us0 %s", tokenEnvVarName, realmEnvVarName, os.Args[0])
-				log.Fatalf("ERROR: Missing environment variable %s", v)
+				log.Fatalf("ERROR: Missing required environment variable %s with default config path %s", v, config)
 			}
 		}
 	}

--- a/tests/endtoend/doc.go
+++ b/tests/endtoend/doc.go
@@ -1,0 +1,1 @@
+package endtoend

--- a/tests/general/container_test.go
+++ b/tests/general/container_test.go
@@ -1,0 +1,117 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/signalfx/splunk-otel-collector/tests/testutils"
+)
+
+func TestDefaultContainerConfigRequiresEnvVars(t *testing.T) {
+	image := os.Getenv("SPLUNK_OTEL_COLLECTOR_IMAGE")
+	if strings.TrimSpace(image) == "" {
+		t.Skipf("skipping container-only test")
+	}
+
+	tests := []struct {
+		name    string
+		env     map[string]string
+		missing string
+	}{
+		{"missing realm", map[string]string{
+			"SPLUNK_REALM":        "",
+			"SPLUNK_ACCESS_TOKEN": "some_token",
+		}, "SPLUNK_REALM"},
+		{"missing token", map[string]string{
+			"SPLUNK_REALM":        "some_realm",
+			"SPLUNK_ACCESS_TOKEN": "",
+		}, "SPLUNK_ACCESS_TOKEN"},
+	}
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(tt *testing.T) {
+			logCore, logs := observer.New(zap.DebugLevel)
+			logger := zap.New(logCore)
+
+			collector, err := testutils.NewCollectorContainer().WithImage(image).WithEnv(testcase.env).WithLogger(logger).WillFail(true).Build()
+			require.NoError(t, err)
+			require.NotNil(t, collector)
+			defer collector.Shutdown()
+			require.NoError(t, collector.Start())
+
+			expectedError := fmt.Sprintf("ERROR: Missing required environment variable %s with default config path /etc/otel/collector/gateway_config.yaml", testcase.missing)
+			require.Eventually(t, func() bool {
+				for _, log := range logs.All() {
+					if strings.Contains(log.Message, expectedError) {
+						return true
+					}
+				}
+				return false
+			}, 30*time.Second, time.Second)
+		})
+	}
+}
+
+func TestSpecifiedContainerConfigDefaultsToCmdLineArgIfEnvVarConflict(t *testing.T) {
+	image := os.Getenv("SPLUNK_OTEL_COLLECTOR_IMAGE")
+	if strings.TrimSpace(image) == "" {
+		t.Skipf("skipping container-only test")
+	}
+
+	logCore, logs := observer.New(zap.DebugLevel)
+	logger := zap.New(logCore)
+
+	env := map[string]string{"SPLUNK_CONFIG": "/not/a/real/path"}
+	config := path.Join(".", "testdata", "logged_hostmetrics.yaml")
+	c := testutils.NewCollectorContainer().WithImage(image).WithEnv(env).WithLogger(logger).WithConfigPath(config)
+	// specify in container path of provided config via cli.
+	collector, err := c.WithArgs("--config", "/etc/config.yaml").Build()
+	require.NoError(t, err)
+	require.NotNil(t, collector)
+	require.NoError(t, collector.Start())
+	defer func() { require.NoError(t, collector.Shutdown()) }()
+
+	require.Eventually(t, func() bool {
+		for _, log := range logs.All() {
+			if strings.Contains(
+				log.Message,
+				`Both SPLUNK_CONFIG and '--config' were specified.  Overriding "/not/a/real/path" environment variable `+
+					`value with "/etc/config.yaml" for this session`,
+			) {
+				return true
+			}
+		}
+		return false
+	}, 20*time.Second, time.Second)
+
+	require.Eventually(t, func() bool {
+		for _, log := range logs.All() {
+			// logged host metric to confirm basic functionality
+			if strings.Contains(log.Message, "Value: ") {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, time.Second)
+}

--- a/tests/general/container_test.go
+++ b/tests/general/container_test.go
@@ -96,8 +96,8 @@ func TestSpecifiedContainerConfigDefaultsToCmdLineArgIfEnvVarConflict(t *testing
 		for _, log := range logs.All() {
 			if strings.Contains(
 				log.Message,
-				`Both SPLUNK_CONFIG and '--config' were specified.  Overriding "/not/a/real/path" environment variable `+
-					`value with "/etc/config.yaml" for this session`,
+				`Both SPLUNK_CONFIG and '--config' were specified. Overriding "/not/a/real/path" environment `+
+					`variable value with "/etc/config.yaml" for this session`,
 			) {
 				return true
 			}

--- a/tests/general/testdata/logged_hostmetrics.yaml
+++ b/tests/general/testdata/logged_hostmetrics.yaml
@@ -1,0 +1,15 @@
+receivers:
+  hostmetrics:
+    collection_interval: 1s
+    scrapers:
+      cpu:
+
+exporters:
+  logging:
+    logLevel: debug
+
+service:
+  pipelines:
+    metrics:
+      receivers: [hostmetrics]
+      exporters: [logging]

--- a/tests/testutils/collector.go
+++ b/tests/testutils/collector.go
@@ -24,6 +24,7 @@ type Collector interface {
 	WithEnv(env map[string]string) Collector
 	WithLogger(logger *zap.Logger) Collector
 	WithLogLevel(level string) Collector
+	WillFail(fail bool) Collector
 	Build() (Collector, error)
 	Start() error
 	Shutdown() error

--- a/tests/testutils/collector_container_test.go
+++ b/tests/testutils/collector_container_test.go
@@ -43,6 +43,16 @@ func TestCollectorContainerBuilders(t *testing.T) {
 	assert.Equal(t, []string{"arg_one", "arg_two", "arg_three"}, withArgs.Args)
 	assert.Empty(t, builder.Args)
 
+	willFail, ok := builder.WillFail(true).(*CollectorContainer)
+	require.True(t, ok)
+	assert.True(t, willFail.Fail)
+	assert.False(t, builder.Fail)
+
+	wontFail, ok := willFail.WillFail(false).(*CollectorContainer)
+	require.True(t, ok)
+	assert.False(t, wontFail.Fail)
+	assert.True(t, willFail.Fail)
+
 	logger := zap.NewNop()
 	withLogger, ok := builder.WithLogger(logger).(*CollectorContainer)
 	require.True(t, ok)

--- a/tests/testutils/collector_process.go
+++ b/tests/testutils/collector_process.go
@@ -36,6 +36,7 @@ type CollectorProcess struct {
 	Env              map[string]string
 	Logger           *zap.Logger
 	LogLevel         string
+	Fail             bool
 	Process          *subprocess.Subprocess
 	subprocessConfig *subprocess.Config
 }
@@ -78,6 +79,12 @@ func (collector CollectorProcess) WithLogger(logger *zap.Logger) Collector {
 // info by default
 func (collector CollectorProcess) WithLogLevel(level string) Collector {
 	collector.LogLevel = level
+	return &collector
+}
+
+// noop at this time
+func (collector CollectorProcess) WillFail(fail bool) Collector {
+	collector.Fail = fail
 	return &collector
 }
 


### PR DESCRIPTION
Currently it's forbidden to set both `SPLUNK_CONFIG` and provide the `--config` cmdline options for our distribution.  This is a little unexpected given cli tools generally allow redundant options while giving priority to command line options and falling back to environment variables.  The current system makes it relatively inconvenient to update startup arguments as changing or clearing the environment variable is also required, which can sometimes be more difficult than updating the cmdline args.

These changes ease the restriction and give priority to the `--config` option with clear logging of which config will be used.  They also provide more context when default config locations are used and required env vars aren't set.

Also including necessary testutils changes for added integration tests.