### PR TITLE
Use the correct agent config filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ A variety of default configuration files are provided:
 - [OpenTelemetry
   Collector](https://github.com/signalfx/splunk-otel-collector/tree/main/cmd/otelcol/config/collector)
   see `full_config_linux.yaml` for a commented configuration with links to full
-  documentation. `agent_config_linux.yaml` is the recommended starting
+  documentation. `agent_config.yaml` is the recommended starting
   configuration for most environments.
 - [Fluentd](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/buildscripts/packaging/fpm/etc/otel/collector/fluentd)
   applicable to Helm or installer script installations only. See the `*.conf`


### PR DESCRIPTION
The example directory has an `agent_config.yaml`, there is no `agent_config_linux.yaml`.