### PR TITLE
Override host.name attribute by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### 🧰 Bug fixes 🧰
+
+- As a bug fix for hosts number miscalculation in Splunk Observability Cloud, Splunk OpenTelemetry Collector running in 
+  agent mode now is configured to override `host.name` attribute of all signals sent from instrumentation libraries by 
+  default (#1307)
+
 ## v0.45.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.45.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.45.0) and the [opentelemetry-collector-contrib v0.45.1](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.45.1) releases.

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -104,13 +104,10 @@ processors:
 
   # Detect if the collector is running on a cloud system, which is important for creating unique cloud provider dimensions.
   # Detector order is important: the `system` detector goes last so it can't preclude cloud detectors from setting host/os info.
+  # Resource detection processor is configured to override all host and cloud attributes because instrumentation
+  # libraries can send wrong values from container environments.
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#ordering
   resourcedetection:
-    detectors: [gce, ecs, ec2, azure, system]
-    override: false
-
-  # Same as above but overrides resource attributes set by receivers
-  resourcedetection/internal:
     detectors: [gce, ecs, ec2, azure, system]
     override: true
 
@@ -174,7 +171,7 @@ service:
       #exporters: [otlp]
     metrics/internal:
       receivers: [prometheus/internal]
-      processors: [memory_limiter, batch, resourcedetection/internal]
+      processors: [memory_limiter, batch, resourcedetection]
       exporters: [signalfx]
       # Use instead when sending to gateway
       #exporters: [otlp]

--- a/cmd/otelcol/config/collector/upstream_agent_config.yaml
+++ b/cmd/otelcol/config/collector/upstream_agent_config.yaml
@@ -99,13 +99,10 @@ processors:
 
   # Detect if the collector is running on a cloud system, which is important for creating unique cloud provider dimensions.
   # Detector order is important: the `system` detector goes last so it can't preclude cloud detectors from setting host/os info.
+  # Resource detection processor is configured to override all host and cloud attributes because instrumentation
+  # libraries can send wrong values from container environments.
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#ordering
   resourcedetection:
-    detectors: [gce, ecs, ec2, azure, system]
-    override: false
-
-  # Same as above but overrides resource attributes set by receivers
-  resourcedetection/internal:
     detectors: [gce, ecs, ec2, azure, system]
     override: true
 
@@ -171,7 +168,7 @@ service:
     # Required for Splunk APM and/or Infrastructure Monitoring
     metrics/internal:
       receivers: [prometheus/internal]
-      processors: [memory_limiter, batch, resourcedetection/internal]
+      processors: [memory_limiter, batch, resourcedetection]
       exporters: [signalfx]
       # Use instead when sending to gateway
       #exporters: [otlp]

--- a/deployments/nomad/otel-agent.nomad
+++ b/deployments/nomad/otel-agent.nomad
@@ -195,7 +195,7 @@ processors:
     detectors:
     - system
     - env
-    override: false
+    override: true
     timeout: 10s
 exporters:
   sapm:


### PR DESCRIPTION
Instrumentation libraries running in container environments cannot always correctly detect host attributes while OTel Collector Agent has all required access to underlying host and can be considered as a source of truth for all host and cloud metadata. This change reconfigures Resource Detection processor on the agent to override all host and cloud attributes by default.