### PR TITLE
Install docker for cve scan

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -461,6 +461,8 @@ cve-scan:
     - main
     - schedules
   before_script:
+    - apt-get update
+    - apt-get install -y docker.io
     - mkdir -p ~/.docker/cli-plugins
     - curl https://github.com/docker/scan-cli-plugin/releases/latest/download/docker-scan_linux_amd64 -L -s -S -o ~/.docker/cli-plugins/docker-scan
     - chmod +x ~/.docker/cli-plugins/docker-scan


### PR DESCRIPTION
Fixes cve-scan gitlab job after the golang image change.