### PR TITLE
Ensure only test certs are stripped from agent bundle

### DIFF
--- a/cmd/otelcol/Dockerfile
+++ b/cmd/otelcol/Dockerfile
@@ -35,7 +35,7 @@ RUN if [ "$ARCH" = "amd64" ]; then \
     else \
         mkdir -p /usr/lib/splunk-otel-collector/agent-bundle; \
     fi
-RUN find /usr/lib/splunk-otel-collector/agent-bundle -name "*.key" -delete -or -name "*.pem" -delete
+RUN find /usr/lib/splunk-otel-collector/agent-bundle -wholename "*test*.key" -delete -or -wholename "*test*.pem" -delete
 
 FROM scratch
 ENV SPLUNK_BUNDLE_DIR=/usr/lib/splunk-otel-collector/agent-bundle

--- a/cmd/otelcol/Dockerfile.windows
+++ b/cmd/otelcol/Dockerfile.windows
@@ -31,7 +31,7 @@ RUN Remove-Item "SignalFxAgent-win64.zip" -force
 RUN Remove-Item "agent-bundle\bin" -force -Recurse
 RUN Remove-Item "agent-bundle\etc" -force -Recurse
 RUN Get-ChildItem -include __pycache__ -recurse -force | Remove-Item -force -Recurse
-RUN Get-ChildItem -recurse -path agent-bundle\* -include *.key,*.pem | Remove-Item -force
+RUN Get-ChildItem -recurse -path agent-bundle\* -include *.key,*.pem | Where-Object { $_.Directory -match 'test' } | Remove-Item -force
 
 # Setting environment variables
 ENV SPLUNK_BUNDLE_DIR="C:\Program Files\Splunk\OpenTelemetry Collector\agent-bundle"

--- a/internal/buildscripts/packaging/fpm/common.sh
+++ b/internal/buildscripts/packaging/fpm/common.sh
@@ -94,7 +94,7 @@ download_smart_agent() {
     mkdir -p "$buildroot/$BUNDLE_BASE_DIR"
     tar -xzf "$buildroot/signalfx-agent.tar.gz" -C "$buildroot/$BUNDLE_BASE_DIR"
     mv "$buildroot/$BUNDLE_BASE_DIR/signalfx-agent" "$buildroot/$AGENT_BUNDLE_INSTALL_DIR"
-    find "$buildroot/$AGENT_BUNDLE_INSTALL_DIR" -name "*.key" -delete -or -name "*.pem" -delete
+    find "$buildroot/$AGENT_BUNDLE_INSTALL_DIR" -wholename "*test*.key" -delete -or -wholename "*test*.pem" -delete
     rm -f "$buildroot/$AGENT_BUNDLE_INSTALL_DIR/bin/signalfx-agent"
     rm -f "$buildroot/$AGENT_BUNDLE_INSTALL_DIR/bin/agent-status"
     rm -f "$buildroot/signalfx-agent.tar.gz"

--- a/internal/buildscripts/packaging/msi/msi-builder/build.sh
+++ b/internal/buildscripts/packaging/msi/msi-builder/build.sh
@@ -212,7 +212,7 @@ download_and_extract_smart_agent() {
     # This defers resolving https://github.com/wixtoolset/issues/issues/5314, which appears to require building on windows.
     # Check if test file content's path is >= 126 (128 w/ 'Z:' prefix in wine).
     find "$output_dir" -wholename "*/tests/*" -exec bash -c 'if [ `echo "{}" | wc -c` -ge 126 ]; then rm -f {}; fi' \;
-    find "$output_dir" -name "*.key" -delete -or -name "*.pem" -delete
+    find "$output_dir" -wholename "*test*.key" -delete -or -wholename "*test*.pem" -delete
     rm -f "${build_dir}/signalfx-agent.zip"
 }
 


### PR DESCRIPTION
Relaxes cert removal from https://github.com/signalfx/splunk-otel-collector/pull/861.  Requests uses the certifi bundle by default and this doesn't appear configurable, so sfxcollectd plugins are experiencing errors:

```
Could not find a suitable TLS CA certificate bundle, invalid path: /usr/lib/splunk-otel-collector/agent-bundle/lib/python3.8/site-packages/certifi/cacert.pem
```