### PR TITLE
translatesfx: add support for vault remote config

### DIFF
--- a/cmd/translatesfx/translatesfx/cli.go
+++ b/cmd/translatesfx/translatesfx/cli.go
@@ -57,7 +57,7 @@ func translateConfig(fname, wd string) string {
 	if err != nil {
 		log.Fatalf("error loading config %q: %v", fname, err)
 	}
-	saExpanded, err := expandSA(orig, wd)
+	saExpanded, vaultPaths, err := expandSA(orig, wd)
 	if err != nil {
 		log.Fatalf("error expanding Smart Agent config: %v", err)
 	}
@@ -65,7 +65,7 @@ func translateConfig(fname, wd string) string {
 	if err != nil {
 		log.Fatalf("error expanding config: %v", err)
 	}
-	oc := saInfoToOtelConfig(saInfo)
+	oc := saInfoToOtelConfig(saInfo, vaultPaths)
 
 	bytes, err := yaml.Marshal(oc)
 	if err != nil {

--- a/cmd/translatesfx/translatesfx/sa_test.go
+++ b/cmd/translatesfx/translatesfx/sa_test.go
@@ -27,7 +27,7 @@ func TestExpandSA_Map(t *testing.T) {
 	var v interface{}
 	err := yaml.UnmarshalStrict([]byte(yml), &v)
 	require.NoError(t, err)
-	out, _, _ := expand(v, "", yamlPath{})
+	out, _, _ := expand(v, "", yamlPath{}, nil)
 	require.NoError(t, err)
 	expected := `myMap:
   baz: glarch
@@ -41,7 +41,7 @@ func TestExpandSA_List(t *testing.T) {
 	var v interface{}
 	err := yaml.UnmarshalStrict([]byte(yml), &v)
 	require.NoError(t, err)
-	out, _, _ := expand(v, "", yamlPath{})
+	out, _, _ := expand(v, "", yamlPath{}, nil)
 	expandedYaml, err := yaml.Marshal(out)
 	require.NoError(t, err)
 	expected := `myList:
@@ -60,7 +60,7 @@ func TestExpandSA_FlattenSlice(t *testing.T) {
 	var v interface{}
 	err := yaml.UnmarshalStrict([]byte(yml), &v)
 	require.NoError(t, err)
-	out, _, _ := expand(v, "", yamlPath{})
+	out, _, _ := expand(v, "", yamlPath{}, nil)
 	expandedYaml, err := yaml.Marshal(out)
 	require.NoError(t, err)
 	expected := `list:
@@ -81,7 +81,7 @@ func TestExpandSA_FlattenMap(t *testing.T) {
 	var v interface{}
 	err := yaml.UnmarshalStrict([]byte(yml), &v)
 	require.NoError(t, err)
-	expanded, _, _ := expand(v, "", yamlPath{})
+	expanded, _, _ := expand(v, "", yamlPath{}, nil)
 	require.NoError(t, err)
 	expected := map[interface{}]interface{}{
 		"map": map[interface{}]interface{}{
@@ -95,7 +95,7 @@ func TestExpandSA_FlattenMap(t *testing.T) {
 
 func TestExpandSA_Complex(t *testing.T) {
 	v := fromYAML(t, "testdata/sa-complex.yaml")
-	expanded, err := expandSA(v, "")
+	expanded, _, err := expandSA(v, "")
 	require.NoError(t, err)
 	assert.Equal(t, "https://api.us1.signalfx.com", expanded["apiUrl"])
 	monitors := expanded["monitors"].([]interface{})
@@ -115,7 +115,7 @@ func TestExpandSA_Complex(t *testing.T) {
 
 func TestMultiMonitors(t *testing.T) {
 	v := fromYAML(t, "testdata/sa-multimonitors.yaml")
-	expanded, err := expandSA(v, "")
+	expanded, _, err := expandSA(v, "")
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(expanded["monitors"].([]interface{})))
 }

--- a/cmd/translatesfx/translatesfx/testdata/otel-e2e-expected.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/otel-e2e-expected.yaml
@@ -7,6 +7,11 @@ config_sources:
   etcd2:
     endpoints:
       - http://127.0.0.1:2379
+  vault/0:
+    endpoint: http://127.0.0.1:8200
+    path: /secret/sfx
+    auth:
+      token: abc123
 extensions:
   k8s_observer:
     auth_type: serviceAccount
@@ -27,7 +32,7 @@ receivers:
   smartagent/processlist:
     type: processlist
   smartagent/signalfx-forwarder:
-    listenAddress: "0.0.0.0:9080"
+    listenAddress: ${vault/0:port}
     type: signalfx-forwarder
   smartagent/vsphere:
     type: vsphere

--- a/cmd/translatesfx/translatesfx/testdata/sa-e2e-input.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/sa-e2e-input.yaml
@@ -12,6 +12,10 @@ configSources:
   etcd2:
     endpoints:
       - http://127.0.0.1:2379
+  vault:
+    vaultAddr: http://127.0.0.1:8200
+    vaultToken: abc123
+
 globalDimensions:
   aaa: 42
   bbb: 111
@@ -26,7 +30,7 @@ monitors:
   - type: collectd/redis
     discoveryRule: container_image =~ "redis" && port == 6379
   - type: signalfx-forwarder
-    listenAddress: 0.0.0.0:9080
+    listenAddress: {"#from": "vault:/secret/sfx[port]"}
   - type: processlist
   - type: vsphere
     host: 1.2.3.4

--- a/cmd/translatesfx/translatesfx/testdata/sa-vault.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/sa-vault.yaml
@@ -1,0 +1,20 @@
+signalFxAccessToken: abc123
+ingestUrl: https://ingest.us1.signalfx.com
+apiUrl: https://api.us1.signalfx.com
+
+bundleDir: /usr/lib/signalfx-agent
+
+collectd:
+  configDir: /var/run/signalfx-agent
+
+configSources:
+  vault:
+    vaultAddr: http://127.0.0.1:8200
+    vaultToken: abc123
+
+monitors:
+  - type: collectd/redis
+    host: localhost
+    port: {"#from": "vault:/secret/redis[port]"}
+  - type: signalfx-forwarder
+    listenAddress: 0.0.0.0:9080

--- a/cmd/translatesfx/translatesfx/translate_test.go
+++ b/cmd/translatesfx/translatesfx/translate_test.go
@@ -51,7 +51,7 @@ func TestSAExpandedToCfgInfo_ZK(t *testing.T) {
 
 func yamlToCfgInfo(t *testing.T, filename string) saCfgInfo {
 	v := fromYAML(t, filename)
-	expanded, err := expandSA(v, "")
+	expanded, _, err := expandSA(v, "")
 	require.NoError(t, err)
 	cfg, err := saExpandedToCfgInfo(expanded)
 	require.NoError(t, err)


### PR DESCRIPTION
This change converts Vault remote configs in Smart Agent to Otel Config Sources.

For example, the following partial Smart Agent config:
```
configSources:
  vault:
    vaultAddr: http://127.0.0.1:8200
    vaultToken: abc123
monitors:
  - type: vsphere
    username: bob
    password: {"#from": "vault:/secret/sfx[password]"}
```

is translated into

```
config_sources:
  vault/0:
    endpoint: http://127.0.0.1:8200
    path: /secret/sfx
    auth:
      token: abc123
receivers:
  smartagent/vsphere:
    username: bob
    password: ${vault/0:password}
```
