### PR TITLE
Update apt sources for buster in wix dockerfile

### DIFF
--- a/internal/buildscripts/packaging/msi/msi-builder/Dockerfile
+++ b/internal/buildscripts/packaging/msi/msi-builder/Dockerfile
@@ -4,6 +4,7 @@
 FROM quay.io/signalfx/wix-dev:latest
 
 USER root
+RUN sed -i s'|stable|buster|' /etc/apt/sources.list
 RUN apt-get update -y
 RUN apt-get install -y curl unzip
 


### PR DESCRIPTION
Workaround for `apt` failures when building the MSI due to move of `stable` sources to `buster`:
```
Err:4 http://security.debian.org/debian-security stable/updates Release
  404  Not Found [IP: 151.101.130.132 80]
Get:5 http://deb.debian.org/debian stable/main i386 Packages [8117 kB]
Reading package lists...
E: The repository 'http://security.debian.org/debian-security stable/updates Release' does not have a Release file.
```