### PR TITLE
Fix docker build in gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,10 +77,12 @@ compile:
   after_script:
     - if [ -e bin/otelcol ]; then rm -f bin/otelcol; fi  # remove the symlink
     - if [ -e bin/translatesfx ]; then rm -f bin/translatesfx; fi  # remove the symlink
+    - if [ -e bin/migratecheckpoint ]; then rm -f bin/migratecheckpoint; fi  # remove the symlink
   artifacts:
     paths:
       - bin/otelcol_*
       - bin/translatesfx_*
+      - bin/migratecheckpoint_*
 
 .sign-release-cache:
   image: 'docker.repo.splunkdev.net/ci-cd/ci-container:python-3.9'

--- a/Makefile
+++ b/Makefile
@@ -227,13 +227,13 @@ binaries-darwin_amd64:
 binaries-linux_amd64:
 	GOOS=linux   GOARCH=amd64 $(MAKE) otelcol
 	GOOS=linux   GOARCH=amd64 $(MAKE) translatesfx
-	GOOS=linux  GOARCH=amd64 $(MAKE) migratecheckpoint
+	GOOS=linux   GOARCH=amd64 $(MAKE) migratecheckpoint
 
 .PHONY: binaries-linux_arm64
 binaries-linux_arm64:
 	GOOS=linux   GOARCH=arm64 $(MAKE) otelcol
 	GOOS=linux   GOARCH=arm64 $(MAKE) translatesfx
-	GOOS=linux  GOARCH=amd64 $(MAKE) migratecheckpoint
+	GOOS=linux   GOARCH=arm64 $(MAKE) migratecheckpoint
 
 .PHONY: binaries-windows_amd64
 binaries-windows_amd64:


### PR DESCRIPTION
Gitlab pipeline currently fails since the `migratecheckpoint` binary wasn't saved as an artifact for the docker image build.