### PR TITLE
avoid using deprecated apt-key

### DIFF
--- a/deployments/ansible/CHANGELOG.md
+++ b/deployments/ansible/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Drop `apt_key` deprecated module in favor of existing `get_url` task (#698)
+
 ## ansible-v0.1.3
 
 - Add meta/runtime.yml (#690)

--- a/deployments/ansible/roles/collector/tasks/apt_install_otel_collector.yml
+++ b/deployments/ansible/roles/collector/tasks/apt_install_otel_collector.yml
@@ -9,19 +9,10 @@
     state: present
     update_cache: yes
 
-- name: Add an apt signing key for Splunk OpenTelemetry Collector
-  ansible.builtin.apt_key:
-    url: "{{ splunk_repo_base_url }}/otel-collector-deb/splunk-B3CD4420.gpg"
-    keyring: /etc/apt/trusted.gpg.d/splunk.gpg
-  when: ansible_version.full is version('2.11.0', '!=')
-
-# NOTE: Using ansible.builtin.get_url instead of ansible.builtin.apt_key due to a bug
-#       in ansible-core 2.11.0 https://github.com/ansible/ansible/issues/74424
 - name: Download an apt signing key for Splunk OpenTelemetry Collector
   ansible.builtin.get_url:
     url: "{{ splunk_repo_base_url }}/otel-collector-deb/splunk-B3CD4420.gpg"
     dest: /etc/apt/trusted.gpg.d/splunk.gpg
-  when: ansible_version.full is version('2.11.0', '==')
 
 - name: Add Splunk OpenTelemetry Collector repo to apt source list
   ansible.builtin.apt_repository:


### PR DESCRIPTION
Hello,

Currently, the ansible role is not usable with proxy set from environment because of a long time and known bug in ansible for apt key module.

I found and tested this workaround here: https://github.com/ansible/ansible/issues/31691#issuecomment-396973282

Here is the underlying relevant code: https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/apt_key.py#L210

Now it is possible to use a playbook like the following:

```yaml
---
- name: "Example of proxy usage with splunk otel"
  hosts: all
  become: true
  tasks:
    - name: "Include splunk_otel_collector"
      import_role:
        name: "signalfx.splunk_otel_collector.collector"
      vars:
        splunk_access_token: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/data/signalfx:token') }}"
        splunk_realm: eu0
        install_fluentd: false
        ansible_no_target_syslog: true
      environment:
        https_proxy: "{{ https_proxy }}"
        http_proxy: "{{ https_proxy }}"
```

Notice the usage of `import_role` to make it static and allow usage of environment variable.

Here is a command to hotfix existing role installed from collection:

```bash
sed -Ei 's/([[:space:]]+)url:[[:space:]](.*)/\1data: '\''{{ lookup\("url", \2, split_lines=False) }}'\''/g' ~/.ansible/collections/ansible_collections/signalfx/splunk_otel_collector/roles/collector/tasks/apt_install_*.yml
```

EDIT: the goal of the PR has change please see https://github.com/signalfx/splunk-otel-collector/pull/698#issuecomment-910123954