### PR TITLE
Enable BuildKit for integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -26,6 +26,9 @@ jobs:
             /home/runner/.cache/go-build
           key: v1-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
       - run: make docker-otelcol
-      - env:
+        env:
+          DOCKER_BUILDKIT: '1'
+      - run: make integration-test
+        env:
           SPLUNK_OTEL_COLLECTOR_IMAGE: 'otelcol:latest'
-        run: make integration-test
+


### PR DESCRIPTION
By default actions don't cache docker layers, which broke `make docker-otelcol` after https://github.com/signalfx/splunk-otel-collector/blob/7839ac2a874d7daa80ac44324067a3a222e106cc/cmd/otelcol/Dockerfile#L46 failed to retrieve the required layer.  Building w/ buildkit appears to resolve.