### PR TITLE
add collector service level proxy for ansible

### DIFF
--- a/deployments/ansible/CHANGELOG.md
+++ b/deployments/ansible/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add proxy support for otel collector service runtime level (#699)
+
 ## ansible-v0.1.3
 
 - Add meta/runtime.yml (#690)

--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -82,7 +82,7 @@ how to use the role in a playbook with minimal required configuration:
   ownership for the collector service. The user/group will be created if they
   do not exist. (**default:** `splunk-otel-collector`)
 
-- `splunk_service_proxy` (Linux only): Set the proxy address to be used by the
+- `splunk_otel_collector_proxy` (Linux only): Set the proxy address to be used by the
   collector service **if** not empty. It must be a full URL as for the linux
   `http_proxy` environment variable like `http://user:pass@10.0.0.42`. Notice
   this proxy is not used by ansible itself during deployment. (**default:** ``)

--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -82,6 +82,11 @@ how to use the role in a playbook with minimal required configuration:
   ownership for the collector service. The user/group will be created if they
   do not exist. (**default:** `splunk-otel-collector`)
 
+- `splunk_service_proxy` (Linux only): Set the proxy address to be used by the
+  collector service **if** not empty. It must be a full URL as for the linux
+  `http_proxy` environment variable like `http://user:pass@10.0.0.42`. Notice
+  this proxy is not used by ansible itself during deployment. (**default:** ``)
+
 - `splunk_memory_total_mib`: Amount of memory in MiB allocated to the Splunk OTel 
   Collector. (**default:** `512`)
 

--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -82,10 +82,12 @@ how to use the role in a playbook with minimal required configuration:
   ownership for the collector service. The user/group will be created if they
   do not exist. (**default:** `splunk-otel-collector`)
 
-- `splunk_otel_collector_proxy` (Linux only): Set the proxy address to be used by the
-  collector service **if** not empty. It must be a full URL as for the linux
-  `http_proxy` environment variable like `http://user:pass@10.0.0.42`. Notice
-  this proxy is not used by ansible itself during deployment. (**default:** ``)
+- `splunk_otel_collector_proxy_http` and `splunk_otel_collector_proxy_https`
+  (Linux only): Set the proxy address, respectively for `http_proxy` and
+  `https_proxy` environment variables, to be used by the collector service
+  **if** at least one of them is not empty. It must be a full URL like
+  `http://user:pass@10.0.0.42`. Notice this proxy is not used by ansible
+  itself during deployment. (**default:** ``)
 
 - `splunk_memory_total_mib`: Amount of memory in MiB allocated to the Splunk OTel 
   Collector. (**default:** `512`)

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -36,4 +36,4 @@ agent_bundle_dir: /usr/lib/splunk-otel-collector/agent-bundle
 splunk_collectd_dir: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
 
 # Configure otel collector service to use a proxy
-splunk_service_proxy: ""
+splunk_otel_collector_proxy: ""

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -36,4 +36,5 @@ agent_bundle_dir: /usr/lib/splunk-otel-collector/agent-bundle
 splunk_collectd_dir: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
 
 # Configure otel collector service to use a proxy
-splunk_otel_collector_proxy: ""
+splunk_otel_collector_proxy_http: ""
+splunk_otel_collector_proxy_https: ""

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -34,3 +34,6 @@ splunk_fluentd_config_source: ""
 
 agent_bundle_dir: /usr/lib/splunk-otel-collector/agent-bundle
 splunk_collectd_dir: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
+
+# Configure otel collector service to use a proxy
+splunk_service_proxy: ""

--- a/deployments/ansible/roles/collector/tasks/linux_install.yml
+++ b/deployments/ansible/roles/collector/tasks/linux_install.yml
@@ -17,6 +17,13 @@
 - name: Set Splunk Otel Collector service owner
   ansible.builtin.import_tasks: collector_service_owner.yml
 
+- name: Set Splunk Otel Collector service proxy
+  ansible.builtin.template:
+    src: collector-service-proxy.conf.j2
+    dest: /etc/systemd/system/splunk-otel-collector.service.d/service-proxy.conf
+  notify: "restart splunk-otel-collector"
+  when: splunk_service_proxy != ""
+
 - name: Set up env file for Splunk OTel Collector service
   ansible.builtin.template:
     src: splunk-otel-collector.conf.j2

--- a/deployments/ansible/roles/collector/tasks/linux_install.yml
+++ b/deployments/ansible/roles/collector/tasks/linux_install.yml
@@ -22,7 +22,7 @@
     src: collector-service-proxy.conf.j2
     dest: /etc/systemd/system/splunk-otel-collector.service.d/service-proxy.conf
   notify: "restart splunk-otel-collector"
-  when: splunk_service_proxy != ""
+  when: splunk_otel_collector_proxy != ""
 
 - name: Set up env file for Splunk OTel Collector service
   ansible.builtin.template:

--- a/deployments/ansible/roles/collector/tasks/linux_install.yml
+++ b/deployments/ansible/roles/collector/tasks/linux_install.yml
@@ -22,7 +22,7 @@
     src: collector-service-proxy.conf.j2
     dest: /etc/systemd/system/splunk-otel-collector.service.d/service-proxy.conf
   notify: "restart splunk-otel-collector"
-  when: splunk_otel_collector_proxy != ""
+  when: splunk_otel_collector_proxy_http != "" or splunk_otel_collector_proxy_https != ""
 
 - name: Set up env file for Splunk OTel Collector service
   ansible.builtin.template:

--- a/deployments/ansible/roles/collector/templates/collector-service-proxy.conf.j2
+++ b/deployments/ansible/roles/collector/templates/collector-service-proxy.conf.j2
@@ -1,0 +1,4 @@
+[Service] 
+Environment="HTTP_PROXY={{ splunk_service_proxy }}" 
+Environment="HTTPS_PROXY={{ splunk_service_proxy }}" 
+Environment="NO_PROXY=localhost,127.0.0.1,::1"

--- a/deployments/ansible/roles/collector/templates/collector-service-proxy.conf.j2
+++ b/deployments/ansible/roles/collector/templates/collector-service-proxy.conf.j2
@@ -1,4 +1,4 @@
 [Service] 
-Environment="HTTP_PROXY={{ splunk_service_proxy }}" 
-Environment="HTTPS_PROXY={{ splunk_service_proxy }}" 
+Environment="HTTP_PROXY={{ splunk_otel_collector_proxy }}" 
+Environment="HTTPS_PROXY={{ splunk_otel_collector_proxy }}" 
 Environment="NO_PROXY=localhost,127.0.0.1,::1"

--- a/deployments/ansible/roles/collector/templates/collector-service-proxy.conf.j2
+++ b/deployments/ansible/roles/collector/templates/collector-service-proxy.conf.j2
@@ -1,4 +1,4 @@
 [Service] 
-Environment="HTTP_PROXY={{ splunk_otel_collector_proxy }}" 
-Environment="HTTPS_PROXY={{ splunk_otel_collector_proxy }}" 
+Environment="HTTP_PROXY={{ splunk_otel_collector_proxy_http }}" 
+Environment="HTTPS_PROXY={{ splunk_otel_collector_proxy_https }}" 
 Environment="NO_PROXY=localhost,127.0.0.1,::1"


### PR DESCRIPTION
Hello,

It is possible to easily use a proxy during ansible deployment by setting right environment variable at playbook level like:

```yaml
---
- name: "Example of proxy usage with splunk otel"
  hosts: all
  become: true
  tasks:
    - name: "Include splunk_otel_collector"
      import_role:
        name: "signalfx.splunk_otel_collector.collector"
      vars:
        splunk_access_token: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/data/signalfx:token') }}"
        splunk_realm: eu0
        install_fluentd: false
      environment:
        https_proxy: "{{ https_proxy }}"
        http_proxy: "{{ https_proxy }}"
        no_proxy: "localhost,127.0.0.1,::1"
```

but it is not possible to configure a proxy to be used by the collector itself.

of course we can add a task after the role import but it seems useful to support this upstream.
