### PR TITLE
gateway config: Remove signalfx exporter from traces pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Remove `signalfx` exporter from traces pipeline in default gateway config (#1393)
+
 ## v0.47.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.47.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.47.0) and the [opentelemetry-collector-contrib v0.47.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.47.0) releases.

--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -112,7 +112,7 @@ service:
       - memory_limiter
       - batch
       #- resource/add_environment
-      exporters: [sapm, signalfx]
+      exporters: [sapm]
     metrics:
       receivers: [otlp, signalfx]
       processors: [memory_limiter, batch]


### PR DESCRIPTION
Remove `signalfx` exporter from traces pipeline. `signalfx` exporter in the traces pipeline is used only for correlation when the Collector runs as an agent. It shouldn't be enabled for a Collector running as the gateway.