### PR TITLE
Add resource_group to gitlab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -396,6 +396,7 @@ release-debs:
     - .sign-release-cache
     - .sign-release
   stage: release
+  resource_group: artifactory-deb
   dependencies:
     - build-deb
   variables:
@@ -413,6 +414,7 @@ release-rpms:
     - .sign-release-cache
     - .sign-release
   stage: release
+  resource_group: artifactory-rpm
   dependencies:
     - build-rpm
   variables:


### PR DESCRIPTION
Restrict concurrent deb/rpm release jobs with `resource_group` to prevent artifactory repo conflicts when multiple pipelines are running at the same time.