### PR TITLE
Migrate lint, coverage, and unit-test jobs from CircleCi to GitHub Action.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,9 +91,6 @@ workflows:
     jobs:
       - windows-test
       - setup-environment
-      - lint:
-          requires:
-            - setup-environment
       - cross-compile:
           requires:
             - setup-environment
@@ -112,12 +109,6 @@ workflows:
       - docker-otelcol-windows:
           requires:
             - cross-compile
-      - test:
-          requires:
-            - setup-environment
-      - coverage:
-          requires:
-            - setup-environment
       - build-package:
           name: deb-package
           package_type: deb
@@ -173,14 +164,6 @@ jobs:
           root: ~/
           paths: go/bin
 
-  lint:
-    executor: golang
-    steps:
-      - attach_to_workspace
-      - run:
-          name: Lint
-          command: make -j4 checklicense impi lint misspell
-
   cross-compile:
     executor: golang
     parallelism: 4
@@ -194,39 +177,6 @@ jobs:
           paths: project/bin
       - store_artifacts:
           path: bin
-
-  test:
-    executor: golang
-    environment:
-      TEST_RESULTS: unit-test-results/junit/results.xml
-    steps:
-      - attach_to_workspace
-      - run:
-          name: Unit tests
-          command: |
-            mkdir -p unit-test-results/junit
-            trap "go-junit-report  -set-exit-code < unit-test-results/go-unit-tests.out > unit-test-results/junit/results.xml" EXIT
-            make test | tee unit-test-results/go-unit-tests.out
-      - store_artifacts:
-          path: unit-test-results
-      - store_test_results:
-          path: unit-test-results/junit
-      - save_module_cache
-
-  coverage:
-    executor: golang
-    steps:
-      - attach_to_workspace
-      - run:
-          name: Install packages.
-          command: sudo apt update && sudo apt-get install bzr time
-      - run:
-          name: Coverage tests
-          command: make test-with-cover
-# DISABLE CODECOV UNTIL THE SCRIPT IS AUDITED AND WE ARE CERTAIN IT IS OK TO TO EXECUTE IT.
-#      - run:
-#          name: Code coverage
-#          command: bash <(curl -s https://codecov.io/bash)
 
   docker-otelcol:
     parameters:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,21 +34,18 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
+            ~/go/bin
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Installing dependency
         run: |
           make install-tools
       
-      - name: Zip artifact for deployment
-        run: zip golang_pkg.zip ~/go/pkg/mod ~/go/bin -qr
-
       - name: Updating workspace
         uses: actions/upload-artifact@v2
         with:
           name: workspace
           path: |
-            golang_pkg.zip
             .
   
   lint:
@@ -66,13 +63,15 @@ jobs:
         with:
           name: workspace
 
-      - name: Unzip artifact
-        run: |
-          unzip -q golang_pkg.zip -d .
-          rm -rf ~/go/bin && mkdir -p ~/go/pkg/mod && mkdir -p ~/go/bin
-          mv ./home/runner/go/bin ~/go && mv ./home/runner/go/pkg/mod ~/go/pkg
-          rm -rf golang_pkg.zip ./home
-      
+      - name: Caching dependency
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
       - name: Lint
         run: |
           make -j4 checklicense impi lint misspell
@@ -92,13 +91,15 @@ jobs:
         with:
           name: workspace
 
-      - name: Unzip workspace
-        run: |
-          unzip -q golang_pkg.zip -d .
-          rm -rf ~/go/bin && mkdir -p ~/go/pkg/mod && mkdir -p ~/go/bin
-          mv ./home/runner/go/bin ~/go && mv ./home/runner/go/pkg/mod ~/go/pkg
-          rm -rf golang_pkg.zip ./home
-      
+      - name: Caching dependency
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
       - name: Unit tests
         run: |
           mkdir -p unit-test-results/junit
@@ -126,12 +127,14 @@ jobs:
         with:
           name: workspace
 
-      - name: Unzip workspace
-        run: |
-          unzip -q golang_pkg.zip -d .
-          rm -rf ~/go/bin && mkdir -p ~/go/pkg/mod && mkdir -p ~/go/bin
-          mv ./home/runner/go/bin ~/go && mv ./home/runner/go/pkg/mod ~/go/pkg
-          rm -rf golang_pkg.zip ./home
+      - name: Caching dependency
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       
       - name: Coverage tests
         run: |
@@ -140,3 +143,4 @@ jobs:
       # - name: Code coverage
       #   run: |
       #     bash <(curl -s https://codecov.io/bash)
+

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,10 @@
 name: build-and-test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
   group: build-and-test-${{ github.event.pull_request.number || github.ref }}
@@ -20,8 +24,6 @@ jobs:
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v2
@@ -40,28 +42,19 @@ jobs:
       - name: Installing dependency
         run: |
           make install-tools
-      
-      - name: Updating workspace
-        uses: actions/upload-artifact@v2
-        with:
-          name: workspace
-          path: |
-            .
   
   lint:
     name: lint
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Downloading workspace
-        uses: actions/download-artifact@v2
-        with:
-          name: workspace
 
       - name: Caching dependency
         uses: actions/cache@v2
@@ -81,15 +74,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Downloading workspace
-        uses: actions/download-artifact@v2
-        with:
-          name: workspace
 
       - name: Caching dependency
         uses: actions/cache@v2
@@ -117,15 +108,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Downloading workspace
-        uses: actions/download-artifact@v2
-        with:
-          name: workspace
 
       - name: Caching dependency
         uses: actions/cache@v2
@@ -143,4 +132,3 @@ jobs:
       # - name: Code coverage
       #   run: |
       #     bash <(curl -s https://codecov.io/bash)
-

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,6 +128,13 @@ jobs:
       - name: Coverage tests
         run: |
           make test-with-cover
+      
+      - name: Uploading artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage-results
+          path: ./coverage.html
+
       # DISABLE CODECOV UNTIL THE SCRIPT IS AUDITED AND WE ARE CERTAIN IT IS OK TO TO EXECUTE IT.
       # - name: Code coverage
       #   run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,142 @@
+name: build-and-test
+
+on: [push, pull_request]
+
+concurrency:
+  group: build-and-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: 3.8.5
+  PIP_VERSION: 20.2.4
+  REQUIREMENTS_PATH: "internal/buildscripts/packaging/tests/requirements.txt"
+  RESULT_PATH: "~/testresults"
+  GO_VERSION: 1.17.2
+
+jobs:
+  setup-environment:
+    name: setup-environment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Caching dependency
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Installing dependency
+        run: |
+          make install-tools
+      
+      - name: Zip artifact for deployment
+        run: zip golang_pkg.zip ~/go/pkg/mod ~/go/bin -qr
+
+      - name: Updating workspace
+        uses: actions/upload-artifact@v2
+        with:
+          name: workspace
+          path: |
+            golang_pkg.zip
+            .
+  
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    needs: [setup-environment]
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Downloading workspace
+        uses: actions/download-artifact@v2
+        with:
+          name: workspace
+
+      - name: Unzip artifact
+        run: |
+          unzip -q golang_pkg.zip -d .
+          rm -rf ~/go/bin && mkdir -p ~/go/pkg/mod && mkdir -p ~/go/bin
+          mv ./home/runner/go/bin ~/go && mv ./home/runner/go/pkg/mod ~/go/pkg
+          rm -rf golang_pkg.zip ./home
+      
+      - name: Lint
+        run: |
+          make -j4 checklicense impi lint misspell
+  
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs: [setup-environment]
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Downloading workspace
+        uses: actions/download-artifact@v2
+        with:
+          name: workspace
+
+      - name: Unzip workspace
+        run: |
+          unzip -q golang_pkg.zip -d .
+          rm -rf ~/go/bin && mkdir -p ~/go/pkg/mod && mkdir -p ~/go/bin
+          mv ./home/runner/go/bin ~/go && mv ./home/runner/go/pkg/mod ~/go/pkg
+          rm -rf golang_pkg.zip ./home
+      
+      - name: Unit tests
+        run: |
+          mkdir -p unit-test-results/junit
+          trap "go-junit-report  -set-exit-code < unit-test-results/go-unit-tests.out > unit-test-results/junit/results.xml" EXIT
+          make test | tee unit-test-results/go-unit-tests.out
+      
+      - name: Uploading artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: unit-test-results
+          path: ./unit-test-results
+
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    needs: [setup-environment]
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Downloading workspace
+        uses: actions/download-artifact@v2
+        with:
+          name: workspace
+
+      - name: Unzip workspace
+        run: |
+          unzip -q golang_pkg.zip -d .
+          rm -rf ~/go/bin && mkdir -p ~/go/pkg/mod && mkdir -p ~/go/bin
+          mv ./home/runner/go/bin ~/go && mv ./home/runner/go/pkg/mod ~/go/pkg
+          rm -rf golang_pkg.zip ./home
+      
+      - name: Coverage tests
+        run: |
+          make test-with-cover
+      # DISABLE CODECOV UNTIL THE SCRIPT IS AUDITED AND WE ARE CERTAIN IT IS OK TO TO EXECUTE IT.
+      # - name: Code coverage
+      #   run: |
+      #     bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Migrate lint, test, and coverage jobs
Ticket: [OTL-1257.](https://signalfuse.atlassian.net/browse/OTL-1257)

Adding GitHub Action jobs of `lint`, `test`, and `coverage`.
Removing CircleCi jobs of `lint`, `test`, and `coverage`.
