### PR TITLE
Restrict workflow runs for relevant paths

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,8 +5,16 @@ on:
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - '**/*.md'
+    paths:
+      - '.github/workflows/build-and-test.yml'
+      - '.github/workflows/scripts/**'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'tests/**'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - '!**.md'
 
 concurrency:
   group: build-and-test-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -5,8 +5,15 @@ on:
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - '**/*.md'
+    paths:
+      - '.github/workflows/windows-test.yml'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'tests/**'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - '!**.md'
 
 concurrency:
   group: windows-test-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
- Only run the `build-and-test` and `windows-test` workflows if there are changes to relevant paths.
- Skip these workflows if only `**.md` files are changed.
