### PR TITLE
Add translatesfx to deb, rpm, msi, and docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,8 +245,10 @@ jobs:
           command: |
             $ErrorActionPreference = 'Stop'
             Copy-Item .\bin\otelcol_windows_amd64.exe .\cmd\otelcol\otelcol.exe
+            Copy-Item .\bin\translatesfx_windows_amd64.exe .\cmd\otelcol\translatesfx.exe
             docker build -t otelcol-windows --build-arg SMART_AGENT_RELEASE=$((Get-Content internal\buildscripts\packaging\smart-agent-release.txt).TrimStart("v")) -f .\cmd\otelcol\Dockerfile.windows .\cmd\otelcol\
             Remove-Item .\cmd\otelcol\otelcol.exe
+            Remove-Item .\cmd\otelcol\translatesfx.exe
       - run:
           name: Run docker image
           command: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -162,6 +162,8 @@ build-linux-image:
   except:
     - schedules
   stage: package
+  dependencies:
+    - compile
   retry: 2
   script:
     - make docker-otelcol SKIP_COMPILE=true
@@ -180,6 +182,8 @@ build-linux-image:
   except:
     - schedules
   stage: package
+  dependencies:
+    - compile
   parallel:
     matrix:
       - ARCH: [amd64, arm64]
@@ -212,9 +216,13 @@ build-msi:
   except:
     - schedules
   stage: package
+  dependencies:
+    - sign-exe
   before_script:
     # build the MSI with the signed exe
+    - mkdir -p bin
     - cp -f dist/signed/otelcol_windows_amd64.exe bin/otelcol_windows_amd64.exe
+    - cp -f dist/signed/translatesfx_windows_amd64.exe bin/translatesfx_windows_amd64.exe
   script:
     - make msi SKIP_COMPILE=true VERSION=${CI_COMMIT_TAG:-}
   artifacts:
@@ -274,6 +282,7 @@ build-push-windows-image:
   retry: 2
   before_script:
     - Copy-Item .\dist\signed\otelcol_windows_amd64.exe .\cmd\otelcol\otelcol.exe
+    - Copy-Item .\dist\signed\translatesfx_windows_amd64.exe .\cmd\otelcol\translatesfx.exe
   script:
     - docker login -u $env:CIRCLECI_QUAY_USERNAME -p $env:CIRCLECI_QUAY_PASSWORD quay.io
     - |

--- a/Makefile
+++ b/Makefile
@@ -198,11 +198,13 @@ delete-tag:
 .PHONY: docker-otelcol
 docker-otelcol:
 ifneq ($(SKIP_COMPILE), true)
-	GOOS=linux $(MAKE) otelcol
+	$(MAKE) binaries-linux_amd64
 endif
 	cp ./bin/otelcol_linux_amd64 ./cmd/otelcol/otelcol
+	cp ./bin/translatesfx_linux_amd64 ./cmd/otelcol/translatesfx
 	docker build -t otelcol --build-arg SMART_AGENT_RELEASE=$(SMART_AGENT_RELEASE) ./cmd/otelcol/
 	rm ./cmd/otelcol/otelcol
+	rm ./cmd/otelcol/translatesfx
 
 .PHONY: binaries-all-sys
 binaries-all-sys: binaries-darwin_amd64 binaries-linux_amd64 binaries-linux_arm64 binaries-windows_amd64

--- a/cmd/otelcol/Dockerfile
+++ b/cmd/otelcol/Dockerfile
@@ -3,9 +3,11 @@ RUN apk --update add ca-certificates
 
 FROM alpine:3.14.2 AS otelcol
 COPY otelcol /
+COPY translatesfx /
 # Note that this shouldn't be necessary, but in some cases the file seems to be
 # copied with the execute bit lost (see #1317)
 RUN chmod 755 /otelcol
+RUN chmod 755 /translatesfx
 
 FROM alpine:3.14.2 AS smartagent
 ARG SMART_AGENT_RELEASE
@@ -26,6 +28,7 @@ ENV SPLUNK_COLLECTD_DIR=${SPLUNK_BUNDLE_DIR}/run/collectd
 ENV PATH=${PATH}:${SPLUNK_BUNDLE_DIR}/bin
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=otelcol /otelcol /
+COPY --from=otelcol /translatesfx /
 # Maintaining interpreter location as required.
 COPY --from=smartagent /usr/lib/splunk-otel-collector/agent-bundle /usr/lib/splunk-otel-collector/agent-bundle
 COPY config/collector/gateway_config.yaml    /etc/otel/collector/gateway_config.yaml

--- a/cmd/otelcol/Dockerfile.windows
+++ b/cmd/otelcol/Dockerfile.windows
@@ -7,6 +7,7 @@ WORKDIR "C:\\Program Files\Splunk\OpenTelemetry Collector"
 
 # Copy the pre-built local binary
 COPY otelcol.exe ./
+COPY translatesfx.exe ./
 
 # Copy the local config
 WORKDIR "C:\ProgramData\Splunk\OpenTelemetry Collector"

--- a/internal/buildscripts/packaging/fpm/common.sh
+++ b/internal/buildscripts/packaging/fpm/common.sh
@@ -29,6 +29,7 @@ SERVICE_USER="splunk-otel-collector"
 SERVICE_GROUP="splunk-otel-collector"
 
 OTELCOL_INSTALL_PATH="/usr/bin/otelcol"
+TRANSLATESFX_INSTALL_PATH="/usr/bin/translatesfx"
 AGENT_CONFIG_REPO_PATH="$REPO_DIR/cmd/otelcol/config/collector/agent_config.yaml"
 AGENT_CONFIG_INSTALL_PATH="/etc/otel/collector/agent_config.yaml"
 GATEWAY_CONFIG_REPO_PATH="$REPO_DIR/cmd/otelcol/config/collector/gateway_config.yaml"
@@ -100,7 +101,8 @@ download_smart_agent() {
 
 setup_files_and_permissions() {
     local otelcol="$1"
-    local buildroot="$2"
+    local translatesfx="$2"
+    local buildroot="$3"
 
     create_user_group
 
@@ -108,6 +110,11 @@ setup_files_and_permissions() {
     cp -f "$otelcol" "$buildroot/$OTELCOL_INSTALL_PATH"
     sudo chown root:root "$buildroot/$OTELCOL_INSTALL_PATH"
     sudo chmod 755 "$buildroot/$OTELCOL_INSTALL_PATH"
+
+    mkdir -p "$buildroot/$(dirname $TRANSLATESFX_INSTALL_PATH)"
+    cp -f "$translatesfx" "$buildroot/$TRANSLATESFX_INSTALL_PATH"
+    sudo chown root:root "$buildroot/$TRANSLATESFX_INSTALL_PATH"
+    sudo chmod 755 "$buildroot/$TRANSLATESFX_INSTALL_PATH"
 
     cp -r "$FPM_DIR/etc" "$buildroot/etc"
     cp -f "$AGENT_CONFIG_REPO_PATH" "$buildroot/$AGENT_CONFIG_INSTALL_PATH"

--- a/internal/buildscripts/packaging/fpm/deb/build.sh
+++ b/internal/buildscripts/packaging/fpm/deb/build.sh
@@ -34,6 +34,7 @@ if [[ -z "$SMART_AGENT_RELEASE" ]]; then
 fi
 
 otelcol_path="$REPO_DIR/bin/otelcol_linux_${ARCH}"
+translatesfx_path="$REPO_DIR/bin/translatesfx_linux_${ARCH}"
 
 buildroot="$(mktemp -d)"
 
@@ -41,7 +42,7 @@ if [ "$ARCH" = "amd64" ]; then
     download_smart_agent "$SMART_AGENT_RELEASE" "$buildroot"
 fi
 
-setup_files_and_permissions "$otelcol_path" "$buildroot"
+setup_files_and_permissions "$otelcol_path" "$translatesfx_path" "$buildroot"
 
 mkdir -p "$OUTPUT_DIR"
 

--- a/internal/buildscripts/packaging/fpm/rpm/build.sh
+++ b/internal/buildscripts/packaging/fpm/rpm/build.sh
@@ -37,6 +37,7 @@ if [[ -z "$SMART_AGENT_RELEASE" ]]; then
 fi
 
 otelcol_path="$REPO_DIR/bin/otelcol_linux_${ARCH}"
+translatesfx_path="$REPO_DIR/bin/translatesfx_linux_${ARCH}"
 
 buildroot="$(mktemp -d)"
 
@@ -47,7 +48,7 @@ elif [[ "$ARCH" = "amd64" ]]; then
     download_smart_agent "$SMART_AGENT_RELEASE" "$buildroot"
 fi
 
-setup_files_and_permissions "$otelcol_path" "$buildroot"
+setup_files_and_permissions "$otelcol_path" "$translatesfx_path" "$buildroot"
 
 mkdir -p "$OUTPUT_DIR"
 

--- a/internal/buildscripts/packaging/msi/make.ps1
+++ b/internal/buildscripts/packaging/msi/make.ps1
@@ -41,6 +41,7 @@ function Install-Tools {
 
 function New-MSI(
     [string]$Otelcol="./bin/otelcol_windows_amd64.exe",
+    [string]$Translatesfx="./bin/translatesfx_windows_amd64.exe",
     [string]$Version="0.0.1",
     [string]$BuildDir="./dist",
     [string]$Config="./cmd/otelcol/config/collector/agent_config.yaml",
@@ -58,7 +59,7 @@ function New-MSI(
     Copy-Item "$FluentdConfDir\*.conf" "$filesDir\fluentd\conf.d" -Recurse
     heat dir "$filesDir" -srd -sreg -gg -template fragment -cg ConfigFiles -dr INSTALLDIR -out "$BuildDir\configfiles.wsx"
     candle -arch x64 -out "$BuildDir\configfiles.wixobj" "$BuildDir\configfiles.wsx"
-    candle -arch x64 -out "$BuildDir\splunk-otel-collector.wixobj" -dVersion="$Version" -dOtelcol="$Otelcol" .\internal\buildscripts\packaging\msi\splunk-otel-collector.wxs
+    candle -arch x64 -out "$BuildDir\splunk-otel-collector.wixobj" -dVersion="$Version" -dOtelcol="$Otelcol" -dTranslatesfx="$Translatesfx" .\internal\buildscripts\packaging\msi\splunk-otel-collector.wxs
     light -ext WixUtilExtension.dll -sval -spdb -out "$BuildDir\$msiName" -b "$filesDir" "$BuildDir\splunk-otel-collector.wixobj" "$BuildDir\configfiles.wixobj"
     if (!(Test-Path "$BuildDir\$msiName")) {
         throw "$BuildDir\$msiName not found!"

--- a/internal/buildscripts/packaging/msi/msi-builder/Dockerfile
+++ b/internal/buildscripts/packaging/msi/msi-builder/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update -y
 RUN apt-get install -y curl unzip
 
 COPY bin/otelcol_windows_amd64.exe /project/bin/otelcol_windows_amd64.exe
+COPY bin/translatesfx_windows_amd64.exe /project/bin/translatesfx_windows_amd64.exe
 COPY cmd/ /project/cmd
 COPY internal/buildscripts/packaging/fpm/ /project/internal/buildscripts/packaging/fpm
 COPY internal/buildscripts/packaging/msi/ /project/internal/buildscripts/packaging/msi

--- a/internal/buildscripts/packaging/msi/msi-builder/build.sh
+++ b/internal/buildscripts/packaging/msi/msi-builder/build.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 WXS_PATH="/project/internal/buildscripts/packaging/msi/splunk-otel-collector.wxs"
 OTELCOL="/project/bin/otelcol_windows_amd64.exe"
+TRANSLATESFX="/project/bin/translatesfx_windows_amd64.exe"
 AGENT_CONFIG="/project/cmd/otelcol/config/collector/agent_config.yaml"
 GATEWAY_CONFIG="/project/cmd/otelcol/config/collector/gateway_config.yaml"
 FLUENTD_CONFIG="/project/internal/buildscripts/packaging/fpm/etc/otel/collector/fluentd/fluent.conf"
@@ -38,6 +39,8 @@ Description:
 OPTIONS:
     --otelcol PATH:          Absolute path to the otelcol exe.
                              Defaults to '$OTELCOL'.
+    --translatesfx PATH:     Absolute path to the translatesfx exe.
+                             Defaults to '$TRANSLATESFX'.
     --agent-config PATH:     Absolute path to the agent config.
                              Defaults to '$AGENT_CONFIG'.
     --gateway-config PATH:   Absolute path to the gateway config.
@@ -60,6 +63,7 @@ EOH
 
 parse_args_and_build() {
     local otelcol="$OTELCOL"
+    local translatesfx="$TRANSLATESFX"
     local agent_config="$AGENT_CONFIG"
     local gateway_config="$GATEWAY_CONFIG"
     local fluentd_config="$FLUENTD_CONFIG"
@@ -74,6 +78,10 @@ parse_args_and_build() {
         case $1 in
             --otelcol)
                 otelcol="$2"
+                shift 1
+                ;;
+            --translatesfx)
+                translatesfx="$2"
                 shift 1
                 ;;
             --agent-config)
@@ -162,7 +170,7 @@ parse_args_and_build() {
     candle -arch x64 -out "${configFilesWixObj//\//\\}" "${configFilesWsx//\//\\}"
 
     collectorWixObj="${build_dir}/splunk-otel-collector.wixobj"
-    candle -arch x64 -out "${collectorWixObj//\//\\}" -dVersion="$version" -dOtelcol="$otelcol" "${WXS_PATH//\//\\}"
+    candle -arch x64 -out "${collectorWixObj//\//\\}" -dVersion="$version" -dOtelcol="$otelcol" -dTranslatesfx="$translatesfx" "${WXS_PATH//\//\\}"
 
     msi="${build_dir}/${msi_name}"
     light -ext WixUtilExtension.dll -sval -out "${msi//\//\\}" -b "${files_dir//\//\\}" "${collectorWixObj//\//\\}" "${configFilesWixObj//\//\\}"

--- a/internal/buildscripts/packaging/msi/splunk-otel-collector.wxs
+++ b/internal/buildscripts/packaging/msi/splunk-otel-collector.wxs
@@ -16,7 +16,8 @@
             <Directory Id="COMPANYDIR" Name="Splunk">
                <Directory Id="INSTALLDIR" Name="OpenTelemetry Collector">
                   <Component Id="ApplicationComponent" Guid="484fa99a-2efe-41cd-a047-98bc1fc71e04">
-                     <File Id="ExecutableFile" Name="otelcol.exe" KeyPath="yes" Source="$(var.Otelcol)"/>
+                     <File Id="OtelcolExecutableFile" Name="otelcol.exe" KeyPath="yes" Source="$(var.Otelcol)"/>
+                     <File Id="TranslatesfxExecutableFile" Name="translatesfx.exe" KeyPath="no" Source="$(var.Translatesfx)"/>
                      <!-- Install the collector service with the config file in ProgramData -->
                      <ServiceInstall
                         Id="Service"


### PR DESCRIPTION
The `translatesfx` binary is added to the same directory as `otelcol` in the packages.  LMK if it should be moved somewhere else.