### PR TITLE
Update SA event type to fix processlist

### DIFF
--- a/internal/receiver/smartagentreceiver/output_test.go
+++ b/internal/receiver/smartagentreceiver/output_test.go
@@ -238,8 +238,10 @@ func TestSendEvent(t *testing.T) {
 	require.Equal(t, 1, len(received))
 	log := received[0]
 	logRecord := log.ResourceLogs().At(0).InstrumentationLibraryLogs().At(0).LogRecords().At(0)
-	assert.Equal(t, "my_event", logRecord.Name())
 	attributes := logRecord.Attributes()
+	eventType, ok := attributes.Get("com.splunk.signalfx.event_type")
+	require.True(t, ok)
+	assert.Equal(t, "my_event", eventType.StringVal())
 	eventProperties, ok := attributes.Get("com.splunk.signalfx.event_properties")
 	require.True(t, ok)
 	val, ok := eventProperties.MapVal().Get("property")


### PR DESCRIPTION
After this change https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/e794616815bd9a145503f87078a623d6e2908e2d the SA processlist monitor stopped working.

This PR uses the new event type attribute in the event to log conversion .
 
Signed-off-by: Dani Louca <dlouca@splunk.com>