### PR TITLE
Fix CI test issues

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -80,6 +80,7 @@ jobs:
           molecule==3.3.0 
           molecule-docker==0.2.4 
           docker==5.0.0
+          ansible-lint==5.4.0
 
       - name: Run Molecule tests.
         run: molecule --base-config ./molecule/config/docker.yml test --all

--- a/deployments/ansible/molecule/default/Dockerfile.j2
+++ b/deployments/ansible/molecule/default/Dockerfile.j2
@@ -13,6 +13,7 @@ RUN zypper -n clean && zypper -n refresh
 RUN zypper -n install -l ansible dbus-1 rpm-python sudo systemd-sysvinit
 {% else %}
 FROM opensuse/leap:15
+RUN sed -i 's|download.opensuse.org|provo-mirror.opensuse.org|' /etc/zypp/repos.d/*.repo
 RUN zypper -n install -l ansible dbus-1 python3-rpm sudo systemd-sysvinit
 {% endif %}
 

--- a/internal/buildscripts/packaging/tests/deployments/puppet/images/rpm/Dockerfile.opensuse-15
+++ b/internal/buildscripts/packaging/tests/deployments/puppet/images/rpm/Dockerfile.opensuse-15
@@ -4,6 +4,7 @@ FROM opensuse/leap:15
 
 ENV container docker
 
+RUN sed -i 's|download.opensuse.org|provo-mirror.opensuse.org|' /etc/zypp/repos.d/*.repo
 RUN zypper -n install -l curl dbus-1 systemd-sysvinit tar wget
 
 RUN rpm --import https://yum.puppet.com/RPM-GPG-KEY-puppet-20250406

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.opensuse-15
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.opensuse-15
@@ -2,6 +2,7 @@ FROM opensuse/leap:15
 
 ENV container docker
 
+RUN sed -i 's|download.opensuse.org|provo-mirror.opensuse.org|' /etc/zypp/repos.d/*.repo
 RUN zypper -n install -l curl dbus-1 systemd-sysvinit tar wget python3-pip ca-certificates
 
 RUN zypper install -y salt salt-minion salt-master

--- a/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.opensuse-15
+++ b/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.opensuse-15
@@ -4,6 +4,7 @@ FROM opensuse/leap:15
 
 ENV container docker
 
+RUN sed -i 's|download.opensuse.org|provo-mirror.opensuse.org|' /etc/zypp/repos.d/*.repo
 RUN zypper -n install -l curl dbus-1 systemd-sysvinit tar wget
 
 RUN (cd /usr/lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \


### PR DESCRIPTION
- opensuse:15 tests have been timing out due to mirrorbrain choosing slow mirrors
- ansible-lint >= 6 no longer supports ansible 2.9