### PR TITLE
sync host metadata for internal metrics

### DIFF
--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -99,6 +99,10 @@ exporters:
     ## to avoid double translations and exclusions.
     #translation_rules: []
     #exclude_metrics: []
+  signalfx/internal:
+    access_token: "${SPLUNK_ACCESS_TOKEN}"
+    realm: "${SPLUNK_REALM}"
+    sync_host_metadata: true
   # Debug
   #logging:
     #loglevel: debug
@@ -120,7 +124,7 @@ service:
     metrics/internal:
       receivers: [prometheus/internal]
       processors: [memory_limiter, batch, resourcedetection/internal]
-      exporters: [signalfx]
+      exporters: [signalfx/internal]
     logs:
       receivers: [otlp, signalfx]
       processors: [memory_limiter, batch]


### PR DESCRIPTION
The current GW config does not sync host metadata by default, which created confusion when users enable hostmetrics (and other GW metrics) and not seeing the host metadata in the backend.


Signed-off-by: Dani Louca <dlouca@splunk.com>