### PR TITLE
add processlist to default config

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -84,6 +84,8 @@ receivers:
   smartagent/signalfx-forwarder:
     type: signalfx-forwarder
     listenAddress: 0.0.0.0:9080
+  smartagent/processlist:
+    type: processlist
   signalfx:
     endpoint: 0.0.0.0:9943
     # Whether to preserve incoming access token and use instead of exporter token
@@ -176,7 +178,7 @@ service:
       # to use signalfx exporter so host metadata gets emitted
       exporters: [signalfx]
     logs/signalfx:
-      receivers: [signalfx]
+      receivers: [signalfx, smartagent/processlist]
       processors: [memory_limiter, batch]
       exporters: [signalfx]
       # Use instead when sending to gateway


### PR DESCRIPTION
The OOTB content in IMM uses the data emitted from processlist monitor, it makes sense to add this by default.
If we agreed to add processlist to the default config, then I will make the same update to the remaining OOTB configs we ship with the splunk distro

Signed-off-by: Dani Louca <dlouca@splunk.com>