### PR TITLE
translatesfx: translate metricsToExclude

### DIFF
--- a/cmd/translatesfx/translatesfx/otel.go
+++ b/cmd/translatesfx/translatesfx/otel.go
@@ -36,6 +36,7 @@ func saInfoToOtelConfig(sa saCfgInfo, vaultPaths []string) *otelCfg {
 	translateSAExtension(sa, otel)
 	translateObservers(sa, otel)
 	translateConfigSources(sa, otel, vaultPaths)
+	translateFilters(sa, otel)
 	return otel
 }
 
@@ -70,6 +71,120 @@ func newOtelCfg() *otelCfg {
 			},
 		},
 	}
+}
+
+func translateFilters(sa saCfgInfo, otel *otelCfg) {
+	if sa.metricsToExclude == nil {
+		return
+	}
+	procName := "filter"
+	otel.Processors[procName] = map[string]interface{}{
+		"metrics": map[string]interface{}{
+			"exclude": map[string]interface{}{
+				"match_type":  "expr",
+				"expressions": saFiltersToExpr(sa.metricsToExclude),
+			},
+		},
+	}
+	otel.Service.Pipelines["metrics"].appendProcessor(procName)
+}
+
+func saFiltersToExpr(excludes []interface{}) []string {
+	var out []string
+	for _, excludeV := range excludes {
+		exclude, ok := excludeV.(map[interface{}]interface{})
+		if !ok {
+			return nil
+		}
+		var names []interface{}
+		namesV, ok := exclude["metricNames"]
+		if !ok {
+			if nameV, metricNameOK := exclude["metricName"]; metricNameOK {
+				names = []interface{}{nameV}
+			} else {
+				return nil
+			}
+		} else {
+			names = namesV.([]interface{})
+		}
+		line := metricNamesToExpr(names)
+
+		dimsV, ok := exclude["dimensions"]
+		var dims map[interface{}]interface{}
+		if ok && dimsV != nil {
+			dims = dimsV.(map[interface{}]interface{})
+		}
+		dimExpr := dimsToExpr(dims)
+		if dimExpr != "" {
+			if line != "" {
+				line += " and "
+			}
+			line += "(" + dimExpr + ")"
+		}
+
+		out = append(out, line)
+	}
+	return out
+}
+
+func metricNamesToExpr(names []interface{}) string {
+	out := ""
+	for _, nameV := range names {
+		name := nameV.(string)
+		rex, negated := globToRegexpStr(name)
+		stmt := fmt.Sprintf("MetricName matches %q", rex)
+		out += wrapStatement(stmt, out == "", negated)
+	}
+	return out
+}
+
+func dimsToExpr(dimSets map[interface{}]interface{}) string {
+	if dimSets == nil {
+		return ""
+	}
+	out := ""
+	for dimsKey, ds := range dimSets {
+		var dimSet []interface{}
+		switch t := ds.(type) {
+		case string:
+			dimSet = []interface{}{t}
+		case []interface{}:
+			dimSet = t
+		}
+
+		for _, dim := range dimSet {
+			rex, negated := globToRegexpStr(dim.(string))
+			stmt := fmt.Sprintf("Label(%q) matches %q", dimsKey, rex)
+			out += wrapStatement(stmt, out == "", negated)
+		}
+	}
+	return out
+}
+
+func wrapStatement(stmt string, empty, negated bool) string {
+	if negated {
+		stmt = "not (" + stmt + ")"
+		if empty {
+			return stmt
+		}
+		return " and " + stmt
+	}
+	if !empty {
+		return " or " + stmt
+	}
+	return stmt
+}
+
+func globToRegexpStr(s string) (string, bool) {
+	negated := false
+	if strings.HasPrefix(s, "!") {
+		s = s[1:]
+		negated = true
+	}
+	s = strings.ReplaceAll(s, ".", `\.`)
+	s = strings.ReplaceAll(s, "*", ".*")
+	s = strings.ReplaceAll(s, "?", ".{1}")
+	return "^" + s + "$", negated
 }
 
 func translateExporters(sa saCfgInfo, cfg *otelCfg) {
@@ -248,6 +363,14 @@ func interfaceMapToStringMap(in map[interface{}]interface{}) map[string]interfac
 	return out
 }
 
+func stringMapToInterfaceMap(in map[string]interface{}) map[interface{}]interface{} {
+	out := map[interface{}]interface{}{}
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
 func saMonitorToRCReceiver(monitor map[string]interface{}) map[string]map[string]interface{} {
 	key := "smartagent/" + monitor["type"].(string)
 	rcr := discoveryRuleToRCRule(monitor["discoveryRule"].(string))
@@ -353,4 +476,9 @@ type rpe struct {
 func (r *rpe) appendReceiver(name string) {
 	r.Receivers = append(r.Receivers, name)
 	sort.Strings(r.Receivers)
+}
+
+func (r *rpe) appendProcessor(name string) {
+	r.Processors = append(r.Processors, name)
+	sort.Strings(r.Processors)
 }

--- a/cmd/translatesfx/translatesfx/testdata/otel-e2e-expected.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/otel-e2e-expected.yaml
@@ -60,6 +60,12 @@ processors:
       - ecs
       - ec2
       - azure
+  filter:
+    metrics:
+      exclude:
+        match_type: expr
+        expressions:
+          - MetricName matches "^unwanted_metric_.*$"
 exporters:
   signalfx:
     access_token: "${include:token}"
@@ -82,8 +88,9 @@ service:
         - smartagent/signalfx-forwarder
         - smartagent/vsphere
       processors:
-        - resourcedetection
+        - filter
         - metricstransform
+        - resourcedetection
       exporters:
         - signalfx
     traces:

--- a/cmd/translatesfx/translatesfx/testdata/otel-e2e-expected.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/otel-e2e-expected.yaml
@@ -65,7 +65,13 @@ processors:
       exclude:
         match_type: expr
         expressions:
-          - MetricName matches "^unwanted_metric_.*$"
+          - MetricName matches "^node_filesystem_.*$" and not (MetricName
+            matches "^node_filesystem_free_bytes$") and not (MetricName matches
+            "^node_filesystem_readonly$")
+          - MetricName matches "^node_network_.*$" and (Label("interface")
+            matches "^.*$" and not (Label("interface") matches "^eth0$"))
+          - MetricName matches "^node_disk_.*$" and (Label("device") matches
+            "^sr.*$")
 exporters:
   signalfx:
     access_token: "${include:token}"

--- a/cmd/translatesfx/translatesfx/testdata/sa-dp-to-exclude-simple.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/sa-dp-to-exclude-simple.yaml
@@ -1,0 +1,15 @@
+---
+signalFxAccessToken: "abc123"
+signalFxRealm: us1
+
+intervalSeconds: 10
+
+logging:
+  level: info
+
+metricsToExclude:
+  - metricNames:
+      - node_filesystem_*
+
+monitors:
+  - type: cpu

--- a/cmd/translatesfx/translatesfx/testdata/sa-dp-to-exclude.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/sa-dp-to-exclude.yaml
@@ -1,0 +1,32 @@
+---
+signalFxAccessToken: "abc123"
+signalFxRealm: us1
+
+intervalSeconds: 10
+
+logging:
+  level: info
+
+metricsToExclude:
+  # This filter causes only the 'free bytes' and 'readonly' filesystem
+  # metrics to be sent, excluding all other metrics that start with
+  # 'node_filesystem_'.
+  - metricNames:
+      - node_filesystem_*
+      - '!node_filesystem_free_bytes'
+      - '!node_filesystem_readonly'
+
+  # This filter causes all network metrics, *except* for those about eth0, to
+  # be dropped.
+  - metricName: node_network_*
+    dimensions:
+      interface: [ '*', '!eth0' ]
+
+  # This filter causes all datapoints that start with 'node_disk_' that have
+  # a 'device' dimension that starts with 'sr' to be dropped.
+  - metricName: node_disk_*
+    dimensions:
+      device: sr*
+
+monitors:
+  - type: cpu

--- a/cmd/translatesfx/translatesfx/testdata/sa-e2e-input.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/sa-e2e-input.yaml
@@ -26,6 +26,10 @@ collectd:
 observers:
   - type: k8s-api
 
+metricsToExclude:
+  - metricNames:
+      - unwanted_metric_*
+
 monitors:
   - type: collectd/redis
     discoveryRule: container_image =~ "redis" && port == 6379

--- a/cmd/translatesfx/translatesfx/testdata/sa-e2e-input.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/sa-e2e-input.yaml
@@ -28,7 +28,17 @@ observers:
 
 metricsToExclude:
   - metricNames:
-      - unwanted_metric_*
+      - node_filesystem_*
+      - '!node_filesystem_free_bytes'
+      - '!node_filesystem_readonly'
+
+  - metricName: node_network_*
+    dimensions:
+      interface: [ '*', '!eth0' ]
+
+  - metricName: node_disk_*
+    dimensions:
+      device: sr*
 
 monitors:
   - type: collectd/redis

--- a/cmd/translatesfx/translatesfx/translate.go
+++ b/cmd/translatesfx/translatesfx/translate.go
@@ -21,13 +21,14 @@ import (
 )
 
 type saCfgInfo struct {
-	globalDims    map[interface{}]interface{}
-	saExtension   map[string]interface{}
-	configSources map[interface{}]interface{}
-	accessToken   string
-	realm         string
-	monitors      []interface{}
-	observers     []interface{}
+	globalDims       map[interface{}]interface{}
+	saExtension      map[string]interface{}
+	configSources    map[interface{}]interface{}
+	accessToken      string
+	realm            string
+	monitors         []interface{}
+	observers        []interface{}
+	metricsToExclude []interface{}
 }
 
 func saExpandedToCfgInfo(saExpanded map[interface{}]interface{}) (saCfgInfo, error) {
@@ -36,13 +37,14 @@ func saExpandedToCfgInfo(saExpanded map[interface{}]interface{}) (saCfgInfo, err
 		return saCfgInfo{}, err
 	}
 	return saCfgInfo{
-		accessToken:   saExpanded["signalFxAccessToken"].(string),
-		realm:         realm,
-		monitors:      saExpanded["monitors"].([]interface{}),
-		globalDims:    globalDims(saExpanded),
-		saExtension:   saExtension(saExpanded),
-		observers:     observers(saExpanded),
-		configSources: configSources(saExpanded),
+		accessToken:      saExpanded["signalFxAccessToken"].(string),
+		realm:            realm,
+		monitors:         saExpanded["monitors"].([]interface{}),
+		globalDims:       globalDims(saExpanded),
+		saExtension:      saExtension(saExpanded),
+		observers:        observers(saExpanded),
+		configSources:    configSources(saExpanded),
+		metricsToExclude: metricsToExclude(saExpanded),
 	}, nil
 }
 
@@ -130,4 +132,16 @@ func configSources(saExpanded map[interface{}]interface{}) map[interface{}]inter
 		return nil
 	}
 	return cs
+}
+
+func metricsToExclude(saExpanded map[interface{}]interface{}) []interface{} {
+	v, ok := saExpanded["metricsToExclude"]
+	if !ok {
+		return nil
+	}
+	l, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	return l
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/signalfx/splunk-otel-collector
 go 1.16
 
 require (
+	github.com/antonmedv/expr v1.8.9
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.1.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/fsnotify/fsnotify v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -424,6 +424,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-xdr v0.0.0-20161123171359-e6a2ba005892/go.mod h1:CTDl0pzVzE5DEzZhPfvhY/9sPFMQIxaJ9VAMs9AagrE=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
+github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc h1:VRRKCwnzqk8QCaRC4os14xoKDdbHqqlJtJA0oc1ZAjg=
 github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denisenkom/go-mssqldb v0.10.0 h1:QykgLZBorFE95+gO3u9esLd0BmbvpWp0/waNNZfHBM8=
 github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
@@ -1966,6 +1967,8 @@ github.com/signalfx/golib/v3 v3.0.0/go.mod h1:p+krygP/cDlWvCBEgdkQp3H16rbP4NW7YQ
 github.com/signalfx/golib/v3 v3.3.33 h1:eRUZr8wydlnNrmpHckharCzAGOe2tM7vYUbj0fPLYmg=
 github.com/signalfx/golib/v3 v3.3.33/go.mod h1:PB7OovVijH7OGhzMewarEcIZG3eG6akWMDucIb5Jnb4=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
+github.com/signalfx/ingest-protocols v0.1.2 h1:AA3hui7XKbnmwsIz4nStwBFVEs23hIAhtQEMCFqZ5NQ=
+github.com/signalfx/ingest-protocols v0.1.2/go.mod h1:DCcHV20IlFlaG/B6E12v5nzWXMHlnggqH6I3cUmOhHs=
 github.com/signalfx/ingest-protocols v0.1.3 h1:DQOQPCxhFVV+9lv9cPlBjRufvL59afLX3R2BuPGJQQo=
 github.com/signalfx/ingest-protocols v0.1.3/go.mod h1:DRkLEiNXgz6GDZNHvQyIZIZazic936eMjQShpyiteVc=
 github.com/signalfx/ondiskencoding v0.0.0-20190715171447-33ec316a03f8/go.mod h1:QnApFvs6JyNrtyeE9dTCtAWYxDqUZv2KzFpuQm853FU=


### PR DESCRIPTION
This change translates a Smart Agent config's metricsToExclude globs to an equivalent Otel filter processor.

Given the following metricsToExclude in a SmartAgent config:
```
metricsToExclude:
  - metricNames:
      - node_filesystem_*
      - '!node_filesystem_free_bytes'
      - '!node_filesystem_readonly'

  - metricName: node_network_*
    dimensions:
      interface: [ '*', '!eth0' ]

  - metricName: node_disk_*
    dimensions:
      device: sr*
```

the following filter processor will be generated:

```
  filter:
    metrics:
      exclude:
        match_type: expr
        expressions:
          - MetricName matches "^node_filesystem_.*$" and not (MetricName
            matches "^node_filesystem_free_bytes$") and not (MetricName matches
            "^node_filesystem_readonly$")
          - MetricName matches "^node_network_.*$" and (Label("interface")
            matches "^.*$" and not (Label("interface") matches "^eth0$"))
          - MetricName matches "^node_disk_.*$" and (Label("device") matches
            "^sr.*$")
```

and added to the metrics pipeline.