### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,3 +228,5 @@ is properly configured, is available
 ## License
 
 [Apache Software License version 2.0](./LICENSE).
+
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.