### PR TITLE
Fix solr integration test

### DIFF
--- a/tests/receivers/smartagent/collectd-solr/testdata/resource_metrics/all.yaml
+++ b/tests/receivers/smartagent/collectd-solr/testdata/resource_metrics/all.yaml
@@ -43,8 +43,6 @@ resource_metrics:
             type: DoubleGauge
           - name: gauge.solr.jvm_heap_usage
             type: DoubleGauge
-          - name: gauge.solr.jvm_memory_pools_Code-Cache_usage
-            type: DoubleGauge
           - name: gauge.solr.jvm_memory_pools_Metaspace_usage
             type: DoubleGauge
           - name: gauge.solr.jvm_total_memory

--- a/tests/receivers/smartagent/collectd-solr/testdata/server/Dockerfile
+++ b/tests/receivers/smartagent/collectd-solr/testdata/server/Dockerfile
@@ -1,5 +1,6 @@
 FROM bitnami/solr:latest
 
+ENV SOLR_JETTY_HOST 0.0.0.0
 ENTRYPOINT ["bash", "-c"]
 CMD ["solr start -c -e techproducts && tail -f /dev/null"]
 


### PR DESCRIPTION
The `latest` image was recently updated and breaks integration tests.