### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,14 @@
 * @signalfx/gdi-data-collection-approvers @signalfx/gdi-data-collection-maintainers
 
 .github/CODEOWNERS @signalfx/gdi-data-collection-maintainers
+
+#####################################################
+#
+# Docs reviewers
+#
+#####################################################
+
+*.md @signalfx/docs
+*.rst @signalfx/docs
+docs/ @signalfx/docs
+README* @signalfx/docs @signalfx/gdi-specification-approvers @signalfx/gdi-specification-maintainers


### PR DESCRIPTION
Updating CODEOWNERS to set docs team as reviewers for docs files.

This change was approved and merged to GDI specs in https://github.com/signalfx/gdi-specification/pull/115/files