### PR TITLE
Fix GOPATH for windows-test in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,8 +262,6 @@ jobs:
     executor:
       name: win/default
       shell: powershell.exe
-    environment:
-      GOPATH=~/go
     steps:
       - checkout
       - restore_module_cache
@@ -271,6 +269,7 @@ jobs:
           name: Upgrade golang
           command: |
             $ErrorActionPreference = 'Stop'
+            $env:GOPATH = "${env:USERPROFILE}\go"
             choco upgrade golang --version=1.17
             refreshenv
             go env -w CGO_ENABLED=0
@@ -281,6 +280,8 @@ jobs:
           name: Unit tests with coverage
           command: |
             $ErrorActionPreference = 'Stop'
+            $env:GOPATH = "${env:USERPROFILE}\go"
+            $env:PATH = "$env:PATH;${env:GOPATH}\bin"
             go-acc ./...
 #      - run:
 #          name: Upload coverage


### PR DESCRIPTION
Not sure what changed, but the `windows-test` job recently started failing due to:
```
go: GOPATH entry cannot start with shell metacharacter '~': "~/go"
```