### PR TITLE
Add support for translating collectd monitors

### DIFF
--- a/cmd/translatesfx/translatesfx/directive.go
+++ b/cmd/translatesfx/translatesfx/directive.go
@@ -218,6 +218,13 @@ func (d directive) expandFiles() (interface{}, error) {
 	return merge(items)
 }
 
+func resolvePath(path, wd string) string {
+	if path[:1] == string(os.PathSeparator) {
+		return path
+	}
+	return filepath.Join(wd, path)
+}
+
 func unmarshal(path string) (interface{}, error) {
 	bytes, err := os.ReadFile(path)
 	if err != nil {

--- a/cmd/translatesfx/translatesfx/otel.go
+++ b/cmd/translatesfx/translatesfx/otel.go
@@ -15,6 +15,7 @@
 package translatesfx
 
 type otelCfg struct {
+	Extensions    map[string]interface{} `yaml:",omitempty"`
 	ConfigSources map[string]interface{} `yaml:"config_sources"`
 	Receivers     map[string]interface{}
 	Processors    map[string]interface{}
@@ -54,6 +55,10 @@ func saInfoToOtelConfig(cfg saCfgInfo) otelCfg {
 			"metrics": rpe,
 		},
 	}
+	if len(cfg.saExtension) > 0 {
+		out.Extensions = cfg.saExtension
+		out.Service["extensions"] = []string{"smartagent"}
+	}
 	return out
 }
 
@@ -74,6 +79,8 @@ func receiverList(receivers map[string]interface{}) []string {
 }
 
 func saMonitorToOtelReceiver(monitor map[interface{}]interface{}) map[interface{}]interface{} {
+	// TODO translate discovery rule (delete for now)
+	delete(monitor, "discoveryRule")
 	return map[interface{}]interface{}{
 		"smartagent/" + monitor["type"].(string): monitor,
 	}

--- a/cmd/translatesfx/translatesfx/testdata/sa-collectd.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/sa-collectd.yaml
@@ -1,0 +1,29 @@
+signalFxAccessToken: abc123
+ingestUrl: https://ingest.us1.signalfx.com
+apiUrl: https://api.us1.signalfx.com
+
+bundleDir: /opt/my-smart-agent-bundle
+
+procPath: /my_custom_proc
+etcPath: /my_custom_etc
+varPath: /my_custom_var
+runPath: /my_custom_run
+sysPath: /my_custom_sys
+
+collectd:
+  readThreads: 10
+  writeQueueLimitHigh: 1000000
+  writeQueueLimitLow: 600000
+  configDir: "/tmp/signalfx-agent/collectd"
+
+monitors:
+  - type: signalfx-forwarder
+    listenAddress: 0.0.0.0:9080
+  - type: collectd/activemq
+    extraDimensions:
+      my_dimension: my_dimension_value
+  - type: collectd/apache
+  - type: postgresql
+    extraDimensions:
+      my_other_dimension: my_other_dimension_value
+  - type: processlist

--- a/cmd/translatesfx/translatesfx/testdata/sa-discoveryrules.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/sa-discoveryrules.yaml
@@ -1,0 +1,35 @@
+signalFxAccessToken: abc123
+ingestUrl: https://ingest.us1.signalfx.com
+apiUrl: https://api.us1.signalfx.com
+
+bundleDir: /opt/my-smart-agent-bundle
+
+procPath: /my_custom_proc
+etcPath: /my_custom_etc
+varPath: /my_custom_var
+runPath: /my_custom_run
+sysPath: /my_custom_sys
+
+observers:
+  - type: k8s-api
+
+collectd:
+  readThreads: 10
+  writeQueueLimitHigh: 1000000
+  writeQueueLimitLow: 600000
+  configDir: "/tmp/signalfx-agent/collectd"
+
+monitors:
+  - type: signalfx-forwarder
+    listenAddress: 0.0.0.0:9080
+  - type: collectd/activemq
+    discoveryRule: container_image =~ "activemq" && private_port == 1099
+    extraDimensions:
+      my_dimension: my_dimension_value
+  - type: collectd/apache
+    discoveryRule: container_image =~ "apache" && private_port == 80
+  - type: postgresql
+    discoveryRule: container_image =~ "postgresql" && private_port == 7199
+    extraDimensions:
+      my_other_dimension: my_other_dimension_value
+  - type: processlist


### PR DESCRIPTION
Manually end-to-end tested using a collectd/redis Smart Agent config. Also now deleting any discovery rules -- will translate them in a subsequent PR.