### PR TITLE
fixes issue with yum_install_fluentd on second run

### DIFF
--- a/deployments/ansible/roles/collector/tasks/yum_install_fluentd.yml
+++ b/deployments/ansible/roles/collector/tasks/yum_install_fluentd.yml
@@ -32,3 +32,7 @@
       - pkgconfig
     state: present
     update_cache: yes
+    register: yum_output
+  failed_when:
+    - "'Nothing to do' not in yum_output.msg"
+    - yum_output.rc > 0


### PR DESCRIPTION
Running against CentOS 7.6 I ran into the following errors after the initial install:

```
fatal: [somehost]: FAILED! => {"changed": false, "changes": {"installed": ["@Development tools"]}, "msg": "Error: Nothing to do\n", "rc": 1, "results": ["libcap-ng-0.7.5-4.el7.x86_64 providing libcap-ng is already installed", "libcap-ng-devel-0.7.5-4.el7.x86_64 providing libcap-ng-devel is already installed", "1:pkgconfig-0.27.1-4.el7.x86_64 providing pkgconfig is already installed", "Group Development tools does not exist.\n"]}
```

This makes it hard to make changes.  My simple fix makes sure that we don't fail when there is "Nothing to do".  `yum` is definitely exiting with a return code of 1 when the collection is already installed - but it's easier to fix this than to fix yum's behavior...