### PR TITLE
Add tar.gz distribution of the Splunk Otel Collector

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -228,7 +228,7 @@ jobs:
     needs: [cross-compile]
     strategy:
       matrix:
-        SYS_PACKAGE: [ "deb", "rpm" ]
+        SYS_PACKAGE: [ "deb", "rpm", "tar" ]
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -237,7 +237,7 @@ build-linux-image:
     paths:
       - dist/otelcol-*.tar
 
-.build-deb-rpm:
+.build-tar-deb-rpm:
   only:
     variables:
       - $CI_COMMIT_BRANCH == "main"
@@ -256,7 +256,7 @@ build-linux-image:
     - ./internal/buildscripts/packaging/fpm/${PKG_TYPE}/build.sh "${CI_COMMIT_TAG:-}" "$ARCH" "./dist"
 
 build-deb:
-  extends: .build-deb-rpm
+  extends: .build-tar-deb-rpm
   variables:
     PKG_TYPE: deb
   artifacts:
@@ -264,12 +264,20 @@ build-deb:
       - dist/*.deb
 
 build-rpm:
-  extends: .build-deb-rpm
+  extends: .build-tar-deb-rpm
   variables:
     PKG_TYPE: rpm
   artifacts:
     paths:
       - dist/*.rpm
+
+build-tar:
+  extends: .build-tar-deb-rpm
+  variables:
+    PKG_TYPE: tar
+  artifacts:
+    paths:
+      - dist/*.tar.gz
 
 build-msi:
   only:
@@ -334,9 +342,34 @@ sign-rpms:
     - pushd dist && tar -czvf packages.tar.gz *.rpm && popd
   after_script:
     - tar -xzvf dist/signed/packages.tar.gz -C dist/signed/
+    - rm dist/signed/packages.tar.gz
   artifacts:
     paths:
       - dist/signed/*.rpm
+
+sign-tar:
+  extends: .submit-request
+  stage: sign-packages
+  only:
+    variables:
+      - $CI_COMMIT_BRANCH == "main"
+      - $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+  needs:
+    - build-tar
+  variables:
+    ARTIFACT: dist/packages.tar.gz
+    SIGN_TYPE: GPG
+    OPTIONS: archive
+    DOWNLOAD_DIR: dist/signed
+  before_script:
+    - pushd dist && tar -czvf packages.tar.gz *.tar.gz && popd
+  after_script:
+    - tar -xzvf dist/signed/packages.tar.gz -C dist/signed/
+    - rm dist/signed/packages.tar.gz
+  artifacts:
+    paths:
+      - dist/signed/*.tar.gz
+      - dist/signed/*.tar.gz.asc
 
 sign-msi:
   extends: .sign-release
@@ -360,15 +393,17 @@ verify-signed-packages:
     - build-deb
     - build-rpm
     - build-msi
+    - build-tar
     - instrumentation-deb
     - instrumentation-rpm
     - sign-debs
     - sign-rpms
     - sign-msi
+    - sign-tar
   script:
     - |
       set -ex
-      for pkg in dist/*.rpm dist/*.deb dist/*.msi; do
+      for pkg in dist/*.rpm dist/*.deb dist/*.msi dist/*.tar.gz; do
         if [[ ! -f dist/signed/$(basename $pkg) ]]; then
           echo "$pkg was not signed!" >&2
           exit 1
@@ -632,6 +667,7 @@ github-release:
     - release-debs
     - release-rpms
     - sign-msi
+    - sign-tar
     - push-linux-image
     - build-push-windows-image
     - choco-release

--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ binaries-windows_amd64:
 	GOOS=windows GOARCH=amd64 EXTENSION=.exe $(MAKE) translatesfx
 	GOOS=windows GOARCH=amd64 EXTENSION=.exe $(MAKE) migratecheckpoint
 
-.PHONY: deb-rpm-package
+.PHONY: deb-rpm-tar-package
 %-package:
 ifneq ($(SKIP_COMPILE), true)
 	$(MAKE) binaries-linux_$(ARCH)

--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -443,9 +443,9 @@ This ensures that the binaries in the bundle have the right loader set on them s
 
 The tar archive contains the default agent and gateway configuration files.
 Both refer to environment variables described in the [Other](#Other) section above.
-Additionally, the agent configuration file requires that you set two environment variables:
-- `SPLUNK_BUNDLE_DIR` (no default): The path to the Smart Agent bundle, e.g. /usr/lib/splunk-otel-collector/agent-bundle
-- `SPLUNK_COLLECTD_DIR` (no default): The path to the collectd config directory for the Smart Agent, e.g. /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
+If you are running the Collector from a non-default location, the Smart Agent receiver and agent configuration file require that you set two environment variables currently used in the Smart Agent extension:
+- `SPLUNK_BUNDLE_DIR` (`/usr/lib/splunk-otel-collector/agent-bundle` default): The path to the Smart Agent bundle, e.g. `/opt/my/environment/splunk-otel-collector/agent-bundle`
+- `SPLUNK_COLLECTD_DIR` (`/usr/lib/splunk-otel-collector/agent-bundle/run/collectd` default): The path to the collectd config directory for the Smart Agent, e.g. `/opt/my/environment/splunk-otel-collector/agent-bundle/run/collectd`
 
 ## Advanced Configuration
 

--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -14,6 +14,7 @@ The following deployment options are supported:
 - [DEB and RPM Packages](#deb-and-rpm-packages)
 - [Docker](#docker)
 - [Binary](#binary)
+- [Tar archive](#tar)
 
 ## Getting Started
 
@@ -425,6 +426,26 @@ make install-tools
 make otelcol
 SPLUNK_ACCESS_TOKEN=12345 SPLUNK_REALM=us0 ./bin/otelcol
 ```
+
+### Tar
+
+We offer for convenience a tar.gz archive of the distribution.
+
+To use the archive:
+
+1. Unarchive it to a directory of your choice on the target system.
+```bash
+tar xzf splunk-otel-collector_<version>_<arch>.tar.gz
+```
+
+2. On amd64 systems, go into the unarchived `agent-bundle` directory and run `bin/patch-interpreter $(pwd)`. 
+This ensures that the binaries in the bundle have the right loader set on them since your host's loader may not be compatible.
+
+The tar archive contains the default agent and gateway configuration files.
+Both refer to environment variables described in the [Other](#Other) section above.
+Additionally, the agent configuration file requires that you set two environment variables:
+- `SPLUNK_BUNDLE_DIR` (no default): The path to the Smart Agent bundle, e.g. /usr/lib/splunk-otel-collector/agent-bundle
+- `SPLUNK_COLLECTD_DIR` (no default): The path to the collectd config directory for the Smart Agent, e.g. /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
 
 ## Advanced Configuration
 

--- a/internal/buildscripts/packaging/fpm/tar/README.md
+++ b/internal/buildscripts/packaging/fpm/tar/README.md
@@ -1,0 +1,13 @@
+# Build splunk-otel-collector tar package
+
+Build the splunk-otel-collector tar package with [fpm](https://github.com/jordansissel/fpm).
+
+To build the tar package, run `make tar-package` from the repo root directory. The tar package will be written to
+`dist/splunk-otel-collector_<version>_<arch>.tar.gz`.
+
+By default, `<arch>` is `amd64` and `<version>` is the latest git tag with `-post` appended, e.g. `1.2.3-post`.
+To override these defaults, set the `ARCH` and `VERSION` environment variables, e.g.
+`make tar-package ARCH=arm64 VERSION=4.5.6`.
+
+Run `pytest -m tar internal/buildscripts/packaging/tests/package_test.py` to run basic installation tests with the built
+package. See [README.md](../../tests/README.md) for how to install `pytest` and more details.

--- a/internal/buildscripts/packaging/fpm/tar/build.sh
+++ b/internal/buildscripts/packaging/fpm/tar/build.sh
@@ -56,6 +56,8 @@ tar_download_smart_agent() {
     tar -xzf "$buildroot/signalfx-agent.tar.gz" -C "$buildroot/"
     mv "$buildroot/signalfx-agent" "$buildroot/$AGENT_BUNDLE_INSTALL_DIR"
     find "$buildroot/$AGENT_BUNDLE_INSTALL_DIR" -wholename "*test*.key" -delete -or -wholename "*test*.pem" -delete
+    rm -f "$buildroot/$AGENT_BUNDLE_INSTALL_DIR/bin/signalfx-agent"
+    rm -f "$buildroot/$AGENT_BUNDLE_INSTALL_DIR/bin/agent-status"
     rm -f "$buildroot/signalfx-agent.tar.gz"
 }
 

--- a/internal/buildscripts/packaging/fpm/tar/build.sh
+++ b/internal/buildscripts/packaging/fpm/tar/build.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Copyright Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euxo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname ${BASH_SOURCE[0]} )" && pwd )"
+. $SCRIPT_DIR/../common.sh
+
+VERSION="${1:-}"
+ARCH="${2:-amd64}"
+OUTPUT_DIR="${3:-$REPO_DIR/dist}"
+SMART_AGENT_RELEASE="${4:-}"
+
+if [[ -z "$VERSION" ]]; then
+    VERSION="$( get_version )"
+fi
+VERSION="${VERSION#v}"
+
+if [[ -z "$SMART_AGENT_RELEASE" ]]; then
+    SMART_AGENT_RELEASE="$(cat $SMART_AGENT_RELEASE_PATH)"
+fi
+
+otelcol_path="$REPO_DIR/bin/otelcol_linux_${ARCH}"
+translatesfx_path="$REPO_DIR/bin/translatesfx_linux_${ARCH}"
+
+buildroot="$(mktemp -d)"
+
+if [ "$ARCH" = "amd64" ]; then
+    download_smart_agent "$SMART_AGENT_RELEASE" "$buildroot"
+fi
+
+setup_files_and_permissions "$otelcol_path" "$translatesfx_path" "$buildroot"
+
+mkdir -p "$OUTPUT_DIR"
+
+sudo fpm -s dir -t tar -n "${PKG_NAME}_${VERSION}_${ARCH}" -v "$VERSION" -f -p "$OUTPUT_DIR" \
+    --vendor "$PKG_VENDOR" \
+    --maintainer "$PKG_MAINTAINER" \
+    --description "$PKG_DESCRIPTION" \
+    --license "$PKG_LICENSE" \
+    --url "$PKG_URL" \
+    --architecture "$ARCH" \
+    --config-files "$AGENT_CONFIG_INSTALL_PATH" \
+    --config-files "$GATEWAY_CONFIG_INSTALL_PATH" \
+    --config-files "$FLUENTD_CONFIG_INSTALL_DIR" \
+    "$buildroot/"=/
+
+cd "$OUTPUT_DIR"
+gzip "${PKG_NAME}_${VERSION}_${ARCH}.tar"

--- a/internal/buildscripts/packaging/fpm/tar/build.sh
+++ b/internal/buildscripts/packaging/fpm/tar/build.sh
@@ -23,8 +23,7 @@ VERSION="${1:-}"
 ARCH="${2:-amd64}"
 OUTPUT_DIR="${3:-$REPO_DIR/dist}"
 SMART_AGENT_RELEASE="${4:-}"
-BUNDLE_BASE_DIR=""
-AGENT_BUNDLE_INSTALL_DIR=""
+AGENT_BUNDLE_INSTALL_DIR="agent-bundle"
 OTELCOL_INSTALL_PATH="/bin/otelcol"
 TRANSLATESFX_INSTALL_PATH="/bin/translatesfx"
 
@@ -52,8 +51,9 @@ tar_download_smart_agent() {
     echo "Downloading $dl_url ..."
     curl -sL "$dl_url" -o "$buildroot/signalfx-agent.tar.gz"
 
-    mkdir -p "$buildroot/$BUNDLE_BASE_DIR"
-    tar -xzf "$buildroot/signalfx-agent.tar.gz" -C "$buildroot/$BUNDLE_BASE_DIR"
+    mkdir -p "$buildroot"
+    tar -xzf "$buildroot/signalfx-agent.tar.gz" -C "$buildroot/"
+    mv "$buildroot/signalfx-agent" "$buildroot/$AGENT_BUNDLE_INSTALL_DIR"
     find "$buildroot/$AGENT_BUNDLE_INSTALL_DIR" -wholename "*test*.key" -delete -or -wholename "*test*.pem" -delete
     rm -f "$buildroot/signalfx-agent.tar.gz"
 }

--- a/internal/buildscripts/packaging/fpm/tar/build.sh
+++ b/internal/buildscripts/packaging/fpm/tar/build.sh
@@ -23,6 +23,58 @@ VERSION="${1:-}"
 ARCH="${2:-amd64}"
 OUTPUT_DIR="${3:-$REPO_DIR/dist}"
 SMART_AGENT_RELEASE="${4:-}"
+BUNDLE_BASE_DIR=""
+AGENT_BUNDLE_INSTALL_DIR=""
+OTELCOL_INSTALL_PATH="/bin/otelcol"
+TRANSLATESFX_INSTALL_PATH="/bin/translatesfx"
+
+tar_download_smart_agent() {
+    local tag="$1"
+    local buildroot="$2"
+    local api_url=""
+    local dl_url=""
+
+    if [ "$tag" = "latest" ]; then
+        tag=$( curl -sL "$SMART_AGENT_RELEASE_URL/latest" | jq -r '.tag_name' )
+        if [ -z "$tag" ]; then
+            echo "Failed to get tag_name for latest release from $SMART_AGENT_RELEASE_URL/latest" >&2
+            exit 1
+        fi
+    fi
+
+    api_url="$SMART_AGENT_RELEASE_URL/tags/$tag"
+    dl_url="$( curl -sL "$api_url" | jq -r '.assets[] .browser_download_url' | grep "signalfx-agent-${tag#v}\.tar\.gz" )"
+    if [ -z "$dl_url" ]; then
+        echo "Failed to get the agent download url from $api_url" >&2
+        exit 1
+    fi
+
+    echo "Downloading $dl_url ..."
+    curl -sL "$dl_url" -o "$buildroot/signalfx-agent.tar.gz"
+
+    mkdir -p "$buildroot/$BUNDLE_BASE_DIR"
+    tar -xzf "$buildroot/signalfx-agent.tar.gz" -C "$buildroot/$BUNDLE_BASE_DIR"
+    find "$buildroot/$AGENT_BUNDLE_INSTALL_DIR" -wholename "*test*.key" -delete -or -wholename "*test*.pem" -delete
+    rm -f "$buildroot/signalfx-agent.tar.gz"
+}
+
+tar_setup_files_and_permissions() {
+    local otelcol="$1"
+    local translatesfx="$2"
+    local buildroot="$3"
+
+    create_user_group
+
+    mkdir -p "$buildroot/$(dirname $OTELCOL_INSTALL_PATH)"
+    cp -f "$otelcol" "$buildroot/$OTELCOL_INSTALL_PATH"
+    sudo chown root:root "$buildroot/$OTELCOL_INSTALL_PATH"
+    sudo chmod 755 "$buildroot/$OTELCOL_INSTALL_PATH"
+
+    mkdir -p "$buildroot/$(dirname $TRANSLATESFX_INSTALL_PATH)"
+    cp -f "$translatesfx" "$buildroot/$TRANSLATESFX_INSTALL_PATH"
+    sudo chown root:root "$buildroot/$TRANSLATESFX_INSTALL_PATH"
+    sudo chmod 755 "$buildroot/$TRANSLATESFX_INSTALL_PATH"
+}
 
 if [[ -z "$VERSION" ]]; then
     VERSION="$( get_version )"
@@ -39,10 +91,10 @@ translatesfx_path="$REPO_DIR/bin/translatesfx_linux_${ARCH}"
 buildroot="$(mktemp -d)"
 
 if [ "$ARCH" = "amd64" ]; then
-    download_smart_agent "$SMART_AGENT_RELEASE" "$buildroot"
+    tar_download_smart_agent "$SMART_AGENT_RELEASE" "$buildroot"
 fi
 
-setup_files_and_permissions "$otelcol_path" "$translatesfx_path" "$buildroot"
+tar_setup_files_and_permissions "$otelcol_path" "$translatesfx_path" "$buildroot"
 
 mkdir -p "$OUTPUT_DIR"
 
@@ -52,10 +104,6 @@ sudo fpm -s dir -t tar -n "${PKG_NAME}_${VERSION}_${ARCH}" -v "$VERSION" -f -p "
     --description "$PKG_DESCRIPTION" \
     --license "$PKG_LICENSE" \
     --url "$PKG_URL" \
-    --architecture "$ARCH" \
-    --config-files "$AGENT_CONFIG_INSTALL_PATH" \
-    --config-files "$GATEWAY_CONFIG_INSTALL_PATH" \
-    --config-files "$FLUENTD_CONFIG_INSTALL_DIR" \
     "$buildroot/"=/
 
 cd "$OUTPUT_DIR"

--- a/internal/buildscripts/packaging/tests/helpers/util.py
+++ b/internal/buildscripts/packaging/tests/helpers/util.py
@@ -26,6 +26,7 @@ TESTS_DIR = Path(__file__).parent.parent.resolve()
 REPO_DIR = TESTS_DIR.parent.parent.parent.parent.resolve()
 DEB_DISTROS = [df.split(".")[-1] for df in glob.glob(str(TESTS_DIR / "images" / "deb" / "Dockerfile.*"))]
 RPM_DISTROS = [df.split(".")[-1] for df in glob.glob(str(TESTS_DIR / "images" / "rpm" / "Dockerfile.*"))]
+TAR_DISTROS = [df.split(".")[-1] for df in glob.glob(str(TESTS_DIR / "images" / "tar" / "Dockerfile.*"))]
 SERVICE_NAME = "splunk-otel-collector"
 SERVICE_OWNER = "splunk-otel-collector"
 OTELCOL_BIN = "/usr/bin/otelcol"
@@ -48,8 +49,10 @@ def run_distro_container(distro, dockerfile=None, path=TESTS_DIR, buildargs=None
     if not dockerfile:
         if distro in DEB_DISTROS:
             dockerfile = TESTS_DIR / "images" / "deb" / f"Dockerfile.{distro}"
-        else:
+        elif distro in RPM_DISTROS:
             dockerfile = TESTS_DIR / "images" / "rpm" / f"Dockerfile.{distro}"
+        else:
+            dockerfile = TESTS_DIR / "images" / "tar" / f"Dockerfile.{distro}"
 
     assert os.path.isfile(str(dockerfile)), f"{dockerfile} not found!"
 

--- a/internal/buildscripts/packaging/tests/images/tar/Dockerfile.tar-centos-7
+++ b/internal/buildscripts/packaging/tests/images/tar/Dockerfile.tar-centos-7
@@ -1,0 +1,20 @@
+# A centos7 image with systemd enabled.  Must be run with:
+# `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
+FROM centos:7
+
+ENV container docker
+
+RUN yum install -y curl procps initscripts systemd wget
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
+    "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;\
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/internal/buildscripts/packaging/tests/package_test.py
+++ b/internal/buildscripts/packaging/tests/package_test.py
@@ -78,7 +78,7 @@ def test_tar_collector_package_install(distro):
         copy_file_into_container(container, pkg_path, f"/test/{pkg_base}")
         run_container_cmd(container, f"tar xzf /test/{pkg_base} -C /tmp")
         run_container_cmd(container, f"test -d /tmp/bin")
-        run_container_cmd(container, f"test -d /tmp/signalfx-agent")
+        run_container_cmd(container, f"test -d /tmp/agent-bundle")
         run_container_cmd(container, f"test -f /tmp/bin/otelcol")
         run_container_cmd(container, f"test -f /tmp/bin/translatesfx")
 

--- a/internal/buildscripts/packaging/tests/package_test.py
+++ b/internal/buildscripts/packaging/tests/package_test.py
@@ -77,10 +77,12 @@ def test_tar_collector_package_install(distro):
 
         copy_file_into_container(container, pkg_path, f"/test/{pkg_base}")
         run_container_cmd(container, f"tar xzf /test/{pkg_base} -C /tmp")
-        run_container_cmd(container, f"test -d /tmp/bin")
-        run_container_cmd(container, f"test -d /tmp/agent-bundle")
-        run_container_cmd(container, f"test -f /tmp/bin/otelcol")
-        run_container_cmd(container, f"test -f /tmp/bin/translatesfx")
+        run_container_cmd(container, f"test -d /tmp/splunk-otel-collector/bin")
+        run_container_cmd(container, f"test -d /tmp/splunk-otel-collector/agent-bundle")
+        run_container_cmd(container, f"test -f /tmp/splunk-otel-collector/bin/otelcol")
+        run_container_cmd(container, f"test -f /tmp/splunk-otel-collector/bin/translatesfx")
+        run_container_cmd(container, f"test -f /tmp/splunk-otel-collector/config/agent_config.yaml")
+        run_container_cmd(container, f"test -f /tmp/splunk-otel-collector/config/gateway_config.yaml")
 
 @pytest.mark.parametrize(
     "distro",

--- a/internal/buildscripts/packaging/tests/package_test.py
+++ b/internal/buildscripts/packaging/tests/package_test.py
@@ -27,6 +27,7 @@ from tests.helpers.util import (
     DEB_DISTROS,
     REPO_DIR,
     RPM_DISTROS,
+    TAR_DISTROS,
     TESTS_DIR,
 )
 
@@ -45,7 +46,7 @@ BUNDLE_DIR = "/usr/lib/splunk-otel-collector/agent-bundle"
 def get_package(distro, name, path):
     if distro in DEB_DISTROS:
         pkg_paths = glob.glob(str(path / f"{name}*amd64.deb"))
-    else:
+    elif distro in RPM_DISTROS:
         pkg_paths = glob.glob(str(path / f"{name}*x86_64.rpm"))
 
     if pkg_paths:
@@ -75,7 +76,7 @@ def test_collector_package_install(distro):
 
     with run_distro_container(distro) as container:
         # install setcap dependency
-        if distro in RPM_DISTROS:
+        if distro in RPM_DISTROS or distro in TAR_DISTROS:
             run_container_cmd(container, get_libcap_command(container))
         else:
             run_container_cmd(container, "apt-get update")
@@ -87,7 +88,7 @@ def test_collector_package_install(distro):
             # install package
             if distro in DEB_DISTROS:
                 run_container_cmd(container, f"dpkg -i /test/{pkg_base}")
-            else:
+            elif distro in RPM_DISTROS:
                 run_container_cmd(container, f"rpm -i /test/{pkg_base}")
 
             run_container_cmd(container, f"test -d {BUNDLE_DIR}")
@@ -125,7 +126,7 @@ def test_collector_package_install(distro):
 
         if distro in DEB_DISTROS:
             run_container_cmd(container, f"dpkg -P {PKG_NAME}")
-        else:
+        elif distro in RPM_DISTROS:
             run_container_cmd(container, f"rpm -e {PKG_NAME}")
 
         time.sleep(5)
@@ -167,7 +168,7 @@ def test_collector_package_upgrade(distro):
             # upgrade package
             if distro in DEB_DISTROS:
                 run_container_cmd(container, f"dpkg -i --force-confold /test/{pkg_base}")
-            else:
+            elif distro in RPM_DISTROS:
                 run_container_cmd(container, f"rpm -U /test/{pkg_base}")
 
             time.sleep(5)

--- a/internal/buildscripts/packaging/tests/pytest.ini
+++ b/internal/buildscripts/packaging/tests/pytest.ini
@@ -6,3 +6,4 @@ markers =
     puppet
     rpm
     salt
+    tar


### PR DESCRIPTION
Adds a tar distro of the Splunk Otel Collector. It doesn't interact with pytest much, as there is no path to upgrade and install is a `tar xzf`.