### PR TITLE
Remove k8s_tagger processor from full_config_linux.yaml

### DIFF
--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -181,11 +181,6 @@ processors:
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor
   batch:
 
-  # Enables the batch processor with default settings
-  # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sprocessor
-  # NOTE: It is very likely additional configuration is required
-  k8s_tagger:
-
   # Enables the resouce processor with default settings
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor
   # NOTE: These settings need to be change when using this processor


### PR DESCRIPTION
The processor is not being used in any of the pipelines, and it was renamed to k8sattributes processor in contrib