### PR TITLE
Add CI job to build libsplunk.so

### DIFF
--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -1,0 +1,39 @@
+name: auto-instrumentation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '.github/workflows/auto-instrumentation.yml'
+      - 'instrumentation/**'
+
+concurrency:
+  group: auto-instrumentation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  libsplunk:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ARCH: [ "amd64", "arm64" ]
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        if: ${{ matrix.ARCH == 'arm64'}}
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
+      - name: Build libsplunk.so
+        run: make -C instrumentation dist ARCH=${{ matrix.ARCH }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: libsplunk-${{ matrix.ARCH }}
+          path: ./instrumentation/dist/libsplunk_${{ matrix.ARCH }}.so

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ __pycache__
 # Heroku
 deployments/heroku/test/.git
 deployments/heroku/test/node_modules
+
+# libsplunk
+/instrumentation/dist/
+/instrumentation/obj/
+/instrumentation/so/
+/instrumentation/tests

--- a/instrumentation/Dockerfile
+++ b/instrumentation/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:11
+
+RUN apt-get update && \
+    apt-get install -y build-essential
+
+WORKDIR /libsplunk
+
+COPY src /libsplunk/src
+COPY Makefile /libsplunk/Makefile

--- a/instrumentation/Makefile
+++ b/instrumentation/Makefile
@@ -1,15 +1,17 @@
+ARCH=amd64
+
 .PHONY: all
 all: so/libsplunk.so
 
 so:
-	mkdir so
+	@mkdir -p so
 
 obj:
-	mkdir obj
+	@mkdir -p obj
 
 .PHONY: clean
 clean:
-	rm tests so/* obj/*
+	rm -f tests so/* obj/*
 
 obj/logger.o: obj src/logger.c
 	gcc -c -Wall -Werror -fpic -o obj/logger.o src/logger.c
@@ -26,3 +28,10 @@ tests: src/splunk.c src/test_main.c
 .PHONY: test
 test: tests
 	./tests
+
+.PHONY: dist
+dist:
+	@mkdir -p dist
+	docker buildx build --platform linux/$(ARCH) -o type=image,name=libsplunk-builder:$(ARCH),push=false .
+	docker run --platform linux/$(ARCH) --rm -v $(CURDIR)/dist:/libsplunk/so libsplunk-builder:$(ARCH) make tests all
+	cp $(CURDIR)/dist/libsplunk.so $(CURDIR)/dist/libsplunk_$(ARCH).so


### PR DESCRIPTION
- Initial CI job to build `libsplunk.so` for amd64 and arm64
- Add basic dockerfile with build dependencies
- Add `dist` makefile target to build docker image and test/compile for `$ARCH`
