### PR TITLE
Add an Ansible Galaxy tag to trigger missed release

### DIFF
--- a/deployments/ansible/galaxy.yml
+++ b/deployments/ansible/galaxy.yml
@@ -18,6 +18,7 @@ tags:
   - gateway
   - logs
   - metrics
+  - o11y
   - observability
   - opentelemetry
   - otel


### PR DESCRIPTION
Depends on https://github.com/signalfx/splunk-otel-collector/pull/683