### PR TITLE
translatesfx: rename metricsToExclude to datapointsToExclude on SA monitors

### DIFF
--- a/cmd/translatesfx/translatesfx/otel_test.go
+++ b/cmd/translatesfx/translatesfx/otel_test.go
@@ -66,6 +66,15 @@ func TestMonitorToReceiver(t *testing.T) {
 	assert.Equal(t, "vsphere", v["type"])
 }
 
+func testvSphereMonitorCfg() map[interface{}]interface{} {
+	return map[interface{}]interface{}{
+		"type":     "vsphere",
+		"host":     "localhost",
+		"username": "administrator",
+		"password": "abc123",
+	}
+}
+
 func TestMonitorToReceiver_Rule(t *testing.T) {
 	otel, w, isRC := saMonitorToOtelReceiver(map[interface{}]interface{}{
 		"type":          "redis",
@@ -274,13 +283,27 @@ func TestInfoToOtelConfig_MetricsToExclude_Regex(t *testing.T) {
 	assert.Equal(t, `MetricName matches "vsphere\\.cpu_\\w*_percent"`, expression)
 }
 
-func testvSphereMonitorCfg() map[interface{}]interface{} {
-	return map[interface{}]interface{}{
-		"type":     "vsphere",
-		"host":     "localhost",
-		"username": "administrator",
-		"password": "abc123",
-	}
+func TestInfoToOtelConfig_MetricsToExclude_Monitor(t *testing.T) {
+	// This metricsToExclude is attached to the monitor, not the agent, which is
+	// apparently an invalid configuration according to the docs, but it actually
+	// works and some customers are using it. If we just rename it to the supported
+	// datapointsToExclude, things work fine in the translated config.
+	cfg, _ := yamlToOtelConfig(t, "testdata/sa-metrics-to-exclude-monitor.yaml")
+
+	_, ok := cfg.Processors["filter"]
+	assert.False(t, ok)
+
+	saReceiver := cfg.Receivers["smartagent/cpu"]
+	_, ok = saReceiver["metricsToExclude"]
+	assert.False(t, ok)
+
+	ex, ok := saReceiver["datapointsToExclude"]
+	assert.True(t, ok)
+	assert.Equal(t, []interface{}{
+		map[interface{}]interface{}{
+			"metricNames": []interface{}{"foo*"},
+		},
+	}, ex)
 }
 
 func yamlToOtelConfig(t *testing.T, filename string) (out *otelCfg, warnings []error) {

--- a/cmd/translatesfx/translatesfx/testdata/sa-metrics-to-exclude-monitor.yaml
+++ b/cmd/translatesfx/translatesfx/testdata/sa-metrics-to-exclude-monitor.yaml
@@ -1,0 +1,14 @@
+---
+signalFxAccessToken: "abc123"
+signalFxRealm: us1
+
+intervalSeconds: 10
+
+logging:
+  level: info
+
+monitors:
+  - type: cpu
+    metricsToExclude:
+      - metricNames:
+          - foo*

--- a/cmd/translatesfx/translatesfx/translate.go
+++ b/cmd/translatesfx/translatesfx/translate.go
@@ -39,8 +39,8 @@ func saExpandedToCfgInfo(saExpanded map[interface{}]interface{}) saCfgInfo {
 		saExtension:      saExtension(saExpanded),
 		observers:        observers(saExpanded),
 		configSources:    configSources(saExpanded),
-		metricsToExclude: metricsToExclude(saExpanded),
-		metricsToInclude: metricsToInclude(saExpanded),
+		metricsToExclude: saToMetricsToExclude(saExpanded),
+		metricsToInclude: saToMetricsToInclude(saExpanded),
 	}
 }
 
@@ -108,11 +108,11 @@ func configSources(saExpanded map[interface{}]interface{}) map[interface{}]inter
 	return cs
 }
 
-func metricsToExclude(saExpanded map[interface{}]interface{}) []interface{} {
+func saToMetricsToExclude(saExpanded map[interface{}]interface{}) []interface{} {
 	return toSlice(saExpanded, "metricsToExclude")
 }
 
-func metricsToInclude(saExpanded map[interface{}]interface{}) []interface{} {
+func saToMetricsToInclude(saExpanded map[interface{}]interface{}) []interface{} {
 	return toSlice(saExpanded, "metricsToInclude")
 }
 


### PR DESCRIPTION
If metricsToExclude is specified for a monitor (not the agent -- this is
apparently an invalid configuration according to the docs, but it actually
works and some customers are using it) rename it to the supported
datapointsToExclude.