### PR TITLE
Allow running integration tests on mac os

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ALL_SRC := $(shell find . -name '*.go' \
 # ALL_PKGS is the list of all packages where ALL_SRC files reside.
 ALL_PKGS := $(shell go list $(sort $(dir $(ALL_SRC))))
 
-ALL_TESTS_DIRS := $(shell find tests -name *_test.go | xargs dirname | uniq | sort -r)
+ALL_TESTS_DIRS := $(shell find tests -name '*_test.go' | xargs -L 1 dirname | uniq | sort -r)
 
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release

--- a/tests/testutils/container_test.go
+++ b/tests/testutils/container_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"io"
 	"path"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -341,10 +342,16 @@ func TestTestcontainersContainerMethods(t *testing.T) {
 	assert.EqualValues(t, "12345/tcp", port)
 	require.NoError(t, err)
 
+	expectedPorts := []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "12345"}}
+	if runtime.GOOS == "darwin" {
+		expectedPorts = append(expectedPorts, nat.PortBinding{HostIP: "::", HostPort: "12345"})
+	}
+
 	portMap, err := alpine.Ports(context.Background())
 	expectedPortMap := nat.PortMap(map[nat.Port][]nat.PortBinding{
-		"12345/tcp": {{HostIP: "0.0.0.0", HostPort: "12345"}},
+		"12345/tcp": expectedPorts,
 	})
+
 	assert.EqualValues(t, expectedPortMap, portMap)
 	require.NoError(t, err)
 

--- a/tests/testutils/testcase.go
+++ b/tests/testutils/testcase.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -106,11 +107,17 @@ func (t *Testcase) SplunkOtelCollector(configFilename string) (Collector, func()
 		collector = &cp
 	}
 
+	otlpEndpointForContainer := t.OTLPEndpoint
+	if runtime.GOOS == "darwin" {
+		port := strings.Split(otlpEndpointForContainer, ":")[1]
+		otlpEndpointForContainer = fmt.Sprintf("host.docker.internal:%s", port)
+	}
+
 	var err error
 	collector = collector.WithConfigPath(
 		path.Join(".", "testdata", configFilename),
 	).WithEnv(map[string]string{
-		"OTLP_ENDPOINT":  t.OTLPEndpoint,
+		"OTLP_ENDPOINT":  otlpEndpointForContainer,
 		"SPLUNK_TEST_ID": t.ID,
 	}).WithLogLevel("debug").WithLogger(t.Logger)
 


### PR DESCRIPTION
These changes slightly update the method of finding test files, reaching the host via [`host.docker.internal`](https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds), and accounting for ipv6* in docker port maps on mac.