### PR TITLE
Upgrade golang to 1.17.6 

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ env:
   PIP_VERSION: 20.2.4
   REQUIREMENTS_PATH: "internal/buildscripts/packaging/tests/requirements.txt"
   RESULT_PATH: "~/testresults"
-  GO_VERSION: 1.17.2
+  GO_VERSION: 1.17.6
 
 jobs:
   setup-environment:

--- a/.github/workflows/deps-test.yml
+++ b/.github/workflows/deps-test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.4
         with:
-          go-version: 1.17.2
+          go-version: 1.17.6
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v2.1.4
         with:
-          go-version: 1.17.2
+          go-version: 1.17.6
       - id: module-cache
         uses: actions/cache@v2
         env:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.2
+          go-version: 1.17.6
 
       - name: Install golang dependency
         run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ whitesource:
     - schedules
   # allow_failure: false
   cache:
-    key: "whitesource-go1.17.2"
+    key: "whitesource-go1.17.6"
     paths:
       - /usr/local/go
       - /go/pkg/mod
@@ -60,8 +60,8 @@ whitesource:
       set -e
       if [ ! -d /usr/local/go ]; then
         pushd /usr/local
-        wget https://golang.org/dl/go1.17.2.linux-amd64.tar.gz
-        tar xzf go1.17.2.linux-amd64.tar.gz
+        wget https://golang.org/dl/go1.17.6.linux-amd64.tar.gz
+        tar xzf go1.17.6.linux-amd64.tar.gz
         popd
       fi
     - export GOROOT=/usr/local/go
@@ -93,7 +93,7 @@ whitesource:
       fi
 
 .go-cache:
-  image: 'docker-hub.repo.splunkdev.net/golang:1.17.2'
+  image: 'docker-hub.repo.splunkdev.net/golang:1.17.6'
   variables:
     GOPATH: "$CI_PROJECT_DIR/.go"
   before_script:


### PR DESCRIPTION
Upgrade Golang to the latest 1.17.x (1.17.6) to address the following vulnerabilities 

- [CVE-2021-41772](https://nvd.nist.gov/vuln/detail/CVE-2021-41772)
- [CVE-2021-41771](https://nvd.nist.gov/vuln/detail/CVE-2021-41771)

This fixes https://github.com/signalfx/splunk-otel-collector/issues/1063
 

Signed-off-by: Dani Louca <dlouca@splunk.com>