### PR TITLE
update env var expansion test with non env var usage

### DIFF
--- a/tests/general/testdata/envvar_labels.yaml
+++ b/tests/general/testdata/envvar_labels.yaml
@@ -18,64 +18,64 @@ processors:
         operations:
           - action: add_label
             new_label: single-dollar-no-curly-braces
-            new_value: $AN_ENVVAR-suffix
+            new_value: $AN_ENVVAR-$nonenvvar-$-suffix $
           - action: add_label
             new_label: single-dollar-curly-braces
-            new_value: ${AN_ENVVAR}-suffix
+            new_value: ${AN_ENVVAR}-$nonenvvar-$-suffix $
           - action: add_label
             new_label: double-dollar-no-curly-braces
-            new_value: $$AN_ENVVAR-suffix
+            new_value: $$AN_ENVVAR-$$nonenvvar-$$-suffix $$
           - action: add_label
             new_label: double-dollar-curly-braces
-            new_value: $${AN_ENVVAR}-suffix
+            new_value: $${AN_ENVVAR}-$$nonenvvar-$$-suffix $$
           - action: add_label
             new_label: triple-dollar-no-curly-braces
-            new_value: $$$AN_ENVVAR-suffix
+            new_value: $$$AN_ENVVAR-$$$nonenvvar-$$$-suffix $$$
           - action: add_label
             new_label: triple-dollar-curly-braces
-            new_value: $$${AN_ENVVAR}-suffix
+            new_value: $$${AN_ENVVAR}-$$$nonenvvar-$$$-suffix $$$
           - action: add_label
             new_label: quadruple-dollar-no-curly-braces
-            new_value: $$$$AN_ENVVAR-suffix
+            new_value: $$$$AN_ENVVAR-$$$$nonenvvar-$$$$-suffix $$$$
           - action: add_label
             new_label: quadruple-dollar-curly-braces
-            new_value: $$$${AN_ENVVAR}-suffix
+            new_value: $$$${AN_ENVVAR}-$$$$nonenvvar-$$$$-suffix $$$$
           - action: add_label
             new_label: quintuple-dollar-no-curly-braces
-            new_value: $$$$$AN_ENVVAR-suffix
+            new_value: $$$$$AN_ENVVAR-$$$$$nonenvvar-$$$$$-suffix $$$$$
           - action: add_label
             new_label: quintuple-dollar-curly-braces
-            new_value: $$$$${AN_ENVVAR}-suffix
+            new_value: $$$$${AN_ENVVAR}-$$$$$nonenvvar-$$$$$-suffix $$$$$
           - action: add_label
             new_label: sextuple-dollar-no-curly-braces
-            new_value: $$$$$$AN_ENVVAR-suffix
+            new_value: $$$$$$AN_ENVVAR-$$$$$$nonenvvar-$$$$$$-suffix $$$$$$
           - action: add_label
             new_label: sextuple-dollar-curly-braces
-            new_value: $$$$$${AN_ENVVAR}-suffix
+            new_value: $$$$$${AN_ENVVAR}-$$$$$$nonenvvar-$$$$$$-suffix $$$$$$
           - action: add_label
             new_label: septuple-dollar-no-curly-braces
-            new_value: $$$$$$$AN_ENVVAR-suffix
+            new_value: $$$$$$$AN_ENVVAR-$$$$$$$nonenvvar-$$$$$$$-suffix $$$$$$$
           - action: add_label
             new_label: septuple-dollar-curly-braces
-            new_value: $$$$$$${AN_ENVVAR}-suffix
+            new_value: $$$$$$${AN_ENVVAR}-$$$$$$$nonenvvar-$$$$$$$-suffix $$$$$$$
           - action: add_label
             new_label: octuple-dollar-no-curly-braces
-            new_value: $$$$$$$$AN_ENVVAR-suffix
+            new_value: $$$$$$$$AN_ENVVAR-$$$$$$$$nonenvvar-$$$$$$$$-suffix $$$$$$$$
           - action: add_label
             new_label: octuple-dollar-curly-braces
-            new_value: $$$$$$$${AN_ENVVAR}-suffix
+            new_value: $$$$$$$${AN_ENVVAR}-$$$$$$$$nonenvvar-$$$$$$$$-suffix $$$$$$$$
           - action: add_label
             new_label: nonuple-dollar-no-curly-braces
-            new_value: $$$$$$$$$AN_ENVVAR-suffix
+            new_value: $$$$$$$$$AN_ENVVAR-$$$$$$$$$nonenvvar-$$$$$$$$$-suffix $$$$$$$$$
           - action: add_label
             new_label: nonuple-dollar-curly-braces
-            new_value: $$$$$$$$${AN_ENVVAR}-suffix
+            new_value: $$$$$$$$${AN_ENVVAR}-$$$$$$$$$nonenvvar-$$$$$$$$$-suffix $$$$$$$$$
           - action: add_label
             new_label: decuple-dollar-no-curly-braces
-            new_value: $$$$$$$$$$AN_ENVVAR-suffix
+            new_value: $$$$$$$$$$AN_ENVVAR-$$$$$$$$$$nonenvvar-$$$$$$$$$$-suffix $$$$$$$$$$
           - action: add_label
             new_label: decuple-dollar-curly-braces
-            new_value: $$$$$$$$$${AN_ENVVAR}-suffix
+            new_value: $$$$$$$$$${AN_ENVVAR}-$$$$$$$$$$nonenvvar-$$$$$$$$$$-suffix $$$$$$$$$$
 
 exporters:
   otlp:

--- a/tests/general/testdata/resource_metrics/envvar_labels.yaml
+++ b/tests/general/testdata/resource_metrics/envvar_labels.yaml
@@ -5,24 +5,23 @@ resource_metrics:
             type: IntGauge
             labels:
               state: used
-              single-dollar-no-curly-braces: an-envvar-value-suffix
-              single-dollar-curly-braces: an-envvar-value-suffix
-              double-dollar-no-curly-braces: $AN_ENVVAR-suffix
-              double-dollar-curly-braces: ${AN_ENVVAR}-suffix
-              triple-dollar-no-curly-braces: $an-envvar-value-suffix
-              triple-dollar-curly-braces: $an-envvar-value-suffix
-              quadruple-dollar-no-curly-braces: $$AN_ENVVAR-suffix
-              quadruple-dollar-curly-braces: $${AN_ENVVAR}-suffix
-              quintuple-dollar-no-curly-braces: $$an-envvar-value-suffix
-              quintuple-dollar-curly-braces: $$an-envvar-value-suffix
-              sextuple-dollar-no-curly-braces: $$$AN_ENVVAR-suffix
-              sextuple-dollar-curly-braces: $$${AN_ENVVAR}-suffix
-              septuple-dollar-no-curly-braces: $$$an-envvar-value-suffix
-              septuple-dollar-curly-braces: $$$an-envvar-value-suffix
-              octuple-dollar-no-curly-braces: $$$$AN_ENVVAR-suffix
-              octuple-dollar-curly-braces: $$$${AN_ENVVAR}-suffix
-              nonuple-dollar-no-curly-braces: $$$$an-envvar-value-suffix
-              nonuple-dollar-curly-braces: $$$$an-envvar-value-suffix
-              decuple-dollar-no-curly-braces: $$$$$AN_ENVVAR-suffix
-              decuple-dollar-curly-braces: $$$$${AN_ENVVAR}-suffix
-
+              single-dollar-no-curly-braces: an-envvar-value--suffix $
+              single-dollar-curly-braces: an-envvar-value--suffix $
+              double-dollar-no-curly-braces: $AN_ENVVAR-$nonenvvar-$-suffix $
+              double-dollar-curly-braces: ${AN_ENVVAR}-$nonenvvar-$-suffix $
+              triple-dollar-no-curly-braces: $an-envvar-value-$-$suffix $$
+              triple-dollar-curly-braces: $an-envvar-value-$-$suffix $$
+              quadruple-dollar-no-curly-braces: $$AN_ENVVAR-$$nonenvvar-$$-suffix $$
+              quadruple-dollar-curly-braces: $${AN_ENVVAR}-$$nonenvvar-$$-suffix $$
+              quintuple-dollar-no-curly-braces: $$an-envvar-value-$$-$$suffix $$$
+              quintuple-dollar-curly-braces: $$an-envvar-value-$$-$$suffix $$$
+              sextuple-dollar-no-curly-braces: $$$AN_ENVVAR-$$$nonenvvar-$$$-suffix $$$
+              sextuple-dollar-curly-braces: $$${AN_ENVVAR}-$$$nonenvvar-$$$-suffix $$$
+              septuple-dollar-curly-braces: $$$an-envvar-value-$$$-$$$suffix $$$$
+              septuple-dollar-no-curly-braces: $$$an-envvar-value-$$$-$$$suffix $$$$
+              octuple-dollar-no-curly-braces: $$$$AN_ENVVAR-$$$$nonenvvar-$$$$-suffix $$$$
+              octuple-dollar-curly-braces: $$$${AN_ENVVAR}-$$$$nonenvvar-$$$$-suffix $$$$
+              nonuple-dollar-no-curly-braces: $$$$an-envvar-value-$$$$-$$$$suffix $$$$$
+              nonuple-dollar-curly-braces: $$$$an-envvar-value-$$$$-$$$$suffix $$$$$
+              decuple-dollar-no-curly-braces: $$$$$AN_ENVVAR-$$$$$nonenvvar-$$$$$-suffix $$$$$
+              decuple-dollar-curly-braces: $$$$${AN_ENVVAR}-$$$$$nonenvvar-$$$$$-suffix $$$$$


### PR DESCRIPTION
These changes better demonstrate `$` escaping requirements when using non-envvar symbols.