### PR TITLE
Add gofmt check to CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,7 +52,38 @@ jobs:
       - name: Installing dependency
         run: |
           make install-tools
-  
+
+  gofmt:
+    name: gofmt
+    runs-on: ubuntu-latest
+    needs: [setup-environment]
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Caching dependency
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: gofmt
+        run: |
+          make install-tools
+          gofmt -s -w .
+          if ! git diff --exit-code; then
+            echo "One or more Go files are not formatted correctly. Run 'gofmt -s -w .' and push the changes."
+            exit 1
+          fi
+
   lint:
     name: lint
     runs-on: ubuntu-latest

--- a/examples/splunk-hec-traces/tracing/main.go
+++ b/examples/splunk-hec-traces/tracing/main.go
@@ -20,7 +20,6 @@ import (
 )
 
 type MyErrorHandler struct {
-
 }
 
 func (m *MyErrorHandler) Handle(err error) {
@@ -62,7 +61,7 @@ func main() {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
 		select {
-			case <-c:
+		case <-c:
 			os.Exit(0)
 		}
 	}()


### PR DESCRIPTION
For some reason, `golangci-lint` doesn't always catch `gofmt` issues.

Example of failed job with file not currently formatted: https://github.com/signalfx/splunk-otel-collector/runs/5778977909?check_suite_focus=true