### PR TITLE
Add env var SPLUNK_CONFIG_YAML for storing configuration YAML

### DIFF
--- a/internal/configprovider/config_source_provider.go
+++ b/internal/configprovider/config_source_provider.go
@@ -37,9 +37,12 @@ type configSourceParserProvider struct {
 }
 
 // NewConfigSourceParserProvider creates a ParserProvider that uses config sources.
-func NewConfigSourceParserProvider(logger *zap.Logger, buildInfo component.BuildInfo, factories ...Factory) parserprovider.ParserProvider {
+func NewConfigSourceParserProvider(pp parserprovider.ParserProvider, logger *zap.Logger, buildInfo component.BuildInfo, factories ...Factory) parserprovider.ParserProvider {
+	if pp == nil {
+		pp = parserprovider.Default()
+	}
 	return &configSourceParserProvider{
-		pp:        parserprovider.Default(),
+		pp:        pp,
 		logger:    logger,
 		factories: factories,
 		buildInfo: buildInfo,

--- a/internal/configprovider/config_source_provider_test.go
+++ b/internal/configprovider/config_source_provider_test.go
@@ -88,6 +88,7 @@ func TestConfigSourceParserProvider(t *testing.T) {
 			}
 
 			pp := NewConfigSourceParserProvider(
+				parserprovider.Default(),
 				zap.NewNop(),
 				component.DefaultBuildInfo(),
 				factories...,


### PR DESCRIPTION
Supplying Splunk Otel Collector configuration yaml via environment variable SPLUNK_CONFIG_YAML. 

One advantage is that this allows for having the config YAML as a parameter value in AWS Systems Manager Parameter Store and thus removing the need to have a volume mounted to a Fargate task to hold the configuration file.