### PR TITLE
Add text linking the new release to its Docker image URL

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -11,6 +11,11 @@ categories:
     label: documentation
 tag-template: - $TITLE @$AUTHOR (#$NUMBER)
 template: |
+  ## [Docker image](https://quay.io/repository/signalfx/splunk-otel-collector)
+    This release is available as a Docker image:
+    
+    `quay.io/signalfx/splunk-otel-collector:$NEXT_MINOR_VERSION`
+  
   ## Changes
 
   $CHANGES

--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -11,11 +11,12 @@ categories:
     label: documentation
 tag-template: - $TITLE @$AUTHOR (#$NUMBER)
 template: |
-  ## [Docker image](https://quay.io/repository/signalfx/splunk-otel-collector)
-    This release is available as a Docker image:
-    
-    `quay.io/signalfx/splunk-otel-collector:$NEXT_MINOR_VERSION`
-  
   ## Changes
 
   $CHANGES
+
+  ## [Docker image](https://quay.io/repository/signalfx/splunk-otel-collector)
+  This release is available as a Docker image:
+    
+  `quay.io/signalfx/splunk-otel-collector:$NEXT_MINOR_VERSION`
+  


### PR DESCRIPTION
This change adds a paragraph at the top of the draft of release notes for new versions of the Splunk OpenTelemetry Collector that links to the Quay page showing releases of the Splunk OpenTelemetry Collector, and text of the Docker image URL one can use to take advantage of the release.

It has not been tested.