### PR TITLE
Remove double dollar ecs config escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This Splunk OpenTelemetry Collector release includes changes from the [opentelem
 ### 🧰 Bug fixes 🧰
 
 - [`smartagent` receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver) will now attempt to create _any_ monitor from a Receiver Creator instance, disregarding its provided `endpoint`. Previously would error out if a monitor did not accept endpoints ([#1107](https://github.com/signalfx/splunk-otel-collector/pull/1107))
+- Remove `$$`-escaped `env` config source usage in ECS configs ([#1139](https://github.com/signalfx/splunk-otel-collector/pull/1139)).
 
 ## v0.41.0
 

--- a/cmd/otelcol/config/collector/ecs_ec2_config.yaml
+++ b/cmd/otelcol/config/collector/ecs_ec2_config.yaml
@@ -78,7 +78,7 @@ receivers:
     type: ecs-metadata
     metadataEndpoint: "${ECS_TASK_METADATA_ENDPOINT}"
     statsEndpoint: "${ECS_TASK_STATS_ENDPOINT}"
-    excludedImages: $${env:ECS_METADATA_EXCLUDED_IMAGES}
+    excludedImages: ${env:ECS_METADATA_EXCLUDED_IMAGES}
 
 processors:
   batch:
@@ -105,7 +105,7 @@ processors:
     metrics:
       exclude:
         match_type: regexp
-        metric_names: $${env:METRICS_TO_EXCLUDE}
+        metric_names: ${env:METRICS_TO_EXCLUDE}
 #  # Optional: The following processor can be used to add a default "deployment.environment" attribute to the logs and
 #  # traces when it's not populated by instrumentation libraries.
 #  # If enabled, make sure to enable this processor in the pipeline below.

--- a/cmd/otelcol/config/collector/fargate_config.yaml
+++ b/cmd/otelcol/config/collector/fargate_config.yaml
@@ -60,7 +60,7 @@ receivers:
     listenAddress: 0.0.0.0:9080
   smartagent/ecs-metadata:
     type: ecs-metadata
-    excludedImages: $${env:ECS_METADATA_EXCLUDED_IMAGES}
+    excludedImages: ${env:ECS_METADATA_EXCLUDED_IMAGES}
 
 processors:
   batch:
@@ -83,7 +83,7 @@ processors:
     metrics:
       exclude:
         match_type: regexp
-        metric_names: $${env:METRICS_TO_EXCLUDE}
+        metric_names: ${env:METRICS_TO_EXCLUDE}
   # Optional: The following processor can be used to add a default "deployment.environment" attribute to the logs and
   # traces when it's not populated by instrumentation libraries.
   # If enabled, make sure to enable this processor in the pipeline below.


### PR DESCRIPTION
This is no longer required and would now lead to warnings during config parsing.