### PR TITLE
Fix auto-instrumentation rpm upgrade

### DIFF
--- a/instrumentation/packaging/fpm/rpm/build.sh
+++ b/instrumentation/packaging/fpm/rpm/build.sh
@@ -58,7 +58,7 @@ sudo fpm -s dir -t rpm -n "$PKG_NAME" -v "$VERSION" -f -p "$OUTPUT_DIR" \
     --rpm-rpmbuild-define "_build_id_links none" \
     --rpm-summary "$PKG_DESCRIPTION" \
     --rpm-use-file-permissions \
-    --after-install "$POSTINSTALL_PATH" \
+    --rpm-posttrans "$POSTINSTALL_PATH" \
     --before-remove "$PREUNINSTALL_PATH" \
     --depends sed \
     --depends grep \


### PR DESCRIPTION
Similar to https://github.com/signalfx/splunk-otel-collector/pull/805/files#diff-1e18523d1853d221c59c60282863f5d50de31e7152dfa51a8b3fd115fdecaec1L65, need to use `--rpm-posttrans` to ensure that the postinstall script runs correctly on upgrade.