### PR TITLE
Add resourcedetection to make the processlist events register with the backend

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -179,7 +179,7 @@ service:
       exporters: [signalfx]
     logs/signalfx:
       receivers: [signalfx, smartagent/processlist]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter, batch, resourcedetection]
       exporters: [signalfx]
       # Use instead when sending to gateway
       #exporters: [otlp]


### PR DESCRIPTION
This is related to https://github.com/signalfx/splunk-otel-collector/pull/1937
Without resourcedetection, the event will be missing the `host.name` label which is used to store the event in the memcache, if host.name is missing then the event is dropped.

Signed-off-by: Dani Louca <dlouca@splunk.com>