### PR TITLE
Fix use of parens vs curly brackets in bash

### DIFF
--- a/examples/otel-logs-routing/docker-compose.yml
+++ b/examples/otel-logs-routing/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   logging:
     image: bash:latest
     container_name: logging
-    command: 'bash -c "while(true) do echo \"$${date} new message\" >> /output/file.log ; sleep 1; done"'
+    command: 'bash -c "while(true) do echo \"$$(date) new message\" >> /output/file.log ; sleep 1; done"'
     volumes:
       - ./output:/output
   # Splunk Enterprise server:

--- a/examples/otel-logs-sanitization-splunk/docker-compose.yml
+++ b/examples/otel-logs-sanitization-splunk/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   logging:
     image: bash:latest
     container_name: logging
-    command: 'bash -c "while(true) do echo \"$${date} my SSN is $$(($$RANDOM % 9))$$(($$RANDOM % 9))$$(($$RANDOM % 9))$$(($$RANDOM % 9))-$$(($$RANDOM % 9))$$(($$RANDOM % 9))$$(($$RANDOM % 9))-$$(($$RANDOM % 9))$$(($$RANDOM % 9))$$(($$RANDOM % 9))$$(($$RANDOM % 9)). Please do not share.\" >> /output/file.log ; sleep 1; done"'
+    command: 'bash -c "while(true) do echo \"$$(date) my SSN is $$(($$RANDOM % 9))$$(($$RANDOM % 9))$$(($$RANDOM % 9))$$(($$RANDOM % 9))-$$(($$RANDOM % 9))$$(($$RANDOM % 9))$$(($$RANDOM % 9))-$$(($$RANDOM % 9))$$(($$RANDOM % 9))$$(($$RANDOM % 9))$$(($$RANDOM % 9)). Please do not share.\" >> /output/file.log ; sleep 1; done"'
     volumes:
       - ./output:/output
   # Splunk Enterprise server:

--- a/examples/otel-logs-splunk/docker-compose.yml
+++ b/examples/otel-logs-splunk/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   logging:
     image: bash:latest
     container_name: logging
-    command: 'bash -c "while(true) do echo \"$${date} new message\" >> /output/file.log ; sleep 1; done"'
+    command: 'bash -c "while(true) do echo \"$$(date) new message\" >> /output/file.log ; sleep 1; done"'
     volumes:
       - ./output:/output
   # Splunk Enterprise server:


### PR DESCRIPTION
Fixes examples that used curly brackets instead of parens to call out to the date function.