### PR TITLE
discovery receiver: add base evaluator and correlations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -144,6 +144,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.19.0 // indirect
 	github.com/aws/smithy-go v1.12.1 // indirect
 	github.com/beevik/ntp v0.3.0 // indirect
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmatcuk/doublestar/v3 v3.0.0 // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -325,6 +325,7 @@ github.com/beevik/ntp v0.3.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NR
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/internal/receiver/discoveryreceiver/correlation.go
+++ b/internal/receiver/discoveryreceiver/correlation.go
@@ -1,0 +1,218 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoveryreceiver
+
+import (
+	"sync"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"go.opentelemetry.io/collector/config"
+	"go.uber.org/zap"
+
+	"github.com/signalfx/splunk-otel-collector/internal/receiver/discoveryreceiver/statussources"
+)
+
+// correlation is a grouping of an endpoint, the observing
+// observer, and a receiver, if any. It's used to unify
+// emitted log record content from evaluated status sources
+// such that no individual source lacks information otherwise
+// only available to others. At this time this means that
+// metrics and component logs will have access to a receiver's
+// observing observer via the Notify event where not available
+// through another means.
+type correlation struct {
+	lastState   endpointState
+	lastUpdated time.Time
+	endpoint    observer.Endpoint
+	receiverID  config.ComponentID
+	observerID  config.ComponentID
+}
+
+// correlationStore provides a centralized interface for up-to-date correlations
+// and receiver attributes as a message passing mechanism by observed components.
+// It manages a reaping loop to prevent stale endpoint buildup over time.
+type correlationStore interface {
+	UpdateEndpoint(endpoint observer.Endpoint, state endpointState, observerID config.ComponentID)
+	GetOrCreate(receiverID config.ComponentID, endpointID observer.EndpointID) correlation
+	Attrs(receiverID config.ComponentID) map[string]string
+	UpdateAttrs(receiverID config.ComponentID, attrs map[string]string)
+	// Start the reaping loop to prevent unnecessary endpoint buildup
+	Start()
+	// Stop the reaping loop
+	Stop()
+}
+
+// store is a collection of mappings used as an instantaneous record of
+// 1. endpoints to their associated receivers->correlations
+// 2. receivers to their endpoint-agnostic Attrs used as a message
+// passing mechanism (currently just for embedded config values).
+// This way the pre-created receiver instances can have attrs
+// before they are created via endpoint.
+type store struct {
+	logger *zap.Logger
+	// correlations is a ~synchronized map[endpointID]map[receiverID]*corr
+	correlations  *sync.Map
+	endpointLocks *keyLock
+	receiverAttrs *sync.Map
+	receiverLocks *keyLock
+	// sentinel for terminating reaper loop
+	sentinel     chan struct{}
+	reapInterval time.Duration
+	ttl          time.Duration
+}
+
+func newCorrelationStore(logger *zap.Logger, ttl time.Duration) correlationStore {
+	return &store{
+		logger:        logger,
+		correlations:  &sync.Map{},
+		endpointLocks: newKeyLock(),
+		receiverAttrs: &sync.Map{},
+		receiverLocks: newKeyLock(),
+		reapInterval:  30 * time.Second,
+		ttl:           ttl,
+		sentinel:      make(chan struct{}, 1),
+	}
+}
+
+// UpdateEndpoint will update all existing correlation timestamps and states by endpoint.ID, or
+// creates a new no-type ~singleton w/ the initial correlation info for later use in correlation creation.
+func (s *store) UpdateEndpoint(endpoint observer.Endpoint, state endpointState, observerID config.ComponentID) {
+	defer s.endpointLocks.Lock(endpoint.ID)()
+	rMap, ok := s.correlations.LoadOrStore(endpoint.ID, &sync.Map{})
+	receiverMap := rMap.(*sync.Map)
+	if !ok {
+		receiverMap.Store(statussources.NoType, &correlation{
+			endpoint:    endpoint,
+			observerID:  observerID,
+			lastState:   state,
+			lastUpdated: time.Now(),
+		})
+		// we've set NoType correlation, which is all we can do
+		return
+	}
+	receiverMap.Range(func(_, c any) bool {
+		corr := c.(*correlation)
+		corr.endpoint = endpoint
+		// set here for unlikely out of order GetOrCreate eventual consistency
+		corr.observerID = observerID
+		corr.lastUpdated = time.Now()
+		corr.lastState = state
+		return true
+	})
+}
+
+// GetOrCreate returns an existing receiver/endpoint correlation or creates a new one
+// based on the no-type ~singleton for the last endpoint update event.
+func (s *store) GetOrCreate(receiverID config.ComponentID, endpointID observer.EndpointID) correlation {
+	endpointUnlock := s.endpointLocks.Lock(endpointID)
+	rMap, ok := s.correlations.LoadOrStore(endpointID, &sync.Map{})
+	receiverMap := rMap.(*sync.Map)
+	if !ok {
+		// this zero value correlation suggests the observer has yet to emit an endpoint event
+		// and this could be an invalid collector state. Likely this flow results from delayed
+		// event handling and the correlation is eventually consistent in UpdateEndpoint.
+		receiverMap.Store(statussources.NoType, &correlation{})
+	}
+	defer s.receiverLocks.Lock(receiverID)()
+	endpointUnlock()
+	c, ok := receiverMap.Load(receiverID)
+	if ok {
+		return *(c.(*correlation))
+	}
+	var noTypeCorrelation *correlation
+	// disregard ok since previous LoadOrStore handling guarantees existence
+	ntCorr, _ := receiverMap.Load(statussources.NoType)
+	noTypeCorrelation = ntCorr.(*correlation)
+	cpCorr := *noTypeCorrelation
+	corr := &cpCorr
+	corr.receiverID = receiverID
+	receiverMap.Store(receiverID, corr)
+	return *corr
+}
+
+func (s *store) Attrs(receiverID config.ComponentID) map[string]string {
+	defer s.receiverLocks.Lock(receiverID)()
+	rInfo, _ := s.receiverAttrs.LoadOrStore(receiverID, map[string]string{})
+	receiverInfo := rInfo.(map[string]string)
+	cp := map[string]string{}
+	for k, v := range receiverInfo {
+		cp[k] = v
+	}
+	return cp
+}
+
+func (s *store) UpdateAttrs(receiverID config.ComponentID, attrs map[string]string) {
+	defer s.receiverLocks.Lock(receiverID)()
+	rAttrs, _ := s.receiverAttrs.LoadOrStore(receiverID, map[string]string{})
+	receiverAttrs := rAttrs.(map[string]string)
+	for k, v := range attrs {
+		receiverAttrs[k] = v
+	}
+	s.receiverAttrs.Store(receiverID, receiverAttrs)
+}
+
+func (s *store) Start() {
+	go func() {
+		timer := time.NewTicker(s.reapInterval)
+		for {
+			select {
+			case <-timer.C:
+				s.reap()
+			case <-s.sentinel:
+				timer.Stop()
+				return
+			}
+		}
+	}()
+}
+
+func (s *store) Stop() {
+	s.sentinel <- struct{}{}
+}
+
+// reap will remove all removed endpoints whose last update is past the ttl
+func (s *store) reap() {
+	s.correlations.Range(func(eID, rMap any) bool {
+		endpointID := eID.(observer.EndpointID)
+		defer s.endpointLocks.Lock(endpointID)()
+		receiverMap := rMap.(*sync.Map)
+		if c, ok := receiverMap.Load(statussources.NoType); ok {
+			corr := c.(*correlation)
+			if corr.lastState == removedState &&
+				time.Since(corr.lastUpdated) > s.ttl {
+				s.correlations.Delete(endpointID)
+			}
+		}
+		return true
+	})
+}
+
+// keyLock is a map of locks for an associated Map to be locked
+// by its keys for a longer duration than the provided atomic ops.
+type keyLock struct {
+	*sync.Map
+}
+
+func newKeyLock() *keyLock {
+	return &keyLock{&sync.Map{}}
+}
+
+func (kl *keyLock) Lock(key any) (unlock func()) {
+	mtx, _ := kl.Map.LoadOrStore(key, &sync.Mutex{})
+	mutex := mtx.(*sync.Mutex)
+	mutex.Lock()
+	return mutex.Unlock
+}

--- a/internal/receiver/discoveryreceiver/correlation_test.go
+++ b/internal/receiver/discoveryreceiver/correlation_test.go
@@ -1,0 +1,249 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoveryreceiver
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/signalfx/splunk-otel-collector/internal/receiver/discoveryreceiver/statussources"
+)
+
+func TestNewCorrelationStore(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	cs := newCorrelationStore(logger, time.Hour)
+	cStore, ok := cs.(*store)
+	require.True(t, ok)
+	require.NotNil(t, cStore)
+	require.Same(t, logger, cStore.logger)
+	require.Equal(t, time.Hour, cStore.ttl)
+	require.Equal(t, 30*time.Second, cStore.reapInterval)
+	require.NotNil(t, time.Hour, cStore.receiverAttrs)
+	require.NotNil(t, time.Hour, cStore.correlations)
+	require.NotNil(t, time.Hour, cStore.endpointLocks)
+	require.NotNil(t, time.Hour, cStore.receiverLocks)
+	require.NotZero(t, cStore.sentinel)
+}
+
+func TestGetOrCreateUndiscoveredReceiver(t *testing.T) {
+	cs := newCorrelationStore(zaptest.NewLogger(t), time.Hour)
+	endpointID := observer.EndpointID("an.endpoint")
+	createdCorr := cs.GetOrCreate(statussources.NoType, endpointID)
+	require.NotNil(t, createdCorr)
+	require.Equal(t, config.NewComponentID(""), createdCorr.receiverID)
+	require.Equal(t, config.NewComponentID(""), createdCorr.observerID)
+	require.Zero(t, createdCorr.endpoint)
+	require.Empty(t, createdCorr.lastState)
+	require.Zero(t, createdCorr.lastUpdated)
+
+	createdCorr.observerID = config.NewComponentID("an.observer")
+	gotCorr := cs.GetOrCreate(statussources.NoType, endpointID)
+	require.NotNil(t, gotCorr)
+	// all returned correlations are copies whose mutations don't persist in storage
+	require.NotSame(t, createdCorr, gotCorr)
+	require.Equal(t, config.NewComponentID(""), gotCorr.observerID)
+}
+
+func TestGetOrCreateDiscoveredReceiver(t *testing.T) {
+	cs := newCorrelationStore(zaptest.NewLogger(t), time.Hour)
+	endpointID := observer.EndpointID("an.endpoint")
+	endpoint := observer.Endpoint{
+		ID:     endpointID,
+		Target: "a.target",
+	}
+	observerID := config.NewComponentIDWithName("observer", "name")
+	now := time.Now()
+	cs.UpdateEndpoint(endpoint, "a.state", observerID)
+
+	corr := cs.GetOrCreate(statussources.NoType, endpointID)
+	require.NotNil(t, corr)
+	require.Equal(t, config.NewComponentID(""), corr.receiverID)
+	require.Equal(t, observerID, corr.observerID)
+	require.Equal(t, endpoint, corr.endpoint)
+	require.Equal(t, endpointState("a.state"), corr.lastState)
+	require.GreaterOrEqual(t, corr.lastUpdated, now)
+
+	receiverID := config.NewComponentIDWithName("receiver", "name")
+	typedReceiverCorr := cs.GetOrCreate(receiverID, endpointID)
+	require.NotNil(t, typedReceiverCorr)
+	require.Equal(t, receiverID, typedReceiverCorr.receiverID)
+	require.Equal(t, observerID, typedReceiverCorr.observerID)
+	require.Equal(t, endpoint, typedReceiverCorr.endpoint)
+	require.Equal(t, endpointState("a.state"), typedReceiverCorr.lastState)
+	require.GreaterOrEqual(t, typedReceiverCorr.lastUpdated, now)
+}
+
+func TestGetOrCreateLaterDiscoveredReceiver(t *testing.T) {
+	cs := newCorrelationStore(zaptest.NewLogger(t), time.Hour)
+	endpointID := observer.EndpointID("an.endpoint")
+	createdCorr := cs.GetOrCreate(statussources.NoType, endpointID)
+	require.NotNil(t, createdCorr)
+	require.Equal(t, config.NewComponentID(""), createdCorr.receiverID)
+	require.Equal(t, config.NewComponentID(""), createdCorr.observerID)
+	require.Zero(t, createdCorr.endpoint)
+	require.Empty(t, createdCorr.lastState)
+	require.Zero(t, createdCorr.lastUpdated)
+
+	endpoint := observer.Endpoint{
+		ID:     endpointID,
+		Target: "a.target",
+	}
+	observerID := config.NewComponentIDWithName("observer", "name")
+	now := time.Now()
+	cs.UpdateEndpoint(endpoint, "a.state", observerID)
+
+	gotCorr := cs.GetOrCreate(statussources.NoType, endpointID)
+	require.NotNil(t, createdCorr)
+	require.Equal(t, config.NewComponentID(""), gotCorr.receiverID)
+	require.Equal(t, observerID, gotCorr.observerID)
+	require.Equal(t, endpoint, gotCorr.endpoint)
+	require.Equal(t, endpointState("a.state"), gotCorr.lastState)
+	require.GreaterOrEqual(t, gotCorr.lastUpdated, now)
+
+	receiverID := config.NewComponentIDWithName("receiver", "name")
+	typedReceiverCorr := cs.GetOrCreate(receiverID, endpointID)
+	require.NotNil(t, typedReceiverCorr)
+	require.Equal(t, receiverID, typedReceiverCorr.receiverID)
+	require.Equal(t, observerID, typedReceiverCorr.observerID)
+	require.Equal(t, endpoint, typedReceiverCorr.endpoint)
+	require.Equal(t, endpointState("a.state"), typedReceiverCorr.lastState)
+	require.GreaterOrEqual(t, typedReceiverCorr.lastUpdated, now)
+}
+
+func TestGetOrCreateLaterDiscoveredReceiverWithUpdatedEndpoint(t *testing.T) {
+	cs := newCorrelationStore(zaptest.NewLogger(t), time.Hour)
+	endpointID := observer.EndpointID("an.endpoint")
+	createdCorr := cs.GetOrCreate(statussources.NoType, endpointID)
+	require.NotNil(t, createdCorr)
+	require.Equal(t, config.NewComponentID(""), createdCorr.receiverID)
+	require.Equal(t, config.NewComponentID(""), createdCorr.observerID)
+	require.Zero(t, createdCorr.endpoint)
+	require.Empty(t, createdCorr.lastState)
+	require.Zero(t, createdCorr.lastUpdated)
+
+	endpoint := observer.Endpoint{
+		ID:     endpointID,
+		Target: "a.target",
+	}
+	observerID := config.NewComponentIDWithName("observer", "name")
+	now := time.Now()
+	cs.UpdateEndpoint(endpoint, "a.state", observerID)
+
+	gotCorr := cs.GetOrCreate(statussources.NoType, endpointID)
+	require.NotNil(t, createdCorr)
+	require.Equal(t, config.NewComponentID(""), gotCorr.receiverID)
+	require.Equal(t, observerID, gotCorr.observerID)
+	require.Equal(t, endpoint, gotCorr.endpoint)
+	require.Equal(t, endpointState("a.state"), gotCorr.lastState)
+	require.GreaterOrEqual(t, gotCorr.lastUpdated, now)
+
+	now = time.Now()
+	cs.UpdateEndpoint(endpoint, "another.state", observerID)
+
+	receiverID := config.NewComponentIDWithName("receiver", "name")
+	typedReceiverCorr := cs.GetOrCreate(receiverID, endpointID)
+	require.NotNil(t, typedReceiverCorr)
+	require.Equal(t, receiverID, typedReceiverCorr.receiverID)
+	require.Equal(t, observerID, typedReceiverCorr.observerID)
+	require.Equal(t, endpoint, typedReceiverCorr.endpoint)
+	require.Equal(t, endpointState("another.state"), typedReceiverCorr.lastState)
+	require.GreaterOrEqual(t, typedReceiverCorr.lastUpdated, now)
+
+	// confirm state change propagates to other receivers
+	noTypedReceiverCorr := cs.GetOrCreate(statussources.NoType, endpointID)
+	require.NotNil(t, createdCorr)
+	require.Equal(t, config.NewComponentID(""), noTypedReceiverCorr.receiverID)
+	require.Equal(t, observerID, noTypedReceiverCorr.observerID)
+	require.Equal(t, endpoint, noTypedReceiverCorr.endpoint)
+	require.Equal(t, endpointState("another.state"), noTypedReceiverCorr.lastState)
+	require.GreaterOrEqual(t, noTypedReceiverCorr.lastUpdated, now)
+}
+
+func TestAttrs(t *testing.T) {
+	cs := newCorrelationStore(zaptest.NewLogger(t), time.Hour)
+	receiverID := config.NewComponentIDWithName("receiver", "name")
+	attrs := cs.Attrs(receiverID)
+	require.Empty(t, attrs)
+	// all returned attrs are copies and don't persist changes in storage
+	attrs["key"] = "value"
+	require.Empty(t, cs.Attrs(receiverID))
+
+	attrs["another.key"] = "another.value"
+	cs.UpdateAttrs(receiverID, attrs)
+	updated := cs.Attrs(receiverID)
+	require.Equal(t, map[string]string{"key": "value", "another.key": "another.value"}, updated)
+
+	cs.UpdateAttrs(receiverID, map[string]string{"key": "changed.value", "yet.another.key": "yet.another.value"})
+	updated = cs.Attrs(receiverID)
+	require.Equal(t, map[string]string{
+		"key":             "changed.value",
+		"another.key":     "another.value",
+		"yet.another.key": "yet.another.value",
+	}, updated)
+}
+
+func TestReaperLoop(t *testing.T) {
+	cs := newCorrelationStore(zaptest.NewLogger(t), time.Nanosecond)
+	cStore, ok := cs.(*store)
+	require.True(t, ok)
+	require.NotNil(t, cStore)
+	// update the reapInterval so as not to wait 30 seconds for test logic
+	cStore.reapInterval = time.Millisecond
+
+	endpointID := observer.EndpointID("an.endpoint")
+	endpoint := observer.Endpoint{
+		ID:     endpointID,
+		Target: "a.target",
+	}
+	observerID := config.NewComponentIDWithName("observer", "name")
+
+	cs.Start()
+	t.Cleanup(cs.Stop)
+
+	cs.UpdateEndpoint(endpoint, addedState, observerID)
+
+	receiverID := config.NewComponentIDWithName("receiver", "name")
+	corr := cs.GetOrCreate(receiverID, endpointID)
+	require.Equal(t, addedState, corr.lastState)
+	rMap, ok := cStore.correlations.Load(endpointID)
+	require.True(t, ok)
+	receiverMap, isMap := rMap.(*sync.Map)
+	require.True(t, isMap)
+
+	noTypeCorr, containsNoType := receiverMap.Load(statussources.NoType)
+	require.True(t, containsNoType)
+	noTypedReceiverCorr, isCorr := noTypeCorr.(*correlation)
+	require.True(t, isCorr)
+	require.Equal(t, addedState, noTypedReceiverCorr.lastState)
+
+	cs.UpdateEndpoint(endpoint, removedState, observerID)
+
+	// repeat check once to ensure loop-driven removal
+	_, hasEndpoint := cStore.correlations.Load(endpointID)
+	require.True(t, hasEndpoint)
+	require.Equal(t, removedState, noTypedReceiverCorr.lastState)
+
+	// confirm reaping occurs within interval
+	require.Eventually(t, func() bool {
+		_, hasCorrelations := cStore.correlations.Load(endpointID)
+		return !hasCorrelations
+	}, 100*time.Millisecond, time.Millisecond) // windows test seems to require more time.
+}

--- a/internal/receiver/discoveryreceiver/evaluator.go
+++ b/internal/receiver/discoveryreceiver/evaluator.go
@@ -1,0 +1,175 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoveryreceiver
+
+import (
+	"encoding/base64"
+	"fmt"
+	"regexp"
+	"sync"
+
+	"github.com/antonmedv/expr"
+	"github.com/antonmedv/expr/vm"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	observerIDAttr = "discovery.observer.id"
+)
+
+// evaluator is the base status matcher that determines if telemetry warrants emitting a matching log record.
+// It also provides embedded config correlation that its embedding structs will utilize.
+type evaluator struct {
+	logger       *zap.Logger
+	config       *Config
+	correlations correlationStore
+	// if match.FirstOnly this ~sync.Map(map[string]struct{}) keeps track of
+	// whether we've already emitted a record for the statement and can skip processing.
+	alreadyLogged *sync.Map
+	exprEnv       func(pattern string) map[string]any
+}
+
+// evaluateMatch parses the provided Match and returns whether it warrants a status log record
+func (e *evaluator) evaluateMatch(match Match, pattern, status string, receiverID config.ComponentID, endpointID observer.EndpointID) (bool, error) {
+	var matchFunc func(p string) (bool, error)
+	var matchPattern string
+
+	var err error
+	switch {
+	case match.Strict != "":
+		matchPattern = match.Strict
+		matchFunc = func(p string) (bool, error) {
+			return p == match.Strict, nil
+		}
+	case match.Regexp != "":
+		matchPattern = match.Regexp
+		var re *regexp.Regexp
+		if re, err = regexp.Compile(matchPattern); err != nil {
+			err = fmt.Errorf("invalid match regexp statement: %w", err)
+		} else {
+			matchFunc = func(p string) (bool, error) { return re.MatchString(p), nil }
+		}
+	case match.Expr != "":
+		matchPattern = match.Expr
+		var program *vm.Program
+		// TODO: cache compiled programs for performance benefit
+		if program, err = expr.Compile(match.Expr, expr.Env(e.exprEnv(pattern))); err != nil {
+			err = fmt.Errorf("invalid match expr statement: %w", err)
+		} else {
+			matchFunc = func(p string) (bool, error) {
+				ret, runErr := vm.Run(program, e.exprEnv(p))
+				if runErr != nil {
+					return false, runErr
+				}
+				return ret.(bool), nil
+			}
+		}
+	default:
+		err = fmt.Errorf("no valid match field provided")
+	}
+	if err != nil {
+		return false, err
+	}
+
+	var shouldLog bool
+	shouldLog, err = matchFunc(pattern)
+	if !shouldLog || err != nil {
+		return false, err
+	}
+
+	if match.FirstOnly {
+		loggedKey := fmt.Sprintf("%s::%s::%s::%s", endpointID, receiverID.String(), status, matchPattern)
+		if _, ok := e.alreadyLogged.LoadOrStore(loggedKey, struct{}{}); ok {
+			shouldLog = false
+		}
+	}
+
+	return shouldLog, nil
+}
+
+// correlateResourceAttributes will copy all `from` attributes to `to` in addition to
+// updating embedded base64 config content, if configured, to include the correlated observer ID
+// that is otherwise unavailable to status sources.
+func (e *evaluator) correlateResourceAttributes(from, to pcommon.Map, corr correlation) {
+	receiverType := string(corr.receiverID.Type())
+	receiverName := corr.receiverID.Name()
+
+	observerID := corr.observerID.String()
+	to.InsertString(observerIDAttr, observerID)
+
+	var receiverAttrs map[string]string
+	hasTemporaryReceiverConfigAttr := false
+	receiverAttrs = e.correlations.Attrs(corr.receiverID)
+
+	if e.config.EmbedReceiverConfig {
+		if _, ok := from.Get(receiverConfigAttr); !ok {
+			// statements don't inherit embedded configs in their resource attributes
+			// from the receiver creator, so we should temporarily include it in `from`
+			// so as not to mutate the original while providing the desired receiver config
+			// value set by the initial receiver config parser.
+			from.InsertString(receiverConfigAttr, receiverAttrs[receiverConfigAttr])
+			hasTemporaryReceiverConfigAttr = true
+		}
+	}
+
+	from.Range(func(k string, v pcommon.Value) bool {
+		if k == receiverConfigAttr && e.config.EmbedReceiverConfig {
+			configVal := v.AsString()
+			if updatedConfig, ok := receiverAttrs[receiverUpdatedConfigAttr]; ok {
+				configVal = updatedConfig
+			} else {
+				var err error
+				if updatedConfig, err = addObserverToEncodedConfig(configVal, observerID); err != nil {
+					// log failure and continue with existing config sans observer
+					e.logger.Debug(fmt.Sprintf("failed adding %q to %s", observerID, receiverConfigAttr), zap.String("receiver.type", receiverType), zap.String("receiver.name", receiverName), zap.Error(err))
+				} else {
+					e.logger.Debug("Adding watch_observer to embedded receiver config receiver attrs", zap.String("observer", corr.observerID.String()), zap.String("receiver.type", receiverType), zap.String("receiver.name", receiverName))
+					e.correlations.UpdateAttrs(corr.receiverID, map[string]string{
+						receiverUpdatedConfigAttr: updatedConfig,
+					})
+					configVal = updatedConfig
+				}
+			}
+			v = pcommon.NewValueString(configVal)
+		}
+		to.Insert(k, v)
+		return true
+	})
+	if hasTemporaryReceiverConfigAttr {
+		from.Remove(receiverConfigAttr)
+	}
+}
+
+func addObserverToEncodedConfig(encoded, observerID string) (string, error) {
+	cfg := map[string]any{}
+	dBytes, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", err
+	}
+	if err = yaml.Unmarshal(dBytes, &cfg); err != nil {
+		return "", err
+	}
+	cfg["watch_observers"] = []string{observerID}
+
+	var cfgYaml []byte
+	if cfgYaml, err = yaml.Marshal(cfg); err != nil {
+		return "", fmt.Errorf("failed embedding receiver config to include %q: %w", observerID, err)
+	}
+	return base64.StdEncoding.EncodeToString(cfgYaml), nil
+}

--- a/internal/receiver/discoveryreceiver/evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/evaluator_test.go
@@ -1,0 +1,209 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoveryreceiver
+
+import (
+	"encoding/base64"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/signalfx/splunk-otel-collector/internal/receiver/discoveryreceiver/statussources"
+)
+
+func setup(t testing.TB) (*evaluator, config.ComponentID, observer.EndpointID) {
+	logger := zaptest.NewLogger(t)
+	alreadyLogged := &sync.Map{}
+	eval := &evaluator{
+		logger:        logger,
+		config:        &Config{},
+		correlations:  newCorrelationStore(logger, time.Hour),
+		alreadyLogged: alreadyLogged,
+		exprEnv: func(pattern string) map[string]any {
+			return map[string]any{"item": pattern}
+		},
+	}
+
+	receiverID := config.NewComponentIDWithName("type", "name")
+	endpointID := observer.EndpointID("endpoint")
+	return eval, receiverID, endpointID
+}
+
+func TestEvaluateMatch(t *testing.T) {
+	eval, receiverID, endpointID := setup(t)
+	anotherReceiverID := config.NewComponentIDWithName("type", "another.name")
+
+	for _, tc := range []struct {
+		typ string
+		m   Match
+	}{
+		{typ: "strict", m: Match{Strict: "must.match"}},
+		{typ: "regexp", m: Match{Regexp: "must.*"}},
+		{typ: "expr", m: Match{Expr: "item == 'must.match'"}},
+	} {
+		t.Run(tc.typ, func(t *testing.T) {
+			tc.m.FirstOnly = true
+			shouldLog, err := eval.evaluateMatch(tc.m, "must.match", "some.status", receiverID, endpointID)
+			require.NoError(t, err)
+			require.True(t, shouldLog)
+
+			shouldLog, err = eval.evaluateMatch(tc.m, "must.match", "some.status", receiverID, endpointID)
+			require.NoError(t, err)
+			require.False(t, shouldLog)
+
+			shouldLog, err = eval.evaluateMatch(tc.m, "must.match", "some.status", anotherReceiverID, endpointID)
+			require.NoError(t, err)
+			require.True(t, shouldLog)
+
+			tc.m.FirstOnly = false
+			shouldLog, err = eval.evaluateMatch(tc.m, "must.match", "some.status", receiverID, endpointID)
+			require.NoError(t, err)
+			require.True(t, shouldLog)
+
+			shouldLog, err = eval.evaluateMatch(tc.m, "doesn't.match", "another.status", receiverID, endpointID)
+			require.NoError(t, err)
+			require.False(t, shouldLog)
+		})
+	}
+}
+
+func TestEvaluateInvalidMatch(t *testing.T) {
+	eval, receiverID, endpointID := setup(t)
+
+	for _, tc := range []struct {
+		typ           string
+		expectedError string
+		m             Match
+	}{
+		{typ: "regexp", m: Match{Regexp: "*"}, expectedError: "invalid match regexp statement: error parsing regexp: missing argument to repetition operator: `*`"},
+		{typ: "expr", m: Match{Expr: "not_a_thing"}, expectedError: "invalid match expr statement: unknown name not_a_thing (1:1)\n | not_a_thing\n | ^"},
+	} {
+		t.Run(tc.typ, func(t *testing.T) {
+			tc.m.FirstOnly = true
+			shouldLog, err := eval.evaluateMatch(tc.m, "a.pattern", "some.status", receiverID, endpointID)
+			require.EqualError(t, err, tc.expectedError)
+			require.False(t, shouldLog)
+		})
+	}
+}
+
+func TestCorrelateResourceAttrs(t *testing.T) {
+	for _, embed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("embed-%v", embed), func(t *testing.T) {
+			eval, _, endpointID := setup(t)
+			eval.config.EmbedReceiverConfig = embed
+
+			endpoint := observer.Endpoint{ID: endpointID}
+			observerID := config.NewComponentIDWithName("type", "name")
+			eval.correlations.UpdateEndpoint(endpoint, addedState, observerID)
+
+			corr := eval.correlations.GetOrCreate(statussources.NoType, endpointID)
+
+			from := pcommon.NewMapFromRaw(
+				map[string]interface{}{
+					"one": "one.val",
+					"two": 2,
+				})
+
+			to := pcommon.NewMap()
+
+			require.Empty(t, eval.correlations.Attrs(statussources.NoType))
+			eval.correlateResourceAttributes(from, to, corr)
+
+			expectedResourceAttrs := map[string]any{
+				"one":                   "one.val",
+				"two":                   int64(2),
+				"discovery.observer.id": "type/name",
+			}
+
+			encodedWatchObserver := base64.StdEncoding.EncodeToString([]byte("watch_observers:\n- type/name\n"))
+			if embed {
+				expectedResourceAttrs["discovery.receiver.config"] = encodedWatchObserver
+			}
+
+			require.Equal(t, expectedResourceAttrs, to.AsRaw())
+
+			attrs := eval.correlations.Attrs(statussources.NoType)
+
+			expectedAttrs := map[string]string{}
+			if embed {
+				expectedAttrs["discovery.receiver.updated.config"] = encodedWatchObserver
+			}
+
+			require.Equal(t, expectedAttrs, attrs)
+		})
+	}
+}
+
+func TestCorrelateResourceAttrsWithExistingConfig(t *testing.T) {
+	for _, embed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("embed-%v", embed), func(t *testing.T) {
+			eval, _, endpointID := setup(t)
+			eval.config.EmbedReceiverConfig = embed
+
+			endpoint := observer.Endpoint{ID: endpointID}
+			observerID := config.NewComponentIDWithName("type", "name")
+			eval.correlations.UpdateEndpoint(endpoint, addedState, observerID)
+
+			corr := eval.correlations.GetOrCreate(statussources.NoType, endpointID)
+
+			encodedConfig := base64.StdEncoding.EncodeToString([]byte("config: some config\nrule: some rule\n"))
+
+			from := pcommon.NewMapFromRaw(
+				map[string]interface{}{
+					"discovery.receiver.config": encodedConfig,
+					"one":                       "one.val",
+					"two":                       2,
+				})
+
+			to := pcommon.NewMap()
+
+			require.Empty(t, eval.correlations.Attrs(statussources.NoType))
+			eval.correlateResourceAttributes(from, to, corr)
+
+			var receiverConfig string
+			if embed {
+				receiverConfig = base64.StdEncoding.EncodeToString([]byte("config: some config\nrule: some rule\nwatch_observers:\n- type/name\n"))
+			} else {
+				receiverConfig = encodedConfig
+			}
+
+			expectedResourceAttrs := map[string]any{
+				"one":                       "one.val",
+				"two":                       int64(2),
+				"discovery.observer.id":     "type/name",
+				"discovery.receiver.config": receiverConfig,
+			}
+
+			require.Equal(t, expectedResourceAttrs, to.AsRaw())
+
+			attrs := eval.correlations.Attrs(statussources.NoType)
+			expectedAttrs := map[string]string{}
+
+			if embed {
+				expectedAttrs["discovery.receiver.updated.config"] = receiverConfig
+			}
+
+			require.Equal(t, expectedAttrs, attrs)
+		})
+	}
+}

--- a/internal/receiver/discoveryreceiver/factory.go
+++ b/internal/receiver/discoveryreceiver/factory.go
@@ -16,6 +16,7 @@ package discoveryreceiver
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
@@ -38,6 +39,7 @@ func createDefaultConfig() config.Receiver {
 		ReceiverSettings:    config.NewReceiverSettings(config.NewComponentID(typeStr)),
 		LogEndpoints:        false,
 		EmbedReceiverConfig: false,
+		CorrelationTTL:      10 * time.Minute,
 	}
 }
 

--- a/internal/receiver/discoveryreceiver/factory_test.go
+++ b/internal/receiver/discoveryreceiver/factory_test.go
@@ -17,6 +17,7 @@ package discoveryreceiver
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,6 +36,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 		ReceiverSettings:    config.NewReceiverSettings(config.NewComponentID(typeStr)),
 		LogEndpoints:        false,
 		EmbedReceiverConfig: false,
+		CorrelationTTL:      10 * time.Minute,
 	}, cfg)
 }
 

--- a/internal/receiver/discoveryreceiver/statussources/common.go
+++ b/internal/receiver/discoveryreceiver/statussources/common.go
@@ -1,0 +1,25 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statussources
+
+import "go.opentelemetry.io/collector/config"
+
+const (
+	EndpointIDAttr   = "discovery.endpoint.id"
+	ReceiverNameAttr = "discovery.receiver.name"
+	ReceiverTypeAttr = "discovery.receiver.type"
+)
+
+var NoType = config.NewComponentID("")

--- a/internal/receiver/discoveryreceiver/testdata/config.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/config.yaml
@@ -5,6 +5,7 @@ receivers:
       - another_observer/with_name
     log_endpoints: true
     embed_receiver_config: true
+    correlation_ttl: 25s
     receivers:
       smartagent/redis:
         rule: type == "container"


### PR DESCRIPTION
These changes introduce a basic evaluator to be later used in metric and statement evaluation, and a correlation system for ensuring that all receiver/endpoint/observer activity is accessible by any one applicable element of the component. This is in preparation for a future PR that actually evaluates metrics and statements for the purposes of emitting log records.