### PR TITLE
fix invalid vault api deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -428,3 +428,9 @@ replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.5.9
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.3
 )
+
+// vault has invalid requirements https://github.com/hashicorp/vault/pull/13321
+replace (
+	github.com/hashicorp/vault/api/auth/approle => github.com/hashicorp/vault/api/auth/approle v0.1.2-0.20211223174530-3688d63348b3
+	github.com/hashicorp/vault/api/auth/userpass => github.com/hashicorp/vault/api/auth/userpass v0.1.1-0.20211223174530-3688d63348b3
+)

--- a/go.sum
+++ b/go.sum
@@ -1398,6 +1398,8 @@ github.com/hashicorp/vault/api v1.2.0/go.mod h1:dAjw0T5shMnrfH7Q/Mst+LrcTKvStZBV
 github.com/hashicorp/vault/api v1.3.0/go.mod h1:EabNQLI0VWbWoGlA+oBLC8PXmR9D60aUVgQGvangFWQ=
 github.com/hashicorp/vault/api v1.3.1 h1:pkDkcgTh47PRjY1NEFeofqR4W/HkNUi9qIakESO2aRM=
 github.com/hashicorp/vault/api v1.3.1/go.mod h1:QeJoWxMFt+MsuWcYhmwRLwKEXrjwAFFywzhptMsTIUw=
+github.com/hashicorp/vault/api/auth/approle v0.1.2-0.20211223174530-3688d63348b3/go.mod h1:MXmq0NA1yii35XYrQYxbvFE0c/P7SjM8iIi3eWfTy4A=
+github.com/hashicorp/vault/api/auth/userpass v0.1.1-0.20211223174530-3688d63348b3/go.mod h1:H/Y6cdoc4ZB+OkqnxzbQvJ1kTCigYuaLncKfv0/gptc=
 github.com/hashicorp/vault/sdk v0.1.8/go.mod h1:tHZfc6St71twLizWNHvnnbiGFo1aq0eD2jGPLtP8kAU=
 github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
 github.com/hashicorp/vault/sdk v0.1.14-0.20190730042320-0dc007d98cc8/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=


### PR DESCRIPTION
The newest version of vault has invalid deps and is breaking `go mod tidy`: https://github.com/hashicorp/vault/pull/13321.

We should probably have `go mod tidy` checks in CI, which I'll try in another PR.