### PR TITLE
translatesfx: directly translate realm and urls from SA to SFx exporter

### DIFF
--- a/cmd/translatesfx/translatesfx/cli.go
+++ b/cmd/translatesfx/translatesfx/cli.go
@@ -61,10 +61,7 @@ func translateConfig(fname, wd string) string {
 	if err != nil {
 		log.Fatalf("error expanding Smart Agent config: %v", err)
 	}
-	saInfo, err := saExpandedToCfgInfo(saExpanded)
-	if err != nil {
-		log.Fatalf("error expanding config: %v", err)
-	}
+	saInfo := saExpandedToCfgInfo(saExpanded)
 	oc := saInfoToOtelConfig(saInfo, vaultPaths)
 
 	bytes, err := yaml.Marshal(oc)

--- a/cmd/translatesfx/translatesfx/otel.go
+++ b/cmd/translatesfx/translatesfx/otel.go
@@ -183,7 +183,7 @@ func globToRegexpStr(s string) (string, bool) {
 }
 
 func translateExporters(sa saCfgInfo, cfg *otelCfg) {
-	cfg.Exporters = sfxExporter(sa.accessToken, sa.realm)
+	cfg.Exporters = sfxExporter(sa)
 }
 
 func translateMonitors(sa saCfgInfo, cfg *otelCfg) {
@@ -341,12 +341,21 @@ func receiverList(receivers map[string]map[string]interface{}) []string {
 	return keys
 }
 
-func sfxExporter(accessToken, realm string) map[string]map[string]interface{} {
+func sfxExporter(sa saCfgInfo) map[string]map[string]interface{} {
+	cfg := map[string]interface{}{
+		"access_token": sa.accessToken,
+	}
+	if sa.realm != "" {
+		cfg["realm"] = sa.realm
+	}
+	if sa.ingestURL != "" {
+		cfg["ingest_url"] = sa.ingestURL
+	}
+	if sa.APIURL != "" {
+		cfg["api_url"] = sa.APIURL
+	}
 	return map[string]map[string]interface{}{
-		"signalfx": {
-			"access_token": accessToken,
-			"realm":        realm,
-		},
+		"signalfx": cfg,
 	}
 }
 

--- a/cmd/translatesfx/translatesfx/otel_test.go
+++ b/cmd/translatesfx/translatesfx/otel_test.go
@@ -76,23 +76,6 @@ func TestMonitorToReceiver_Rule(t *testing.T) {
 	require.True(t, ok)
 }
 
-func TestAPIURLToRealm(t *testing.T) {
-	us0, _ := apiURLToRealm(map[interface{}]interface{}{
-		"apiUrl": "https://api.signalfx.com",
-	})
-	assert.Equal(t, "us0", us0)
-
-	us1, _ := apiURLToRealm(map[interface{}]interface{}{
-		"apiUrl": "https://api.us1.signalfx.com",
-	})
-	assert.Equal(t, "us1", us1)
-
-	us2, _ := apiURLToRealm(map[interface{}]interface{}{
-		"signalFxRealm": "us2",
-	})
-	assert.Equal(t, "us2", us2)
-}
-
 func TestMTOperations(t *testing.T) {
 	ops := mtOperations(map[interface{}]interface{}{
 		"d": "3",
@@ -297,7 +280,7 @@ func yamlToOtelConfig(t *testing.T, filename string) *otelCfg {
 	cfg := fromYAML(t, filename)
 	expanded, vaultPaths, err := expandSA(cfg, "")
 	require.NoError(t, err)
-	info, err := saExpandedToCfgInfo(expanded)
+	info := saExpandedToCfgInfo(expanded)
 	require.NoError(t, err)
 	return saInfoToOtelConfig(info, vaultPaths)
 }
@@ -595,4 +578,11 @@ func TestOptionalForwarder(t *testing.T) {
 	assert.False(t, ok)
 	_, ok = cfg.Receivers["smartagent/signalfx-forwarder"]
 	assert.False(t, ok)
+}
+
+func TestSFxExporterUrls(t *testing.T) {
+	cfg := yamlToOtelConfig(t, "testdata/sa-collectd.yaml")
+	exporter := cfg.Exporters["signalfx"]
+	assert.Equal(t, "https://ingest.us1.signalfx.com", exporter["ingest_url"])
+	assert.Equal(t, "https://api.us1.signalfx.com", exporter["api_url"])
 }

--- a/cmd/translatesfx/translatesfx/testdata/sa-e2e-input.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/sa-e2e-input.yaml
@@ -1,6 +1,5 @@
 signalFxAccessToken: { "#from": "token" }
-ingestUrl: https://ingest.us1.signalfx.com
-apiUrl: https://api.us1.signalfx.com
+signalFxRealm: us1
 
 bundleDir: /usr/lib/signalfx-agent
 

--- a/cmd/translatesfx/translatesfx/translate_test.go
+++ b/cmd/translatesfx/translatesfx/translate_test.go
@@ -25,7 +25,8 @@ import (
 
 func TestSAExpandedToCfgInfo(t *testing.T) {
 	cfg := yamlToCfgInfo(t, "testdata/sa-complex.yaml")
-	assert.Equal(t, "us1", cfg.realm)
+	assert.Equal(t, "https://ingest.us1.signalfx.com", cfg.ingestURL)
+	assert.Equal(t, "https://api.us1.signalfx.com", cfg.APIURL)
 	assert.Equal(t, "${include:testdata/token}", cfg.accessToken)
 	assert.Equal(t, 3, len(cfg.monitors))
 	assert.Equal(t, 2, len(cfg.globalDims))
@@ -53,9 +54,7 @@ func yamlToCfgInfo(t *testing.T, filename string) saCfgInfo {
 	v := fromYAML(t, filename)
 	expanded, _, err := expandSA(v, "")
 	require.NoError(t, err)
-	cfg, err := saExpandedToCfgInfo(expanded)
-	require.NoError(t, err)
-	return cfg
+	return saExpandedToCfgInfo(expanded)
 }
 
 func fromYAML(t *testing.T, filename string) interface{} {


### PR DESCRIPTION
Previous version extracted the realm from the SA config's apiURL (which may not even have been specified). This change just translates apiURL, ingestURL, and realm directly from SA config to the SFx exporter config.