### PR TITLE
Only use config server if env var unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ In addition, the following components can be configured:
   - Information about migrating from the SignalFx Smart Agent can be found
     [here](docs/signalfx-smart-agent-migration.md)
 
+By default the Splunk OpenTelemetry Collector provides a sensitive value-redacting, local config server listening at
+`http://localhost:55554/debug/configz/effective` that is helpful in troubleshooting. To disable this feature please
+set the `SPLUNK_DEBUG_CONFIG_SERVER` environment variable to any value other than `true`. To set the desired port to
+listen to configure the `SPLUNK_DEBUG_CONFIG_SERVER_PORT` environment variable.
+
 ## Upgrade guidelines
 
 The following changes need to be done to configuration files for Splunk OTel Collector for specific

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -75,7 +75,9 @@ func main() {
 
 	// Allow dumping configuration locally by default
 	// Used by support bundle script
-	_ = os.Setenv(configServerEnabledEnvVar, "true")
+	if _, ok := os.LookupEnv(configServerEnabledEnvVar); !ok {
+		_ = os.Setenv(configServerEnabledEnvVar, "true")
+	}
 
 	factories, err := components.Get()
 	if err != nil {


### PR DESCRIPTION
We currently force the config server to be enabled despite this not being always desirable. These changes document the feature and enable the server if its env var is unset.