### PR TITLE
custom configuration file templating support

### DIFF
--- a/deployments/ansible/roles/collector/tasks/linux_install.yml
+++ b/deployments/ansible/roles/collector/tasks/linux_install.yml
@@ -38,7 +38,7 @@
   notify: "restart splunk-otel-collector"
 
 - name: Push custom config for Splunk OTel Collector, if provided
-  ansible.builtin.copy:
+  ansible.builtin.template:
     src: "{{ splunk_otel_collector_config_source }}"
     dest: "{{ splunk_otel_collector_config }}"
     owner: "{{ splunk_service_user }}"


### PR DESCRIPTION
waiting for feature or answer addressing https://github.com/signalfx/splunk-otel-collector/issues/700, using `template` module instead of `copy` will, at least, allow user to inject some variables from ansible to the otel collector config file.

For example if we need to define secret values in otel collector file, the only way is to hardcode them in the static file.
another way could be to provide variable to change src of `splunk-otel-collector.conf.j2`. this will allow users to define his own custom variable and use them in the otel collector yaml config file which could so remain static but this way seems less powerful.