### PR TITLE
Set required URL and TOKEN env vars for agent config

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -289,19 +289,26 @@ func setMemoryLimit(memTotalSizeMiB int) int {
 
 // Sets environment variables expected by agent_config.yaml if missing
 func setDefaultEnvVars() {
-	realm := os.Getenv("SPLUNK_REALM")
-	token := os.Getenv("SPLUNK_ACCESS_TOKEN")
-	testArgs := [][]string{
-		{"SPLUNK_API_URL", "https://api." + realm + ".signalfx.com"},
-		{"SPLUNK_INGEST_URL", "https://ingest." + realm + ".signalfx.com"},
-		{"SPLUNK_TRACE_URL", "https://ingest." + realm + ".signalfx.com/v2/trace"},
-		{"SPLUNK_HEC_URL", "https://ingest." + realm + ".signalfx.com/v1/log"},
-		{"SPLUNK_HEC_TOKEN", token},
+	realm, realmOk := os.LookupEnv("SPLUNK_REALM")
+	if realmOk {
+		testArgs := [][]string{
+			{"SPLUNK_API_URL", "https://api." + realm + ".signalfx.com"},
+			{"SPLUNK_INGEST_URL", "https://ingest." + realm + ".signalfx.com"},
+			{"SPLUNK_TRACE_URL", "https://ingest." + realm + ".signalfx.com/v2/trace"},
+			{"SPLUNK_HEC_URL", "https://ingest." + realm + ".signalfx.com/v1/log"},
+		}
+		for _, v := range testArgs {
+			_, ok := os.LookupEnv(v[0])
+			if !ok {
+				os.Setenv(v[0], v[1])
+			}
+		}
 	}
-	for _, v := range testArgs {
-		_, ok := os.LookupEnv(v[0])
+	token, tokenOk := os.LookupEnv("SPLUNK_ACCESS_TOKEN")
+	if tokenOk {
+		_, ok := os.LookupEnv("SPLUNK_HEC_TOKEN")
 		if !ok {
-			os.Setenv(v[0], v[1])
+			os.Setenv("SPLUNK_HEC_TOKEN", token)
 		}
 	}
 }

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -289,7 +289,6 @@ func setMemoryLimit(memTotalSizeMiB int) int {
 
 // Sets environment variables expected by agent_config.yaml if missing
 func setDefaultEnvVars() {
-	var tmpVar string
 	realm := os.Getenv("SPLUNK_REALM")
 	token := os.Getenv("SPLUNK_ACCESS_TOKEN")
 	testArgs := [][]string{
@@ -300,8 +299,8 @@ func setDefaultEnvVars() {
 		{"SPLUNK_HEC_TOKEN", token},
 	}
 	for _, v := range testArgs {
-		tmpVar = os.Getenv(v[0])
-		if tmpVar == "" {
+		_, ok := os.LookupEnv(v[0])
+		if !ok {
 			os.Setenv(v[0], v[1])
 		}
 	}

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -291,26 +291,19 @@ func setMemoryLimit(memTotalSizeMiB int) int {
 func setDefaultEnvVars() {
 	var tmpVar string
 	realm := os.Getenv("SPLUNK_REALM")
-	tmpVar = os.Getenv("SPLUNK_API_URL")
-	if tmpVar == "" {
-		os.Setenv("SPLUNK_API_URL", "https://api."+realm+".signalfx.com")
-	}
-	tmpVar = os.Getenv("SPLUNK_INGEST_URL")
-	if tmpVar == "" {
-		os.Setenv("SPLUNK_INGEST_URL", "https://ingest."+realm+".signalfx.com")
-	}
-	tmpVar = os.Getenv("SPLUNK_TRACE_URL")
-	if tmpVar == "" {
-		os.Setenv("SPLUNK_TRACE_URL", "https://ingest."+realm+".signalfx.com/v2/trace")
-	}
-	tmpVar = os.Getenv("SPLUNK_HEC_URL")
-	if tmpVar == "" {
-		os.Setenv("SPLUNK_HEC_URL", "https://ingest."+realm+".signalfx.com/v1/log")
-	}
 	token := os.Getenv("SPLUNK_ACCESS_TOKEN")
-	tmpVar = os.Getenv("SPLUNK_HEC_TOKEN")
-	if tmpVar == "" {
-		os.Setenv("SPLUNK_HEC_TOKEN", token)
+	testArgs := [][]string{
+		{"SPLUNK_API_URL", "https://api." + realm + ".signalfx.com"},
+		{"SPLUNK_INGEST_URL", "https://ingest." + realm + ".signalfx.com"},
+		{"SPLUNK_TRACE_URL", "https://ingest." + realm + ".signalfx.com/v2/trace"},
+		{"SPLUNK_HEC_URL", "https://ingest." + realm + ".signalfx.com/v1/log"},
+		{"SPLUNK_HEC_TOKEN", token},
+	}
+	for _, v := range testArgs {
+	    tmpVar = os.Getenv(v[0])
+	    if tmpVar == "" {
+	    	os.Setenv(v[0], v[1])
+	    }
 	}
 }
 

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -62,6 +62,7 @@ func main() {
 
 	if !contains(os.Args[1:], "-h") && !contains(os.Args[1:], "--help") {
 		checkRuntimeParams()
+		setDefaultEnvVars()
 	}
 
 	// Allow dumping configuration locally by default
@@ -284,6 +285,33 @@ func setMemoryLimit(memTotalSizeMiB int) int {
 	os.Setenv(memLimitMiBEnvVarName, strconv.Itoa(memLimit))
 	log.Printf("Set memory limit to %d MiB", memLimit)
 	return memLimit
+}
+
+// Sets environment variables expected by agent_config.yaml if missing
+func setDefaultEnvVars() {
+	var tmpVar string
+	realm := os.Getenv("SPLUNK_REALM")
+	tmpVar = os.Getenv("SPLUNK_API_URL")
+	if tmpVar == "" {
+		os.Setenv("SPLUNK_API_URL", "https://api."+realm+".signalfx.com")
+	}
+	tmpVar = os.Getenv("SPLUNK_INGEST_URL")
+	if tmpVar == "" {
+		os.Setenv("SPLUNK_INGEST_URL", "https://ingest."+realm+".signalfx.com")
+	}
+	tmpVar = os.Getenv("SPLUNK_TRACE_URL")
+	if tmpVar == "" {
+		os.Setenv("SPLUNK_TRACE_URL", "https://ingest."+realm+".signalfx.com/v2/trace")
+	}
+	tmpVar = os.Getenv("SPLUNK_HEC_URL")
+	if tmpVar == "" {
+		os.Setenv("SPLUNK_HEC_URL", "https://ingest."+realm+".signalfx.com/v1/log")
+	}
+	token := os.Getenv("SPLUNK_ACCESS_TOKEN")
+	tmpVar = os.Getenv("SPLUNK_HEC_TOKEN")
+	if tmpVar == "" {
+		os.Setenv("SPLUNK_HEC_TOKEN", token)
+	}
 }
 
 // Returns a ParserProvider that reads configuration YAML from an environment variable when applicable.

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -300,10 +300,10 @@ func setDefaultEnvVars() {
 		{"SPLUNK_HEC_TOKEN", token},
 	}
 	for _, v := range testArgs {
-	    tmpVar = os.Getenv(v[0])
-	    if tmpVar == "" {
-	    	os.Setenv(v[0], v[1])
-	    }
+		tmpVar = os.Getenv(v[0])
+		if tmpVar == "" {
+			os.Setenv(v[0], v[1])
+		}
 	}
 }
 

--- a/cmd/otelcol/main_test.go
+++ b/cmd/otelcol/main_test.go
@@ -115,7 +115,8 @@ func TestCheckRuntimeParams_LimitAndBallastEnvs(t *testing.T) {
 func TestSetDefaultEnvVars(t *testing.T) {
 	realm := "us1"
 	token := "1234"
-	val := "test"
+	valTest := "test"
+	valEmpty := ""
 
 	os.Setenv("SPLUNK_REALM", realm)
 	os.Setenv("SPLUNK_ACCESS_TOKEN", token)
@@ -128,19 +129,27 @@ func TestSetDefaultEnvVars(t *testing.T) {
 		{"SPLUNK_HEC_TOKEN", token},
 	}
 	for _, v := range testArgs {
-		tmpVar := os.Getenv(v[0])
-		if tmpVar != v[1] {
-			t.Errorf("Expected %v got %v for %v", v[1], tmpVar, v[0])
+		val, _ := os.LookupEnv(v[0])
+		if val != v[1] {
+			t.Errorf("Expected %v got %v for %v", v[1], val, v[0])
 		}
 	}
 
 	testArgs2 := []string{"SPLUNK_API_URL", "SPLUNK_INGEST_URL", "SPLUNK_TRACE_URL", "SPLUNK_HEC_URL", "SPLUNK_HEC_TOKEN"}
 	for _, v := range testArgs2 {
-		os.Setenv(v, val)
+		os.Setenv(v, valTest)
 		setDefaultEnvVars()
-		tmpVar := os.Getenv(v)
-		if tmpVar != val {
-			t.Errorf("Expected %v got %v for %v", val, tmpVar, v)
+		val, _ := os.LookupEnv(v)
+		if val != valTest {
+			t.Errorf("Expected %v got %v for %v", valTest, val, v)
+		}
+	}
+	for _, v := range testArgs2 {
+		os.Setenv(v, valEmpty)
+		setDefaultEnvVars()
+		val, _ := os.LookupEnv(v)
+		if val != valEmpty {
+			t.Errorf("Expected %v got %v for %v", valEmpty, val, v)
 		}
 	}
 }

--- a/cmd/otelcol/main_test.go
+++ b/cmd/otelcol/main_test.go
@@ -112,6 +112,39 @@ func TestCheckRuntimeParams_LimitAndBallastEnvs(t *testing.T) {
 	os.Clearenv()
 }
 
+func TestSetDefaultEnvVars(t *testing.T) {
+	realm := "us1"
+	token := "1234"
+	val := "test"
+
+	os.Setenv("SPLUNK_REALM", realm)
+	os.Setenv("SPLUNK_ACCESS_TOKEN", token)
+	setDefaultEnvVars()
+	testArgs := [][]string{
+		{"SPLUNK_API_URL", "https://api." + realm + ".signalfx.com"},
+		{"SPLUNK_INGEST_URL", "https://ingest." + realm + ".signalfx.com"},
+		{"SPLUNK_TRACE_URL", "https://ingest." + realm + ".signalfx.com/v2/trace"},
+		{"SPLUNK_HEC_URL", "https://ingest." + realm + ".signalfx.com/v1/log"},
+		{"SPLUNK_HEC_TOKEN", token},
+	}
+	for _, v := range testArgs {
+		tmpVar := os.Getenv(v[0])
+		if tmpVar != v[1] {
+			t.Errorf("Expected %v got %v for %v", v[1], tmpVar, v[0])
+		}
+	}
+
+	testArgs2 := []string{"SPLUNK_API_URL", "SPLUNK_INGEST_URL", "SPLUNK_TRACE_URL", "SPLUNK_HEC_URL", "SPLUNK_HEC_TOKEN"}
+	for _, v := range testArgs2 {
+		os.Setenv(v, val)
+		setDefaultEnvVars()
+		tmpVar := os.Getenv(v)
+		if tmpVar != val {
+			t.Errorf("Expected %v got %v for %v", val, tmpVar, v)
+		}
+	}
+}
+
 func TestCheckRuntimeParams_MemTotalLimitAndBallastEnvs(t *testing.T) {
 	oldArgs := os.Args
 	assert.NoError(t, os.Setenv(configEnvVarName, path.Join("../../", defaultLocalSAPMConfig)))

--- a/cmd/otelcol/main_test.go
+++ b/cmd/otelcol/main_test.go
@@ -113,6 +113,15 @@ func TestCheckRuntimeParams_LimitAndBallastEnvs(t *testing.T) {
 }
 
 func TestSetDefaultEnvVars(t *testing.T) {
+	testArgs := []string{"SPLUNK_API_URL", "SPLUNK_INGEST_URL", "SPLUNK_TRACE_URL", "SPLUNK_HEC_URL", "SPLUNK_HEC_TOKEN"}
+	for _, v := range testArgs {
+		setDefaultEnvVars()
+		_, ok := os.LookupEnv(v)
+		if ok {
+			t.Errorf("Expected %v unset given SPLUNK_ACCESS_TOKEN or SPLUNK_TOKEN is unset", v)
+		}
+	}
+
 	realm := "us1"
 	token := "1234"
 	valTest := "test"
@@ -121,22 +130,21 @@ func TestSetDefaultEnvVars(t *testing.T) {
 	os.Setenv("SPLUNK_REALM", realm)
 	os.Setenv("SPLUNK_ACCESS_TOKEN", token)
 	setDefaultEnvVars()
-	testArgs := [][]string{
+	testArgs2 := [][]string{
 		{"SPLUNK_API_URL", "https://api." + realm + ".signalfx.com"},
 		{"SPLUNK_INGEST_URL", "https://ingest." + realm + ".signalfx.com"},
 		{"SPLUNK_TRACE_URL", "https://ingest." + realm + ".signalfx.com/v2/trace"},
 		{"SPLUNK_HEC_URL", "https://ingest." + realm + ".signalfx.com/v1/log"},
 		{"SPLUNK_HEC_TOKEN", token},
 	}
-	for _, v := range testArgs {
+	for _, v := range testArgs2 {
 		val, _ := os.LookupEnv(v[0])
 		if val != v[1] {
 			t.Errorf("Expected %v got %v for %v", v[1], val, v[0])
 		}
 	}
 
-	testArgs2 := []string{"SPLUNK_API_URL", "SPLUNK_INGEST_URL", "SPLUNK_TRACE_URL", "SPLUNK_HEC_URL", "SPLUNK_HEC_TOKEN"}
-	for _, v := range testArgs2 {
+	for _, v := range testArgs {
 		os.Setenv(v, valTest)
 		setDefaultEnvVars()
 		val, _ := os.LookupEnv(v)
@@ -144,7 +152,8 @@ func TestSetDefaultEnvVars(t *testing.T) {
 			t.Errorf("Expected %v got %v for %v", valTest, val, v)
 		}
 	}
-	for _, v := range testArgs2 {
+
+	for _, v := range testArgs {
 		os.Setenv(v, valEmpty)
 		setDefaultEnvVars()
 		val, _ := os.LookupEnv(v)


### PR DESCRIPTION
If you deploy Splunk OTel Connector outside of installer script then the
gateway configuration is used. If the agent configuration was desired,
it was really hard to switch:

```
$ > SPLUNK_ACCESS_TOKEN=1234 SPLUNK_REALM=us0 SPLUNK_CONFIG=../cmd/otelcol/config/collector/agent_config.yaml ./otelcol_darwin_amd64
2021/07/23 11:30:17 main.go:198: Set config to ../cmd/otelcol/config/collector/agent_config.yaml
2021/07/23 11:30:17 main.go:283: Set ballast to 168 MiB
2021/07/23 11:30:17 main.go:307: Set memory limit to 460 MiB
2021-07-23T11:30:17.907-0400	info	service/collector.go:283	Starting otelcol...	{"Version": "v0.29.0-43-g491b2f0", "NumCPU": 12}
2021-07-23T11:30:17.910-0400	info	service/collector.go:343	Using memory ballast	{"MiBs": 168}
2021-07-23T11:30:17.910-0400	info	service/collector.go:188	Setting up own telemetry...
2021-07-23T11:30:17.919-0400	info	service/telemetry.go:99	Serving Prometheus metrics	{"address": ":8888", "level": 0, "service.instance.id": "c928a31c-d214-4287-b7bb-d2b802138d1c"}
2021-07-23T11:30:17.919-0400	info	service/collector.go:224	Loading configuration...
2021-07-23T11:30:17.939-0400	info	service/collector.go:240	Applying configuration...
Error: cannot build extensions: cannot build builtExtensions: failed to create extension http_forwarder: 'egress.endpoint' config option cannot be empty
2021/07/23 11:30:17 main.go:94: application run finished with error: cannot build extensions: cannot build builtExtensions: failed to create extension http_forwarder: 'egress.endpoint' config option cannot be empty
```

To make it work:

```
SPLUNK_ACCESS_TOKEN=1234 SPLUNK_REALM=us0 SPLUNK_CONFIG=../cmd/otelcol/config/collector/agent_config.yaml \
  SPLUNK_API_URL=https://api.us0.signalfx.com SPLUNK_INGEST_URL=https://ingest.us0.signalfx.com \
  SPLUNK_TRACE_URL=https://ingest.us0.signalfx.com/v2/trace SPLUNK_HEC_URL=https://ingest.us0.signalfx.com/v1/log\
  ./otelcol_darwin_amd64
```

This is awful customer experience. The behavior is not surprising as the
agent config needs to optimize for both direct to SaaS and via gateway
data routing. The installer script mitigates this today.

The good news is that this is straightforward to address. Given
`SPLUNK_REALM` is required and the SaaS URLs are known and same for
`SPLUNK_ACCESS_TOKEN` we can set the required environment variable if
not manually specified.