### PR TITLE
Add Heroku buildpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-bin/
+/bin/
 dist/
 
 # GoLand IDEA

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ __pycache__
 
 # Ansible Molecule
 .cache
+
+# Heroku
+deployments/heroku/test/.git
+deployments/heroku/test/node_modules

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ This distribution is supported on and packaged for a variety of platforms includ
   - Configuration management
     - [Ansible](https://galaxy.ansible.com/signalfx/splunk_otel_collector)
     - [Puppet](https://forge.puppet.com/modules/signalfx/splunk_otel_collector)
+  - Platform as a Service
+    - [Heroku](deployments/heroku/README.md)
   - [Manual](./docs/getting-started/linux-manual.md) including DEB/RPM packages, Docker, and binary
 - Windows
   - [Installer script (recommended)](./docs/getting-started/windows-installer.md)

--- a/deployments/heroku/README.md
+++ b/deployments/heroku/README.md
@@ -1,0 +1,65 @@
+# Splunk OpenTelemetry Connector Heroku Buildpack
+
+A Heroku buildpack to install and run the Splunk OpenTelemetry Connector on a
+Dyno and send data to Splunk Observability Cloud.
+
+> :construction: This project is currently in **BETA**
+
+## Getting Started
+
+[Install the Heroku CLI, login, and create an
+app](https://devcenter.heroku.com/articles/heroku-cli). Add and configure the
+buildpack:
+
+```
+# cd into the Heroku project directory
+# WARNING: running `heroku` command outside of project directories
+#          will result in unexpected behavior
+#cd test
+#git init
+#heroku apps:create splunk-example
+
+# Configure Heroku App to expose Dyno metadata
+# This metadata is required by the Splunk OpenTelemetry Connector to
+# set global dimensions such as `app_name`, `app_id` and `dyno_id`.
+# See [here](https://devcenter.heroku.com/articles/dyno-metadata) for more information.
+heroku labs:enable runtime-dyno-metadata
+
+# Add buildpack for Splunk OpenTelemetry Connector
+heroku buildpacks:add https://github.com/signalfx/splunk-otel-collector-heroku.git#<BUILDPACK_VERSION>
+# Required for test application
+#heroku buildpacks:add heroku/nodejs
+
+# Setup required environment variables
+heroku config:set SPLUNK_ACCESS_TOKEN=<YOUR_ACCESS_TOKEN>
+heroku config:set SPLUNK_REALM=<YOUR_REALM>
+
+# Optionally define custom configuration file
+#heroku config:set SPLUNK_OTEL_CONFIG=/app/test/config.yaml
+
+# If these buildpacks are being added to an existing project,
+# create an empty commit prior to deploying the app
+git commit --allow-empty -m "empty commit"
+
+# Deploy your app
+git push heroku main
+
+# Check logs
+#heroku logs -a splunk-example --tail
+```
+
+## Advanced Configuration
+
+Use the following environment variables to configure this buildpack
+
+| Environment Variable      | Required | Default                                             | Description                                                                     |
+| ----------------------    | -------- | -------                                             | -------------------------------------------------------------------------       |
+| `SPLUNK_REALM`            | Yes      | `us0`                                               | Your Splunk realm.                                                              |
+| `SPLUNK_TOKEN`            | Yes      |                                                     | Your Splunk access token.                                                       |
+| `SPLUNK_API_URL`          | No       | `https://api.SPLUNK_REALM.signalfx.com`             | The Splunk API base URL.                                                        |
+| `SPLUNK_CONFIG`           | No       | `/app/config.yaml`                                  | The configuration to use. `/app/.splunk/config.yaml` used if default not found. |
+| `SPLUNK_INGEST_URL`       | No       | `https://ingest.SPLUNK_REALM.signalfx.com`          | The Splunk Infrastructure Monitoring base URL.                                  |
+| `SPLUNK_LOG_FILE`         | No       | `/dev/stdout`                                       | Specify location of agent logs. If not specified, logs will go to stdout.       |
+| `SPLUNK_MEMORY_TOTAL_MIB` | No       | `512`                                               | Total available memory to agent.                                                |
+| `SPLUNK_OTEL_VERSION`     | No       | `latest`                                            | Version of Splunk OTel Connector to use. Defaults to latest.                    |
+| `SPLUNK_TRACE_URL`        | No       | `https://ingest.SPLUNK_REALM.signalfx.com/v2/trace` | The Splunk APM base URL.                                                        |

--- a/deployments/heroku/README.md
+++ b/deployments/heroku/README.md
@@ -3,8 +3,6 @@
 A Heroku buildpack to install and run the Splunk OpenTelemetry Connector on a
 Dyno and send data to Splunk Observability Cloud.
 
-> :construction: This project is currently in **BETA**
-
 ## Getting Started
 
 [Install the Heroku CLI, login, and create an
@@ -26,7 +24,7 @@ buildpack:
 heroku labs:enable runtime-dyno-metadata
 
 # Add buildpack for Splunk OpenTelemetry Connector
-heroku buildpacks:add https://github.com/signalfx/splunk-otel-collector-heroku.git#<BUILDPACK_VERSION>
+heroku buildpacks:add https://github.com/signalfx/splunk-otel-collector.git#heroku-v<BUILDPACK_VERSION>
 # Required for test application
 #heroku buildpacks:add heroku/nodejs
 
@@ -35,7 +33,7 @@ heroku config:set SPLUNK_ACCESS_TOKEN=<YOUR_ACCESS_TOKEN>
 heroku config:set SPLUNK_REALM=<YOUR_REALM>
 
 # Optionally define custom configuration file
-#heroku config:set SPLUNK_OTEL_CONFIG=/app/test/config.yaml
+#heroku config:set SPLUNK_CONFIG=/app/config.yaml
 
 # If these buildpacks are being added to an existing project,
 # create an empty commit prior to deploying the app
@@ -54,7 +52,7 @@ Use the following environment variables to configure this buildpack
 
 | Environment Variable      | Required | Default                                             | Description                                                                     |
 | ----------------------    | -------- | -------                                             | -------------------------------------------------------------------------       |
-| `SPLUNK_REALM`            | Yes      | `us0`                                               | Your Splunk realm.                                                              |
+| `SPLUNK_REALM`            | Yes      |                                                     | Your Splunk realm.                                                              |
 | `SPLUNK_TOKEN`            | Yes      |                                                     | Your Splunk access token.                                                       |
 | `SPLUNK_API_URL`          | No       | `https://api.SPLUNK_REALM.signalfx.com`             | The Splunk API base URL.                                                        |
 | `SPLUNK_CONFIG`           | No       | `/app/config.yaml`                                  | The configuration to use. `/app/.splunk/config.yaml` used if default not found. |

--- a/deployments/heroku/bin/compile
+++ b/deployments/heroku/bin/compile
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+BUILD_DIR=$1
+CACHE_DIR=$2
+ENV_DIR=$3
+BUILDPACK_DIR=$(cd "$(dirname "$0")"; cd ..; pwd)
+
+indent() {
+  sed -u 's/^/       /'
+}
+
+# Use the latest version of Splunk OpenTelemetry Connector if none is specified
+SPLUNK_OTEL_VERSION=$(curl -s https://api.github.com/repos/signalfx/splunk-otel-collector/releases/latest | grep tarball_url | cut -d'"' -f4 | cut -d'/' -f8 | cut -d'v' -f2)
+# Get Splunk OpenTelemetry Connector version from the environment if available
+if [ -f "$ENV_DIR/SPLUNK_OTEL_VERSION" ]; then
+  SPLUNK_OTEL_VERSION=$(cat "$ENV_DIR/SPLUNK_OTEL_VERSION")
+fi
+splunk_otel_connector="otelcol_linux_amd64"
+
+# Use the latest version of the SignalFx Agent if none is specified
+SFX_AGENT_VERSION=$(curl -s https://api.github.com/repos/signalfx/signalfx-agent/releases/latest | grep tarball_url | cut -d'"' -f4 | cut -d'/' -f8 | cut -d'v' -f2)
+# Get SignalFx Agent version from the environment if available
+if [ -f "$ENV_DIR/SFX_AGENT_VERSION" ]; then
+  SFX_AGENT_VERSION=$(cat "$ENV_DIR/SFX_AGENT_VERSION")
+fi
+signalfx_agent_tar="signalfx-agent-$SFX_AGENT_VERSION.tar.gz"
+
+SPLUNK_CONFIG_DIR="$BUILD_DIR/.splunk"
+SFX_AGENT_CONFIG_DIR="$SPLUNK_CONFIG_DIR/etc/signalfx-agent"
+mkdir -p "$SPLUNK_CONFIG_DIR/etc/signalfx-agent"
+cp "$BUILDPACK_DIR/setup/config.yaml" "$SPLUNK_CONFIG_DIR"
+
+echo "-----> Downloading Splunk OpenTelemetry Connector $SPLUNK_OTEL_VERSION ($splunk_otel_connector)"
+wget -P "$SPLUNK_CONFIG_DIR/" "https://github.com/signalfx/splunk-otel-collector/releases/download/v$SPLUNK_OTEL_VERSION/$splunk_otel_connector" -o $splunk_otel_connector > /dev/null 2>&1
+#curl -L "https://github.com/signalfx/splunk-otel-collector/releases/download/v$SPLUNK_OTEL_VERSION/$splunk_otel_connector" -o $SPLUNK_CONFIG_DIR/$splunk_otel_connector > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Downloading Splunk OpenTelemetry Connector tarball failed" | indent
+    echo "$SPLUNK_OTEL_VERSION may not be a valid version of the Splunk OpenTelemetry Connector." | indent
+    echo "Find valid versions here: https://github.com/signalfx/splunk-otel-collector/tags" | indent
+    exit 1;
+fi
+
+echo "-----> Downloading SignalFx Agent Bundle $SFX_AGENT_VERSION ($signalfx_agent_tar)"
+wget -P "$SPLUNK_CONFIG_DIR/" "https://github.com/signalfx/signalfx-agent/releases/download/v$SFX_AGENT_VERSION/$signalfx_agent_tar" -o $signalfx_agent_tar > /dev/null 2>&1
+#curl -L "https://github.com/signalfx/signalfx-agent/releases/download/v$SFX_AGENT_VERSION/$signalfx_agent_tar" -o $SPLUNK_CONFIG_DIR/$signalfx_agent_tar > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Downloading agent tarball failed" | indent
+    echo "$SFX_AGENT_VERSION may not be a valid version of the SignalFx Agent." | indent
+    echo "Find valid versions here: https://github.com/signalfx/signalfx-agent/tags" | indent
+    exit 1;
+fi
+
+echo "-----> Extracting SignalFx Agent Bundle"
+tar -xf "$SPLUNK_CONFIG_DIR/$signalfx_agent_tar" -C "$SPLUNK_CONFIG_DIR"
+rm -f "$SPLUNK_CONFIG_DIR/$signalfx_agent_tar"
+
+mkdir -p "$BUILD_DIR/.profile.d"
+cp "$BUILDPACK_DIR/setup/agent.sh" "$BUILD_DIR/.profile.d/"
+chmod +x "$BUILD_DIR/.profile.d/agent.sh"

--- a/deployments/heroku/bin/compile
+++ b/deployments/heroku/bin/compile
@@ -1,5 +1,19 @@
 #!/bin/sh
 
+# Copyright Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
@@ -26,8 +40,6 @@ fi
 signalfx_agent_tar="signalfx-agent-$SFX_AGENT_VERSION.tar.gz"
 
 SPLUNK_CONFIG_DIR="$BUILD_DIR/.splunk"
-SFX_AGENT_CONFIG_DIR="$SPLUNK_CONFIG_DIR/etc/signalfx-agent"
-mkdir -p "$SPLUNK_CONFIG_DIR/etc/signalfx-agent"
 cp "$BUILDPACK_DIR/setup/config.yaml" "$SPLUNK_CONFIG_DIR"
 
 echo "-----> Downloading Splunk OpenTelemetry Connector $SPLUNK_OTEL_VERSION ($splunk_otel_connector)"

--- a/deployments/heroku/bin/detect
+++ b/deployments/heroku/bin/detect
@@ -1,3 +1,17 @@
 #!/bin/sh
 
+# Copyright Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 echo "Splunk OpenTelemetry Connector installation" && exit 0

--- a/deployments/heroku/bin/detect
+++ b/deployments/heroku/bin/detect
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Splunk OpenTelemetry Connector installation" && exit 0

--- a/deployments/heroku/bin/release
+++ b/deployments/heroku/bin/release
@@ -1,5 +1,19 @@
 #!/bin/sh
 
+# Copyright Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cat <<EOF
 ---
 EOF

--- a/deployments/heroku/bin/release
+++ b/deployments/heroku/bin/release
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cat <<EOF
+---
+EOF

--- a/deployments/heroku/setup/agent.sh
+++ b/deployments/heroku/setup/agent.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+if [ "$DYNOTYPE" == "run" ]; then
+    exit 0
+fi
+
+# Set configuration file
+
+export SPLUNK_CONFIG_DIR="$HOME/.splunk"
+export SPLUNK_COLLECTD_CONFIG_DIR="$SPLUNK_CONFIG_DIR/signalfx-agent/var/run/collectd"
+mkdir -p "$SPLUNK_COLLECTD_CONFIG_DIR"
+
+export FALLBACK_AGENT_CONFIG="$SPLUNK_CONFIG_DIR/config.yaml"
+export DEFAULT_APP_CONFIG="$HOME/config.yaml"
+
+if [[ -f "$DEFAULT_APP_CONFIG" ]]; then
+    export SPLUNK_CONFIG="${SPLUNK_CONFIG-$DEFAULT_APP_CONFIG}"
+else
+    # Can be overridden by an envvar
+    export SPLUNK_CONFIG="${SPLUNK_CONFIG-$FALLBACK_AGENT_CONFIG}"
+fi
+
+# Set other env vars
+
+if [[ -z "$SPLUNK_API_URL" ]]; then
+    export SPLUNK_API_URL="https://api.$SPLUNK_REALM.signalfx.com"
+fi
+if [[ -z "$SPLUNK_INGEST_URL" ]]; then
+    export SPLUNK_INGEST_URL="https://ingest.$SPLUNK_REALM.signalfx.com"
+fi
+if [[ -z "$SPLUNK_TRACE_URL" ]]; then
+    export SPLUNK_TRACE_URL="https://ingest.$SPLUNK_REALM.signalfx.com/v2/trace"
+fi
+
+export SPLUNK_BUNDLE_DIR="$SPLUNK_CONFIG_DIR/signalfx-agent"
+
+if [[ -z "$SPLUNK_LOG_FILE" ]]; then
+    export SPLUNK_LOG_FILE=/dev/stdout
+else
+    mkdir -p $(dirname $SPLUNK_LOG_FILE)
+fi
+
+# Start connector
+
+chmod a+x $SPLUNK_CONFIG_DIR/otelcol_linux_amd64
+$SPLUNK_CONFIG_DIR/otelcol_linux_amd64 > $SPLUNK_LOG_FILE 2>&1&

--- a/deployments/heroku/setup/agent.sh
+++ b/deployments/heroku/setup/agent.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 if [ "$DYNOTYPE" == "run" ]; then
     exit 0
 fi
@@ -41,6 +55,8 @@ else
 fi
 
 # Start connector
+
+(cd $SPLUNK_CONFIG_DIR/signalfx-agent/ && bin/patch-interpreter $SPLUNK_CONFIG_DIR/signalfx-agent/)
 
 chmod a+x $SPLUNK_CONFIG_DIR/otelcol_linux_amd64
 $SPLUNK_CONFIG_DIR/otelcol_linux_amd64 > $SPLUNK_LOG_FILE 2>&1&

--- a/deployments/heroku/setup/config.yaml
+++ b/deployments/heroku/setup/config.yaml
@@ -1,0 +1,150 @@
+config_sources:
+  env:
+    defaults:
+      HEROKU_DYNO_ID: "unset"
+      HEROKU_APP_ID: "unset"
+      HEROKU_APP_NAME: "unset"
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+  http_forwarder:
+    ingress:
+      endpoint: 0.0.0.0:6060
+    egress:
+      endpoint: "${SPLUNK_API_URL}"
+      # Use instead when sending to gateway
+      #endpoint: "${SPLUNK_GATEWAY_URL}"
+  smartagent:
+    bundleDir: "${SPLUNK_BUNDLE_DIR}"
+    collectd:
+      configDir: "${SPLUNK_COLLECTD_DIR}"
+  zpages:
+    #endpoint: 0.0.0.0:55679
+
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:14250
+      thrift_binary:
+        endpoint: 0.0.0.0:6832
+      thrift_compact:
+        endpoint: 0.0.0.0:6831
+      thrift_http:
+        endpoint: 0.0.0.0:14268
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:55681
+  # This section is used to collect the OpenTelemetry Collector metrics
+  # Even if just a Splunk APM customer, these metrics are included
+  prometheus/internal:
+    config:
+      scrape_configs:
+      - job_name: 'otel-collector'
+        scrape_interval: 10s
+        static_configs:
+        - targets: ['0.0.0.0:8888']
+        metric_relabel_configs:
+          - source_labels: [ __name__ ]
+            regex: '.*grpc_io.*'
+            action: drop
+  smartagent/heroku-metadata:
+    type: heroku-metadata
+  smartagent/signalfx-forwarder:
+    type: signalfx-forwarder
+    listenAddress: 0.0.0.0:9080
+  signalfx:
+    endpoint: 0.0.0.0:9943
+  zipkin:
+    endpoint: 0.0.0.0:9411
+
+processors:
+  batch:
+  # Enabling the memory_limiter is strongly recommended for every pipeline.
+  # Configuration is based on the amount of memory allocated to the collector.
+  # In general, the ballast should be set to 1/3 of the collector's memory, the limit
+  # should be 90% of the collector's memory up to 2GB. The simplest way to specify the
+  # ballast size is set the value of SPLUNK_BALLAST_SIZE_MIB env variable. Alternatively, the
+  # --mem-ballast-size-mib command line flag can be passed and take priority.
+  # For more information about memory limiter, see
+  # https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiter/README.md
+  memory_limiter:
+    ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
+    check_interval: 2s
+    limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+  attributes/heroku:
+    actions:
+    - action: insert
+      key: dyno_id
+      value: ${env:HEROKU_DYNO_ID}
+    - action: insert
+      key: app_id
+      value: ${env:HEROKU_APP_ID}
+    - action: insert
+      key: app_name
+      value: ${env:HEROKU_APP_NAME}
+  metricstransform/heroku:
+    transforms:
+    - include: .*
+      match_type: regexp
+      action: update
+      operations:
+        - action: add_label
+          new_label: dyno_id
+          new_value: ${env:HEROKU_DYNO_ID}
+        - action: add_label
+          new_label: app_id
+          new_value: ${env:HEROKU_APP_ID}
+        - action: add_label
+          new_label: app_name
+          new_value: ${env:HEROKU_APP_NAME}
+  # Optional: The following processor can be used to add a default "deployment.environment" attribute to the logs and 
+  # traces when it's not populated by instrumentation libraries.
+  # If enabled, make sure to enable this processor in the pipeline below.
+  #resource/add_environment:
+    #attributes:
+      #- action: insert
+        #key: deployment.environment
+        #value: staging/production/...
+
+exporters:
+  # Traces
+  sapm:
+    access_token: "${SPLUNK_ACCESS_TOKEN}"
+    endpoint: "${SPLUNK_TRACE_URL"
+  # Metrics + Events
+  signalfx:
+    access_token: "${SPLUNK_ACCESS_TOKEN}"
+    api_url: "${SPLUNK_API_URL}"
+    ingest_url: "${SPLUNK_INGEST_URL}"
+  # Send to gateway
+  #otlp:
+  # endpoint: "${SPLUNK_GATEWAY_URL}:4317"
+  # insecure: true
+  # Debug
+  logging:
+    loglevel: debug
+
+service:
+  extensions: [health_check, http_forwarder, zpages]
+  pipelines:
+    traces:
+      receivers: [jaeger, otlp, smartagent/signalfx-forwarder, zipkin]
+      processors:
+      - memory_limiter
+      - batch
+      - attributes/heroku
+      #- resource/add_environment
+      exporters: [sapm, signalfx]
+    metrics:
+      receivers: [otlp, signalfx, smartagent/heroku-metadata, smartagent/signalfx-forwarder]
+      processors: [memory_limiter, batch, metricstransform/heroku]
+      exporters: [signalfx]
+    metrics/internal:
+      receivers: [prometheus/internal]
+      processors: [memory_limiter, batch, metricstransform/heroku]
+      exporters: [signalfx]

--- a/deployments/heroku/test/Procfile
+++ b/deployments/heroku/test/Procfile
@@ -1,0 +1,1 @@
+web: node send_metrics.js

--- a/deployments/heroku/test/README.md
+++ b/deployments/heroku/test/README.md
@@ -1,0 +1,10 @@
+# Example Heroku App
+
+Simple NodeJS application based on [SignalFx
+NodeJS](https://github.com/signalfx/signalfx-nodejs). Emits metrics to local
+Splunk OpenTelemetry Connector. See Procfile for run command. To run locally:
+
+```
+npm install signalfx
+node send_metrics.js
+```

--- a/deployments/heroku/test/config.yaml
+++ b/deployments/heroku/test/config.yaml
@@ -1,0 +1,160 @@
+config_sources:
+  env:
+    defaults:
+      HEROKU_DYNO_ID: "unset"
+      HEROKU_APP_ID: "unset"
+      HEROKU_APP_NAME: "unset"
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+  http_forwarder:
+    ingress:
+      endpoint: 0.0.0.0:6060
+    egress:
+      endpoint: "https://api.${SPLUNK_REALM}.signalfx.com"
+      # Use instead when sending to gateway
+      #endpoint: "${SPLUNK_GATEWAY_URL}"
+  smartagent:
+    bundleDir: "${SPLUNK_BUNDLE_DIR}"
+    collectd:
+      configDir: "${SPLUNK_COLLECTD_DIR}"
+  zpages:
+    #endpoint: 0.0.0.0:55679
+
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:14250
+      thrift_binary:
+        endpoint: 0.0.0.0:6832
+      thrift_compact:
+        endpoint: 0.0.0.0:6831
+      thrift_http:
+        endpoint: 0.0.0.0:14268
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:55681
+  # This section is used to collect the OpenTelemetry Collector metrics
+  # Even if just a Splunk APM customer, these metrics are included
+  prometheus/internal:
+    config:
+      scrape_configs:
+      - job_name: 'otel-collector'
+        scrape_interval: 10s
+        static_configs:
+        - targets: ['0.0.0.0:8888']
+        metric_relabel_configs:
+          - source_labels: [ __name__ ]
+            regex: '.*grpc_io.*'
+            action: drop
+  smartagent/heroku-metadata:
+    type: heroku-metadata
+  smartagent/signalfx-forwarder:
+    type: signalfx-forwarder
+    listenAddress: 0.0.0.0:9080
+  signalfx:
+    endpoint: 0.0.0.0:9943
+  zipkin:
+    endpoint: 0.0.0.0:9411
+
+processors:
+  batch:
+  # Enabling the memory_limiter is strongly recommended for every pipeline.
+  # Configuration is based on the amount of memory allocated to the collector.
+  # In general, the ballast should be set to 1/3 of the collector's memory, the limit
+  # should be 90% of the collector's memory up to 2GB. The simplest way to specify the
+  # ballast size is set the value of SPLUNK_BALLAST_SIZE_MIB env variable. Alternatively, the
+  # --mem-ballast-size-mib command line flag can be passed and take priority.
+  # For more information about memory limiter, see
+  # https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiter/README.md
+  memory_limiter:
+    ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
+    check_interval: 2s
+    limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+  attributes/heroku:
+    actions:
+    - action: insert
+      key: dyno_id
+      value: ${env:HEROKU_DYNO_ID}
+    - action: insert
+      key: app_id
+      value: ${env:HEROKU_APP_ID}
+    - action: insert
+      key: app_name
+      value: ${env:HEROKU_APP_NAME}
+  # TODO [flands]: Does not work if env var is empty
+  # Also unclear whether this behaves like insert of attributes processor
+  metricstransform/heroku:
+    transforms:
+    - include: .*
+      match_type: regexp
+      action: update
+      operations:
+        - action: add_label
+          new_label: dyno_id
+          new_value: ${env:HEROKU_DYNO_ID}
+        - action: add_label
+          new_label: app_id
+          new_value: ${env:HEROKU_APP_ID}
+        - action: add_label
+          new_label: app_name
+          new_value: ${env:HEROKU_APP_NAME}
+  # Optional: The following processor can be used to add a default "deployment.environment" attribute to the logs and 
+  # traces when it's not populated by instrumentation libraries.
+  # If enabled, make sure to enable this processor in the pipeline below.
+  #resource/add_environment:
+    #attributes:
+      #- action: insert
+        #key: deployment.environment
+        #value: staging/production/...
+
+exporters:
+  # Traces
+  sapm:
+    access_token: "${SPLUNK_ACCESS_TOKEN}"
+    endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com/v2/trace"
+  # Metrics + Events
+  signalfx:
+    access_token: "${SPLUNK_ACCESS_TOKEN}"
+    realm: "${SPLUNK_REALM}"
+    # Use instead when sending to gateway
+    #api_url: http://${SPLUNK_GATEWAY_URL}:6060
+    #ingest_url: http://${SPLUNK_GATEWAY_URL}:9943
+  # Send to gateway
+  #otlp:
+  # endpoint: "${SPLUNK_GATEWAY_URL}:4317"
+  # insecure: true
+  # Debug
+  logging:
+    loglevel: debug
+
+service:
+  extensions: [health_check, http_forwarder, zpages]
+  pipelines:
+    traces:
+      receivers: [jaeger, otlp, smartagent/signalfx-forwarder, zipkin]
+      processors:
+      - memory_limiter
+      - batch
+      - attributes/heroku
+      #- resource/add_environment
+      exporters: [sapm, signalfx]
+      # Use instead when sending to gateway
+      #exporters: [otlp, signalfx]
+    metrics:
+      receivers: [otlp, signalfx, smartagent/heroku-metadata, smartagent/signalfx-forwarder]
+      processors: [memory_limiter, batch, metricstransform/heroku]
+      exporters: [signalfx, logging]
+      # Use instead when sending to gateway
+      #exporters: [otlp]
+    metrics/internal:
+      receivers: [prometheus/internal]
+      processors: [memory_limiter, batch, metricstransform/heroku]
+      exporters: [signalfx]
+      # Use instead when sending to gateway
+      #exporters: [otlp]

--- a/deployments/heroku/test/package.json
+++ b/deployments/heroku/test/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "splunk-heroku-test",
+  "version": "0.0.1",
+  "description": "Node.js client library for Splunk",
+  "homepage": "https://splunk.com",
+  "repository": "https://github.com/signalfx/signalfx-nodejs",
+  "author": {
+    "name": "Splunk, Inc",
+    "email": "info@splunk.com",
+    "url": "https://splunk.com"
+  },
+  "dependencies": {
+    "signalfx": "^7.4.0"
+  },
+  "engines": {
+    "node": ">=8.0.0 <15"
+  },
+  "license": "Apache-2.0"
+}

--- a/deployments/heroku/test/send_metrics.js
+++ b/deployments/heroku/test/send_metrics.js
@@ -1,3 +1,17 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 var signalFx = require('signalfx');
 

--- a/deployments/heroku/test/send_metrics.js
+++ b/deployments/heroku/test/send_metrics.js
@@ -1,0 +1,29 @@
+'use strict';
+var signalFx = require('signalfx');
+
+var token = 'YOUR SIGNALFX TOKEN'; // Replace with you token
+
+var client = new signalFx.Ingest(token, {
+  ingestEndpoint: "http://localhost:9080",
+  enableAmazonUniqueId: false, // Set this parameter to `true` to retrieve and add Amazon unique identifier as dimension
+  dimensions: {dyno_id: 'test.cust_dim'} // This dimension will be added to every datapoint and event
+});
+
+// Sent datapoints routine
+var counter = 0;
+function loop() {
+  setTimeout(function () {
+    console.log(counter);
+    var timestamp = (new Date()).getTime();
+    var gauges = [{metric: 'test.cpu', value: counter % 10, timestamp: timestamp}];
+    var counters = [{metric: 'cpu_cnt', value: counter % 2, timestamp: timestamp}];
+
+    // Send datapoint
+    client.send({gauges: gauges, counters: counters});
+
+    counter += 1;
+    loop();
+  }, 1000);
+}
+
+loop();


### PR DESCRIPTION
The SignalFx Smart Agent has a Heroku buildpack. Create the same
packaging for Splunk OpenTelemetry Connector adding the Smart Agent
bundle. Includes complete feature parity with Smart Agent buildpack.

Changes from Smart Agent buildpack:

- Default to latest releases instead of hard-coding an old version
- More exposed configuration options
- Example application to make it easier to get started (modified from
  signalfx-nodejs)
- Included in same repository instead of dedicated