### PR TITLE
Upgrade to Go 1.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   golang:
     docker:
-      - image: cimg/go:1.16
+      - image: cimg/go:1.17
 
 commands:
   attach_to_workspace:
@@ -195,7 +195,7 @@ jobs:
 
   docker-otelcol:
     docker:
-      - image: cimg/go:1.16
+      - image: cimg/go:1.17
     steps:
       - attach_to_workspace
       - setup_remote_docker
@@ -232,7 +232,7 @@ jobs:
       - run:
           name: Upgrade golang
           command: |
-            choco upgrade golang --version=1.16
+            choco upgrade golang --version=1.17
             refreshenv
             go env -w CGO_ENABLED=0
             go install github.com/ory/go-acc@v0.2.6

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ stages:
   - github-release
 
 .go-cache:
-  image: 'docker.repo.splunkdev.net/ci-cd/ci-container:golang-1.16'
+  image: 'docker.repo.splunkdev.net/ci-cd/ci-container:golang-1.17'
   variables:
     GOPATH: "$CI_PROJECT_DIR/.go"
   before_script:

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -47,9 +47,9 @@ const (
 	realmEnvVarName           = "SPLUNK_REALM"
 	tokenEnvVarName           = "SPLUNK_ACCESS_TOKEN"
 
-	defaultDockerSAPMConfig        = "/etc/otel/collector/gateway_config.yaml"
+	defaultDockerSAPMConfig        = "/etc/otel/collector/agent_config.yaml"
 	defaultDockerOTLPConfig        = "/etc/otel/collector/otlp_config_linux.yaml"
-	defaultLocalSAPMConfig         = "cmd/otelcol/config/collector/gateway_config.yaml"
+	defaultLocalSAPMConfig         = "cmd/otelcol/config/collector/agent_config.yaml"
 	defaultLocalOTLPConfig         = "cmd/otelcol/config/collector/otlp_config_linux.yaml"
 	defaultMemoryBallastPercentage = 33
 	defaultMemoryLimitPercentage   = 90

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector
 
-go 1.16
+go 1.17
 
 require (
 	cloud.google.com/go/kms v0.1.0 // indirect

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/tests
 
-go 1.16
+go 1.17
 
 require (
 	github.com/docker/docker v20.10.8+incompatible


### PR DESCRIPTION
Upgrading to go 1.17 to address [this](https://nvd.nist.gov/vuln/detail/CVE-2021-29923) CVE