### PR TITLE
Add support for non-persisted journald

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -131,7 +131,7 @@ $ journalctl -u my-service.service -f
 - Check
   [zpages](https://github.com/open-telemetry/opentelemetry-collector/blob/main/extension/zpagesextension)
   for samples (`http://localhost:55679/debug/tracez`); may require `endpoint`
-  configuration
+  configuration (lynx is a good CLI tool if needed)
 - Enable [logging
   exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter)
   and check logs (`journalctl -u splunk-otel-collector.service -f`)
@@ -147,9 +147,17 @@ journald and `/var/log/syslog.log` for events.
 > up the log line
 
 ```bash
-$ echo "2021-03-17 02:14:44 +0000 [debug]: test" >>/var/log/syslog.log
-$ echo "2021-03-17 02:14:44 +0000 [debug]: test" | systemd-cat
+$ echo "Jun 17 02:14:44 my-server fluentd[11111]: [debug] syslog test" >>/var/log/syslog
+$ echo "2021-03-17 02:14:44 +0000 [debug]: syslog test" | systemd-cat
 ```
+
+Here is an example of a log record that will NOT be collected:
+
+```bash
+$ echo "2021-03-17 02:14:44 +0000 my-server fluentd[11111]: [debug] syslog test" >>/var/log/syslog
+```
+
+Why? Because the timestamp parser will fail. Enable debug logs to confirm this.
 
 ## Trace Collection
 

--- a/internal/buildscripts/packaging/fpm/etc/otel/collector/fluentd/conf.d/journald.conf
+++ b/internal/buildscripts/packaging/fpm/etc/otel/collector/fluentd/conf.d/journald.conf
@@ -46,7 +46,6 @@
 #
 
 <source>
-  @id journald
   @type systemd
   @label @SPLUNK
   tag "journald"
@@ -55,7 +54,24 @@
   <storage>
     @type local
     persistent true
-    path /var/log/td-agent/journald.pos.json
+    path /var/log/td-agent/journald.var.pos.json
+  </storage>
+  <entry>
+    fields_strip_underscores true
+    fields_lowercase true
+  </entry>
+</source>
+
+<source>
+  @type systemd
+  @label @SPLUNK
+  tag "journald"
+  path "/run/log/journal"
+  read_from_head false
+  <storage>
+    @type local
+    persistent true
+    path /var/log/td-agent/journald.run.pos.json
   </storage>
   <entry>
     fields_strip_underscores true


### PR DESCRIPTION
Journald can either persist data in /var/log/journald or temporarily
store in /run/log/journald. A clean Ubuntun 20.04 Docker container will
NOT persist journald by default -- as a result, Fluentd will NOT pick up
the data. Update the Fluentd default configuration to ensure this data
is collected.

Note: the tail plugin supports a comma-separate list of paths, it does
not appear the journald plugin does.

Tested locally.

Also update the troubleshooting guide as the example provided does not
work with the syslog parser.