### PR TITLE
Pin dotenv to 2.7.6 for fpm

### DIFF
--- a/instrumentation/packaging/fpm/install-deps.sh
+++ b/instrumentation/packaging/fpm/install-deps.sh
@@ -20,4 +20,5 @@ apt-get update
 
 apt-get install -y ruby ruby-dev rubygems build-essential git rpm sudo curl jq
 
+gem install --no-document dotenv -v 2.7.6
 gem install --no-document fpm -v 1.11.0

--- a/internal/buildscripts/packaging/fpm/install-deps.sh
+++ b/internal/buildscripts/packaging/fpm/install-deps.sh
@@ -20,5 +20,5 @@ apt-get update
 
 apt-get install -y ruby ruby-dev rubygems build-essential git rpm sudo curl jq
 
+gem install --no-document dotenv -v 2.7.6
 gem install --no-document fpm -v 1.11.0
-


### PR DESCRIPTION
Workaround for compatibility issue with latest dotenv release causing fpm to fail when building deb/rpm packages: https://github.com/signalfx/splunk-otel-collector/runs/7527424773?check_suite_focus=true