### PR TITLE
auto add system.type dimension to all sa receiver datapoints

### DIFF
--- a/internal/receiver/smartagentreceiver/receiver.go
+++ b/internal/receiver/smartagentreceiver/receiver.go
@@ -176,8 +176,7 @@ func (r *Receiver) createMonitor(monitorType string, host component.Host) (monit
 		output.AddExtraDimension(k, v)
 	}
 
-	systemTypeVal := fmt.Sprintf("smartagent-%s", monitorType)
-	output.AddExtraDimension(systemTypeKey, systemTypeVal)
+	output.AddExtraDimension(systemTypeKey, monitorType)
 
 	// Configure SmartAgentConfigProvider to gather any global config overrides and
 	// set required envs.

--- a/internal/receiver/smartagentreceiver/receiver.go
+++ b/internal/receiver/smartagentreceiver/receiver.go
@@ -40,6 +40,7 @@ import (
 )
 
 const setOutputErrMsg = "unable to set Output field of monitor"
+const systemTypeKey = "system.type"
 
 type Receiver struct {
 	monitor             interface{}
@@ -174,6 +175,9 @@ func (r *Receiver) createMonitor(monitorType string, host component.Host) (monit
 	for k, v := range r.config.monitorConfig.MonitorConfigCore().ExtraDimensions {
 		output.AddExtraDimension(k, v)
 	}
+
+	systemTypeVal := fmt.Sprintf("smartagent-%s", monitorType)
+	output.AddExtraDimension(systemTypeKey, systemTypeVal)
 
 	// Configure SmartAgentConfigProvider to gather any global config overrides and
 	// set required envs.

--- a/internal/receiver/smartagentreceiver/receiver.go
+++ b/internal/receiver/smartagentreceiver/receiver.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
@@ -176,7 +177,7 @@ func (r *Receiver) createMonitor(monitorType string, host component.Host) (monit
 		output.AddExtraDimension(k, v)
 	}
 
-	output.AddExtraDimension(systemTypeKey, monitorType)
+	output.AddExtraDimension(systemTypeKey, stripMonitorTypePrefix(monitorType))
 
 	// Configure SmartAgentConfigProvider to gather any global config overrides and
 	// set required envs.
@@ -193,6 +194,14 @@ func (r *Receiver) createMonitor(monitorType string, host component.Host) (monit
 	}
 
 	return monitor, err
+}
+
+func stripMonitorTypePrefix(s string) string {
+	idx := strings.Index(s, "/")
+	if idx == -1 {
+		return s
+	}
+	return s[idx+1:]
 }
 
 func (r *Receiver) setUpSmartAgentConfigProvider(extensions map[config.ComponentID]component.Extension) {

--- a/internal/receiver/smartagentreceiver/receiver_test.go
+++ b/internal/receiver/smartagentreceiver/receiver_test.go
@@ -146,7 +146,7 @@ func TestSmartAgentReceiver(t *testing.T) {
 
 						systemType, ok := attributes.Get("system.type")
 						require.True(t, ok)
-						assert.Equal(t, "smartagent-cpu", systemType.StringVal())
+						assert.Equal(t, "cpu", systemType.StringVal())
 
 						// mark metric as having been seen
 						cpuNum, _ := attributes.Get("cpu")

--- a/internal/receiver/smartagentreceiver/receiver_test.go
+++ b/internal/receiver/smartagentreceiver/receiver_test.go
@@ -144,6 +144,10 @@ func TestSmartAgentReceiver(t *testing.T) {
 						require.True(t, ok)
 						assert.Equal(t, "required_value", labelVal.StringVal())
 
+						systemType, ok := attributes.Get("system.type")
+						require.True(t, ok)
+						assert.Equal(t, "smartagent-cpu", systemType.StringVal())
+
 						// mark metric as having been seen
 						cpuNum, _ := attributes.Get("cpu")
 						seenName := fmt.Sprintf("%s%s", name, cpuNum.StringVal())

--- a/internal/receiver/smartagentreceiver/receiver_test.go
+++ b/internal/receiver/smartagentreceiver/receiver_test.go
@@ -166,6 +166,11 @@ func TestSmartAgentReceiver(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestStripMonitorTypePrefix(t *testing.T) {
+	assert.Equal(t, "nginx", stripMonitorTypePrefix("collectd/nginx"))
+	assert.Equal(t, "cpu", stripMonitorTypePrefix("cpu"))
+}
+
 func TestStartReceiverWithInvalidMonitorConfig(t *testing.T) {
 	t.Cleanup(cleanUp)
 	cfg := newConfig("invalid", "cpu", -123)


### PR DESCRIPTION
Add `system.type` dimension to all datapoints, where `system.type` == "smartagent-&lt;monitor-name&gt;" in support of pivot sidebar. Not sure about "smartagent-&lt;monitor-name&gt;" -- open to other possibilities.