### PR TITLE
Clean up example:

### DIFF
--- a/examples/otel-logs-processor-splunk/docker-compose.yml
+++ b/examples/otel-logs-processor-splunk/docker-compose.yml
@@ -1,22 +1,21 @@
 version: "3"
 services:
-  # Sample Go application producing logs.
   logging:
     image: bash:latest
     container_name: logging
-    command: 'bash -c "while(true) do echo \"$${date} log new message\" >> /output/file.log ; sleep 1; done"'
+    command: 'bash -c "while(true) do echo \"$$(date) log new message\" >> /output/file.log ; sleep 1; done"'
     volumes:
       - ./output:/output
   logging2:
     image: bash:latest
     container_name: logging2
-    command: 'bash -c "while(true) do echo \"$${date} log2 new message\" >> /output/file2.log ; sleep 1; done"'
+    command: 'bash -c "while(true) do echo \"$$(date) log2 new message\" >> /output/file2.log ; sleep 1; done"'
     volumes:
       - ./output:/output
   logging3:
     image: bash:latest
     container_name: logging3
-    command: 'bash -c "while(true) do echo \"$${date} log3 new message\" >> /output/file3.log ; sleep 1; done"'
+    command: 'bash -c "while(true) do echo \"$$(date) log3 new message\" >> /output/file3.log ; sleep 1; done"'
     volumes:
       - ./output:/output
   # Splunk Enterprise server:

--- a/examples/otel-logs-processor-splunk/otel-collector-config.yml
+++ b/examples/otel-logs-processor-splunk/otel-collector-config.yml
@@ -31,8 +31,6 @@ exporters:
         # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
         # For this demo, we use a self-signed certificate on the Splunk docker instance, so this flag is set to true.
         insecure_skip_verify: true
-    logging:
-      loglevel: debug
 processors:
     batch:
     attributes/log:
@@ -83,4 +81,4 @@ service:
       logs:
         receivers: [filelog]
         processors: [batch, attributes/log, attributes/log2, attributes/log3]
-        exporters: [splunk_hec/logs, logging]
+        exporters: [splunk_hec/logs]


### PR DESCRIPTION
* Remove bad comment
* Use proper bash syntax to print dates
* Remove logging exporter