### PR TITLE
Update OTLP HTTP receiver endpoint to use port 4318 in default configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This Splunk OpenTelemetry Collector release includes changes from the [opentelem
 
 - Initial [Chocolatey package](https://github.com/signalfx/splunk-otel-collector/blob/main/docs/getting-started/windows-manual.md#chocolatey-installation) release
 - Update bundled Smart Agent to [v5.16.0](https://github.com/signalfx/signalfx-agent/releases/tag/v5.16.0)
+- Update OTLP HTTP endpoint in default configuration files (#1017)
 
 ### 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This Splunk OpenTelemetry Collector release includes changes from the [opentelem
 
 - Initial [Chocolatey package](https://github.com/signalfx/splunk-otel-collector/blob/main/docs/getting-started/windows-manual.md#chocolatey-installation) release
 - Update bundled Smart Agent to [v5.16.0](https://github.com/signalfx/signalfx-agent/releases/tag/v5.16.0)
-- Update OTLP HTTP endpoint in default configuration files (#1017)
+- Update OTLP HTTP receiver endpoint to use port 4318 in default configuration files (#1017)
 
 ### 🧰 Bug fixes 🧰
 

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -67,7 +67,7 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:55681
+        endpoint: 0.0.0.0:4318
   # This section is used to collect the OpenTelemetry Collector metrics
   # Even if just a Splunk APM customer, these metrics are included
   prometheus/internal:

--- a/cmd/otelcol/config/collector/ecs_ec2_config.yaml
+++ b/cmd/otelcol/config/collector/ecs_ec2_config.yaml
@@ -50,7 +50,7 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:55681
+        endpoint: 0.0.0.0:4318
   # This section is used to collect the OpenTelemetry Collector metrics
   # Even if just a Splunk APM customer, these metrics are included
   prometheus/internal:

--- a/cmd/otelcol/config/collector/fargate_config.yaml
+++ b/cmd/otelcol/config/collector/fargate_config.yaml
@@ -34,7 +34,7 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:55681
+        endpoint: 0.0.0.0:4318
   # This section is used to collect the OpenTelemetry Collector metrics
   # Even if just a Splunk APM customer, these metrics are included
   prometheus/internal:

--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -35,14 +35,14 @@ receivers:
 
   # Enables the otlp receiver with default settings
   #  - grpc (default endpoint = 0.0.0.0:4317)
-  #  - http (default endpoint = 0.0.0.0:55681)
+  #  - http (default endpoint = 0.0.0.0:4318)
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver
   otlp:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:55681
+        endpoint: 0.0.0.0:4318
 
   #############################################################################
   # Traces
@@ -410,7 +410,7 @@ exporters:
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter
   # NOTE: These settings should be updated to the proper destination
   otlphttp:
-    endpoint: otelcol2:55681
+    endpoint: otelcol2:4318
     compression: gzip
     headers:
       X-SF-TOKEN: "${SPLUNK_ACCESS_TOKEN}"

--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -33,7 +33,7 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:55681
+        endpoint: 0.0.0.0:4318
   # This section is used to collect the OpenTelemetry Collector metrics
   # Even if just a Splunk APM customer, these metrics are included
   prometheus/internal:

--- a/cmd/otelcol/config/collector/otlp_config_linux.yaml
+++ b/cmd/otelcol/config/collector/otlp_config_linux.yaml
@@ -17,7 +17,7 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:55681
+        endpoint: 0.0.0.0:4318
   # This section is used to collect the OpenTelemetry Collector metrics
   # Even if just a Splunk APM customer, these metrics are included
   prometheus/internal:

--- a/cmd/otelcol/config/collector/upstream_agent_config.yaml
+++ b/cmd/otelcol/config/collector/upstream_agent_config.yaml
@@ -64,7 +64,7 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:55681
+        endpoint: 0.0.0.0:4318
   # This section is used to collect the OpenTelemetry Collector metrics
   # Even if just a Splunk APM customer, these metrics are included
   prometheus/internal:

--- a/deployments/nomad/otel-agent.nomad
+++ b/deployments/nomad/otel-agent.nomad
@@ -169,7 +169,7 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:55681
+        endpoint: 0.0.0.0:4318
   prometheus/agent:
     config:
       scrape_configs:

--- a/deployments/nomad/otel-gateway.nomad
+++ b/deployments/nomad/otel-gateway.nomad
@@ -152,7 +152,7 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:55681
+        endpoint: 0.0.0.0:4318
   signalfx:
     access_token_passthrough: true
     endpoint: 0.0.0.0:9943

--- a/examples/kubernetes-yaml/splunk-otel-collector-agent.yaml
+++ b/examples/kubernetes-yaml/splunk-otel-collector-agent.yaml
@@ -50,7 +50,7 @@ data:
           grpc:
             endpoint: 0.0.0.0:4317
           http:
-            endpoint: 0.0.0.0:55681
+            endpoint: 0.0.0.0:4318
       sapm:
         endpoint: 0.0.0.0:7276
       signalfx:

--- a/examples/kubernetes-yaml/splunk-otel-collector-gateway.yaml
+++ b/examples/kubernetes-yaml/splunk-otel-collector-gateway.yaml
@@ -50,7 +50,7 @@ data:
           grpc:
             endpoint: 0.0.0.0:4317
           http:
-            endpoint: 0.0.0.0:55681
+            endpoint: 0.0.0.0:4318
       sapm:
         endpoint: 0.0.0.0:7276
       signalfx:
@@ -157,9 +157,11 @@ spec:
     protocol: UDP
   - name: thrift-http # Default endpoint for Jaeger Thrift receiver.
     port: 14268
-  - name: otlp # Default endpoint for OpenTelemetry gRPC receiver.
+  - name: otlp # Default endpoint for OTLP gRPC receiver.
     port: 4317
-  - name: otlp-http # Default endpoint for OpenTelemetry gRPC receiver.
+  - name: otlp-http # Default endpoint for OTLP HTTP receiver.
+    port: 4318
+  - name: otlp-http-old # Legacy endpoint for OTLP HTTP receiver.
     port: 55681
   - name: http-forwarder # Default endpoint for HTTP Forwarder extension.
     port: 6060

--- a/examples/nomad/otel-demo.nomad
+++ b/examples/nomad/otel-demo.nomad
@@ -147,7 +147,7 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:55681
+        endpoint: 0.0.0.0:4318
   prometheus/collector:
     config:
       scrape_configs:


### PR DESCRIPTION
Migrate from legacy endpoint. The migration must be smooth because setting up default OTLP HTTP endpoint also enables the legacy one https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/otlp.go#L146-L157. 

With this change, the collector will be listening on both 0.0.0.0:4318 and 0.0.0.0:55681 endpoints.

Warning for configured legacy endpoint added here: https://github.com/open-telemetry/opentelemetry-collector/pull/4519