### PR TITLE
hostmetadata when sending to GW

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -172,9 +172,9 @@ service:
     metrics/internal:
       receivers: [prometheus/internal]
       processors: [memory_limiter, batch, resourcedetection]
+      # When sending to gateway, at least one metrics pipeline needs
+      # to use signalfx exporter so host metadata gets emitted
       exporters: [signalfx]
-      # Use instead when sending to gateway
-      #exporters: [otlp]
     logs/signalfx:
       receivers: [signalfx]
       processors: [memory_limiter, batch]


### PR DESCRIPTION
The current comment suggests to switch all exporters to OTLP when sending to GW, which breaks the metadata updates.
At least one `signalfx` exporter should exists to update the host metadata properties.


Signed-off-by: Dani Louca <dlouca@splunk.com>