### PR TITLE
zk config source: remove config validation for zk endpoints

### DIFF
--- a/internal/configsource/zookeeperconfigsource/README.md
+++ b/internal/configsource/zookeeperconfigsource/README.md
@@ -12,20 +12,21 @@ Zookeeper config sources:
 ```yaml
 config_sources:
   zookeeper:
-    # endpoint is the Zookeeper server addresses. Config source will try to connect to
-    # these endpoints to access an Zookeeper cluster.
-    endpoints: [http://localhost:2181]
+    # endpoints is an array of Zookeeper server addresses. Config source will 
+    # try to connect to these endpoints to access Zookeeper clusters.
+    endpoints: [localhost:2181]
     # timeout sets the amount of time for which a session is considered valid after
     # losing connection to a server. Within the session timeout it's possible to 
     # reestablish a connection to a different server and keep the same session.
     timeout: 10s
 ```
 
-If multiple paths are needed create different instances of the config source, example:
+If multiple paths are needed, create different instances of the config 
+source. For example:
 
 ```yaml
 config_sources:
-    # Assuming that the environment variables ZOOKEEPER_ADDR is the defined and the 
+    # Assuming that the environment variable ZOOKEEPER_ADDR is defined and 
     # different secrets are on the same server but at different paths.
     zookeeper:
       endpoints: [$ZOOKEEPER_ADDR]

--- a/internal/configsource/zookeeperconfigsource/factory.go
+++ b/internal/configsource/zookeeperconfigsource/factory.go
@@ -17,8 +17,6 @@ package zookeeperconfigsource
 import (
 	"context"
 	"errors"
-	"fmt"
-	"net/url"
 	"time"
 
 	"go.opentelemetry.io/collector/config"
@@ -35,11 +33,8 @@ const (
 	defaultTimeout  = time.Second * 10
 )
 
-// Private error types to help with testability.
-type (
-	errMissingEndpoint struct{ error }
-	errInvalidEndpoint struct{ error }
-)
+// Private error type to help with testability.
+type errMissingEndpoint struct{ error }
 
 type zkFactory struct{}
 
@@ -60,12 +55,6 @@ func (v *zkFactory) CreateConfigSource(_ context.Context, params configprovider.
 
 	if len(zkCfg.Endpoints) == 0 {
 		return nil, &errMissingEndpoint{errors.New("cannot connect to zk without any endpoints")}
-	}
-
-	for _, uri := range zkCfg.Endpoints {
-		if _, err := url.ParseRequestURI(uri); err != nil {
-			return nil, &errInvalidEndpoint{fmt.Errorf("invalid endpoint %q: %w", uri, err)}
-		}
 	}
 
 	return &zookeeperconfigsource{

--- a/internal/configsource/zookeeperconfigsource/factory_test.go
+++ b/internal/configsource/zookeeperconfigsource/factory_test.go
@@ -44,23 +44,9 @@ func TestZookeeperFactory_CreateConfigSource(t *testing.T) {
 			wantErr: &errMissingEndpoint{},
 		},
 		{
-			name: "invalid_endpoint",
-			config: &Config{
-				Endpoints: []string{"some\bad/endpoint"},
-			},
-			wantErr: &errInvalidEndpoint{},
-		},
-		{
-			name: "invalid_endpoint_partial",
-			config: &Config{
-				Endpoints: []string{"http://localhost:8200", "bad endpoint"},
-			},
-			wantErr: &errInvalidEndpoint{},
-		},
-		{
 			name: "success",
 			config: &Config{
-				Endpoints: []string{"http://localhost:8200"},
+				Endpoints: []string{"localhost:8200"},
 			},
 		},
 	}


### PR DESCRIPTION
Previous ZK endpoint validation required endpoints to be valid URLs, but URLs don't appear
to be valid ZK endpoints. ZK needs a bare hostname or a hostname:port. This change removes
the endpoint validation altogether and leaves it to ZK. Change manually tested on Linux
against the latest ZK.