### PR TITLE
fmt/lint against 1.19

### DIFF
--- a/cmd/migratecheckpoint/main.go
+++ b/cmd/migratecheckpoint/main.go
@@ -18,7 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -130,7 +130,7 @@ func (m *Migrator) MigrateJournaldPos(matches []string) {
 			if err != nil {
 				continue
 			}
-			byteValue, _ := ioutil.ReadAll(jsonFile)
+			byteValue, _ := io.ReadAll(jsonFile)
 			var cursor journaldCursor
 			err = json.Unmarshal(byteValue, &cursor)
 			if err != nil {

--- a/cmd/translatesfx/translatesfx/translate_test.go
+++ b/cmd/translatesfx/translatesfx/translate_test.go
@@ -15,7 +15,7 @@
 package translatesfx
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -58,7 +58,7 @@ func yamlToCfgInfo(t *testing.T, filename string) saCfgInfo {
 }
 
 func fromYAML(t *testing.T, filename string) any {
-	yml, err := ioutil.ReadFile(filename)
+	yml, err := os.ReadFile(filename)
 	require.NoError(t, err)
 	var v any
 	err = yaml.UnmarshalStrict(yml, &v)

--- a/internal/configprovider/config_server_test.go
+++ b/internal/configprovider/config_server_test.go
@@ -16,7 +16,7 @@
 package configprovider
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -178,7 +178,7 @@ func assertValidYAMLPages(t *testing.T, expected map[string]any, path string) {
 		assert.NoError(t, resp.Body.Close())
 	})
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	var unmarshalled map[string]any

--- a/internal/configprovider/manager.go
+++ b/internal/configprovider/manager.go
@@ -73,17 +73,17 @@ var ddBackwardCompatible = func() bool {
 // The current syntax to reference a config source in a YAML is provisional. Currently
 // single-line:
 //
-//    param_to_be_retrieved: $<cfgSrcName>:<selector>[?<params_url_query_format>]
+//	param_to_be_retrieved: $<cfgSrcName>:<selector>[?<params_url_query_format>]
 //
 // bracketed single-line:
 //
-//    param_to_be_retrieved: ${<cfgSrcName>:<selector>[?<params_url_query_format>]}
+//	param_to_be_retrieved: ${<cfgSrcName>:<selector>[?<params_url_query_format>]}
 //
 // and multi-line are supported:
 //
-//    param_to_be_retrieved: |
-//      $<cfgSrcName>: <selector>
-//      [<params_multi_line_YAML>]
+//	param_to_be_retrieved: |
+//	  $<cfgSrcName>: <selector>
+//	  [<params_multi_line_YAML>]
 //
 // The <cfgSrcName> is a name string used to identify the config source instance to be used
 // to retrieve the value.
@@ -97,16 +97,18 @@ var ddBackwardCompatible = func() bool {
 // Hypothetical example in a YAML file:
 //
 // component:
-//   config_field: $file:/etc/secret.bin?binary=true
+//
+//	config_field: $file:/etc/secret.bin?binary=true
 //
 // For multi-line format <params_multi_line_YAML> uses syntax as a YAML inside YAML. Possible usage
 // example in a YAML file:
 //
 // component:
-//   config_field: |
-//     $yamltemplate: /etc/log_template.yaml
-//     logs_path: /var/logs/
-//     timeout: 10s
+//
+//	config_field: |
+//	  $yamltemplate: /etc/log_template.yaml
+//	  logs_path: /var/logs/
+//	  timeout: 10s
 //
 // Not all config sources need these optional parameters, they are used to provide extra control when
 // retrieving and data to be injected into the configuration.
@@ -114,33 +116,33 @@ var ddBackwardCompatible = func() bool {
 // Assuming a config source named "env" that retrieve environment variables and one named "file" that
 // retrieves contents from individual files, here are some examples:
 //
-//    component:
-//      # Retrieves the value of the environment variable LOGS_DIR.
-//      logs_dir: $env:LOGS_DIR
+//	component:
+//	  # Retrieves the value of the environment variable LOGS_DIR.
+//	  logs_dir: $env:LOGS_DIR
 //
-//      # Retrieves the value from the file /etc/secret.bin and injects its contents as a []byte.
-//      bytes_from_file: $file:/etc/secret.bin?binary=true
+//	  # Retrieves the value from the file /etc/secret.bin and injects its contents as a []byte.
+//	  bytes_from_file: $file:/etc/secret.bin?binary=true
 //
-//      # Retrieves the value from the file /etc/text.txt and injects its contents as a string.
-//      # Hypothetically the "file" config source by default tries to inject the file contents
-//      # as a string if params doesn't specify that "binary" is true.
-//      text_from_file: $file:/etc/text.txt
+//	  # Retrieves the value from the file /etc/text.txt and injects its contents as a string.
+//	  # Hypothetically the "file" config source by default tries to inject the file contents
+//	  # as a string if params doesn't specify that "binary" is true.
+//	  text_from_file: $file:/etc/text.txt
 //
 // Bracketed single-line should be used when concatenating a suffix to the value retrieved by
 // the config source. Example:
 //
-//    component:
-//      # Retrieves the value of the environment variable LOGS_DIR and appends /component.log to it.
-//      log_file_fullname: ${env:LOGS_DIR}/component.log
+//	component:
+//	  # Retrieves the value of the environment variable LOGS_DIR and appends /component.log to it.
+//	  log_file_fullname: ${env:LOGS_DIR}/component.log
 //
 // Environment variables are expanded before passed to the config source when used in the selector or
 // the optional parameters. Example:
 //
-//    component:
-//      # Retrieves the value from the file text.txt located on the path specified by the environment
-//      # variable DATA_PATH. The name of the environment variable is the string after the delimiter
-//      # until the first character different than '_' and non-alpha-numeric.
-//      text_from_file: $file:$DATA_PATH/text.txt
+//	component:
+//	  # Retrieves the value from the file text.txt located on the path specified by the environment
+//	  # variable DATA_PATH. The name of the environment variable is the string after the delimiter
+//	  # until the first character different than '_' and non-alpha-numeric.
+//	  text_from_file: $file:$DATA_PATH/text.txt
 //
 // Since environment variables and config sources both use the '$', with or without brackets, as a prefix
 // for their expansion it is necessary to have a way to distinguish between them. For the non-bracketed
@@ -148,21 +150,21 @@ var ddBackwardCompatible = func() bool {
 // that character is a ':' it will treat it as a config source and as environment variable otherwise.
 // For example:
 //
-//    component:
-//      field_0: $PATH:/etc/logs # Injects the data from a config sourced named "PATH" using the selector "/etc/logs".
-//      field_1: $PATH/etc/logs  # Expands the environment variable "PATH" and adds the suffix "/etc/logs" to it.
+//	component:
+//	  field_0: $PATH:/etc/logs # Injects the data from a config sourced named "PATH" using the selector "/etc/logs".
+//	  field_1: $PATH/etc/logs  # Expands the environment variable "PATH" and adds the suffix "/etc/logs" to it.
 //
 // So if you need to include an environment followed by ':' the bracketed syntax must be used instead:
 //
-//    component:
-//      field_0: ${PATH}:/etc/logs # Expands the environment variable "PATH" and adds the suffix ":/etc/logs" to it.
+//	component:
+//	  field_0: ${PATH}:/etc/logs # Expands the environment variable "PATH" and adds the suffix ":/etc/logs" to it.
 //
 // For the bracketed syntax the presence of ':' inside the brackets indicates that code will treat the bracketed
 // contents as a config source. For example:
 //
-//    component:
-//      field_0: ${file:/var/secret.txt} # Injects the data from a config sourced named "file" using the selector "/var/secret.txt".
-//      field_1: ${file}:/var/secret.txt # Expands the environment variable "file" and adds the suffix ":/var/secret.txt" to it.
+//	component:
+//	  field_0: ${file:/var/secret.txt} # Injects the data from a config sourced named "file" using the selector "/var/secret.txt".
+//	  field_1: ${file}:/var/secret.txt # Expands the environment variable "file" and adds the suffix ":/var/secret.txt" to it.
 //
 // If the character following the '$' is in the set {'*', '#', '$', '@', '!', '?', '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
 // the code will consider it to be the name of an environment variable to expand, or config source if followed by ':'. Do not use any of these

--- a/internal/configsource/includeconfigsource/source_test.go
+++ b/internal/configsource/includeconfigsource/source_test.go
@@ -17,7 +17,6 @@ package includeconfigsource
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -95,10 +94,10 @@ func TestIncludeConfigSource_DeleteFile(t *testing.T) {
 
 	// Copy test file
 	src := path.Join("testdata", "scalar_data_file")
-	contents, err := ioutil.ReadFile(src)
+	contents, err := os.ReadFile(src)
 	require.NoError(t, err)
 	dst := path.Join("testdata", "copy_scalar_data_file")
-	require.NoError(t, ioutil.WriteFile(dst, contents, 0600))
+	require.NoError(t, os.WriteFile(dst, contents, 0600))
 	t.Cleanup(func() {
 		// It should be removed prior to this so an error is expected.
 		assert.Error(t, os.Remove(dst))
@@ -132,10 +131,10 @@ func TestIncludeConfigSource_DeleteFileError(t *testing.T) {
 
 	// Copy test file
 	src := path.Join("testdata", "scalar_data_file")
-	contents, err := ioutil.ReadFile(src)
+	contents, err := os.ReadFile(src)
 	require.NoError(t, err)
 	dst := path.Join("testdata", "copy_scalar_data_file")
-	require.NoError(t, ioutil.WriteFile(dst, contents, 0600))
+	require.NoError(t, os.WriteFile(dst, contents, 0600))
 	f, err := os.OpenFile(dst, os.O_RDWR, 0)
 	require.NoError(t, err)
 	t.Cleanup(func() {


### PR DESCRIPTION
With latest go release builds will fail due to fmt differences and deprecated ioutil functions.