### PR TITLE
Edit contributing and add callouts to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,17 @@ When filing an issue, please do *NOT* include:
 - Internal identifiers such as JIRA tickets
 - Any sensitive information related to your environment, users, etc.
 
+## Documentation
+
+The Splunk Observability documentation is hosted on https://docs.splunk.com/Observability,
+which contains all the prescriptive guidance for Splunk Observability products. 
+Prescriptive guidance consists of step-by-step instructions, conceptual material,
+and decision support for customers. Reference documentation and development 
+documentation is hosted on this repository.
+
+You can send feedback about Splunk Observability docs by clicking the Feedback 
+button on any of our documentation pages.
+
 ## Contributing via Pull Requests
 
 Contributions via Pull Requests (PRs) are much appreciated. Before sending us a

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+The official documentation for this distribution can be found here:
+
+https://docs.splunk.com/Observability/gdi/opentelemetry/opentelemetry.html

--- a/docs/agent-vs-gateway.md
+++ b/docs/agent-vs-gateway.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Determine your deployment mode](https://docs.splunk.com/Observability/gdi/opentelemetry/deployment-modes.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [Determine your deployment mode](https://docs.splunk.com/Observability/gdi/opentelemetry/deployment-modes.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 
 # Agent versus Gateway
 

--- a/docs/agent-vs-gateway.md
+++ b/docs/agent-vs-gateway.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Determine your deployment mode](https://docs.splunk.com/Observability/gdi/opentelemetry/deployment-modes.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+
 # Agent versus Gateway
 
 Splunk OpenTelemetry Connector provides a single binary and two deployment

--- a/docs/agent-vs-gateway.md
+++ b/docs/agent-vs-gateway.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Determine your deployment mode](https://docs.splunk.com/Observability/gdi/opentelemetry/deployment-modes.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [Determine your deployment mode](https://docs.splunk.com/Observability/gdi/opentelemetry/deployment-modes.html). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 
 # Agent versus Gateway
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 
 # Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+
 # Architecture
 
 This distribution can be deployed in the below ways.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 
 # Architecture
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 
 # Components
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 
 # Components
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+
 # Components
 
 The distribution offers support for the following components.

--- a/docs/experimental/splunk-forwarder-integration.md
+++ b/docs/experimental/splunk-forwarder-integration.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Install and configure Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/opentelemetry.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+
 # Splunk Forwarder Integration
 
 > WARNING: The following is not supported or tested today. Performance testing,

--- a/docs/experimental/splunk-forwarder-integration.md
+++ b/docs/experimental/splunk-forwarder-integration.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Install and configure Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/opentelemetry.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [Install and configure Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/opentelemetry.html). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 
 # Splunk Forwarder Integration
 

--- a/docs/experimental/splunk-forwarder-integration.md
+++ b/docs/experimental/splunk-forwarder-integration.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Install and configure Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/opentelemetry.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [Install and configure Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/opentelemetry.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 
 # Splunk Forwarder Integration
 

--- a/docs/experimental/using-fluentd-only.md
+++ b/docs/experimental/using-fluentd-only.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Install and configure Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/opentelemetry.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [Install and configure Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/opentelemetry.html). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 
 # Sending logs directly from Fluentd to Splunk Log Observer  
 

--- a/docs/experimental/using-fluentd-only.md
+++ b/docs/experimental/using-fluentd-only.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Install and configure Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/opentelemetry.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+
 # Sending logs directly from Fluentd to Splunk Log Observer  
 
 > WARNING: The following is not supported or tested today. Performance testing,

--- a/docs/experimental/using-fluentd-only.md
+++ b/docs/experimental/using-fluentd-only.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Install and configure Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/opentelemetry.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [Install and configure Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/opentelemetry.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 
 # Sending logs directly from Fluentd to Splunk Log Observer  
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [](). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+
 # FAQ
 
 - **What’s new in latest splunk-otel-collector release?** See the

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [](). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [](). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 
 # FAQ
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,3 @@
-> The official Splunk documentation for this page is [](). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
-
 # FAQ
 
 - **What’s new in latest splunk-otel-collector release?** See the

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [](). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [](). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 
 # FAQ
 

--- a/docs/getting-started/kubernetes-yaml.md
+++ b/docs/getting-started/kubernetes-yaml.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Install on Kubernetes](https://docs.splunk.com/Observability/gdi/opentelemetry/install-k8s.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [Install on Kubernetes](https://docs.splunk.com/Observability/gdi/opentelemetry/install-k8s.html). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 # Kubernetes YAML
 
 The easiest and recommended way to get started on Kubernetes is to leverage the

--- a/docs/getting-started/kubernetes-yaml.md
+++ b/docs/getting-started/kubernetes-yaml.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Install on Kubernetes](https://docs.splunk.com/Observability/gdi/opentelemetry/install-k8s.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [Install on Kubernetes](https://docs.splunk.com/Observability/gdi/opentelemetry/install-k8s.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 # Kubernetes YAML
 
 The easiest and recommended way to get started on Kubernetes is to leverage the

--- a/docs/getting-started/kubernetes-yaml.md
+++ b/docs/getting-started/kubernetes-yaml.md
@@ -1,3 +1,4 @@
+> The official Splunk documentation for this page is [Install on Kubernetes](https://docs.splunk.com/Observability/gdi/opentelemetry/install-k8s.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
 # Kubernetes YAML
 
 The easiest and recommended way to get started on Kubernetes is to leverage the

--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Install on Linux](https://docs.splunk.com/Observability/gdi/opentelemetry/install-linux.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+
 # Linux Installer Script
 
 For non-containerized Linux environments, an installer script is available. The

--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Install on Linux](https://docs.splunk.com/Observability/gdi/opentelemetry/install-linux.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [Install on Linux](https://docs.splunk.com/Observability/gdi/opentelemetry/install-linux.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 
 # Linux Installer Script
 

--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Install on Linux](https://docs.splunk.com/Observability/gdi/opentelemetry/install-linux.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [Install on Linux](https://docs.splunk.com/Observability/gdi/opentelemetry/install-linux.html). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 
 # Linux Installer Script
 

--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Install on Linux](https://docs.splunk.com/Observability/gdi/opentelemetry/install-linux.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [Install on Linux](https://docs.splunk.com/Observability/gdi/opentelemetry/install-linux.html). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 
 # Linux Manual
 

--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Install on Linux](https://docs.splunk.com/Observability/gdi/opentelemetry/install-linux.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+
 # Linux Manual
 
 The easiest and recommended way to get started is with the [Linux installer

--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Install on Linux](https://docs.splunk.com/Observability/gdi/opentelemetry/install-linux.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [Install on Linux](https://docs.splunk.com/Observability/gdi/opentelemetry/install-linux.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 
 # Linux Manual
 

--- a/docs/getting-started/windows-installer.md
+++ b/docs/getting-started/windows-installer.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Install on Windows](https://docs.splunk.com/Observability/gdi/opentelemetry/install-windows.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [Install on Windows](https://docs.splunk.com/Observability/gdi/opentelemetry/install-windows.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 
 # Windows Installer Script
 

--- a/docs/getting-started/windows-installer.md
+++ b/docs/getting-started/windows-installer.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Install on Windows](https://docs.splunk.com/Observability/gdi/opentelemetry/install-windows.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [Install on Windows](https://docs.splunk.com/Observability/gdi/opentelemetry/install-windows.html). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 
 # Windows Installer Script
 

--- a/docs/getting-started/windows-installer.md
+++ b/docs/getting-started/windows-installer.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Install on Windows](https://docs.splunk.com/Observability/gdi/opentelemetry/install-windows.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+
 # Windows Installer Script
 
 For Windows 64-bit environments, an installer script is available. The

--- a/docs/getting-started/windows-manual.md
+++ b/docs/getting-started/windows-manual.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Install on Windows](https://docs.splunk.com/Observability/gdi/opentelemetry/install-windows.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+
 # Windows Manual
 
 The following deployment options are supported:

--- a/docs/getting-started/windows-manual.md
+++ b/docs/getting-started/windows-manual.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Install on Windows](https://docs.splunk.com/Observability/gdi/opentelemetry/install-windows.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [Install on Windows](https://docs.splunk.com/Observability/gdi/opentelemetry/install-windows.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 
 # Windows Manual
 

--- a/docs/getting-started/windows-manual.md
+++ b/docs/getting-started/windows-manual.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Install on Windows](https://docs.splunk.com/Observability/gdi/opentelemetry/install-windows.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [Install on Windows](https://docs.splunk.com/Observability/gdi/opentelemetry/install-windows.html). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 
 # Windows Manual
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 
 # Monitoring
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+
 # Monitoring
 
 The default configuration automatically scrapes the Collector's own metrics and

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 
 # Monitoring
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 
 # Security
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 
 # Security
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+
 # Security
 
 Start by reviewing the [OpenTelemetry Collector security

--- a/docs/sizing.md
+++ b/docs/sizing.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 
 # Sizing
 

--- a/docs/sizing.md
+++ b/docs/sizing.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 
 # Sizing
 

--- a/docs/sizing.md
+++ b/docs/sizing.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Use Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+
 # Sizing
 
 The OpenTelemetry Collector can be scaled up or out as needed. Sizing is based

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Trobleshoot issues when collecting data](https://docs.splunk.com/Observability/gdi/opentelemetry/troubleshooting.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+> The official Splunk documentation for this page is [Trobleshoot issues when collecting data](https://docs.splunk.com/Observability/gdi/opentelemetry/troubleshooting.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
 
 # Troubleshooting
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,4 +1,4 @@
-> The official Splunk documentation for this page is [Trobleshoot issues when collecting data](https://docs.splunk.com/Observability/gdi/opentelemetry/troubleshooting.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTING#documentation.md).
+> The official Splunk documentation for this page is [Trobleshoot issues when collecting data](https://docs.splunk.com/Observability/gdi/opentelemetry/troubleshooting.html). For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING#documentation.md).
 
 # Troubleshooting
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Trobleshoot issues when collecting data](https://docs.splunk.com/Observability/gdi/opentelemetry/troubleshooting.html). For instructions on how to contribute to the docs, see [CONTRIBUTE.md](../CONTRIBUTE.md).
+
 # Troubleshooting
 
 Start by reviewing the [OpenTelemetry Collector troubleshooting


### PR DESCRIPTION
- Adding the docs paragraph to CONTRIBUTING.md, as per GDI Specs PR https://github.com/signalfx/gdi-specification/pull/129
- Adding callouts that point to equivalent official docs (when applicable)
- Adding README file in docs folder 

These changes were discussed and approved by @flands and Traci Morrison.