### PR TITLE
Enabling shared pipeline for profiling by default

### DIFF
--- a/cmd/otelcol/config/collector/ecs_ec2_config.yaml
+++ b/cmd/otelcol/config/collector/ecs_ec2_config.yaml
@@ -153,11 +153,11 @@ service:
       exporters: [signalfx]
     logs:
       receivers: [otlp]
-#      processors:
-#        - memory_limiter
-#        - batch
-#        - resourcedetection
-#      #- resource/add_environment
+      processors:
+        - memory_limiter
+        - batch
+        - resourcedetection
+      #- resource/add_environment
       exporters: [splunk_hec]
 #      # Use instead when sending to gateway
 #      #exporters: [otlp]

--- a/cmd/otelcol/config/collector/ecs_ec2_config.yaml
+++ b/cmd/otelcol/config/collector/ecs_ec2_config.yaml
@@ -125,12 +125,12 @@ exporters:
     access_token: "${SPLUNK_ACCESS_TOKEN}"
     realm: "${SPLUNK_REALM}"
     correlation:
-#  # Logs
-#  splunk_hec:
-#    token: "${SPLUNK_HEC_TOKEN}"
-#    endpoint: "${SPLUNK_HEC_URL}"
-#    source: "otel"
-#    sourcetype: "otel"
+  # Logs
+  splunk_hec:
+    token: "${SPLUNK_HEC_TOKEN}"
+    endpoint: "${SPLUNK_HEC_URL}"
+    source: "otel"
+    sourcetype: "otel"
 
 service:
   extensions: [health_check, http_forwarder, zpages, memory_ballast]
@@ -151,15 +151,13 @@ service:
       receivers: [prometheus/internal]
       processors: [memory_limiter, batch, resourcedetection/internal]
       exporters: [signalfx]
-#    logs:
-#      receivers: [otlp]
+    logs:
+      receivers: [otlp]
 #      processors:
 #        - memory_limiter
 #        - batch
 #        - resourcedetection
 #      #- resource/add_environment
-#      exporters: [splunk_hec]
+      exporters: [splunk_hec]
 #      # Use instead when sending to gateway
 #      #exporters: [otlp]
-
-

--- a/cmd/otelcol/config/collector/ecs_ec2_config.yaml
+++ b/cmd/otelcol/config/collector/ecs_ec2_config.yaml
@@ -125,7 +125,7 @@ exporters:
     access_token: "${SPLUNK_ACCESS_TOKEN}"
     realm: "${SPLUNK_REALM}"
     correlation:
-  # Logs
+  # Logs + Profiling
   splunk_hec:
     token: "${SPLUNK_HEC_TOKEN}"
     endpoint: "${SPLUNK_HEC_URL}"
@@ -159,5 +159,5 @@ service:
         - resourcedetection
       #- resource/add_environment
       exporters: [splunk_hec]
-#      # Use instead when sending to gateway
-#      #exporters: [otlp]
+      # Use instead when sending to gateway
+      #exporters: [otlp]

--- a/cmd/otelcol/config/collector/fargate_config.yaml
+++ b/cmd/otelcol/config/collector/fargate_config.yaml
@@ -127,10 +127,10 @@ service:
       exporters: [signalfx]
     logs:
       receivers: [otlp]
-#      processors:
-#        - memory_limiter
-#        - batch
-#        - resourcedetection
+      processors:
+        - memory_limiter
+        - batch
+        - resourcedetection
 #      #- resource/add_environment
       exporters: [splunk_hec]
 #      # Use instead when sending to gateway

--- a/cmd/otelcol/config/collector/fargate_config.yaml
+++ b/cmd/otelcol/config/collector/fargate_config.yaml
@@ -103,7 +103,7 @@ exporters:
     access_token: "${SPLUNK_ACCESS_TOKEN}"
     realm: "${SPLUNK_REALM}"
     correlation:
-  # Logs
+  # Logs + Profiling
   splunk_hec:
     token: "${SPLUNK_HEC_TOKEN}"
     endpoint: "${SPLUNK_HEC_URL}"
@@ -131,7 +131,7 @@ service:
         - memory_limiter
         - batch
         - resourcedetection
-#      #- resource/add_environment
+      #- resource/add_environment
       exporters: [splunk_hec]
-#      # Use instead when sending to gateway
-#      #exporters: [otlp]
+      # Use instead when sending to gateway
+      #exporters: [otlp]

--- a/cmd/otelcol/config/collector/fargate_config.yaml
+++ b/cmd/otelcol/config/collector/fargate_config.yaml
@@ -103,12 +103,12 @@ exporters:
     access_token: "${SPLUNK_ACCESS_TOKEN}"
     realm: "${SPLUNK_REALM}"
     correlation:
-#  # Logs
-#  splunk_hec:
-#    token: "${SPLUNK_HEC_TOKEN}"
-#    endpoint: "${SPLUNK_HEC_URL}"
-#    source: "otel"
-#    sourcetype: "otel"
+  # Logs
+  splunk_hec:
+    token: "${SPLUNK_HEC_TOKEN}"
+    endpoint: "${SPLUNK_HEC_URL}"
+    source: "otel"
+    sourcetype: "otel"
 
 service:
   extensions: [health_check, http_forwarder, zpages, memory_ballast]
@@ -125,13 +125,13 @@ service:
       receivers: [signalfx, smartagent/signalfx-forwarder, smartagent/ecs-metadata, prometheus/internal]
       processors: [memory_limiter, batch, resourcedetection]
       exporters: [signalfx]
-#    logs:
-#      receivers: [otlp]
+    logs:
+      receivers: [otlp]
 #      processors:
 #        - memory_limiter
 #        - batch
 #        - resourcedetection
 #      #- resource/add_environment
-#      exporters: [splunk_hec]
+      exporters: [splunk_hec]
 #      # Use instead when sending to gateway
 #      #exporters: [otlp]


### PR DESCRIPTION
Since the pipeline for logs and profiling is the same, this is a PR to enable it for ec2/ecs and fargate by default to avoid any configuration changes to do so.  

Context: https://docs.google.com/document/d/1KABqbnRCi--JGc6ZHIADMeyccTlTrUJZnPVQZk7F4Cs/edit?disco=AAAATAk4C5Y