### PR TITLE
Correct ecs ec2 metadata endpoints, filter processor, and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Update default `td-agent` version to 4.3.2 in the [Linux installer script](https://github.com/signalfx/splunk-otel-collector/blob/main/docs/getting-started/linux-installer.md) to support log collection with fluentd on Ubuntu 22.04
 
+### 🧰 Bug fixes 🧰
+
+- Correct invalid environment variable expansion for ECS task metadata endpoints on EC2 (#1764)
+
 ## v0.54.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.54.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.54.0) and the [opentelemetry-collector-contrib v0.54.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.54.0) releases.

--- a/cmd/otelcol/config/collector/ecs_ec2_config.yaml
+++ b/cmd/otelcol/config/collector/ecs_ec2_config.yaml
@@ -5,6 +5,8 @@ config_sources:
     defaults:
       METRICS_TO_EXCLUDE: []
       ECS_METADATA_EXCLUDED_IMAGES: []
+      ECS_TASK_METADATA_ENDPOINT: "${ECS_CONTAINER_METADATA_URI_V4}/task"
+      ECS_TASK_STATS_ENDPOINT: "${ECS_CONTAINER_METADATA_URI_V4}/task/stats"
 
 extensions:
   health_check:
@@ -76,8 +78,8 @@ receivers:
     listenAddress: 0.0.0.0:9080
   smartagent/ecs-metadata:
     type: ecs-metadata
-    metadataEndpoint: "${ECS_TASK_METADATA_ENDPOINT}"
-    statsEndpoint: "${ECS_TASK_STATS_ENDPOINT}"
+    metadataEndpoint: "${env:ECS_TASK_METADATA_ENDPOINT}"
+    statsEndpoint: "${env:ECS_TASK_STATS_ENDPOINT}"
     excludedImages: ${env:ECS_METADATA_EXCLUDED_IMAGES}
 
 processors:
@@ -98,10 +100,9 @@ processors:
   resourcedetection/internal:
     detectors: [ecs]
     override: true
-  # Enables the filter processor with example settings
+  # Defines the filter processor with example settings
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/filterprocessor
-  # NOTE: These settings need to be change when using this processor
-  filter/1:
+  filter:
     metrics:
       exclude:
         match_type: regexp
@@ -145,11 +146,11 @@ service:
       exporters: [sapm, signalfx]
     metrics:
       receivers: [hostmetrics, signalfx, smartagent/signalfx-forwarder, smartagent/ecs-metadata]
-      processors: [memory_limiter, batch, resourcedetection]
+      processors: [memory_limiter, batch, filter, resourcedetection]
       exporters: [signalfx]
     metrics/internal:
       receivers: [prometheus/internal]
-      processors: [memory_limiter, batch, resourcedetection/internal]
+      processors: [memory_limiter, batch, filter, resourcedetection/internal]
       exporters: [signalfx]
     logs:
       receivers: [otlp]

--- a/deployments/ecs/ec2/splunk-otel-collector.json
+++ b/deployments/ecs/ec2/splunk-otel-collector.json
@@ -4,20 +4,20 @@
       "cpu": 0,
       "environment": [
         {
-          "name": "ECS_METADATA_EXCLUDED_IMAGES",
-          "value": "[\"quay.io/signalfx/splunk-otel-collector\"]"
-        },
-        {
           "name": "SPLUNK_ACCESS_TOKEN",
           "value": "MY_SPLUNK_ACCESS_TOKEN"
+        },
+        {
+          "name": "SPLUNK_REALM",
+          "value": "MY_SPLUNK_REALM"
         },
         {
           "name": "SPLUNK_CONFIG",
           "value": "/etc/otel/collector/ecs_ec2_config.yaml"
         },
         {
-          "name": "SPLUNK_REALM",
-          "value": "MY_SPLUNK_REALM"
+          "name": "ECS_METADATA_EXCLUDED_IMAGES",
+          "value": "[\"quay.io/signalfx/splunk-otel-collector\"]"
         },
         {
           "name": "HOST_PROC",


### PR DESCRIPTION
The existing ecs on ec2 config relies on environment variables being evaluated twice, which is only now possible by deferring the second execution with the env config source. These changes use this method and also include the previously unused filter processor.

Also includes doc updates for more helpful information.