### PR TITLE
Update agent-vs-gateway.md

### DIFF
--- a/docs/agent-vs-gateway.md
+++ b/docs/agent-vs-gateway.md
@@ -2,7 +2,7 @@
 
 Splunk OpenTelemetry Connector provides a single binary and two deployment
 modes as outlined in the [architecture](architecture.md). The recommended
-[getting started](../#getting-started) installation steps cover deploying in
+[getting started](https://github.com/signalfx/splunk-otel-collector#getting-started) installation steps cover deploying in
 either mode and come with a [default
 configuration](https://github.com/signalfx/splunk-otel-collector/tree/main/cmd/otelcol/config/collector).
 


### PR DESCRIPTION
Documentation error, "getting started" links to a page that does not exist. Updated it to link to the getting-started at the head of the repo. 