### PR TITLE
Restrict concurrent integration test jobs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,6 +15,10 @@ on:
       - '!internal/buildscripts/packaging/*/**'
       - 'tests/**'
 
+concurrency:
+  group: integration-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker-otelcol:
     name: docker-otelcol


### PR DESCRIPTION
Similar to our other workflows, auto-cancel in-progress integration test jobs for the same PR or branch.