### PR TITLE
Initial discovery receiver skeleton

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarder v0.58.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.58.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver v0.58.0
@@ -309,7 +310,6 @@ require (
 	github.com/observiq/ctimefmt v1.0.0 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.58.0 // indirect

--- a/internal/receiver/discoveryreceiver/README.md
+++ b/internal/receiver/discoveryreceiver/README.md
@@ -155,20 +155,20 @@ receivers:
                    // Only emit a single log record for this status entry instead of one for each matching received metric (`false`, the default)
                    first_only: true
                    record:
-                     severity: info
+                     severity_text: info
                      body: Successfully able to connect to Redis container.
              statements:
                partial:
                  - regexp: (WRONGPASS|NOAUTH|ERR AUTH)
                    first_only: true
                    record:
-                     severity: warn
+                     severity_text: warn
                      body: Container appears to be accepting redis connections but the default auth setting is incorrect. 
                failed:
                  - regexp: ConnectionRefusedError
                    first_only: true
                    record:
-                     severity: debug
+                     severity_text: debug
                      body: Container appears to not be accepting redis connections.
 exporters:
   logging:
@@ -302,7 +302,7 @@ Flags: 0
 | Name | Type | Default | Docs |
 | ---- | ---- | ------- | ---- |
 | `rule` (required) | string | <no value> | The Receiver Creator compatible discover rule |
-| `config` | map[string]interface{} | <no value> | The receiver instance configuration, including any Receiver Creator endpoint env value expr program value expansion |
+| `config` | map[string]any | <no value> | The receiver instance configuration, including any Receiver Creator endpoint env value expr program value expansion |
 | `resource_attributes` | map[string]string | <no value> | A mapping of string resource attributes and their (expr program compatible) values to include in reported metrics for status log record matches |
 | `status` | map[string]Match | <no value> | A mapping of `metrics` and/or `statements` to Match items for status evaluation |
 
@@ -322,7 +322,7 @@ Flags: 0
 
 | Name | Type | Default | Docs |
 | ---- | ---- | ------- | ---- |
-| `severity` | string | Emitted log statement severity level, if any, or "info" | The emitted log record's severity text |
+| `severity_text` | string | Emitted log statement severity level, if any, or "info" | The emitted log record's severity text |
 | `body` | string | Emitted log statement message | The emitted log record's body |
 | `attributes` | map[string]string | Emitted log statements fields | The emitted log record's attributes |
 

--- a/internal/receiver/discoveryreceiver/config.go
+++ b/internal/receiver/discoveryreceiver/config.go
@@ -1,0 +1,162 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoveryreceiver
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/config"
+	"go.uber.org/multierr"
+)
+
+var (
+	_ config.Receiver = (*Config)(nil)
+
+	allowedStatusTypes = []string{"successful", "partial", "failed"}
+	allowedStatuses    = func() map[string]struct{} {
+		sm := map[string]struct{}{}
+		for _, status := range allowedStatusTypes {
+			sm[status] = struct{}{}
+		}
+		return sm
+	}()
+
+	allowedMatchTypes = []string{"regexp", "strict", "expr"}
+)
+
+type Config struct {
+	// Receivers is a mapping of receivers to discover to their receiver creator configs
+	// and evaluated metrics and application statements, which are used to determine component status.
+	Receivers               map[config.ComponentID]ReceiverEntry `mapstructure:"receivers"`
+	config.ReceiverSettings `mapstructure:",squash"`
+	// The configured Observer extensions from which to receive Endpoint events.
+	// Must implement the observer.Observable interface.
+	WatchObservers []config.ComponentID `mapstructure:"watch_observers"`
+	// Whether to emit log records for all endpoint activity, consisting of Endpoint
+	// content as record attributes.
+	LogEndpoints bool `mapstructure:"log_endpoints"`
+	// Whether to include the receiver config as a base64-encoded "discovery.receiver.config"
+	// resource attribute string value. Will also contain the configured observer that
+	// produced the endpoint leading to receiver creation in `watch_observers`.
+	// Warning: these values will include the literal receiver subconfig from the parent Collector config.
+	// The feature provides no secret redaction and its output is easily decodable into plaintext.
+	EmbedReceiverConfig bool `mapstructure:"embed_receiver_config"`
+}
+
+// ReceiverEntry is a definition for a receiver instance to instantiate for each Endpoint matching
+// the defined rule. Its Config, ResourceAttributes, and Rule will be marshaled to the internal
+// Receiver Creator config.
+type ReceiverEntry struct {
+	Config             map[string]any    `mapstructure:"config"`
+	Status             *Status           `mapstructure:"status"`
+	ResourceAttributes map[string]string `mapstructure:"resource_attributes"`
+	Rule               string            `mapstructure:"rule"`
+}
+
+// Status defines the Match rules for applicable app and telemetry sources.
+// At this time only Metrics and zap logger Statements status source types are supported.
+type Status struct {
+	Metrics    map[string][]Match `mapstructure:"metrics"`
+	Statements map[string][]Match `mapstructure:"statements"`
+}
+
+// Match defines the rules for the desired match type and resulting log record
+// content emitted by the Discovery receiver
+type Match struct {
+	Record    *LogRecord `mapstructure:"log_record"`
+	Strict    string     `mapstructure:"strict"`
+	Regexp    string     `mapstructure:"regexp"`
+	Expr      string     `mapstructure:"expr"`
+	FirstOnly bool       `mapstructure:"first_only"`
+}
+
+// LogRecord is a definition of the desired plog.LogRecord content to emit for a match.
+type LogRecord struct {
+	Attributes   map[string]string `mapstructure:"attributes"`
+	SeverityText string            `mapstructure:"severity_text"`
+	Body         string            `mapstructure:"body"`
+}
+
+func (cfg *Config) Validate() error {
+	var err error
+	for rName, rEntry := range cfg.Receivers {
+		if e := rEntry.validate(); e != nil {
+			err = multierr.Combine(err, fmt.Errorf("receiver %q validation failure: %w", rName, e))
+		}
+	}
+
+	if cfg.WatchObservers == nil || len(cfg.WatchObservers) == 0 {
+		err = multierr.Combine(err, fmt.Errorf("`watch_observers` must be defined and include at least one configured observer extension"))
+	}
+
+	return err
+}
+
+func (re *ReceiverEntry) validate() error {
+	if err := re.Status.validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Status) validate() error {
+	if s == nil {
+		return fmt.Errorf("`status` must be defined and contain at least one `metrics` or `statements` mapping")
+	}
+
+	if len(s.Metrics) == 0 && len(s.Statements) == 0 {
+		return fmt.Errorf("`status` must contain at least one `metrics` or `statements` mapping with at least one of %v", allowedStatusTypes)
+	}
+
+	var err error
+	statusSources := []struct {
+		matches    map[string][]Match
+		sourceType string
+	}{{s.Metrics, "metrics"}, {s.Statements, "statements"}}
+	for _, statusSource := range statusSources {
+		for statusType, statements := range statusSource.matches {
+			if _, ok := allowedStatuses[statusType]; !ok {
+				err = multierr.Combine(err, fmt.Errorf("unsupported status %q. must be one of %v", statusType, allowedStatusTypes))
+				continue
+			}
+			for _, logMatch := range statements {
+				var matchTypes []string
+				if logMatch.Strict != "" {
+					matchTypes = append(matchTypes, "strict")
+				}
+				if logMatch.Regexp != "" {
+					matchTypes = append(matchTypes, "regexp")
+				}
+				if logMatch.Expr != "" {
+					matchTypes = append(matchTypes, "expr")
+				}
+				if len(matchTypes) != 1 {
+					err = multierr.Combine(err, fmt.Errorf(
+						"`%s` status source type `%s` match type validation failed. Must provide one of %v but received %v", statusSource.sourceType, statusType, allowedMatchTypes, matchTypes,
+					))
+				}
+				if e := logMatch.Record.validate(); e != nil {
+					err = multierr.Combine(err, fmt.Errorf(" %q log record validation failure: %w", statusType, e))
+				}
+			}
+		}
+	}
+	return err
+}
+
+func (lr *LogRecord) validate() error {
+	// TODO: supported severity text validation
+	return nil
+}

--- a/internal/receiver/discoveryreceiver/config_test.go
+++ b/internal/receiver/discoveryreceiver/config_test.go
@@ -1,0 +1,143 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoveryreceiver
+
+import (
+	"fmt"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/service/servicetest"
+)
+
+func TestValidConfig(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Receivers[typeStr] = factory
+	collectorConfig, err := servicetest.LoadConfig(
+		path.Join(".", "testdata", "config.yaml"), factories,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, collectorConfig)
+
+	assert.Equal(t, len(collectorConfig.Receivers), 1)
+
+	cfg := collectorConfig.Receivers[config.NewComponentID(typeStr)].(*Config)
+	require.Equal(t, &Config{
+		Receivers: map[config.ComponentID]ReceiverEntry{
+			config.NewComponentIDWithName("smartagent", "redis"): {
+				Config: map[string]any{
+					"auth": "password",
+					"host": "`host`",
+					"port": "`port`",
+					"type": "collectd/redis",
+				},
+				Status: &Status{
+					Metrics: map[string][]Match{
+						"successful": {
+							Match{
+								Record: &LogRecord{
+									Attributes: map[string]string{
+										"attr_one": "attr_one_val",
+										"attr_two": "attr_two_val",
+									},
+									SeverityText: "info",
+									Body:         "smartagent/redis receiver successful status",
+								},
+								Strict:    "",
+								Regexp:    ".*",
+								Expr:      "",
+								FirstOnly: true,
+							},
+						},
+					},
+					Statements: map[string][]Match{
+						"failed": {
+							{
+								Strict:    "",
+								Regexp:    "ConnectionRefusedError",
+								Expr:      "",
+								FirstOnly: true,
+								Record: &LogRecord{
+									Attributes:   map[string]string{},
+									SeverityText: "info",
+									Body:         "container appears to not be accepting redis connections",
+								},
+							},
+						},
+						"partial": {
+							{
+								Strict:    "",
+								Regexp:    "(WRONGPASS|NOAUTH|ERR AUTH)",
+								Expr:      "",
+								FirstOnly: false,
+								Record: &LogRecord{
+									Attributes:   nil,
+									SeverityText: "warn",
+									Body:         "desired log invalid auth log body",
+								},
+							},
+						},
+					},
+				},
+				ResourceAttributes: map[string]string{
+					"receiver_attribute": "receiver_attribute_value",
+				},
+				Rule: "type == \"container\"",
+			},
+		},
+		ReceiverSettings:    config.NewReceiverSettings(config.NewComponentID("discovery")),
+		LogEndpoints:        true,
+		EmbedReceiverConfig: true,
+		WatchObservers: []config.ComponentID{
+			config.NewComponentID("an_observer"),
+			config.NewComponentIDWithName("another_observer", "with_name"),
+		},
+	},
+		cfg)
+	require.NoError(t, cfg.Validate())
+}
+
+func TestInvalidConfigs(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.Nil(t, err)
+	factory := NewFactory()
+	factories.Receivers[typeStr] = factory
+
+	tests := []struct{ name, expectedError string }{
+		{name: "no_watch_observers", expectedError: "receiver \"discovery\" has invalid configuration: `watch_observers` must be defined and include at least one configured observer extension"},
+		{name: "missing_status", expectedError: "receiver \"discovery\" has invalid configuration: receiver \"a_receiver\" validation failure: `status` must be defined and contain at least one `metrics` or `statements` mapping"},
+		{name: "missing_status_metrics_and_statements", expectedError: "receiver \"discovery\" has invalid configuration: receiver \"a_receiver\" validation failure: `status` must be defined and contain at least one `metrics` or `statements` mapping"},
+		{name: "invalid_status_types", expectedError: `receiver "discovery" has invalid configuration: receiver "a_receiver" validation failure: unsupported status "unsupported". must be one of [successful partial failed]; unsupported status "another_unsupported". must be one of [successful partial failed]`},
+		{name: "multiple_status_match_types", expectedError: "receiver \"discovery\" has invalid configuration: receiver \"a_receiver\" validation failure: `metrics` status source type `successful` match type validation failed. Must provide one of [regexp strict expr] but received [strict regexp]; `statements` status source type `failed` match type validation failed. Must provide one of [regexp strict expr] but received [strict expr]"},
+	}
+
+	for _, test := range tests {
+		func(name, expectedError string) {
+			t.Run(name, func(t *testing.T) {
+				_, err = servicetest.LoadConfigAndValidate(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", name)), factories)
+				require.Error(t, err)
+				require.EqualError(t, err, expectedError)
+			})
+		}(test.name, test.expectedError)
+	}
+}

--- a/internal/receiver/discoveryreceiver/factory.go
+++ b/internal/receiver/discoveryreceiver/factory.go
@@ -1,0 +1,55 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoveryreceiver
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer"
+)
+
+const (
+	typeStr = "discovery"
+)
+
+func NewFactory() component.ReceiverFactory {
+	return component.NewReceiverFactory(
+		typeStr,
+		createDefaultConfig,
+		component.WithLogsReceiver(createLogsReceiver, component.StabilityLevelInDevelopment))
+}
+
+func createDefaultConfig() config.Receiver {
+	return &Config{
+		ReceiverSettings:    config.NewReceiverSettings(config.NewComponentID(typeStr)),
+		LogEndpoints:        false,
+		EmbedReceiverConfig: false,
+	}
+}
+
+func createLogsReceiver(
+	_ context.Context,
+	settings component.ReceiverCreateSettings,
+	cfg config.Receiver,
+	consumer consumer.Logs,
+) (component.LogsReceiver, error) {
+	dCfg := cfg.(*Config)
+	if err := dCfg.Validate(); err != nil {
+		return nil, err
+	}
+	return newDiscoveryReceiver(settings, dCfg, consumer)
+}

--- a/internal/receiver/discoveryreceiver/factory_test.go
+++ b/internal/receiver/discoveryreceiver/factory_test.go
@@ -1,0 +1,74 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoveryreceiver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configtest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configtest.CheckConfigStruct(cfg))
+	require.Equal(t, &Config{
+		ReceiverSettings:    config.NewReceiverSettings(config.NewComponentID(typeStr)),
+		LogEndpoints:        false,
+		EmbedReceiverConfig: false,
+	}, cfg)
+}
+
+func TestCreateLogsReceiver(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	params := component.ReceiverCreateSettings{}
+	receiver, err := factory.CreateLogsReceiver(context.Background(), params, cfg, consumertest.NewNop())
+	assert.Error(t, err)
+	assert.EqualError(t, err, "`watch_observers` must be defined and include at least one configured observer extension")
+	assert.Nil(t, receiver)
+}
+
+func TestCreateMetricsReceiver(t *testing.T) {
+	factory := NewFactory()
+	cfg := &Config{}
+	require.Error(t, cfg.Validate())
+
+	params := component.ReceiverCreateSettings{}
+	receiver, err := factory.CreateMetricsReceiver(context.Background(), params, cfg, consumertest.NewNop())
+	require.Error(t, err)
+	assert.EqualError(t, err, "telemetry type is not supported")
+	assert.Nil(t, receiver)
+}
+
+func TestCreateTracesReceiver(t *testing.T) {
+	factory := NewFactory()
+	cfg := &Config{}
+	require.Error(t, cfg.Validate())
+
+	params := component.ReceiverCreateSettings{}
+	receiver, err := factory.CreateTracesReceiver(context.Background(), params, cfg, consumertest.NewNop())
+	require.Error(t, err)
+	assert.EqualError(t, err, "telemetry type is not supported")
+	assert.Nil(t, receiver)
+}

--- a/internal/receiver/discoveryreceiver/receiver.go
+++ b/internal/receiver/discoveryreceiver/receiver.go
@@ -1,0 +1,115 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoveryreceiver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/obsreport"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+var _ component.LogsReceiver = (*discoveryReceiver)(nil)
+
+// Discovery receiver is a metrics consumer from the internal receiver creator
+// but it will be evaluating them for log record conversion
+var _ consumer.Metrics = (*discoveryReceiver)(nil)
+
+type discoveryReceiver struct {
+	logsConsumer      consumer.Logs
+	logger            *zap.Logger
+	config            *Config
+	obsreportReceiver *obsreport.Receiver
+	observables       map[config.ComponentID]observer.Observable
+	settings          component.ReceiverCreateSettings
+}
+
+func newDiscoveryReceiver(
+	settings component.ReceiverCreateSettings,
+	config *Config,
+	consumer consumer.Logs,
+) (*discoveryReceiver, error) { // nolint:unparam
+	d := &discoveryReceiver{
+		config: config,
+		obsreportReceiver: obsreport.NewReceiver(obsreport.ReceiverSettings{
+			ReceiverID:             config.ID(),
+			Transport:              "none",
+			ReceiverCreateSettings: settings,
+		}),
+		logger:       settings.TelemetrySettings.Logger,
+		settings:     settings,
+		logsConsumer: consumer,
+	}
+
+	return d, nil
+}
+
+func (d *discoveryReceiver) Start(ctx context.Context, host component.Host) (err error) {
+	if d.observables, err = d.observablesFromHost(host); err != nil {
+		return fmt.Errorf("failed obtaining observables from host: %w", err)
+	}
+	return nil
+}
+
+func (d *discoveryReceiver) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+func (d *discoveryReceiver) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{}
+}
+
+func (d *discoveryReceiver) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	// TODO: md -> plog.Logs and evaluation
+	return nil
+}
+
+// observablesFromHost finds configured `watch_observers` extension instances from the host
+// by their ComponentID. It is based on the equivalent logic in the Receiver Creator:
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/d6042eda45ec9d8a5df1ae553388eaca67d9d16c/receiver/receivercreator/receiver.go#L79
+func (d *discoveryReceiver) observablesFromHost(host component.Host) (map[config.ComponentID]observer.Observable, error) {
+	watchObservables := map[config.ComponentID]observer.Observable{}
+	for _, obs := range d.config.WatchObservers {
+		for cid, ext := range host.GetExtensions() {
+			if cid != obs {
+				continue
+			}
+
+			observable, ok := ext.(observer.Observable)
+			if !ok {
+				return nil, fmt.Errorf("extension %q in watch_observers is not an observer", obs.String())
+			}
+			watchObservables[obs] = observable
+		}
+	}
+
+	// Make sure all specified watch_observers are present
+	for _, obs := range d.config.WatchObservers {
+		if watchObservables[obs] == nil {
+			return nil, fmt.Errorf("failed to find observer %q as a configured extension", obs)
+		}
+	}
+	if len(watchObservables) == 0 {
+		d.logger.Warn("no observers were configured so discoveryreceiver will be inactive")
+	}
+
+	return watchObservables, nil
+}

--- a/internal/receiver/discoveryreceiver/receiver_test.go
+++ b/internal/receiver/discoveryreceiver/receiver_test.go
@@ -1,0 +1,152 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoveryreceiver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+)
+
+func TestNewDiscoveryReceiver(t *testing.T) {
+	rcs := component.ReceiverCreateSettings{
+		TelemetrySettings: component.TelemetrySettings{
+			Logger:         zap.NewNop(),
+			TracerProvider: trace.NewNoopTracerProvider(),
+		},
+	}
+	cfg := &Config{}
+	receiver, err := newDiscoveryReceiver(rcs, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, receiver)
+}
+
+func TestObservablesFromHost(t *testing.T) {
+	nopObsID := config.NewComponentID("nop_observer")
+	nopObs := &nopObserver{}
+	nopObsIDWithName := config.NewComponentIDWithName("nop_observer", "with_name")
+	nopObsWithName := &nopObserver{}
+	nopObsvbleID := config.NewComponentID("nop_observable")
+	nopObsvble := &nopObservable{}
+	nopObsvbleIDWithName := config.NewComponentIDWithName("nop_observable", "with_name")
+	nopObsvbleWithName := &nopObservable{}
+
+	for _, tt := range []struct {
+		name                string
+		extensions          map[config.ComponentID]component.Extension
+		expectedObservables map[config.ComponentID]observer.Observable
+		expectedError       string
+		watchObservers      []config.ComponentID
+	}{
+		{name: "mixed non-observables ids",
+			extensions: map[config.ComponentID]component.Extension{
+				nopObsID:     nopObs,
+				nopObsvbleID: nopObsvble,
+			},
+			watchObservers: []config.ComponentID{nopObsID, nopObsvbleID},
+			expectedError:  `extension "nop_observer" in watch_observers is not an observer`,
+		},
+		{name: "mixed non-observables ids with names",
+			extensions: map[config.ComponentID]component.Extension{
+				nopObsIDWithName:     nopObsWithName,
+				nopObsvbleIDWithName: nopObsvbleWithName,
+			},
+			watchObservers: []config.ComponentID{nopObsIDWithName, nopObsvbleIDWithName},
+			expectedError:  `extension "nop_observer/with_name" in watch_observers is not an observer`,
+		},
+		{name: "only missing extension",
+			extensions: map[config.ComponentID]component.Extension{
+				nopObsvbleID: nopObsvble,
+			},
+			watchObservers: []config.ComponentID{nopObsID},
+			expectedError:  `failed to find observer "nop_observer" as a configured extension`,
+		},
+		{name: "happy path",
+			extensions: map[config.ComponentID]component.Extension{
+				nopObsvbleID:         nopObsvble,
+				nopObsvbleIDWithName: nopObsvbleWithName,
+			},
+			watchObservers: []config.ComponentID{nopObsvbleID, nopObsvbleIDWithName},
+			expectedObservables: map[config.ComponentID]observer.Observable{
+				nopObsvbleID:         nopObsvble,
+				nopObsvbleIDWithName: nopObsvbleWithName,
+			},
+		},
+	} {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			rcs := component.ReceiverCreateSettings{
+				TelemetrySettings: component.TelemetrySettings{
+					Logger:         zap.NewNop(),
+					TracerProvider: trace.NewNoopTracerProvider(),
+				},
+			}
+			host := mockHost{extensions: test.extensions}
+			cfg := &Config{WatchObservers: test.watchObservers}
+			receiver, err := newDiscoveryReceiver(rcs, cfg, consumertest.NewNop())
+			require.NoError(t, err)
+			require.NotNil(t, receiver)
+
+			observables, err := receiver.observablesFromHost(host)
+			if test.expectedError != "" {
+				require.Error(t, err)
+				require.EqualError(t, err, test.expectedError)
+				require.Nil(t, observables)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expectedObservables, observables)
+			}
+		})
+	}
+}
+
+type mockHost struct {
+	component.Host
+	extensions map[config.ComponentID]component.Extension
+}
+
+func (mh mockHost) GetFactory(_ component.Kind, _ config.Type) component.Factory {
+	return nil
+}
+
+func (mh mockHost) GetExtensions() map[config.ComponentID]component.Extension {
+	return mh.extensions
+}
+
+type nopObserver struct{}
+
+var _ component.Extension = (*nopObserver)(nil)
+var _ observer.Observable = (*nopObservable)(nil)
+
+func (m nopObserver) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+func (m nopObserver) Shutdown(_ context.Context) error {
+	return nil
+}
+
+type nopObservable struct {
+	nopObserver
+}
+
+func (m nopObservable) ListAndWatch(_ observer.Notify) {}
+func (m nopObservable) Unsubscribe(_ observer.Notify)  {}

--- a/internal/receiver/discoveryreceiver/testdata/config.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/config.yaml
@@ -1,0 +1,50 @@
+receivers:
+  discovery:
+    watch_observers:
+      - an_observer
+      - another_observer/with_name
+    log_endpoints: true
+    embed_receiver_config: true
+    receivers:
+      smartagent/redis:
+        rule: type == "container"
+        config:
+          type: collectd/redis
+          auth: password
+          host: '`host`'
+          port: '`port`'
+        resource_attributes:
+          receiver_attribute: receiver_attribute_value
+        status:
+          metrics:
+            successful:
+              - regexp: '.*'
+                first_only: true
+                log_record:
+                  severity_text: info
+                  body: smartagent/redis receiver successful status
+                  attributes:
+                    attr_one: attr_one_val
+                    attr_two: attr_two_val
+          statements:
+            failed:
+              - regexp: ConnectionRefusedError
+                first_only: true
+                log_record:
+                  attributes: {}
+                  severity_text: info
+                  body: container appears to not be accepting redis connections
+            partial:
+              - regexp: (WRONGPASS|NOAUTH|ERR AUTH)
+                first_only: false
+                log_record:
+                  severity_text: warn
+                  body: desired log invalid auth log body
+exporters:
+  nop:
+
+service:
+  pipelines:
+    logs:
+      receivers: [discovery]
+      exporters: [nop]

--- a/internal/receiver/discoveryreceiver/testdata/invalid_status_types.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/invalid_status_types.yaml
@@ -1,0 +1,24 @@
+extensions:
+
+receivers:
+  discovery:
+    watch_observers:
+      - an_observer
+    receivers:
+      a_receiver:
+        rule: a rule
+        status:
+          metrics:
+            unsupported:
+              - regexp: '.*'
+          statements:
+            another_unsupported:
+              - regexp: '.*'
+exporters:
+  nop:
+
+service:
+  pipelines:
+    logs:
+      receivers: [discovery]
+      exporters: [nop]

--- a/internal/receiver/discoveryreceiver/testdata/missing_status.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/missing_status.yaml
@@ -1,0 +1,17 @@
+extensions:
+
+receivers:
+  discovery:
+    watch_observers:
+      - an_observer
+    receivers:
+      a_receiver:
+        rule: a rule
+exporters:
+  nop:
+
+service:
+  pipelines:
+    logs:
+      receivers: [discovery]
+      exporters: [nop]

--- a/internal/receiver/discoveryreceiver/testdata/missing_status_metrics_and_statements.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/missing_status_metrics_and_statements.yaml
@@ -1,0 +1,18 @@
+extensions:
+
+receivers:
+  discovery:
+    watch_observers:
+      - an_observer
+    receivers:
+      a_receiver:
+        rule: a rule
+        status:
+exporters:
+  nop:
+
+service:
+  pipelines:
+    logs:
+      receivers: [discovery]
+      exporters: [nop]

--- a/internal/receiver/discoveryreceiver/testdata/multiple_status_match_types.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/multiple_status_match_types.yaml
@@ -1,0 +1,26 @@
+extensions:
+
+receivers:
+  discovery:
+    watch_observers:
+      - an_observer
+    receivers:
+      a_receiver:
+        rule: a rule
+        status:
+          metrics:
+            successful:
+              - regexp: 'a regex'
+                strict: 'a strict'
+          statements:
+            failed:
+              - strict: 'another strict'
+                expr: 'an expr'
+exporters:
+  nop:
+
+service:
+  pipelines:
+    logs:
+      receivers: [discovery]
+      exporters: [nop]

--- a/internal/receiver/discoveryreceiver/testdata/no_watch_observers.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/no_watch_observers.yaml
@@ -1,0 +1,13 @@
+extensions:
+
+receivers:
+  discovery:
+    watch_observers:
+exporters:
+  nop:
+
+service:
+  pipelines:
+    logs:
+      receivers: [discovery]
+      exporters: [nop]


### PR DESCRIPTION
These changes introduce the initial Discovery receiver component methods and config validation (proposed readme: https://github.com/signalfx/splunk-otel-collector/pull/1812).