### PR TITLE
Update solr repo in dockerfile

### DIFF
--- a/tests/receivers/smartagent/collectd-solr/testdata/server/Dockerfile
+++ b/tests/receivers/smartagent/collectd-solr/testdata/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/bitnami/solr:latest
+FROM bitnami/solr:latest
 
 ENTRYPOINT ["bash", "-c"]
 CMD ["solr start -c -e techproducts && tail -f /dev/null"]


### PR DESCRIPTION
The `quay.io/bitnami/solr:latest` image is no longer accessible.