### PR TITLE
Update exclude list for semgrep

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ semgrep:
   retry: 2
   variables:
     SAST_SCANNER: "Semgrep"
-    SEMGREP_EXCLUDE: "examples,internal/buildscripts,tests,*_test.go"
+    SEMGREP_EXCLUDE: "examples,internal/buildscripts,tests,*_test.go,cmd/otelcol/Dockerfile.windows,deployments/ansible/molecule"
     alert_mode: "policy"
   after_script:
     - echo "Check results at $CI_PIPELINE_URL/security"


### PR DESCRIPTION
The splunk semgrep policy was recently updated and now fails if Dockerfiles do not define or run as `USER` .  This change excludes the windows and ansible test Dockerfiles from semgrep scans.