### PR TITLE
Enable otlp receiver in the gateway logs pipeline

### DIFF
--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -122,6 +122,6 @@ service:
       processors: [memory_limiter, batch, resourcedetection/internal]
       exporters: [signalfx]
     logs:
-      receivers: [signalfx]
+      receivers: [otlp, signalfx]
       processors: [memory_limiter, batch]
       exporters: [signalfx]


### PR DESCRIPTION
The agent config says use OTLP to send logs to the gateway, but the receiver is not enabled on the gateway side