### PR TITLE
Change default config server port to 55554

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -41,7 +41,7 @@ is configured in.
 
 - `http(s)://0.0.0.0:13133/` Health endpoint useful for load balancer monitoring
 - `http(s)://0.0.0.0:[6831|6832|14250|14268]/api/traces` Jaeger [gRPC|Thrift HTTP] receiver
-- `http(s)://localhost:55555/debug/configz/[initial|effective]` in-memory configuration
+- `http(s)://localhost:55554/debug/configz/[initial|effective]` in-memory configuration
 - `http(s)://localhost:55679/debug/[tracez|pipelinez]` zPages monitoring
 - `http(s)://0.0.0.0:4317` OpenTelemetry gRPC receiver
 - `http(s)://0.0.0.0:6060` HTTP Forwarder used to receive Smart Agent `apiUrl` data

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,8 +31,8 @@ In addition, it is important to gather support information including:
 
 - Configuration file
   - Running OpenTelemetry Collector
-    - `http://localhost:55555/debug/configz/initial`
-    - `http://localhost:55555/debug/configz/effective`
+    - `http://localhost:55554/debug/configz/initial`
+    - `http://localhost:55554/debug/configz/effective`
   - Kubernetes: `kubectl get configmap my-configmap -o yaml >my-configmap.yaml`
   - Linux: `/etc/otel/collector`
 - Logs and ideally debug logs

--- a/internal/buildscripts/packaging/fpm/etc/otel/collector/splunk-support-bundle.sh
+++ b/internal/buildscripts/packaging/fpm/etc/otel/collector/splunk-support-bundle.sh
@@ -124,11 +124,11 @@ getConfig() {
     fi
     # Also need to get config in memory as dynamic config may modify stored config
     # It's possible user has disabled collecting in memory config
-    if timeout 1 bash -c 'cat < /dev/null > /dev/tcp/localhost/55555'; then
-        curl -s http://localhost:55555/debug/configz/initial >"$TMPDIR"/config/initial.yaml 2>&1
-        curl -s http://localhost:55555/debug/configz/effective >"$TMPDIR"/config/effective.yaml 2>&1
+    if timeout 1 bash -c 'cat < /dev/null > /dev/tcp/localhost/55554'; then
+        curl -s http://localhost:55554/debug/configz/initial >"$TMPDIR"/config/initial.yaml 2>&1
+        curl -s http://localhost:55554/debug/configz/effective >"$TMPDIR"/config/effective.yaml 2>&1
     else
-        echo "WARN: localhost:55555 unavailable so in memory configuration not collected"
+        echo "WARN: localhost:55554 unavailable so in memory configuration not collected"
     fi
 
 }

--- a/internal/configprovider/config_server.go
+++ b/internal/configprovider/config_server.go
@@ -30,7 +30,7 @@ const (
 	configServerEnabledEnvVar = "SPLUNK_DEBUG_CONFIG_SERVER"
 	configServerPortEnvVar    = "SPLUNK_DEBUG_CONFIG_SERVER_PORT"
 
-	defaultConfigServerEndpoint = "localhost:55555"
+	defaultConfigServerEndpoint = "localhost:55554"
 )
 
 type configServer struct {


### PR DESCRIPTION
It appears Mac OS Big Sur uses port 55555:
https://developer.apple.com/forums/thread/671197. To ease user
experience, change the default port of the config server.

While this is a breaking change, the port is only exposed locally and
used by the support bundle script. As a result, this should not have
user impact beyond education of the updated port.