### PR TITLE
Set path ownership on deb/rpm postinstall

### DIFF
--- a/internal/buildscripts/packaging/fpm/postinstall.sh
+++ b/internal/buildscripts/packaging/fpm/postinstall.sh
@@ -20,6 +20,14 @@ if [ -f /usr/lib/splunk-otel-collector/agent-bundle/bin/patch-interpreter ]; the
     /usr/lib/splunk-otel-collector/agent-bundle/bin/patch-interpreter /usr/lib/splunk-otel-collector/agent-bundle
 fi
 
+if [ -d /etc/otel/collector ]; then
+    chown -R splunk-otel-collector:splunk-otel-collector /etc/otel/collector
+fi
+
+if [ -d /usr/lib/splunk-otel-collector ]; then
+    chown -R splunk-otel-collector:splunk-otel-collector /usr/lib/splunk-otel-collector
+fi
+
 if command -v systemctl >/dev/null 2>&1; then
     systemctl daemon-reload
     systemctl enable splunk-otel-collector.service


### PR DESCRIPTION
Ensures that the paths are accessible by the `splunk-otel-collector` service user/group if the deb/rpm package is not installed by the installer script.