### PR TITLE
Support set flag and update log-level example usage

### DIFF
--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -288,7 +288,7 @@ docker run --rm -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=us0 \
     -p 13133:13133 -p 14250:14250 -p 14268:14268 -p 4317:4317 -p 6060:6060 \
     -p 8888:8888 -p 9080:9080 -p 9411:9411 -p 9943:9943 \
     --name otelcol quay.io/signalfx/splunk-otel-collector:latest \
-    --log-level=DEBUG
+    --set=service.telemetry.logs.level=debug
 ```
 
 > Use `--help` to see all available CLI arguments.

--- a/docs/getting-started/windows-manual.md
+++ b/docs/getting-started/windows-manual.md
@@ -129,7 +129,7 @@ service:
 For older versions of the Collector you can alter the service `ImagePath` before restarting:
 
 ```sh
-Set-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Services\splunk-otel-collector" -name "ImagePath" -value "C:\Program Files\Splunk\OpenTelemetry Collector\otelcol.exe --log-level debug"
+Set-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Services\splunk-otel-collector" -name "ImagePath" -value "C:\Program Files\Splunk\OpenTelemetry Collector\otelcol.exe --set=service.telemetry.logs.level=debug"
 Restart-Service splunk-otel-collector
 
 # Reverting after observing logs:

--- a/examples/prometheus-federation/docker-compose.yml
+++ b/examples/prometheus-federation/docker-compose.yml
@@ -37,7 +37,7 @@ services:
   otelcollector:
     image: quay.io/signalfx/splunk-otel-collector:0.29.0
     container_name: otelcollector
-    command: ["--config=/etc/otel-collector-config.yml", "--log-level=DEBUG"]
+    command: ["--config=/etc/otel-collector-config.yml", "--set=service.telemetry.logs.level=debug"]
     volumes:
       - ./otel-collector-config.yml:/etc/otel-collector-config.yml
     depends_on:

--- a/examples/splunk-hec-metrics/docker-compose.yml
+++ b/examples/splunk-hec-metrics/docker-compose.yml
@@ -37,7 +37,7 @@ services:
   otelcollector:
     image:  quay.io/signalfx/splunk-otel-collector:0.29.0
     container_name: otelcollector
-    command: ["--config=/etc/otel-collector-config.yml", "--log-level=DEBUG"]
+    command: ["--config=/etc/otel-collector-config.yml", "--set=service.telemetry.logs.level=debug"]
     volumes:
       - ./otel-collector-config.yml:/etc/otel-collector-config.yml
     depends_on:

--- a/examples/splunk-hec-traces/docker-compose.yml
+++ b/examples/splunk-hec-traces/docker-compose.yml
@@ -32,7 +32,7 @@ services:
   otelcollector:
     image: quay.io/signalfx/splunk-otel-collector:0.29.0
     container_name: otelcollector
-    command: ["--config=/etc/otel-collector-config.yml", "--log-level=DEBUG"]
+    command: ["--config=/etc/otel-collector-config.yml", "--set=service.telemetry.logs.level=debug"]
     volumes:
       - ./otel-collector-config.yml:/etc/otel-collector-config.yml
     depends_on:

--- a/examples/splunk-hec/docker-compose.yml
+++ b/examples/splunk-hec/docker-compose.yml
@@ -42,7 +42,7 @@ services:
   otelcollector:
     image:  quay.io/signalfx/splunk-otel-collector:0.29.0
     container_name: otelcollector
-    command: ["--config=/etc/otel-collector-config.yml", "--log-level=DEBUG"]
+    command: ["--config=/etc/otel-collector-config.yml", "--set=service.telemetry.logs.level=debug"]
     volumes:
       - ./otel-collector-config.yml:/etc/otel-collector-config.yml
     depends_on:

--- a/tests/testutils/collector_process.go
+++ b/tests/testutils/collector_process.go
@@ -59,7 +59,7 @@ func (collector CollectorProcess) WithConfigPath(path string) Collector {
 	return &collector
 }
 
-// []string{"--log-level", collector.LogLevel, "--config", collector.ConfigPath, "--metrics-level", "none"} by default
+// []string{"--set=service.telemetry.logs.level={collector.LogLevel}", "--config", collector.ConfigPath, "--metrics-level", "none"} by default
 func (collector CollectorProcess) WithArgs(args ...string) Collector {
 	collector.Args = args
 	return &collector
@@ -110,7 +110,7 @@ func (collector CollectorProcess) Build() (Collector, error) {
 	}
 	if collector.Args == nil {
 		collector.Args = []string{
-			"--log-level", collector.LogLevel, "--config", collector.ConfigPath, "--metrics-level", "none",
+			fmt.Sprintf("--set=service.telemetry.logs.level=%s", collector.LogLevel), "--config", collector.ConfigPath, "--metrics-level", "none",
 		}
 	}
 

--- a/tests/testutils/collector_process_test.go
+++ b/tests/testutils/collector_process_test.go
@@ -92,7 +92,7 @@ func TestCollectorProcessBuildDefaults(t *testing.T) {
 	assert.Equal(t, "someconfigpath", collector.ConfigPath)
 	assert.NotNil(t, collector.Logger)
 	assert.Equal(t, "info", collector.LogLevel)
-	assert.Equal(t, []string{"--log-level", "info", "--config", "someconfigpath", "--metrics-level", "none"}, collector.Args)
+	assert.Equal(t, []string{"--set=service.telemetry.logs.level=info", "--config", "someconfigpath", "--metrics-level", "none"}, collector.Args)
 }
 
 func TestStartAndShutdownInvalidWithoutBuilding(t *testing.T) {


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-collector/commit/a51bf5a2753263aa0284f76548847bea46e75d07 broke `--set` support for our distribution and https://github.com/open-telemetry/opentelemetry-collector/commit/48a2e01652fa679c89259866210473fc0d42ca95 removed `--log-level` support from the collector so that setting non-info log level requires manual config changes (read: inconvenient).

These changes ~port the `--set` properties parser and use it in our default config provider.  Also updates `--log-level` usage throughout project to the required `--set service.telemetry.logs.level` value.