### PR TITLE
Remove libcap dependency from rpm

### DIFF
--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -43,6 +43,8 @@ apt-get install -y splunk-otel-collector
 ```
 - RPM:
 ```sh
+yum install -y libcap  # Required for enabling cap_dac_read_search and cap_sys_ptrace capabilities on the collector
+
 cat <<EOH > /etc/yum.repos.d/splunk-otel-collector.repo
 [splunk-otel-collector]
 name=Splunk OpenTelemetry Collector Repository

--- a/internal/buildscripts/packaging/fpm/postinstall.sh
+++ b/internal/buildscripts/packaging/fpm/postinstall.sh
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-setcap CAP_SYS_PTRACE,CAP_DAC_READ_SEARCH=+eip /usr/bin/otelcol
+if command -v setcap >/dev/null 2>&1; then
+    setcap CAP_SYS_PTRACE,CAP_DAC_READ_SEARCH=+eip /usr/bin/otelcol
+fi
 
 if [ -f /usr/lib/splunk-otel-collector/agent-bundle/bin/patch-interpreter ]; then
     /usr/lib/splunk-otel-collector/agent-bundle/bin/patch-interpreter /usr/lib/splunk-otel-collector/agent-bundle

--- a/internal/buildscripts/packaging/fpm/rpm/build.sh
+++ b/internal/buildscripts/packaging/fpm/rpm/build.sh
@@ -60,7 +60,6 @@ sudo fpm -s dir -t rpm -n "$PKG_NAME" -v "$VERSION" -f -p "$OUTPUT_DIR" \
     --architecture "$ARCH" \
     --rpm-summary "$PKG_DESCRIPTION" \
     --rpm-use-file-permissions \
-    --depends libcap \
     --before-install "$PREINSTALL_PATH" \
     --after-install "$POSTINSTALL_PATH" \
     --before-remove "$PREUNINSTALL_PATH" \


### PR DESCRIPTION
- Initial step to support suse since the automatic dependency on `libcap` prevents the installation of the collector rpm on suse
- Next steps: Add suse/zypper support to installer script, ansible, puppet, and docs (need to wait for the rpm with this change to be released to artifactory)