### PR TITLE
Fix evaluating env variables in ecs ec2 config

### DIFF
--- a/cmd/otelcol/config/collector/ecs_ec2_config.yaml
+++ b/cmd/otelcol/config/collector/ecs_ec2_config.yaml
@@ -78,7 +78,7 @@ receivers:
     type: ecs-metadata
     metadataEndpoint: "${ECS_TASK_METADATA_ENDPOINT}"
     statsEndpoint: "${ECS_TASK_STATS_ENDPOINT}"
-    excludedImages: ${env:ECS_METADATA_EXCLUDED_IMAGES}
+    excludedImages: $${env:ECS_METADATA_EXCLUDED_IMAGES}
 
 processors:
   batch:
@@ -105,7 +105,7 @@ processors:
     metrics:
       exclude:
         match_type: regexp
-        metric_names: ${env:METRICS_TO_EXCLUDE}
+        metric_names: $${env:METRICS_TO_EXCLUDE}
 #  # Optional: The following processor can be used to add a default "deployment.environment" attribute to the logs and
 #  # traces when it's not populated by instrumentation libraries.
 #  # If enabled, make sure to enable this processor in the pipeline below.


### PR DESCRIPTION
We need this double evaluation to expand the lists, otherwise it is interpreted as a string and doesn't work. The `METRICS_TO_EXCLUDE` is described but isn't present in any of the pipelines, so I'll submit a follow up PR to enable that.