### PR TITLE
Enable collecting in memory config locally by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,15 +88,21 @@ All you need to get started is:
 - [Splunk Access Token](https://docs.splunk.com/Observability/admin/authentication-tokens/org-tokens.html#admin-org-tokens)
 - [Splunk Realm](https://dev.splunk.com/observability/docs/realms_in_endpoints/)
 - [Agent or Gateway mode](docs/agent-vs-gateway.md)
-- [Double-check exposed ports](https://github.com/signalfx/splunk-otel-collector/blob/main/docs/security.md#exposed-endpoints) to make sure your environment doesn't have conflicts. Ports can be changed in the collector's configuration.
+- [Double-check exposed
+  ports](https://github.com/signalfx/splunk-otel-collector/blob/main/docs/security.md#exposed-endpoints)
+  to make sure your environment doesn't have conflicts. Ports can be changed in
+  the collector's configuration.
 
 This distribution is supported on and packaged for a variety of platforms including:
 
 - Kubernetes
   - [Helm (recommended)](https://github.com/signalfx/splunk-otel-collector-chart)
-  - [YAML](https://github.com/signalfx/splunk-otel-collector/blob/main/docs/getting-started/kubernetes-yaml.md)
+  - [YAML](https://github.com/signalfx/splunk-otel-collector-chart/tree/main/rendered)
 - Linux
   - [Installer script (recommended)](./docs/getting-started/linux-installer.md)
+  - Configuration management
+    - [Ansible](https://galaxy.ansible.com/signalfx/splunk_otel_collector)
+    - [Puppet](https://forge.puppet.com/modules/signalfx/splunk_otel_collector)
   - [Manual](./docs/getting-started/linux-manual.md)
 - Windows
   - [Installer script (recommended)](./docs/getting-started/windows-installer.md)

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -35,12 +35,13 @@ import (
 )
 
 const (
-	ballastEnvVarName     = "SPLUNK_BALLAST_SIZE_MIB"
-	configEnvVarName      = "SPLUNK_CONFIG"
-	memLimitMiBEnvVarName = "SPLUNK_MEMORY_LIMIT_MIB"
-	memTotalEnvVarName    = "SPLUNK_MEMORY_TOTAL_MIB"
-	realmEnvVarName       = "SPLUNK_REALM"
-	tokenEnvVarName       = "SPLUNK_ACCESS_TOKEN"
+	ballastEnvVarName          = "SPLUNK_BALLAST_SIZE_MIB"
+	configEnvVarName           = "SPLUNK_CONFIG"
+	configServerEnabledEnvVar = "SPLUNK_DEBUG_CONFIG_SERVER"
+	memLimitMiBEnvVarName      = "SPLUNK_MEMORY_LIMIT_MIB"
+	memTotalEnvVarName         = "SPLUNK_MEMORY_TOTAL_MIB"
+	realmEnvVarName            = "SPLUNK_REALM"
+	tokenEnvVarName            = "SPLUNK_ACCESS_TOKEN"
 
 	defaultDockerSAPMConfig        = "/etc/otel/collector/gateway_config.yaml"
 	defaultDockerOTLPConfig        = "/etc/otel/collector/otlp_config_linux.yaml"
@@ -60,6 +61,10 @@ func main() {
 	if !contains(args, "-h") && !contains(args, "--help") {
 		checkRuntimeParams()
 	}
+
+	// Allow dumping configuration locally by default
+	// Used by support bundle script
+	os.Setenv(configServerEnabledEnvVar, "true")
 
 	factories, err := components.Get()
 	if err != nil {

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -35,13 +35,13 @@ import (
 )
 
 const (
-	ballastEnvVarName          = "SPLUNK_BALLAST_SIZE_MIB"
-	configEnvVarName           = "SPLUNK_CONFIG"
+	ballastEnvVarName         = "SPLUNK_BALLAST_SIZE_MIB"
+	configEnvVarName          = "SPLUNK_CONFIG"
 	configServerEnabledEnvVar = "SPLUNK_DEBUG_CONFIG_SERVER"
-	memLimitMiBEnvVarName      = "SPLUNK_MEMORY_LIMIT_MIB"
-	memTotalEnvVarName         = "SPLUNK_MEMORY_TOTAL_MIB"
-	realmEnvVarName            = "SPLUNK_REALM"
-	tokenEnvVarName            = "SPLUNK_ACCESS_TOKEN"
+	memLimitMiBEnvVarName     = "SPLUNK_MEMORY_LIMIT_MIB"
+	memTotalEnvVarName        = "SPLUNK_MEMORY_TOTAL_MIB"
+	realmEnvVarName           = "SPLUNK_REALM"
+	tokenEnvVarName           = "SPLUNK_ACCESS_TOKEN"
 
 	defaultDockerSAPMConfig        = "/etc/otel/collector/gateway_config.yaml"
 	defaultDockerOTLPConfig        = "/etc/otel/collector/otlp_config_linux.yaml"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,6 +30,9 @@ End-to-end architecture information is helpful including:
 In addition, it is important to gather support information including:
 
 - Configuration file
+  - Running OpenTelemetry Collector
+    - `http://localhost:55555/debug/configz/initial`
+    - `http://localhost:55555/debug/configz/effective`
   - Kubernetes: `kubectl get configmap my-configmap -o yaml >my-configmap.yaml`
   - Linux: `/etc/otel/collector`
 - Logs and ideally debug logs

--- a/internal/buildscripts/packaging/fpm/etc/otel/collector/splunk-support-bundle.sh
+++ b/internal/buildscripts/packaging/fpm/etc/otel/collector/splunk-support-bundle.sh
@@ -122,6 +122,15 @@ getConfig() {
         echo "       Run this script with a user who has permissions to this directory."
         exit 1
     fi
+    # Also need to get config in memory as dynamic config may modify stored config
+    # It's possible user has disabled collecting in memory config
+    if timeout 1 bash -c 'cat < /dev/null > /dev/tcp/localhost/55555'; then
+        curl -s http://localhost:55555/debug/configz/initial >"$TMPDIR"/config/initial.yaml 2>&1
+        curl -s http://localhost:55555/debug/configz/effective >"$TMPDIR"/config/effective.yaml 2>&1
+    else
+        echo "WARN: localhost:55555 unavailable so in memory configuration not collected"
+    fi
+
 }
 
 #######################################


### PR DESCRIPTION
Configured main.go to enable in memory config gathering locally. In
addition, updated support bundle to capture this information.