### PR TITLE
kubeletstatsreceiver introduced a regression in version v0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🧰 Bug fixes 🧰
+
+- [`kubeletstats` receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) introduced a regression in version 52.0 that can break metrics for Kubernetes pods and containers, pinning this receiver's version to v0.51.0 until the regression is resolved (#1638)
+
 ## v0.52.1
 
 ### 🚀 New components 🚀

--- a/go.mod
+++ b/go.mod
@@ -479,3 +479,6 @@ replace github.com/googleapis/gnostic v0.5.6 => github.com/googleapis/gnostic v0
 
 // required to drop dependency on deprecated git.apache.org/thrift.git
 exclude go.opencensus.io v0.19.1
+
+// A kubeletstatsreceiver regression was introduced in v0.52.0 (Splunk charts break for pod and container metrics)
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver => github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.51.0

--- a/go.sum
+++ b/go.sum
@@ -1602,8 +1602,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsr
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver v0.52.0/go.mod h1:5yoVCfVtMHf6cqPpUAV3VageoZkh7dYcK0/PwYD62+E=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.52.0 h1:3C8l3Cu04HEhbcOP73HNs8a5C3jusIh1rktmKBa8gCo=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.52.0/go.mod h1:9/BMQL5gKAC5bVKdwtZS6ZwWV4sM5OHuXtS8JJBZRYA=
-github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.52.0 h1:yQGJ5HH7xEbuJkz8k57DsmI2EtJCWTPLAfvDsUHMfUQ=
-github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.52.0/go.mod h1:/JH8C6NNUnNNLmifupavAZTmWYLlkCjO5Wh6o7zP/Ow=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.51.0 h1:GPOPCj/mnFZLYW/Gf+oJ2rdcW9KCesj3tMj4XHKBqAk=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.51.0/go.mod h1:Oy2OosfZ6sjd9AhnRsV3llfr0d/rFP39iOHrxjwi+bc=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver v0.52.0 h1:Us0bKgTQpSNpfx4MnptIFb+eJBivAjRTPJnOgiXoi5U=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver v0.52.0/go.mod h1:gVogArUM9y2d7ShJMjBIdKB/2VAUZN9Xoss3JISTDg0=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusexecreceiver v0.52.0 h1:7TPtzrWHmw5ch2c5qYZr4xTVvg3LjBB0oAPPAZA9aFw=


### PR DESCRIPTION
The kubeletstatsreceiver introduced a regression in version v0.52.0 that can break metrics for Kubernetes pods and containers, pinning this receiver's version to v0.51.0 until the regression is resolved.