### PR TITLE
Fix memory limit calculation for deployments with 20Gi+ of total memory

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -89,7 +89,7 @@ processors:
   # Enabling the memory_limiter is strongly recommended for every pipeline.
   # Configuration is based on the amount of memory allocated to the collector.
   # In general, the ballast should be set to 1/3 of the collector's memory, the limit
-  # should be 90% of the collector's memory up to 2GB. The simplest way to specify the
+  # should be 90% of the collector's memory. The simplest way to specify the
   # ballast size is set the value of SPLUNK_BALLAST_SIZE_MIB env variable. Alternatively, the
   # --mem-ballast-size-mib command line flag can be passed and take priority.
   # For more information about memory limiter, see

--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -221,7 +221,7 @@ processors:
   # Configuration is based on the amount of memory allocated to the collector.
   # The configuration below assumes 2GB of memory. In general, the ballast
   # should be set to 1/3 of the collector's memory, the limit should be 90% of
-  # the collector's memory up to 2GB.
+  # the collector's memory.
   # NOTE: These settings need to be change when using this processor
   memory_limiter:
     ballast_size_mib: 650

--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -54,7 +54,7 @@ processors:
   # Enabling the memory_limiter is strongly recommended for every pipeline.
   # Configuration is based on the amount of memory allocated to the collector.
   # In general, the ballast should be set to 1/3 of the collector's memory, the limit
-  # should be 90% of the collector's memory up to 2GB. The simplest way to specify the
+  # should be 90% of the collector's memory. The simplest way to specify the
   # ballast size is set the value of SPLUNK_BALLAST_SIZE_MIB env variable. Alternatively, the
   # --mem-ballast-size-mib command line flag can be passed and take priority.
   # For more information about memory limiter, see

--- a/cmd/otelcol/config/collector/otlp_config_linux.yaml
+++ b/cmd/otelcol/config/collector/otlp_config_linux.yaml
@@ -46,7 +46,7 @@ processors:
   # Enabling the memory_limiter is strongly recommended for every pipeline.
   # Configuration is based on the amount of memory allocated to the collector.
   # In general, the ballast should be set to 1/3 of the collector's memory, the limit
-  # should be 90% of the collector's memory up to 2GB. The simplest way to specify the
+  # should be 90% of the collector's memory. The simplest way to specify the
   # ballast size is set the value of SPLUNK_BALLAST_SIZE_MIB env variable. Alternatively, the
   # --mem-ballast-size-mib command line flag can be passed and take priority.
   # For more information about memory limiter, see

--- a/cmd/otelcol/config/collector/upstream_agent_config.yaml
+++ b/cmd/otelcol/config/collector/upstream_agent_config.yaml
@@ -6,7 +6,7 @@
 # - SPLUNK_ACCESS_TOKEN: The Splunk access token to authenticate requests
 # - SPLUNK_API_URL: The Splunk API URL, e.g. https://api.us0.signalfx.com
 # - SPLUNK_BALLAST_SIZE_MIB: This size of the ballast which should be 1/3 to 1/2 of memory allocated
-# - SPLUNK_MEMORY_LIMIT_MIB: 80% of memory allocated up to 2GB
+# - SPLUNK_MEMORY_LIMIT_MIB: 90% of memory allocated
 # - SPLUNK_HEC_TOKEN: The Splunk HEC authentication token
 # - SPLUNK_HEC_URL: The Splunk HEC endpoint URL, e.g. https://ingest.us0.signalfx.com/v1/log
 # - SPLUNK_INGEST_URL: The Splunk ingest URL, e.g. https://ingest.us0.signalfx.com
@@ -83,7 +83,7 @@ processors:
   # Enabling the memory_limiter is strongly recommended for every pipeline.
   # Configuration is based on the amount of memory allocated to the collector.
   # In general, the ballast should be set to 1/3 of the collector's memory, the limit
-  # should be 90% of the collector's memory up to 2GB. The simplest way to specify the
+  # should be 90% of the collector's memory. The simplest way to specify the
   # ballast size is set the value of SPLUNK_BALLAST_SIZE_MIB env variable. Alternatively, the
   # --mem-ballast-size-mib command line flag can be passed and take priority.
   # For more information about memory limiter, see

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -52,7 +52,6 @@ const (
 	defaultLocalOTLPConfig         = "cmd/otelcol/config/collector/otlp_config_linux.yaml"
 	defaultMemoryBallastPercentage = 33
 	defaultMemoryLimitPercentage   = 90
-	defaultMemoryLimitMaxMiB       = 2048
 	defaultMemoryTotalMiB          = 512
 )
 
@@ -291,11 +290,6 @@ func setMemoryLimit(memTotalSizeMiB int) {
 	// If not, calculate it from memTotalSizeMiB
 	if memoryLimit == "" {
 		memLimit = memTotalSizeMiB * defaultMemoryLimitPercentage / 100
-		// The memory limit should be set to defaultMemoryLimitPercentage of total memory
-		// while reserving a maximum of defaultMemoryLimitMaxMiB of memory.
-		if (memTotalSizeMiB - memLimit) > defaultMemoryLimitMaxMiB {
-			memLimit = defaultMemoryLimitMaxMiB
-		}
 	} else {
 		memLimit, _ = strconv.Atoi(memoryLimit)
 	}

--- a/cmd/otelcol/main_test.go
+++ b/cmd/otelcol/main_test.go
@@ -249,7 +249,7 @@ func TestSetMemoryLimit(t *testing.T) {
 	os.Unsetenv(memLimitMiBEnvVarName)
 	setMemoryLimit(100000)
 
-	HelperTestSetMemoryLimit("2048", t)
+	HelperTestSetMemoryLimit("90000", t)
 
 	os.Args = oldArgs
 	os.Setenv(memLimitMiBEnvVarName, "200")

--- a/examples/kubernetes-yaml/splunk-otel-collector-agent.yaml
+++ b/examples/kubernetes-yaml/splunk-otel-collector-agent.yaml
@@ -96,8 +96,8 @@ data:
       # Configuration is based on the amount of memory allocated to the collector.
       # The configuration below assumes 2GB of memory. In general, the ballast
       # should be set to 1/3 of the collector's memory, the limit should be 90% of
-      # the collector's memory up to 2GB, and the spike should be 25% of the
-      # collector's memory up to 2GB. In addition, the "--mem-ballast-size-mib" CLI
+      # the collector's memory, and the spike should be 25% of the
+      # collector's memory. In addition, the "--mem-ballast-size-mib" CLI
       # flag must be set to the same value as the "ballast_size_mib". For more
       # information, see
       # https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiter/README.md

--- a/examples/kubernetes-yaml/splunk-otel-collector-gateway.yaml
+++ b/examples/kubernetes-yaml/splunk-otel-collector-gateway.yaml
@@ -96,8 +96,8 @@ data:
       # Configuration is based on the amount of memory allocated to the collector.
       # The configuration below assumes 2GB of memory. In general, the ballast
       # should be set to 1/3 of the collector's memory, the limit should be 90% of
-      # the collector's memory up to 2GB, and the spike should be 25% of the
-      # collector's memory up to 2GB. In addition, the "--mem-ballast-size-mib" CLI
+      # the collector's memory, and the spike should be 25% of the
+      # collector's memory. In addition, the "--mem-ballast-size-mib" CLI
       # flag must be set to the same value as the "ballast_size_mib". For more
       # information, see
       # https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiter/README.md


### PR DESCRIPTION
Bug: If `SPLUNK_MEMORY_TOTAL_MIB` set to more than 20480, the calculated memory limit drops from 90% to 2048 and collector is failing to start with 
```
main.go:283: Memory limit (2048) is less than 2x ballast (6761). Increase memory limit or decrease ballast size.
```

This change fixes the bug and removes the unnecessary complication for default memory limit calculation. If user wants to adjust memory allocation for a 20Gb+ deployment they can always use `SPLUNK_MEMORY_LIMIT_MIB` env var.