### PR TITLE
Update S3 release process

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -9,8 +9,8 @@
    to set it up.
 1. You must have access to the `o11y-gdi/splunk-otel-collector-releaser` gitlab
    repo and CI/CD pipeline.
-1. You must have an AWS access key that has permissions to push to the SignalFx
-   S3 bucket, i.e. `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+1. You must have prod access and the `splunkcloud_account_power` role in `us0`
+   to push to the SignalFx S3 bucket.
 1. Install Python 3, [pip](https://pip.pypa.io/en/stable/installing/),
    and [virtualenv](https://virtualenv.pypa.io/en/latest/) on your workstation.
 1. Install the required dependencies with pip in virtualenv on your workstation:
@@ -52,11 +52,12 @@
    [CHANGELOG.md](../CHANGELOG.md).
 1. Download the MSI (`splunk-otel-collector-<VERSION>-amd64.msi`) from the
    Github Release to your workstation.
+1. Request prod access via slack and the `splunkcloud_account_power` role with
+   `okta-aws-setup us0`.
 1. Run the following script in virtualenv to push the signed MSI and installer
    scripts to S3 (replace `PATH_TO_MSI` with the path to the signed MSI file
-   downloaded from the previous step, and `AWS_ACCESS_KEY_ID` and
-   `AWS_SECRET_ACCESS_KEY` with your personal AWS access key).
+   downloaded from the previous step).
    ```
    $ source venv/bin/activate  # if not already in virtualenv
-   $ ./internal/buildscripts/packaging/release/sign_release.py --stage=release --path=PATH_TO_MSI --installers --no-sign-msi --aws-key-id=AWS_ACCESS_KEY_ID --aws-key=AWS_SECRET_ACCESS_KEY
+   $ ./internal/buildscripts/packaging/release/sign_release.py --stage=release --path=PATH_TO_MSI --installers --no-sign-msi
    ```

--- a/internal/buildscripts/packaging/release/helpers/release_args.py
+++ b/internal/buildscripts/packaging/release/helpers/release_args.py
@@ -100,37 +100,6 @@ def check_artifactory_args(args):
     assert args.artifactory_token, f"Artifactory token not set for {ARTIFACTORY_URL}"
 
 
-def add_aws_args(parser):
-    aws_args = parser.add_argument_group("AWS Access Key")
-    aws_args.add_argument(
-        "--aws-key-id",
-        type=str,
-        default=os.environ.get("AWS_ACCESS_KEY_ID"),
-        metavar="AWS_ACCESS_KEY_ID",
-        required=False,
-        help=f"""
-            AWS Access Key ID for s3://{S3_BUCKET}.
-            Required if the AWS_ACCESS_KEY_ID env var is not set'.
-        """,
-    )
-    aws_args.add_argument(
-        "--aws-key",
-        type=str,
-        default=os.environ.get("AWS_SECRET_ACCESS_KEY"),
-        metavar="AWS_SECRET_ACCESS_KEY",
-        required=False,
-        help=f"""
-            AWS Secret Access Key for s3://{S3_BUCKET}.
-            Required if the AWS_SECRET_ACCESS_KEY env var is not set'.
-        """,
-    )
-
-
-def check_aws_args(args):
-    assert args.aws_key_id, "AWS Access Key ID not set"
-    assert args.aws_key, "AWS Secret Access Key not set"
-
-
 def get_asset(path):
     assert os.path.isfile(path), f"{path} not found!"
     asset = Asset(path=path)
@@ -214,7 +183,6 @@ def get_args_and_asset():
 
     add_artifactory_args(parser)
     add_signing_args(parser)
-    add_aws_args(parser)
 
     args = parser.parse_args()
 
@@ -227,10 +195,7 @@ def get_args_and_asset():
     if asset and not (asset.component == "msi" and args.no_sign_msi):
         check_signing_args(args)
 
-    if not args.no_push:
-        if args.installers or asset.component == "msi":
-            check_aws_args(args)
-        elif asset.component in ("deb", "rpm"):
-            check_artifactory_args(args)
+    if not args.no_push and asset and asset.component in ("deb", "rpm"):
+        check_artifactory_args(args)
 
     return args, asset

--- a/internal/buildscripts/packaging/release/sign_release.py
+++ b/internal/buildscripts/packaging/release/sign_release.py
@@ -65,7 +65,7 @@ def main():
 
     # Release installer scripts to S3
     if args.installers and not args.no_push:
-        release_installers_to_s3(args.aws_key_id, args.aws_key, force=args.force)
+        release_installers_to_s3(force=args.force)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Remove the AWS key requirement for S3 releases since it is now replaced by the new okta auth process.  This is temporary until we can automate from gitlab.