### PR TITLE
Update linux installer to always set SPLUNK_MEMORY_TOTAL_MIB

### DIFF
--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -744,9 +744,8 @@ parse_args_and_install() {
   echo "Splunk OpenTelemetry Collector Version: ${collector_version}"
   if [ -n "$ballast" ]; then
     echo "Ballast Size in MIB: $ballast"
-  else
-    echo "Memory Size in MIB: $memory"
   fi
+  echo "Memory Size in MIB: $memory"
   echo "Realm: $realm"
   echo "Ingest Endpoint: $ingest_url"
   echo "API Endpoint: $api_url"
@@ -814,10 +813,9 @@ parse_args_and_install() {
   configure_env_file "SPLUNK_TRACE_URL" "$trace_url" "$collector_env_path"
   configure_env_file "SPLUNK_HEC_URL" "$hec_url" "$collector_env_path"
   configure_env_file "SPLUNK_HEC_TOKEN" "$hec_token" "$collector_env_path"
+  configure_env_file "SPLUNK_MEMORY_TOTAL_MIB" "$memory" "$collector_env_path"
   if [ -n "$ballast" ]; then
     configure_env_file "SPLUNK_BALLAST_SIZE_MIB" "$ballast" "$collector_env_path"
-  else
-    configure_env_file "SPLUNK_MEMORY_TOTAL_MIB" "$memory" "$collector_env_path"
   fi
   if [ -d "$collector_bundle_dir" ]; then
     configure_env_file "SPLUNK_BUNDLE_DIR" "$collector_bundle_dir" "$collector_env_path"

--- a/internal/buildscripts/packaging/tests/installer_test.py
+++ b/internal/buildscripts/packaging/tests/installer_test.py
@@ -43,7 +43,7 @@ AGENT_CONFIG_PATH = "/etc/otel/collector/agent_config.yaml"
 GATEWAY_CONFIG_PATH = "/etc/otel/collector/gateway_config.yaml"
 OLD_CONFIG_PATH = "/etc/otel/collector/splunk_config_linux.yaml"
 TOTAL_MEMORY = "256"
-BALLAST = "128"
+BALLAST = "64"
 REALM = "test"
 
 
@@ -66,11 +66,10 @@ def verify_env_file(container, mode="agent", ballast=None):
     run_container_cmd(container, f"grep '^SPLUNK_TRACE_URL=https://ingest.{REALM}.signalfx.com/v2/trace$' {env_path}")
     run_container_cmd(container, f"grep '^SPLUNK_HEC_URL=https://ingest.{REALM}.signalfx.com/v1/log$' {env_path}")
     run_container_cmd(container, f"grep '^SPLUNK_HEC_TOKEN=testing123$' {env_path}")
+    run_container_cmd(container, f"grep '^SPLUNK_MEMORY_TOTAL_MIB={TOTAL_MEMORY}$' {env_path}")
 
     if ballast:
         run_container_cmd(container, f"grep '^SPLUNK_BALLAST_SIZE_MIB={BALLAST}$' {env_path}")
-    else:
-        run_container_cmd(container, f"grep '^SPLUNK_MEMORY_TOTAL_MIB={TOTAL_MEMORY}$' {env_path}")
 
 
 def verify_support_bundle(container):
@@ -146,7 +145,7 @@ def test_installer_mode(distro, version, mode):
     )
 @pytest.mark.parametrize("version", VERSIONS)
 def test_installer_ballast(distro, version):
-    install_cmd = f"sh -x /test/install.sh -- testing123 --realm {REALM} --ballast {BALLAST}"
+    install_cmd = f"sh -x /test/install.sh -- testing123 --realm {REALM} --memory {TOTAL_MEMORY} --ballast {BALLAST}"
 
     if version != "latest":
         install_cmd = f"{install_cmd} --collector-version {version.lstrip('v')}"


### PR DESCRIPTION
For #656.   Ensures that `SPLUNK_MEMORY_TOTAL_MIB` is set in the environment file if the `--ballast` option is specified.