### PR TITLE
add notes to readme clarifying signalfx exporter required for events

### DIFF
--- a/docs/signalfx-smart-agent-migration.md
+++ b/docs/signalfx-smart-agent-migration.md
@@ -67,7 +67,7 @@ Below is an equivalent, recommended Collector configuration.  Notice that the
 `signalfx-forwarder` monitor's associated `smartagent/signalfx-forwarder` receiver instance
 is part of both `metrics` and `traces` pipelines using the `signalfx` and `sapm` exporters,
 respectively. Also note the `processlist` monitor's associated `smartagent/processlist` receiver
-instance is part of `logs` pipeline using the `resourcedetection` processor and a `signalfx` exporter.
+instance is part of `logs` pipeline using the `resourcedetection` processor and a required `signalfx` exporter.
 The additional metric monitors utilize the
 [Receiver Creator](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/receivercreator/README.md):
 

--- a/docs/signalfx-smart-agent-migration.md
+++ b/docs/signalfx-smart-agent-migration.md
@@ -67,7 +67,7 @@ Below is an equivalent, recommended Collector configuration.  Notice that the
 `signalfx-forwarder` monitor's associated `smartagent/signalfx-forwarder` receiver instance
 is part of both `metrics` and `traces` pipelines using the `signalfx` and `sapm` exporters,
 respectively. Also note the `processlist` monitor's associated `smartagent/processlist` receiver
-instance is part of `logs` pipeline using the `resourcedetection` processor and a required `signalfx` exporter.
+instance is part of `logs` pipeline using the `resourcedetection` processor that sets the required `host.name` resource attribute and a required `signalfx` exporter.
 The additional metric monitors utilize the
 [Receiver Creator](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/receivercreator/README.md):
 

--- a/internal/receiver/smartagentreceiver/README.md
+++ b/internal/receiver/smartagentreceiver/README.md
@@ -40,12 +40,12 @@ you can specify the empty array `[]` to disable.
 functionality](https://dev.splunk.com/observability/docs/datamodel/ingest#Send-custom-events) should also be made members of
 a `logs` pipeline that utilizes a [SignalFx
 exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/signalfxexporter/README.md)
-that will make the event submission requests.  It's recommended, and in the case of the Processlist monitor required,
+that will make the event submission requests. It's recommended, and in the case of the Processlist monitor required,
 to use a [Resource Detection
 processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/README.md)
 to ensure that host identity and other useful information is made available as event dimensions.
 Receiver entries that should be added to logs pipelines include `kubernetes-events`, `nagios`, `processlist`, and potentially any
-`telegraf/*` monitors like `telegraf/exec`.  An example of this is provided below.
+`telegraf/*` monitors like `telegraf/exec`.  The `signalfx` exporter is required for sending events to SignalFx, the `splunk_hec` exporter does not support sending events. An example of this is provided below.
 
 Example:
 


### PR DESCRIPTION
As a result of https://github.com/signalfx/splunk-otel-collector/issues/1246