### PR TITLE
Update the splunk-otel-collector docker image to fix broken examples

### DIFF
--- a/examples/prometheus-federation/docker-compose.yml
+++ b/examples/prometheus-federation/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - /opt/splunk/etc
   # OpenTelemetry Collector
   otelcollector:
-    image: quay.io/signalfx/splunk-otel-collector:0.5.0
+    image: quay.io/signalfx/splunk-otel-collector:0.29.0
     container_name: otelcollector
     command: ["--config=/etc/otel-collector-config.yml", "--log-level=DEBUG"]
     volumes:

--- a/examples/splunk-hec-metrics/docker-compose.yml
+++ b/examples/splunk-hec-metrics/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - /opt/splunk/etc
   # OpenTelemetry Collector
   otelcollector:
-    image:  quay.io/signalfx/splunk-otel-collector:0.5.0
+    image:  quay.io/signalfx/splunk-otel-collector:0.29.0
     container_name: otelcollector
     command: ["--config=/etc/otel-collector-config.yml", "--log-level=DEBUG"]
     volumes:

--- a/examples/splunk-hec/docker-compose.yml
+++ b/examples/splunk-hec/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - /opt/splunk/etc
   # OpenTelemetry Collector
   otelcollector:
-    image:  quay.io/signalfx/splunk-otel-collector:0.5.0
+    image:  quay.io/signalfx/splunk-otel-collector:0.29.0
     container_name: otelcollector
     command: ["--config=/etc/otel-collector-config.yml", "--log-level=DEBUG"]
     volumes:


### PR DESCRIPTION
The example projects fail to run, the otel-collector-config health_check extension contains an endpoint entry which didn't exist when docker image 0.5.0 was built, it was added with https://github.com/open-telemetry/opentelemetry-collector/pull/2782
