### PR TITLE
smartagent: correct collectd/hadoopjmx type for windows validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🧰 Bug fixes 🧰
+
+- Correct collectd/hadoopjmx monitor type in windows Smart Agent receiver config validation [#1254](https://github.com/signalfx/splunk-otel-collector/pull/1254)
+
 ## v0.44.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.44.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.44.0) and the [opentelemetry-collector-contrib v0.44.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.44.0) releases.

--- a/internal/receiver/smartagentreceiver/config.go
+++ b/internal/receiver/smartagentreceiver/config.go
@@ -39,7 +39,7 @@ var (
 	nonWindowsMonitors      = map[string]bool{
 		"collectd/activemq": true, "collectd/apache": true, "collectd/cassandra": true, "collectd/chrony": true,
 		"collectd/cpu": true, "collectd/cpufreq": true, "collectd/custom": true, "collectd/df": true, "collectd/disk": true,
-		"collectd/genericjmx": true, "collectd/hadoop": true, "collectd/kafka": true, "collectd/kafka_consumer": true,
+		"collectd/genericjmx": true, "collectd/hadoopjmx": true, "collectd/kafka": true, "collectd/kafka_consumer": true,
 		"collectd/kafka_producer": true, "collectd/load": true, "collectd/memcached": true, "collectd/memory": true,
 		"collectd/mysql": true, "collectd/netinterface": true, "collectd/nginx": true, "collectd/php-fpm": true,
 		"collectd/postgresql": true, "collectd/processes": true, "collectd/protocols": true,


### PR DESCRIPTION
`collectd/hadoop` is python based and functional on windows.