### PR TITLE
Add auto instrumentation to installer script

### DIFF
--- a/.github/workflows/installer-script-test.yml
+++ b/.github/workflows/installer-script-test.yml
@@ -25,6 +25,7 @@ jobs:
     strategy:
       matrix:
         PACKAGE_TYPE: [ "deb", "rpm" ]
+        INSTRUMENTATION: [ "true", "false" ]
     env:
       PYTHON_VERSION: 3.8.5
       PIP_VERSION: 20.2.4
@@ -60,8 +61,12 @@ jobs:
         timeout-minutes: 45
         run: |
           mkdir -p ${{ env.RESULT_PATH }}
-          echo ${{ matrix.PACKAGE_TYPE }}
-          pytest -n2 --verbose -m ${{ matrix.PACKAGE_TYPE }} \
+          if [ "${{ matrix.INSTRUMENTATION }}" = "true" ]; then
+            markers="${{ matrix.PACKAGE_TYPE }} and instrumentation"
+          else
+            markers="${{ matrix.PACKAGE_TYPE }} and not instrumentation"
+          fi
+          pytest -n2 --verbose -m "$markers" \
             --junitxml=${{ env.RESULT_PATH }}/results.xml \
             --html=${{ env.RESULT_PATH }}/results.html \
             --self-contained-html \
@@ -70,5 +75,5 @@ jobs:
       - name: Uploading artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: installer-script-test-${{ matrix.PACKAGE_TYPE }}-result
+          name: linux-installer-script-test-${{ matrix.PACKAGE_TYPE }}-${{ matrix.INSTRUMENTATION }}-result
           path: ${{ env.RESULT_PATH }}

--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -9,10 +9,10 @@ script deploys and configures:
 - [SignalFx Smart Agent and collectd bundle](https://github.com/signalfx/signalfx-agent/releases) (**x86_64/amd64 platforms only**)
 - [Fluentd (via the TD Agent)](https://www.fluentd.org/)
   - Optional, **enabled** by default
-  - See the [Fluentd Configuration](#fluentd-configuration) section for more details or how to disable installation
+  - See the [Fluentd Configuration](#fluentd-configuration) section for additional information, including how to skip installation.
 - [Splunk OpenTelemetry Auto Instrumentation for Java](https://github.com/signalfx/splunk-otel-collector/tree/main/instrumentation#linux-java-auto-instrumentation)
   - Optional, **disabled** by default
-  - See the [Auto Instrumentation](#auto-instrumentation) section for how to enable installation and more details
+  - See the [Auto Instrumentation](#auto-instrumentation) section for additional information, including how to enable installation.
 
 > IMPORTANT: systemd is required to use this script.
 
@@ -34,7 +34,7 @@ curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-co
 sh /tmp/splunk-otel-collector.sh -h
 ```
 
-Run the below command on your host to begin installation with the default
+Run the following command on your host to begin installation with the default
 options.  Replace these variables:
 
 - `SPLUNK_REALM`: Which realm to send the data to (for example: `us0`)
@@ -261,14 +261,14 @@ sudo sh /tmp/splunk-otel-collector.sh --with-instrumentation --realm SPLUNK_REAL
 To automatically define the optional `deployment.environment` resource
 attribute at installation time, run the installer script with the
 `--deployment-environment VALUE` option (replace `VALUE` with the desired
-attribute value, e.g. `prod`):
+attribute value, for example, `prod`):
 ```sh
 curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-collector.sh && \
 sudo sh /tmp/splunk-otel-collector.sh --with-instrumentation --deployment-environment VALUE --realm SPLUNK_REALM -- SPLUNK_ACCESS_TOKEN
 ```
 
-**Note:** After successful installation, the Java application(s) on the host need to be
-manually started/restarted for auto instrumentation to take effect.
+**Note:** After successful installation, the Java application(s) on the host
+need to be manually started/restarted for Auto Instrumentation to take effect.
 
 #### Post-Install Configuration
 
@@ -277,7 +277,11 @@ manually started/restarted for auto instrumentation to take effect.
   (`/usr/lib/splunk-instrumentation/libsplunk.so`).  If necessary, custom
   library paths can be manually added to this file.
 - The `/usr/lib/splunk-instrumentation/instrumentation.conf` file can be
-  manually configured for resource attributes and other options.  If the
+  manually configured for resource attributes and other parameters.  By
+  default, this file will contain the `java_agent_jar` parameter set to the
+  path of the installed [Java instrumentation agent](
+  https://github.com/signalfx/splunk-otel-java)
+  (`/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar`).  If the
   `--deployment-environment VALUE` installer script option was specified,
   the `deployment.environment=VALUE` resource attribute will be automatically
   added to this file.
@@ -290,7 +294,7 @@ need to be manually started/restarted to source the updated values.
 
 #### Upgrade
 
-To upgrade the Instrumentation package, run the following commands on your
+To upgrade the Auto Instrumentation package, run the following commands on your
 system (requires `root` privileges):
 - Debian:
   ```sh
@@ -314,10 +318,14 @@ system (requires `root` privileges):
     sudo zypper update splunk-otel-auto-instrumentation
     ```
 
+**Note:** After successful upgrade, the Java application(s) on the host need to
+be manually started/restarted for the upgraded Auto Instrumentation to take
+effect.
+
 ### Uninstall
 
-If you wish to uninstall the Collector, Fluentd, and Instrumentation packages,
-you can run:
+If you wish to uninstall the Collector, Fluentd, and Auto Instrumentation
+packages, you can run:
 
 ```sh
 curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-collector.sh && \

--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -268,7 +268,7 @@ sudo sh /tmp/splunk-otel-collector.sh --with-instrumentation --deployment-enviro
 ```
 
 **Note:** After successful installation, the Java application(s) on the host need to be
-manually started/restarted.
+manually started/restarted for auto instrumentation to take effect.
 
 #### Post-Install Configuration
 
@@ -286,7 +286,7 @@ See [Linux Java Auto Instrumentation](https://github.com/signalfx/splunk-otel-co
 for more details.
 
 **Note:** After any configuration changes, the Java application(s) on the host
-need to be manually started/restarted.
+need to be manually started/restarted to source the updated values.
 
 #### Upgrade
 

--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -272,10 +272,10 @@ manually started/restarted.
 
 #### Post-Install Configuration
 
-- The `/etc/ld.so.preload` file will be automatically updated with the path to
-  the installed instrumentation library, i.e.
-  `/usr/lib/splunk-instrumentation/libsplunk.so`.  If necessary, custom library
-  paths can be manually added to this file.
+- The `/etc/ld.so.preload` file will be automatically updated with the default
+  path to the installed instrumentation library
+  (`/usr/lib/splunk-instrumentation/libsplunk.so`).  If necessary, custom
+  library paths can be manually added to this file.
 - The `/usr/lib/splunk-instrumentation/instrumentation.conf` file can be
   manually configured for resource attributes and other options.  If the
   `--deployment-environment VALUE` installer script option was specified,

--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -268,18 +268,19 @@ sudo sh /tmp/splunk-otel-collector.sh --with-instrumentation --deployment-enviro
 ```
 
 **Note:** After successful installation, the Java application(s) on the host
-need to be manually started/restarted for Auto Instrumentation to take effect.
+need to be manually started/restarted for automatic instrumentation to take
+effect.
 
 #### Post-Install Configuration
 
-- The `/etc/ld.so.preload` file will be automatically updated with the default
-  path to the installed instrumentation library
+- The `/etc/ld.so.preload` file will be automatically created/updated with the
+  default path to the installed instrumentation library
   (`/usr/lib/splunk-instrumentation/libsplunk.so`).  If necessary, custom
   library paths can be manually added to this file.
-- The `/usr/lib/splunk-instrumentation/instrumentation.conf` file can be
-  manually configured for resource attributes and other parameters.  By
+- The `/usr/lib/splunk-instrumentation/instrumentation.conf` configuration file
+  can be manually configured for resource attributes and other parameters.  By
   default, this file will contain the `java_agent_jar` parameter set to the
-  path of the installed [Java instrumentation agent](
+  path of the installed [Java Instrumentation Agent](
   https://github.com/signalfx/splunk-otel-java)
   (`/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar`).  If the
   `--deployment-environment VALUE` installer script option was specified,
@@ -290,7 +291,8 @@ See [Linux Java Auto Instrumentation](https://github.com/signalfx/splunk-otel-co
 for more details.
 
 **Note:** After any configuration changes, the Java application(s) on the host
-need to be manually started/restarted to source the updated values.
+need to be manually started/restarted to source the updated values from the
+configuration file.
 
 #### Upgrade
 
@@ -302,7 +304,9 @@ system (requires `root` privileges):
   sudo apt-get --only-upgrade splunk-otel-auto-instrumentation
   ```
   **Note:** You may be prompted to keep or overwrite the configuration file at
-  `/usr/lib/splunk-instrumentation/instrumentation.conf`.
+  `/usr/lib/splunk-instrumentation/instrumentation.conf`.  Choosing to
+  overwrite will revert this file to the default file provided by the new
+  package.
 - RPM:
   - `yum`
     ```sh
@@ -319,8 +323,7 @@ system (requires `root` privileges):
     ```
 
 **Note:** After successful upgrade, the Java application(s) on the host need to
-be manually started/restarted for the upgraded Auto Instrumentation to take
-effect.
+be manually started/restarted in order for the changes to take effect.
 
 ### Uninstall
 

--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -45,7 +45,7 @@ installed on x86_64/amd64 platforms.
         apt-get update
         apt-get install -y splunk-otel-collector
 
-        # Optional: install Splunk OpenTelemetry Auto Instrumentation
+        # Optional: install Splunk OpenTelemetry Auto Instrumentation for Java
         apt-get install -y splunk-otel-auto-instrumentation
         ```
     - RPM with `yum`:
@@ -63,7 +63,7 @@ installed on x86_64/amd64 platforms.
 
         yum install -y splunk-otel-collector
 
-        # Optional: install Splunk OpenTelemetry Auto Instrumentation
+        # Optional: install Splunk OpenTelemetry Auto Instrumentation for Java
         yum install -y splunk-otel-auto-instrumentation
         ```
     - RPM with `dnf`:
@@ -81,7 +81,7 @@ installed on x86_64/amd64 platforms.
 
         dnf install -y splunk-otel-collector
 
-        # Optional: install Splunk OpenTelemetry Auto Instrumentation
+        # Optional: install Splunk OpenTelemetry Auto Instrumentation for Java
         dnf install -y splunk-otel-auto-instrumentation
         ```
     - RPM with `zypper`:
@@ -99,13 +99,13 @@ installed on x86_64/amd64 platforms.
 
         zypper install -y splunk-otel-collector
 
-        # Optional: install Splunk OpenTelemetry Auto Instrumentation
+        # Optional: install Splunk OpenTelemetry Auto Instrumentation for Java
         zypper install -y splunk-otel-auto-instrumentation
         ```
 1. See the [Collector Debian/RPM Post-Install
    Configuration](#collector-debianrpm-post-install-configuration) section.
-1. If the optional Auto Instrumentation package was installed,
-   see the [Auto Instrumentation Post-Install
+1. If the optional Splunk OpenTelemetry Auto Instrumentation for Java package
+   was installed, see the [Auto Instrumentation Post-Install
    Configuration](#auto-instrumentation-post-install-configuration) section.
 1. If log collection is required, see the [Fluentd](#fluentd) section.
 1. To upgrade the Collector, run the following commands:
@@ -141,8 +141,10 @@ installed on x86_64/amd64 platforms.
      sudo apt-get update
      sudo apt-get install --only-upgrade splunk-otel-auto-instrumentation
      ```
-     **Note:** You may be prompted to keep or overwrite the configuration file at
-     `/usr/lib/splunk-instrumentation/instrumentation.conf`.
+     **Note:** You may be prompted to keep or overwrite the configuration file
+     at `/usr/lib/splunk-instrumentation/instrumentation.conf`.  Choosing to
+     overwrite will revert this file to the default file provided by the new
+     package.
    - RPM:
      - `yum`
        ```sh
@@ -291,8 +293,10 @@ and install it with the following commands (requires `root` privileges).
       ```sh
       sudo dpkg -i <path to splunk-otel-auto-instrumentation deb>
       ```
-      **Note:** You may be prompted to keep or overwrite the configuration file at
-      `/usr/lib/splunk-instrumentation/instrumentation.conf`.
+      **Note:** You may be prompted to keep or overwrite the configuration file
+      at `/usr/lib/splunk-instrumentation/instrumentation.conf`.  Choosing to
+      overwrite will revert this file to the default file provided by the new
+      package.
     - RPM
       ```sh
       sudo rpm -Uvh <path to splunk-otel-auto-instrumentation rpm>
@@ -300,14 +304,14 @@ and install it with the following commands (requires `root` privileges).
 
 #### Auto Instrumentation Post-Install Configuration
 
-- The `/etc/ld.so.preload` file will be automatically updated with the default
-  path to the installed instrumentation library
+- The `/etc/ld.so.preload` file will be automatically created/updated with the
+  default path to the installed instrumentation library
   (`/usr/lib/splunk-instrumentation/libsplunk.so`).  If necessary, custom
   library paths can be manually added to this file.
-- The `/usr/lib/splunk-instrumentation/instrumentation.conf` file can be
-  manually configured for resource attributes and other parameters.  By
+- The `/usr/lib/splunk-instrumentation/instrumentation.conf` configuration file
+  can be manually configured for resource attributes and other parameters.  By
   default, this file will contain the `java_agent_jar` parameter set to the
-  path of the installed [Java instrumentation agent](
+  path of the installed [Java Instrumentation Agent](
   https://github.com/signalfx/splunk-otel-java)
   (`/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar`).
 
@@ -315,8 +319,9 @@ See [Linux Java Auto Instrumentation](https://github.com/signalfx/splunk-otel-co
 for more details.
 
 **Note:** After installation/upgrade or any configuration changes, the Java
-application(s) on the host need to be manually started/restarted for Auto
-Instrumentation to take effect or to source the updated values.
+application(s) on the host need to be manually started/restarted for automatic
+instrumentation to take effect and/or to source the updated values in the
+configuration file.
 
 #### Fluentd
 

--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -44,6 +44,9 @@ installed on x86_64/amd64 platforms.
         echo 'deb https://splunk.jfrog.io/splunk/otel-collector-deb release main' > /etc/apt/sources.list.d/splunk-otel-collector.list
         apt-get update
         apt-get install -y splunk-otel-collector
+
+        # Optional: install Splunk OpenTelemetry Auto Instrumentation
+        apt-get install -y splunk-otel-auto-instrumentation
         ```
     - RPM with `yum`:
         ```sh
@@ -59,6 +62,9 @@ installed on x86_64/amd64 platforms.
         EOH
 
         yum install -y splunk-otel-collector
+
+        # Optional: install Splunk OpenTelemetry Auto Instrumentation
+        yum install -y splunk-otel-auto-instrumentation
         ```
     - RPM with `dnf`:
         ```sh
@@ -74,6 +80,9 @@ installed on x86_64/amd64 platforms.
         EOH
 
         dnf install -y splunk-otel-collector
+
+        # Optional: install Splunk OpenTelemetry Auto Instrumentation
+        dnf install -y splunk-otel-auto-instrumentation
         ```
     - RPM with `zypper`:
         ```sh
@@ -89,43 +98,72 @@ installed on x86_64/amd64 platforms.
         EOH
 
         zypper install -y splunk-otel-collector
+
+        # Optional: install Splunk OpenTelemetry Auto Instrumentation
+        zypper install -y splunk-otel-auto-instrumentation
         ```
 1. See the [Collector Debian/RPM Post-Install
    Configuration](#collector-debianrpm-post-install-configuration) section.
+1. If the optional Auto Instrumentation package was installed,
+   see the [Auto Instrumentation Post-Install
+   Configuration](#auto-instrumentation-post-install-configuration) section.
 1. If log collection is required, see the [Fluentd](#fluentd) section.
 1. To upgrade the Collector, run the following commands:
+    - Debian:
+      ```sh
+      sudo apt-get update
+      sudo apt-get install --only-upgrade splunk-otel-collector
+      ```
+      **Note:** If the default configuration files in `/etc/otel/collector` have
+      been modified after initial installation, you may be prompted to keep the
+      existing files or overwrite the files from the new Collector package.
+    - RPM:
+        - `yum`
+          ```sh
+          sudo yum upgrade splunk-otel-collector
+          ```
+        - `dnf`:
+          ```sh
+          sudo dnf upgrade splunk-otel-collector
+          ```
+        - `zypper`
+          ```sh
+          sudo zypper refresh
+          sudo zypper update splunk-otel-collector
+          ```
+      **Note:** If the default configuration files in `/etc/otel/collector` have
+      been modified after initial installation, the existing files will be
+      preserved and the files from the new Collector package may be installed
+      with a `.rpmnew` extension.
+1. To upgrade the Auto Instrumentation package, run the following commands:
    - Debian:
      ```sh
      sudo apt-get update
-     sudo apt-get install --only-upgrade splunk-otel-collector
+     sudo apt-get install --only-upgrade splunk-otel-auto-instrumentation
      ```
-     **Note:** If the default configuration files in `/etc/otel/collector` have
-     been modified after initial installation, you may be prompted to keep the
-     existing files or overwrite the files from the new Collector package.
+     **Note:** You may be prompted to keep or overwrite the configuration file at
+     `/usr/lib/splunk-instrumentation/instrumentation.conf`.
    - RPM:
      - `yum`
        ```sh
-       sudo yum upgrade splunk-otel-collector
+       sudo yum upgrade splunk-otel-auto-instrumentation
        ```
      - `dnf`:
        ```sh
-       sudo dnf upgrade splunk-otel-collector
+       sudo dnf upgrade splunk-otel-auto-instrumentation
        ```
      - `zypper`
        ```sh
        sudo zypper refresh
-       sudo zypper update splunk-otel-collector
+       sudo zypper update splunk-otel-instrumentation
        ```
-     **Note:** If the default configuration files in `/etc/otel/collector` have
-     been modified after initial installation, the existing files will be
-     preserved and the files from the new Collector package may be installed
-     with a `.rpmnew` extension.
 
 #### Collector Debian/RPM Packages
 
 If you prefer to install the Collector without the [installer script
-](./linux-installer.md) or the Debian/RPM Repositories in the previous section,
-you can download the individual Debian or RPM package from [Github Releases](
+](./linux-installer.md) or the [Debian/RPM Repositories
+](#collector-debianrpm-packages) in the previous section, you can download the
+individual Debian or RPM package from [Github Releases](
 https://github.com/signalfx/splunk-otel-collector/releases) and install it with
 the following commands (requires `root` privileges).
 
@@ -136,8 +174,8 @@ installed on x86_64/amd64 platforms.
 > IMPORTANT: `systemctl` is a requirement to run the Collector as a service.
 > Otherwise, manually running the Collector is required.
 
-1. Download the appropriate Debian or RPM package for the target system from
-   [Github Releases](
+1. Download the appropriate `splunk-otel-collector` Debian or RPM package for
+   the target system from [Github Releases](
    https://github.com/signalfx/splunk-otel-collector/releases).
 1. Run the following commands to install the `setcap` dependency and the
    Collector package (replace `<path to splunk-otel-collector deb/rpm>` with
@@ -165,8 +203,9 @@ installed on x86_64/amd64 platforms.
 1. See the [Collector Debian/RPM Post-Install
    Configuration](#collector-debianrpm-post-install-configuration) section.
 1. If log collection is required, see the [Fluentd](#fluentd) section.
-1. To upgrade the Collector package, download the appropriate Debian or RPM
-   package for the target system from [Github Releases](
+1. To upgrade the Collector package, download the appropriate
+   `splunk-otel-collector` Debian or RPM package for the target system from
+   [Github Releases](
    https://github.com/signalfx/splunk-otel-collector/releases) and run the
    following commands (replace `<path to splunk-otel-collector deb/rpm>` with
    the local path to the downloaded Collector package):
@@ -215,6 +254,68 @@ installed on x86_64/amd64 platforms.
    ```sh
    sudo journalctl -u splunk-otel-collector
    ```
+
+#### Auto Instrumentation Debian/RPM Packages
+
+If you prefer to install the Auto Instrumentation package without the
+[installer script](./linux-installer.md) or the [Debian/RPM Repositories
+](#collector-debianrpm-packages) in the previous section, you can download the
+individual Debian or RPM package from [Github Releases](
+https://github.com/signalfx/splunk-otel-collector/releases)
+and install it with the following commands (requires `root` privileges).
+
+1. Download the appropriate `splunk-otel-auto-instrumentation` Debian or RPM
+   package for the target system from [Github Releases](
+   https://github.com/signalfx/splunk-otel-collector/releases).
+1. Run the following commands to install the Auto Instrumentation package
+   (replace `<path to splunk-otel-auto-instrumentation deb/rpm>` with
+   the local path to the downloaded Auto Instrumentation package):
+    - Debian:
+        ```sh
+        dpkg -i <path to splunk-otel-auto-instrumentation deb>
+        ```
+    - RPM:
+        ```sh
+        rpm -ivh <path to splunk-otel-auto-instrumentation rpm>
+        ```
+1. See the [Auto Instrumentation Debian/RPM Post-Install
+   Configuration](#auto-instrumentation-post-install-configuration) section.
+1. To upgrade the Auto Instrumentation package, download the appropriate
+   `splunk-auto-auto-instrumentation` Debian or RPM
+   package for the target system from [Github Releases](
+   https://github.com/signalfx/splunk-otel-collector/releases) and run the
+   following commands (replace `<path to splunk-otel-auto-instrumentation
+   deb/rpm>` with the local path to the downloaded Auto Instrumentation
+   package):
+    - Debian:
+      ```sh
+      sudo dpkg -i <path to splunk-otel-auto-instrumentation deb>
+      ```
+      **Note:** You may be prompted to keep or overwrite the configuration file at
+      `/usr/lib/splunk-instrumentation/instrumentation.conf`.
+    - RPM
+      ```sh
+      sudo rpm -Uvh <path to splunk-otel-auto-instrumentation rpm>
+      ```
+
+#### Auto Instrumentation Post-Install Configuration
+
+- The `/etc/ld.so.preload` file will be automatically updated with the default
+  path to the installed instrumentation library
+  (`/usr/lib/splunk-instrumentation/libsplunk.so`).  If necessary, custom
+  library paths can be manually added to this file.
+- The `/usr/lib/splunk-instrumentation/instrumentation.conf` file can be
+  manually configured for resource attributes and other options.  If the
+  `--deployment-environment VALUE` installer script option was specified,
+  the `deployment.environment=VALUE` resource attribute will be automatically
+  added to this file.
+
+See [Linux Java Auto Instrumentation](https://github.com/signalfx/splunk-otel-collector/tree/main/instrumentation#linux-java-auto-instrumentation)
+for more details.
+
+**Note:** After installation/upgrade or any configuration changes, the Java
+application(s) on the host need to be manually started/restarted for auto
+instrumentation to take effect or to source the updated values.
 
 #### Fluentd
 

--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -305,17 +305,18 @@ and install it with the following commands (requires `root` privileges).
   (`/usr/lib/splunk-instrumentation/libsplunk.so`).  If necessary, custom
   library paths can be manually added to this file.
 - The `/usr/lib/splunk-instrumentation/instrumentation.conf` file can be
-  manually configured for resource attributes and other options.  If the
-  `--deployment-environment VALUE` installer script option was specified,
-  the `deployment.environment=VALUE` resource attribute will be automatically
-  added to this file.
+  manually configured for resource attributes and other parameters.  By
+  default, this file will contain the `java_agent_jar` parameter set to the
+  path of the installed [Java instrumentation agent](
+  https://github.com/signalfx/splunk-otel-java)
+  (`/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar`).
 
 See [Linux Java Auto Instrumentation](https://github.com/signalfx/splunk-otel-collector/tree/main/instrumentation#linux-java-auto-instrumentation)
 for more details.
 
 **Note:** After installation/upgrade or any configuration changes, the Java
-application(s) on the host need to be manually started/restarted for auto
-instrumentation to take effect or to source the updated values.
+application(s) on the host need to be manually started/restarted for Auto
+Instrumentation to take effect or to source the updated values.
 
 #### Fluentd
 

--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -165,9 +165,9 @@ installed on x86_64/amd64 platforms.
 If you prefer to install the Collector without the [installer script
 ](./linux-installer.md) or the [Debian/RPM Repositories
 ](#collector-debianrpm-packages) in the previous section, you can download the
-individual Debian or RPM package from [Github Releases](
-https://github.com/signalfx/splunk-otel-collector/releases) and install it with
-the following commands (requires `root` privileges).
+individual Debian or RPM package from the [GitHub Releases](
+https://github.com/signalfx/splunk-otel-collector/releases) page and install it
+with the following commands (requires `root` privileges).
 
 **Note:** The [SignalFx Smart Agent and collectd bundle](
 https://github.com/signalfx/signalfx-agent/releases) is only supported and
@@ -177,8 +177,8 @@ installed on x86_64/amd64 platforms.
 > Otherwise, manually running the Collector is required.
 
 1. Download the appropriate `splunk-otel-collector` Debian or RPM package for
-   the target system from [Github Releases](
-   https://github.com/signalfx/splunk-otel-collector/releases).
+   the target system from the [GitHub Releases](
+   https://github.com/signalfx/splunk-otel-collector/releases) page.
 1. Run the following commands to install the `setcap` dependency and the
    Collector package (replace `<path to splunk-otel-collector deb/rpm>` with
    the local path to the downloaded Collector package):
@@ -207,8 +207,8 @@ installed on x86_64/amd64 platforms.
 1. If log collection is required, see the [Fluentd](#fluentd) section.
 1. To upgrade the Collector package, download the appropriate
    `splunk-otel-collector` Debian or RPM package for the target system from
-   [Github Releases](
-   https://github.com/signalfx/splunk-otel-collector/releases) and run the
+   the [GitHub Releases](
+   https://github.com/signalfx/splunk-otel-collector/releases) page and run the
    following commands (replace `<path to splunk-otel-collector deb/rpm>` with
    the local path to the downloaded Collector package):
    - Debian:
@@ -262,13 +262,13 @@ installed on x86_64/amd64 platforms.
 If you prefer to install the Auto Instrumentation package without the
 [installer script](./linux-installer.md) or the [Debian/RPM Repositories
 ](#collector-debianrpm-packages) in the previous section, you can download the
-individual Debian or RPM package from [Github Releases](
-https://github.com/signalfx/splunk-otel-collector/releases)
+individual Debian or RPM package from the [GitHub Releases](
+https://github.com/signalfx/splunk-otel-collector/releases) page
 and install it with the following commands (requires `root` privileges).
 
 1. Download the appropriate `splunk-otel-auto-instrumentation` Debian or RPM
-   package for the target system from [Github Releases](
-   https://github.com/signalfx/splunk-otel-collector/releases).
+   package for the target system from the [GitHub Releases](
+   https://github.com/signalfx/splunk-otel-collector/releases) page.
 1. Run the following commands to install the Auto Instrumentation package
    (replace `<path to splunk-otel-auto-instrumentation deb/rpm>` with
    the local path to the downloaded Auto Instrumentation package):
@@ -284,8 +284,8 @@ and install it with the following commands (requires `root` privileges).
    Configuration](#auto-instrumentation-post-install-configuration) section.
 1. To upgrade the Auto Instrumentation package, download the appropriate
    `splunk-auto-auto-instrumentation` Debian or RPM
-   package for the target system from [Github Releases](
-   https://github.com/signalfx/splunk-otel-collector/releases) and run the
+   package for the target system from the [GitHub Releases](
+   https://github.com/signalfx/splunk-otel-collector/releases) page and run the
    following commands (replace `<path to splunk-otel-auto-instrumentation
    deb/rpm>` with the local path to the downloaded Auto Instrumentation
    package):

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -101,6 +101,12 @@ elif [ "$distro_codename" = "jessie" ]; then
   default_td_agent_version="$default_td_agent_version_jessie"
 fi
 
+default_instrumentation_version="latest"
+default_deployment_environment=""
+instrumentation_config_path="/usr/lib/splunk-instrumentation/instrumentation.conf"
+instrumentation_so_path="/usr/lib/splunk-instrumentation/libsplunk.so"
+instrumentation_jar_path="/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar"
+
 repo_for_stage() {
   local repo_url=$1
   local stage=$2
@@ -277,6 +283,7 @@ install_yum_package() {
 
 ensure_not_installed() {
   local with_fluentd="$1"
+  local with_instrumentation="$2"
   local agents="otelcol"
 
   if [ "$with_fluentd" = "true" ]; then
@@ -290,6 +297,12 @@ ensure_not_installed() {
       exit 1
     fi
   done
+
+  if [ "$with_instrumentation" = "true" ] && [ -f "$instrumentation_so_path" ]; then
+    echo "$instrumentation_so_path already exists which implies that the instrumentation library has already been installed." >&2
+    echo "Please uninstall the instrumentation library and re-run this script" >&2
+    exit 1
+  fi
 }
 
 configure_env_file() {
@@ -390,12 +403,49 @@ configure_fluentd() {
   fi
 }
 
+update_instrumentation_config() {
+  local deployment_environment="$1"
+
+  if [ -f "$instrumentation_config_path" ]; then
+    echo "Adding 'deployment.environment=${deployment_environment}' resource attribute to $instrumentation_config_path"
+    if grep -q '^resource_attributes=' "$instrumentation_config_path"; then
+      # traverse through existing resource attributes to add/update deployment.environment
+      deployment_environment_found="false"
+      attributes=""
+      for i in $(grep '^resource_attributes=' "$instrumentation_config_path" | sed 's|^resource_attributes=||' | sed 's|,| |g'); do
+        key="$(echo "$i" | cut -d= -f1)"
+        value="$(echo "$i" | cut -d= -f2)"
+        if [ "$key" = "deployment.environment" ]; then
+          deployment_environment_found="true"
+          value="$deployment_environment"
+        fi
+        attributes="${attributes},${key}=${value}"
+      done
+      if [ "$deployment_environment_found" != "true" ]; then
+        attributes="${attributes},deployment.environment=${deployment_environment}"
+      fi
+      attributes=$(echo "$attributes" | sed 's|^,||')
+      ts="$(date '+%Y%m%d-%H%M%S')"
+      echo "Saving $instrumentation_config_path as ${instrumentation_config_path}.bak.${ts}"
+      cp "$instrumentation_config_path" "${instrumentation_config_path}.bak.${ts}"
+      sed -i "s|^resource_attributes=.*|resource_attributes=${attributes}|" "$instrumentation_config_path"
+    else
+      # "resource_attributes=" line not found, simply append the line to the config file
+      echo "resource_attributes=deployment.environment=${deployment_environment}" >> "$instrumentation_config_path"
+    fi
+  else
+    echo "$instrumentation_config_path not found!" >&2
+    exit 1
+  fi
+}
+
 install() {
   local stage="$1"
   local collector_version="$2"
   local td_agent_version="$3"
   local skip_collector_repo="$4"
   local skip_fluentd_repo="$5"
+  local instrumentation_version="$6"
 
   case "$distro" in
     ubuntu|debian)
@@ -421,6 +471,9 @@ install() {
         install_apt_package "td-agent" "$td_agent_version"
         apt-get -y install build-essential libcap-ng0 libcap-ng-dev pkg-config
         systemctl stop td-agent
+      fi
+      if [ -n "$instrumentation_version" ]; then
+        install_apt_package "splunk-otel-auto-instrumentation" "$instrumentation_version"
       fi
       ;;
     amzn|centos|ol|rhel)
@@ -448,6 +501,9 @@ install() {
         done
         systemctl stop td-agent
       fi
+      if [ -n "$instrumentation_version" ]; then
+        install_yum_package "splunk-otel-auto-instrumentation" "$instrumentation_version"
+      fi
       ;;
     sles|opensuse*)
       if [ "$skip_collector_repo" = "false" ]; then
@@ -457,6 +513,9 @@ install() {
       zypper -n --gpg-auto-import-keys refresh
       install_yum_package "libcap-progs"
       install_yum_package "splunk-otel-collector" "$collector_version"
+      if [ -n "$instrumentation_version" ]; then
+        install_yum_package "splunk-otel-auto-instrumentation" "$instrumentation_version"
+      fi
       ;;
     *)
       echo "Your distro ($distro) is not supported or could not be determined" >&2
@@ -466,16 +525,20 @@ install() {
 }
 
 uninstall() {
-  case "$distro" in
-    ubuntu|debian)
-      for agent in otelcol td-agent; do
-        if command -v $agent 2>&1 >/dev/null; then
-          pkg="$agent"
-          if [ "$agent" = "otelcol" ]; then
-            pkg="splunk-otel-collector"
-          fi
-          if dpkg -s $pkg 2>&1 >/dev/null; then
-            systemctl stop $pkg || true
+  for agent in otelcol td-agent $instrumentation_so_path; do
+    if command -v $agent >/dev/null 2>&1; then
+      pkg="$agent"
+      if [ "$agent" = "otelcol" ]; then
+        pkg="splunk-otel-collector"
+      elif [ "$agent" = "$instrumentation_so_path" ]; then
+        pkg="splunk-otel-auto-instrumentation"
+      fi
+      case "$distro" in
+        ubuntu|debian)
+          if dpkg -s $pkg >/dev/null 2>&1; then
+            if [ "$pkg" != "splunk-otel-auto-instrumentation" ]; then
+              systemctl stop $pkg || true
+            fi
             apt-get purge -y $pkg 2>&1
             echo "Successfully removed the $pkg package"
           else
@@ -484,18 +547,12 @@ uninstall() {
             echo "$agent_path needs to be manually removed/uninstalled" >&2
             exit 1
           fi
-        fi
-      done
-      ;;
-    amzn|centos|ol|rhel|sles|opensuse*)
-      for agent in otelcol td-agent; do
-        if command -v $agent 2>&1 >/dev/null; then
-          pkg="$agent"
-          if [ "$agent" = "otelcol" ]; then
-            pkg="splunk-otel-collector"
-          fi
-          if rpm -q $pkg 2>&1 >/dev/null; then
-            systemctl stop $pkg || true
+          ;;
+        amzn|centos|ol|rhel|sles|opensuse*)
+          if rpm -q $pkg >/dev/null 2>&1; then
+            if [ "$pkg" != "splunk-otel-auto-instrumentation" ]; then
+              systemctl stop $pkg || true
+            fi
             if command -v yum >/dev/null 2>&1; then
               yum remove -y $pkg 2>&1
             elif command -v dnf >/dev/null 2>&1; then
@@ -510,14 +567,14 @@ uninstall() {
             echo "$agent_path needs to be manually removed/uninstalled" >&2
             exit 1
           fi
-        fi
-      done
-      ;;
-    *)
-      echo "Your distro ($distro) is not supported or could not be determined" >&2
-      exit 1
-      ;;
-  esac
+          ;;
+        *)
+          echo "Your distro ($distro) is not supported or could not be determined" >&2
+          exit 1
+          ;;
+      esac
+    fi
+  done
 }
 
 usage() {
@@ -563,6 +620,12 @@ Options:
   --uninstall                       Removes the Splunk OpenTelemetry Collector for Linux
   --with[out]-fluentd               Whether to install and configure fluentd to forward log events to the collector
                                     (default: --with-fluentd)
+  --with[out]-instrumentation       Whether to install and configure the splunk-otel-auto-instrumentation package
+                                    (default: --without-instrumentation)
+  --deployment-environment <value>  Set the 'deployment.environment' resource attribute to the specified value.
+                                    Only applicable if the '--with-instrumentation' option is also specified.
+                                    (default: empty)
+  --instrumentation-version         The splunk-otel-auto-instrumentation package version to install (default: $default_instrumentation_version)
   --                                Use -- if access_token starts with -
 
 EOH
@@ -632,6 +695,9 @@ parse_args_and_install() {
   local collector_config_path=
   local skip_collector_repo="false"
   local skip_fluentd_repo="false"
+  local with_instrumentation="false"
+  local instrumentation_version="$default_instrumentation_version"
+  local deployment_environment="$default_deployment_environment"
 
   while [ -n "${1-}" ]; do
     case $1 in
@@ -719,6 +785,20 @@ parse_args_and_install() {
       --without-fluentd)
         with_fluentd="false"
         ;;
+      --with-instrumentation)
+        with_instrumentation="true"
+        ;;
+      --without-instrumentation)
+        with_instrumentation="false"
+        ;;
+      --instrumentation-version)
+        instrumentation_version="$2"
+        shift 1
+        ;;
+      --deployment-environment)
+        deployment_environment="$2"
+        shift 1
+        ;;
       --)
         access_token="$2"
         shift 1
@@ -781,7 +861,7 @@ parse_args_and_install() {
       ;;
   esac
 
-  ensure_not_installed "$with_fluentd"
+  ensure_not_installed "$with_fluentd" "$with_instrumentation"
 
   if [ -z "$access_token" ]; then
     access_token=$(request_access_token)
@@ -807,6 +887,11 @@ parse_args_and_install() {
     td_agent_version=""
   fi
 
+  if [ "$with_instrumentation" != "true" ]; then
+    instrumentation_version=""
+    deployment_environment=""
+  fi
+
   if [ -z "$trace_url" ]; then
     trace_url="${ingest_url}/v2/trace"
   fi
@@ -824,13 +909,23 @@ parse_args_and_install() {
   if [ "$with_fluentd" = "true" ]; then
     echo "TD Agent (Fluentd) Version: $td_agent_version"
   fi
+  if [ "$with_instrumentation" = "true" ]; then
+    echo "Splunk OpenTelemetry Auto Instrumentation Version: $instrumentation_version"
+    if [ -n "$deployment_environment" ]; then
+      echo "  Resource Attribute: deployment.environment=${deployment_environment}"
+    fi
+  fi
 
   if [ "${VERIFY_ACCESS_TOKEN:-true}" = "true" ] && ! verify_access_token "$access_token" "$ingest_url" "$insecure"; then
     echo "Your access token could not be verified. This may be due to a network connectivity issue." >&2
     exit 1
   fi
 
-  install "$stage" "$collector_version" "$td_agent_version" "$skip_collector_repo" "$skip_fluentd_repo"
+  install "$stage" "$collector_version" "$td_agent_version" "$skip_collector_repo" "$skip_fluentd_repo" "$instrumentation_version"
+
+  if [ "$with_instrumentation" = "true" ] && [ -n "$deployment_environment" ]; then
+    update_instrumentation_config "$deployment_environment"
+  fi
 
   create_user_group "$service_user" "$service_group"
   configure_service_owner "$service_user" "$service_group"
@@ -960,6 +1055,16 @@ restarted to apply the changes by running the following command as root:
 EOH
   fi
 
+  if [ "$with_instrumentation" = "true" ]; then
+    cat <<EOH
+The Splunk OpenTelemetry Auto Instrumentation package has been installed.
+/etc/ld.so.preload has been configured for the instrumentation library at $instrumentation_so_path.
+The configuration file is located at $instrumentation_config_path.
+
+The Java application(s) on the host need to be manually started/restarted.
+
+EOH
+  fi
   exit 0
 }
 

--- a/internal/buildscripts/packaging/tests/installer_test.py
+++ b/internal/buildscripts/packaging/tests/installer_test.py
@@ -45,6 +45,8 @@ OLD_CONFIG_PATH = "/etc/otel/collector/splunk_config_linux.yaml"
 TOTAL_MEMORY = "256"
 BALLAST = "64"
 REALM = "test"
+INSTR_CONF_PATH = "/usr/lib/splunk-instrumentation/instrumentation.conf"
+LIBSPLUNK_PATH = "/usr/lib/splunk-instrumentation/libsplunk.so"
 
 
 def verify_env_file(container, mode="agent", ballast=None):
@@ -88,6 +90,16 @@ def verify_support_bundle(container):
     run_container_cmd(container, "test -f /tmp/splunk-support-bundle.tar.gz")
 
 
+def verify_uninstall(container, distro):
+    run_container_cmd(container, "sh -x /test/install.sh --uninstall")
+
+    for pkg in ("splunk-otel-collector", "td-agent", "splunk-otel-auto-instrumentation"):
+        if distro in DEB_DISTROS:
+            assert container.exec_run(f"dpkg -s {pkg}").exit_code != 0
+        else:
+            assert container.exec_run(f"rpm -q {pkg}").exit_code != 0
+
+
 @pytest.mark.installer
 @pytest.mark.parametrize(
     "distro",
@@ -115,6 +127,12 @@ def test_installer_mode(distro, version, mode):
             run_container_cmd(container, install_cmd, env={"VERIFY_ACCESS_TOKEN": "false"})
             time.sleep(5)
 
+            # verify splunk-otel-auto-instrumentation is not installed
+            if distro in DEB_DISTROS:
+                assert container.exec_run("dpkg -s splunk-otel-auto-instrumentation").exit_code != 0
+            else:
+                assert container.exec_run("rpm -q splunk-otel-auto-instrumentation").exit_code != 0
+
             # verify env file created with configured parameters
             verify_env_file(container, mode=mode)
 
@@ -127,7 +145,7 @@ def test_installer_mode(distro, version, mode):
             # test support bundle script
             verify_support_bundle(container)
 
-            run_container_cmd(container, "sh -x /test/install.sh --uninstall")
+            verify_uninstall(container, distro)
 
         finally:
             if "opensuse" not in distro:
@@ -172,7 +190,7 @@ def test_installer_ballast(distro, version):
             if "opensuse" not in distro:
                 assert container.exec_run("systemctl status td-agent").exit_code == 0
 
-            run_container_cmd(container, "sh -x /test/install.sh --uninstall")
+            verify_uninstall(container, distro)
 
         finally:
             if "opensuse" not in distro:
@@ -219,6 +237,8 @@ def test_installer_service_owner(distro, version):
             if "opensuse" not in distro:
                 assert container.exec_run("systemctl status td-agent").exit_code == 0
 
+            verify_uninstall(container, distro)
+
         finally:
             if "opensuse" not in distro:
                 run_container_cmd(container, "journalctl -u td-agent --no-pager")
@@ -262,7 +282,111 @@ def test_installer_without_fluentd(distro, version):
             else:
                 assert container.exec_run("rpm -q td-agent").exit_code != 0
 
-            run_container_cmd(container, "sh -x /test/install.sh --uninstall")
+            verify_uninstall(container, distro)
+
+        finally:
+            run_container_cmd(container, f"journalctl -u {SERVICE_NAME} --no-pager")
+
+
+@pytest.mark.installer
+@pytest.mark.instrumentation
+@pytest.mark.parametrize(
+    "distro",
+    [pytest.param(distro, marks=pytest.mark.deb) for distro in DEB_DISTROS]
+    + [pytest.param(distro, marks=pytest.mark.rpm) for distro in RPM_DISTROS],
+    )
+@pytest.mark.parametrize("version", VERSIONS)
+def test_installer_with_instrumentation(distro, version):
+    install_cmd = f"sh -x /test/install.sh -- testing123 --realm {REALM} --memory {TOTAL_MEMORY} --with-instrumentation"
+
+    if version != "latest":
+        install_cmd = f"{install_cmd} --collector-version {version.lstrip('v')}"
+
+    if STAGE != "release":
+        assert STAGE in ("test", "beta"), f"Unsupported stage '{STAGE}'!"
+        install_cmd = f"{install_cmd} --{STAGE}"
+
+    print(f"Testing installation on {distro} from {STAGE} stage ...")
+    with run_distro_container(distro) as container:
+        copy_file_into_container(container, INSTALLER_PATH, "/test/install.sh")
+
+        try:
+            # run installer script
+            run_container_cmd(container, install_cmd, env={"VERIFY_ACCESS_TOKEN": "false"})
+            time.sleep(5)
+
+            # verify env file created with configured parameters
+            verify_env_file(container)
+
+            # verify collector service status
+            assert wait_for(lambda: service_is_running(container, service_owner=SERVICE_OWNER))
+
+            # verify splunk-otel-auto-instrumentation is installed
+            if distro in DEB_DISTROS:
+                assert container.exec_run("dpkg -s splunk-otel-auto-instrumentation").exit_code == 0
+            else:
+                assert container.exec_run("rpm -q splunk-otel-auto-instrumentation").exit_code == 0
+
+            # verify /etc/ld.so.preload is configured
+            run_container_cmd(container, f"grep '^{LIBSPLUNK_PATH}$' /etc/ld.so.preload")
+
+            # verify deployment.environment attribute is not set
+            run_container_cmd(container, f"grep -v '^resource_attributes=deployment.environment=.*$' {INSTR_CONF_PATH}")
+
+            verify_uninstall(container, distro)
+
+        finally:
+            run_container_cmd(container, f"journalctl -u {SERVICE_NAME} --no-pager")
+
+
+@pytest.mark.installer
+@pytest.mark.instrumentation
+@pytest.mark.parametrize(
+    "distro",
+    [pytest.param(distro, marks=pytest.mark.deb) for distro in DEB_DISTROS]
+    + [pytest.param(distro, marks=pytest.mark.rpm) for distro in RPM_DISTROS],
+    )
+@pytest.mark.parametrize("version", VERSIONS)
+def test_installer_with_deployment_environment(distro, version):
+    install_cmd = f"sh -x /test/install.sh -- testing123 --realm {REALM} --memory {TOTAL_MEMORY} --with-instrumentation"
+
+    if version != "latest":
+        install_cmd = f"{install_cmd} --collector-version {version.lstrip('v')}"
+
+    if STAGE != "release":
+        assert STAGE in ("test", "beta"), f"Unsupported stage '{STAGE}'!"
+        install_cmd = f"{install_cmd} --{STAGE}"
+
+    install_cmd = f"{install_cmd} --deployment-environment test"
+
+    print(f"Testing installation on {distro} from {STAGE} stage ...")
+    with run_distro_container(distro) as container:
+        copy_file_into_container(container, INSTALLER_PATH, "/test/install.sh")
+
+        try:
+            # run installer script
+            run_container_cmd(container, install_cmd, env={"VERIFY_ACCESS_TOKEN": "false"})
+            time.sleep(5)
+
+            # verify env file created with configured parameters
+            verify_env_file(container)
+
+            # verify collector service status
+            assert wait_for(lambda: service_is_running(container, service_owner=SERVICE_OWNER))
+
+            # verify splunk-otel-auto-instrumentation is installed
+            if distro in DEB_DISTROS:
+                assert container.exec_run("dpkg -s splunk-otel-auto-instrumentation").exit_code == 0
+            else:
+                assert container.exec_run("rpm -q splunk-otel-auto-instrumentation").exit_code == 0
+
+            # verify /etc/ld.so.preload is configured
+            run_container_cmd(container, f"grep '^{LIBSPLUNK_PATH}$' /etc/ld.so.preload")
+
+            # verify deployment.environment is set
+            run_container_cmd(container, f"grep '^resource_attributes=deployment.environment=test$' {INSTR_CONF_PATH}")
+
+            verify_uninstall(container, distro)
 
         finally:
             run_container_cmd(container, f"journalctl -u {SERVICE_NAME} --no-pager")

--- a/internal/buildscripts/packaging/tests/pytest.ini
+++ b/internal/buildscripts/packaging/tests/pytest.ini
@@ -2,4 +2,5 @@
 markers =
     deb
     installer
+    instrumentation
     rpm


### PR DESCRIPTION
- Add `--with-instrumentation` option to install the `splunk-otel-auto-instrumentation` deb/rpm package from artifactory (disabled by default)
- Add `--deployment-environment VALUE` option to define the `deployment.environment=VALUE` resource attribute in  the instrumentation config file
