### PR TITLE
Add trivy security scan jobs

### DIFF
--- a/.github/workflows/trivy-scans.yml
+++ b/.github/workflows/trivy-scans.yml
@@ -1,0 +1,62 @@
+name: trivy scans
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '.github/workflows/trivy-scans.yml'
+      - '.trivyignore'
+
+env:
+  GO_VERSION: '1.18.3'
+
+jobs:
+  trivy-fs-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Run trivy filesystem scan
+        uses: aquasecurity/trivy-action@0.6.1
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          skip-dirs: 'deployments,examples,instrumentation/packaging,internal/buildscripts/packaging,tests'
+          format: 'table'
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+
+  trivy-image-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - id: module-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-go-modules
+        with:
+          path: |
+            /home/runner/go/pkg/mod
+            /home/runner/.cache/go-build
+          key: v1-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+      - run: make docker-otelcol
+        env:
+          DOCKER_BUILDKIT: '1'
+      - name: Run trivy image scan
+        uses: aquasecurity/trivy-action@0.6.1
+        with:
+          scan-type: 'image'
+          image-ref: 'otelcol:latest'
+          format: 'table'
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# False positive, resolved in https://github.com/signalfx/splunk-otel-collector/pull/1817
+CVE-2022-1996


### PR DESCRIPTION
https://github.com/aquasecurity/trivy
- Run vulnerability scans for the repo and the collector image (currently only on pushes to main)
- Fail for high and critical vulnerabilities
- Example of failed jobs for detected vulnerability before it was updated: https://github.com/signalfx/splunk-otel-collector/actions/runs/2755673358