### PR TITLE
Add jmx monitor integration test

### DIFF
--- a/tests/receivers/smartagent/jmx/jmx_test.go
+++ b/tests/receivers/smartagent/jmx/jmx_test.go
@@ -1,0 +1,34 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"path"
+	"testing"
+
+	"github.com/signalfx/splunk-otel-collector/tests/testutils"
+)
+
+var cassandra = []testutils.Container{
+	testutils.NewContainer().WithContext(
+		path.Join(".", "testdata", "server"),
+	).WithExposedPorts("7199:7199").WithName("cassandra").WillWaitForPorts("7199"),
+}
+
+func TestJmxReceiverProvidesAllMetrics(t *testing.T) {
+	testutils.AssertAllMetricsReceived(
+		t, "all.yaml", "all_metrics_config.yaml", cassandra,
+	)
+}

--- a/tests/receivers/smartagent/jmx/testdata/all_metrics_config.yaml
+++ b/tests/receivers/smartagent/jmx/testdata/all_metrics_config.yaml
@@ -1,0 +1,75 @@
+receivers:
+  smartagent/jmx:
+    type: jmx
+    host: localhost
+    port: 7199
+    username: cassandra
+    password: cassandra
+    intervalSeconds: 1
+    groovyScript: |
+      ss = util.queryJMX("org.apache.cassandra.db:type=StorageService").first()
+
+      // Copied and modified from https://github.com/apache/cassandra
+      def parseFileSize(String value) {
+        if (!value.matches("\\d+(\\.\\d+)? (GiB|KiB|MiB|TiB|bytes)")) {
+          throw new IllegalArgumentException(
+            String.format("value %s is not a valid human-readable file size", value));
+        }
+        if (value.endsWith(" TiB")) {
+          return Math.round(Double.valueOf(value.replace(" TiB", "")) * 1e12);
+        }
+        else if (value.endsWith(" GiB")) {
+          return Math.round(Double.valueOf(value.replace(" GiB", "")) * 1e9);
+        }
+        else if (value.endsWith(" KiB")) {
+          return Math.round(Double.valueOf(value.replace(" KiB", "")) * 1e3);
+        }
+        else if (value.endsWith(" MiB")) {
+          return Math.round(Double.valueOf(value.replace(" MiB", "")) * 1e6);
+        }
+        else if (value.endsWith(" bytes")) {
+          return Math.round(Double.valueOf(value.replace(" bytes", "")));
+        }
+        else {
+          throw new IllegalStateException(String.format("FileUtils.parseFileSize() reached an illegal state parsing %s", value));
+        }
+      }
+
+      localEndpoint = ss.HostIdToEndpoint.get(ss.LocalHostId)
+      dims = [host_id: ss.LocalHostId, cluster_name: ss.ClusterName]
+
+      // Equivalent of "Up/Down" in the `nodetool status` output.
+      // 1 = Live; 0 = Dead; -1 = Unknown
+      output.sendDatapoint(util.makeGauge(
+        "cassandra.status",
+        ss.LiveNodes.contains(localEndpoint) ? 1 : (ss.DeadNodes.contains(localEndpoint) ? 0 : -1),
+        dims))
+
+      output.sendDatapoint(util.makeGauge(
+        "cassandra.state",
+        ss.JoiningNodes.contains(localEndpoint) ? 3 : (ss.LeavingNodes.contains(localEndpoint) ? 2 : 1),
+        dims))
+
+      output.sendDatapoint(util.makeGauge(
+        "cassandra.load",
+        parseFileSize(ss.LoadString),
+        dims))
+
+      log.info(ss.Ownership.toString())
+      output.sendDatapoint(util.makeGauge(
+        "cassandra.ownership",
+        ss.Ownership.get(InetAddress.getByName(localEndpoint)),
+        dims))
+
+exporters:
+  otlp:
+    endpoint: "${OTLP_ENDPOINT}"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - smartagent/jmx
+      exporters: [otlp]

--- a/tests/receivers/smartagent/jmx/testdata/resource_metrics/all.yaml
+++ b/tests/receivers/smartagent/jmx/testdata/resource_metrics/all.yaml
@@ -1,0 +1,11 @@
+resource_metrics:
+  - instrumentation_library_metrics:
+      - metrics:
+          - name: cassandra.status
+            type: DoubleGauge
+          - name: cassandra.state
+            type: DoubleGauge
+          - name: cassandra.load
+            type: DoubleGauge
+          - name: cassandra.ownership
+            type: DoubleGauge

--- a/tests/receivers/smartagent/jmx/testdata/server/Dockerfile
+++ b/tests/receivers/smartagent/jmx/testdata/server/Dockerfile
@@ -1,0 +1,10 @@
+FROM cassandra:3.11
+
+# Configures Cassandra with remote JMX with username/password of
+# cassandra/cassandra
+
+ENV LOCAL_JMX=no
+
+RUN echo 'cassandra readonly' > /etc/cassandra/jmxremote.access &&\
+    echo 'cassandra cassandra' > /etc/cassandra/jmxremote.password &&\
+	chmod 0400 /etc/cassandra/jmxremote*


### PR DESCRIPTION
Basic test (without TLS) ported from https://github.com/signalfx/signalfx-agent/tree/main/tests/monitors/jmx
