### PR TITLE
check if monitor accepts endpoints before setting host/port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This Splunk OpenTelemetry Collector release includes changes from the [opentelem
 - [`docker_observer`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/dockerobserver) to detect and create container endpoints, to be used with the [`receiver_creator`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/receivercreator) (#1044)
 - [`ecs_task_observer`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/ecstaskobserver) to detect and create ECS task container endpoints, to be used with the [`receiver_creator`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/receivercreator) (#1125)
 
+### 🧰 Bug fixes 🧰
+
+- [`smartagent` receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver) will now attempt to create _any_ monitor from a Receiver Creator instance, disregarding its provided `endpoint`. Previously would error out if a monitor did not accept endpoints ([#1107](https://github.com/signalfx/splunk-otel-collector/pull/1107))
+
 ## v0.41.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.41.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.41.0) and the [opentelemetry-collector-contrib v0.41.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.41.0) releases.

--- a/internal/receiver/smartagentreceiver/config_linux_test.go
+++ b/internal/receiver/smartagentreceiver/config_linux_test.go
@@ -61,6 +61,7 @@ func TestLoadConfigWithLinuxOnlyMonitors(t *testing.T) {
 			Port: 6379,
 			URL:  "http://{{.Host}}:{{.Port}}/mod_status?auto",
 		},
+		acceptsEndpoints: true,
 	}, apacheCfg)
 	require.NoError(t, apacheCfg.validate())
 
@@ -80,6 +81,7 @@ func TestLoadConfigWithLinuxOnlyMonitors(t *testing.T) {
 			},
 			ClusterName: "somecluster",
 		},
+		acceptsEndpoints: true,
 	}, kafkaCfg)
 	require.NoError(t, kafkaCfg.validate())
 
@@ -95,6 +97,7 @@ func TestLoadConfigWithLinuxOnlyMonitors(t *testing.T) {
 			Host: "localhost",
 			Port: 5309,
 		},
+		acceptsEndpoints: true,
 	}, memcachedCfg)
 	require.NoError(t, memcachedCfg.validate())
 
@@ -109,6 +112,7 @@ func TestLoadConfigWithLinuxOnlyMonitors(t *testing.T) {
 			},
 			Path: "/status",
 		},
+		acceptsEndpoints: true,
 	}, phpCfg)
 	require.NoError(t, phpCfg.validate())
 }

--- a/internal/receiver/smartagentreceiver/receiver.go
+++ b/internal/receiver/smartagentreceiver/receiver.go
@@ -112,6 +112,9 @@ func (r *Receiver) Start(_ context.Context, host component.Host) error {
 		monitorType: r.config.monitorConfig.MonitorConfigCore().Type,
 	}, r.logger)
 
+	if !r.config.acceptsEndpoints {
+		r.logger.Info("This Smart Agent monitor does not use Host/Port config fields. If either are set, they will be ignored.", zap.String("monitor_type", monitorType))
+	}
 	r.monitor, err = r.createMonitor(monitorType, host)
 	if err != nil {
 		return fmt.Errorf("failed creating monitor %q: %w", monitorType, err)


### PR DESCRIPTION
Only select smart-agent monitors can be created via endpoints. This is
defined as a struct tag on the monitor configs "acceptsEndpoints". In
the case where we attempt to set Host/Port on a monitor that has it's
"acceptsEndpoints" value set to false, an error occurs and we do not
create the monitor.

This change would create the monitor but avoid setting the
Host/Port fields. This allows the receiver creator to
create any smart-agent monitor with receiver creator.