### PR TITLE
Provide informative unsupported monitor error on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🧰 Bug fixes 🧰
+
+- Provide informative unsupported monitor error on Windows for Smart Agent receiver [#1150](https://github.com/signalfx/splunk-otel-collector/pull/1150)
+
 ## v0.42.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.42.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.42.0) and the [opentelemetry-collector-contrib v0.42.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.42.0) releases.

--- a/internal/receiver/smartagentreceiver/config_windows_test.go
+++ b/internal/receiver/smartagentreceiver/config_windows_test.go
@@ -1,0 +1,42 @@
+// Copyright OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build windows
+// +build windows
+
+package smartagentreceiver
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/service/servicetest"
+)
+
+func TestLoadUnsupportedCollectdMonitorOnWindows(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Receivers[typeStr] = factory
+	cfg, err := servicetest.LoadConfig(
+		path.Join(".", "testdata", "collectd_apache.yaml"), factories,
+	)
+	require.Error(t, err)
+	require.EqualError(t, err,
+		`error reading receivers configuration for "smartagent/collectd/apache": smart agent monitor type "collectd/apache" is not supported on windows platforms`)
+	require.Nil(t, cfg)
+}

--- a/internal/receiver/smartagentreceiver/testdata/collectd_apache.yaml
+++ b/internal/receiver/smartagentreceiver/testdata/collectd_apache.yaml
@@ -1,0 +1,16 @@
+receivers:
+  smartagent/collectd/apache:
+    type: collectd/apache
+
+processors:
+  nop:
+
+exporters:
+  nop:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [smartagent/collectd/apache]
+      processors: [nop]
+      exporters: [nop]


### PR DESCRIPTION
The existing error is vague for windows users who aren't aware that existing platform support is enforced in SA receiver. These changes provide more detail instead of saying the monitor isn't known.