### PR TITLE
translatesfx: translate metricsToInclude filters to expr

### DIFF
--- a/cmd/translatesfx/translatesfx/testdata/otel-e2e-expected.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/otel-e2e-expected.yaml
@@ -65,13 +65,13 @@ processors:
       exclude:
         match_type: expr
         expressions:
-          - MetricName matches "^node_filesystem_.*$" and not (MetricName
-            matches "^node_filesystem_free_bytes$") and not (MetricName matches
-            "^node_filesystem_readonly$")
-          - MetricName matches "^node_network_.*$" and (Label("interface")
-            matches "^.*$" and not (Label("interface") matches "^eth0$"))
-          - MetricName matches "^node_disk_.*$" and (Label("device") matches
-            "^sr.*$")
+          - MetricName matches "^node_filesystem_.*$" and not (MetricName matches "^node_filesystem_free_bytes$")
+            and (not (MetricName matches "^node_filesystem_readonly$"))
+          - MetricName matches "^node_network_.*$" and (Label("interface") matches "^.*$"
+            and not (Label("interface") matches "^eth0$")) and (not (MetricName matches
+            "^node_filesystem_readonly$"))
+          - MetricName matches "^node_disk_.*$" and (Label("device") matches "^sr.*$")
+            and (not (MetricName matches "^node_filesystem_readonly$"))
 exporters:
   signalfx:
     access_token: "${include:token}"

--- a/cmd/translatesfx/translatesfx/testdata/sa-e2e-input.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/sa-e2e-input.yaml
@@ -29,7 +29,6 @@ metricsToExclude:
   - metricNames:
       - node_filesystem_*
       - '!node_filesystem_free_bytes'
-      - '!node_filesystem_readonly'
 
   - metricName: node_network_*
     dimensions:
@@ -38,6 +37,10 @@ metricsToExclude:
   - metricName: node_disk_*
     dimensions:
       device: sr*
+
+metricsToInclude:
+  - metricNames:
+      - node_filesystem_readonly
 
 monitors:
   - type: collectd/redis

--- a/cmd/translatesfx/translatesfx/translate.go
+++ b/cmd/translatesfx/translatesfx/translate.go
@@ -25,6 +25,7 @@ type saCfgInfo struct {
 	monitors         []interface{}
 	observers        []interface{}
 	metricsToExclude []interface{}
+	metricsToInclude []interface{}
 }
 
 func saExpandedToCfgInfo(saExpanded map[interface{}]interface{}) saCfgInfo {
@@ -39,6 +40,7 @@ func saExpandedToCfgInfo(saExpanded map[interface{}]interface{}) saCfgInfo {
 		observers:        observers(saExpanded),
 		configSources:    configSources(saExpanded),
 		metricsToExclude: metricsToExclude(saExpanded),
+		metricsToInclude: metricsToInclude(saExpanded),
 	}
 }
 
@@ -107,7 +109,15 @@ func configSources(saExpanded map[interface{}]interface{}) map[interface{}]inter
 }
 
 func metricsToExclude(saExpanded map[interface{}]interface{}) []interface{} {
-	v, ok := saExpanded["metricsToExclude"]
+	return toSlice(saExpanded, "metricsToExclude")
+}
+
+func metricsToInclude(saExpanded map[interface{}]interface{}) []interface{} {
+	return toSlice(saExpanded, "metricsToInclude")
+}
+
+func toSlice(saExpanded map[interface{}]interface{}, key string) []interface{} {
+	v, ok := saExpanded[key]
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
SA's `metricsToInclude` overrides any matching `metricsToExclude`. This change
translates SmartAgent metricsToInclude filters and appends them to filter
processor expr expressions.

For example, the following SA filters:

```
metricsToExclude:
  - metricNames:
      - node_filesystem_*

metricsToInclude:
  - metricNames:
      - node_filesystem_readonly
```

should translate to:

```
filter:
  metrics:
    exclude:
      match_type: expr
      expressions:
      - MetricName matches "^node_filesystem_.*$" and
        (not (MetricName matches "^node_filesystem_readonly$"))
```