### PR TITLE
Fix evaluating env variables in fargate config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add Chocolately package support. (#724)
+- Fix evaluating env variables in fargate config (#935)
 
 ## v0.38.0
 

--- a/cmd/otelcol/config/collector/fargate_config.yaml
+++ b/cmd/otelcol/config/collector/fargate_config.yaml
@@ -60,7 +60,7 @@ receivers:
     listenAddress: 0.0.0.0:9080
   smartagent/ecs-metadata:
     type: ecs-metadata
-    excludedImages: ${env:ECS_METADATA_EXCLUDED_IMAGES}
+    excludedImages: $${env:ECS_METADATA_EXCLUDED_IMAGES}
 
 processors:
   batch:
@@ -83,7 +83,7 @@ processors:
     metrics:
       exclude:
         match_type: regexp
-        metric_names: ${env:METRICS_TO_EXCLUDE}
+        metric_names: $${env:METRICS_TO_EXCLUDE}
   # Optional: The following processor can be used to add a default "deployment.environment" attribute to the logs and
   # traces when it's not populated by instrumentation libraries.
   # If enabled, make sure to enable this processor in the pipeline below.

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -354,7 +354,7 @@ func newBaseParserProvider() config.MapProvider {
 	configYaml := os.Getenv(configYamlEnvVarName)
 
 	if configPath == "" && configYaml != "" {
-		return parserprovider.NewInMemoryMapProvider(bytes.NewBufferString(configYaml))
+		return parserprovider.NewExpandMapProvider(parserprovider.NewInMemoryMapProvider(bytes.NewBufferString(configYaml)))
 	}
 
 	return parserprovider.NewDefaultMapProvider(configPath, nil)


### PR DESCRIPTION
We need this double evaluation to expand the lists, otherwise it is interpreted as a string and doesn't work.