### PR TITLE
[Ansible] Fix `splunk_bundle_dir` parameter inconsistency

### DIFF
--- a/deployments/ansible/CHANGELOG.md
+++ b/deployments/ansible/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- Rename `agent_bundle_dir` parameter to `splunk_bundle_dir` (#810)
+
+### 💡 Enhancements 💡
+
 - Add SUSE support (collector only) (#748)
 
 ## ansible-v0.2.0

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -38,7 +38,7 @@ splunk_fluentd_config_source: ""
 
 # Default path on Linux: "/usr/lib/splunk-otel-collector/agent-bundle".
 # Default path on Windows: "%ProgramFiles%\Splunk\OpenTelemetry Collector\agent-bundle".
-agent_bundle_dir: ""
+splunk_bundle_dir: ""
 
 # Default path on Linux: "/usr/lib/splunk-otel-collector/agent-bundle/run/collectd".
 # Default path on Windows: "%ProgramFiles%\Splunk\OpenTelemetry Collector\agent-bundle\run\collectd".

--- a/deployments/ansible/roles/collector/tasks/collector_service_owner.yml
+++ b/deployments/ansible/roles/collector/tasks/collector_service_owner.yml
@@ -34,7 +34,7 @@
 
 - name: Set Otel Collector agent bundle directory
   ansible.builtin.file:
-    path: "{{ agent_bundle_dir }}"
+    path: "{{ splunk_bundle_dir }}"
     state: directory
     owner: "{{ splunk_service_user }}"
     group: "{{ splunk_service_group }}"

--- a/deployments/ansible/roles/collector/tasks/vars.yml
+++ b/deployments/ansible/roles/collector/tasks/vars.yml
@@ -13,9 +13,9 @@
       {%- else -%}
         /etc/otel/collector/fluentd/fluent.conf
       {%- endif -%}
-    agent_bundle_dir: |-
-      {%- if agent_bundle_dir -%}
-        {{ agent_bundle_dir }}
+    splunk_bundle_dir: |-
+      {%- if splunk_bundle_dir -%}
+        {{ splunk_bundle_dir }}
       {%- else -%}
         /usr/lib/splunk-otel-collector/agent-bundle
       {%- endif -%}
@@ -30,8 +30,8 @@
 - name: set default vars for Windows
   set_fact:
     splunk_bundle_dir: |-
-      {%- if agent_bundle_dir -%}
-        {{ agent_bundle_dir }}
+      {%- if splunk_bundle_dir -%}
+        {{ splunk_bundle_dir }}
       {%- else -%}
         {{ansible_env.ProgramFiles}}\Splunk\OpenTelemetry Collector\agent-bundle
       {%- endif -%}

--- a/deployments/ansible/roles/collector/templates/splunk-otel-collector.conf.j2
+++ b/deployments/ansible/roles/collector/templates/splunk-otel-collector.conf.j2
@@ -8,5 +8,5 @@ SPLUNK_HEC_URL=${SPLUNK_INGEST_URL}/v1/log
 SPLUNK_HEC_TOKEN={{ splunk_access_token }}
 SPLUNK_MEMORY_TOTAL_MIB={{ splunk_memory_total_mib }}
 SPLUNK_BALLAST_SIZE_MIB={{ splunk_ballast_size_mib }}
-SPLUNK_BUNDLE_DIR={{ agent_bundle_dir }}
+SPLUNK_BUNDLE_DIR={{ splunk_bundle_dir }}
 SPLUNK_COLLECTD_DIR={{ splunk_collectd_dir }}


### PR DESCRIPTION
Documentation mentions `splunk_bundle_dir` parameter, but in reality `agent_bundle_dir` is used instead. This change makes the parameter consistent under `splunk_bundle_dir` name.