### PR TITLE
properly parse receiver creator endpoints in SA receiver

### DIFF
--- a/internal/receiver/smartagentreceiver/config.go
+++ b/internal/receiver/smartagentreceiver/config.go
@@ -16,9 +16,9 @@ package smartagentreceiver
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"strconv"
-	"strings"
 
 	"github.com/signalfx/defaults"
 	_ "github.com/signalfx/signalfx-agent/pkg/core" // required to invoke monitor registration via init() calls
@@ -148,12 +148,14 @@ func setHostAndPortViaEndpoint(endpoint string, monitorConfig interface{}) error
 		return nil
 	}
 
-	var host string
 	var port uint16
-	splat := strings.Split(endpoint, ":")
-	host = splat[0]
-	if len(splat) == 2 {
-		portStr := splat[1]
+	host, portStr, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		// best effort
+		host = endpoint
+	}
+
+	if portStr != "" {
 		port64, err := strconv.ParseUint(portStr, 10, 16)
 		if err != nil {
 			return fmt.Errorf("cannot determine port via Endpoint: %w", err)

--- a/internal/receiver/smartagentreceiver/config_test.go
+++ b/internal/receiver/smartagentreceiver/config_test.go
@@ -255,14 +255,14 @@ func TestLoadConfigWithEndpoints(t *testing.T) {
 	haproxyCfg := cfg.Receivers[config.NewIDWithName(typeStr, "haproxy")].(*Config)
 	require.Equal(t, &Config{
 		ReceiverSettings: config.NewReceiverSettings(config.NewIDWithName(typeStr, "haproxy")),
-		Endpoint:         "haproxyhost:2345",
+		Endpoint:         "[fe80::20c:29ff:fe59:9446]:2345",
 		monitorConfig: &haproxy.Config{
 			MonitorConfig: saconfig.MonitorConfig{
 				Type:                "haproxy",
 				IntervalSeconds:     123,
 				DatapointsToExclude: []saconfig.MetricFilter{},
 			},
-			Host:      "haproxyhost",
+			Host:      "fe80::20c:29ff:fe59:9446",
 			Port:      2345,
 			Username:  "SomeUser",
 			Password:  "secret",
@@ -292,7 +292,7 @@ func TestLoadConfigWithEndpoints(t *testing.T) {
 	hadoopCfg := cfg.Receivers[config.NewIDWithName(typeStr, "hadoop")].(*Config)
 	require.Equal(t, &Config{
 		ReceiverSettings: config.NewReceiverSettings(config.NewIDWithName(typeStr, "hadoop")),
-		Endpoint:         "hadoophost:12345",
+		Endpoint:         "[::]:12345",
 		monitorConfig: &hadoop.Config{
 			MonitorConfig: saconfig.MonitorConfig{
 				Type:                "collectd/hadoop",

--- a/internal/receiver/smartagentreceiver/testdata/endpoints_config.yaml
+++ b/internal/receiver/smartagentreceiver/testdata/endpoints_config.yaml
@@ -1,6 +1,6 @@
 receivers:
   smartagent/haproxy:
-    endpoint: haproxyhost:2345
+    endpoint: "[fe80::20c:29ff:fe59:9446]:2345"
     type: haproxy
     intervalSeconds: 123
     username: SomeUser
@@ -11,7 +11,7 @@ receivers:
     port: 6379
     intervalSeconds: 234
   smartagent/hadoop:
-    endpoint: hadoophost:12345
+    endpoint: "[::]:12345"
     type: collectd/hadoop
     host: localhost
     port: 8088


### PR DESCRIPTION
The current endpoint parser was implemented naively and should accept ipv6 addresses.