### PR TITLE
puppet: Bump default td-agent version to 4.3.0

### DIFF
--- a/deployments/puppet/manifests/params.pp
+++ b/deployments/puppet/manifests/params.pp
@@ -1,6 +1,6 @@
 # Class for default param values based on OS
 class splunk_otel_collector::params {
-  $fluentd_version_default = '4.1.0'
+  $fluentd_version_default = '4.3.0'
   $fluentd_version_jessie  = '3.3.0-1'
   $fluentd_version_stretch = '3.7.1-0'
 

--- a/deployments/puppet/metadata.json
+++ b/deployments/puppet/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx-splunk_otel_collector",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Splunk, Inc.",
   "summary": "This module installs the Splunk OpenTelemetry Collector via distro packages and configures it.",
   "license": "Apache-2.0",


### PR DESCRIPTION
For https://signalfuse.atlassian.net/browse/OTL-1227