### PR TITLE
discovery receiver: add metrics evaluation

### DIFF
--- a/internal/receiver/discoveryreceiver/metric_evaluator.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator.go
@@ -16,26 +16,198 @@ package discoveryreceiver
 
 import (
 	"context"
+	"fmt"
+	"sync"
+	"time"
 
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/signalfx/splunk-otel-collector/internal/receiver/discoveryreceiver/statussources"
 )
 
 var _ consumer.Metrics = (*metricEvaluator)(nil)
 
+const (
+	metricMatch = "metric.match"
+)
+
+var (
+	jsonMarshaler = pmetric.NewJSONMarshaler()
+)
+
 // metricEvaluator conforms to a consumer.Metrics to receive any metrics from
 // receiver creator-created receivers and determine if they match any configured
 // Status match rules. If so, they emit log records for the matching metric.
-type metricEvaluator struct{}
+type metricEvaluator struct {
+	*evaluator
+	pLogs chan plog.Logs
+}
 
-func newMetricEvaluator() *metricEvaluator {
-	return &metricEvaluator{}
+func newMetricEvaluator(logger *zap.Logger, cfg *Config, pLogs chan plog.Logs, correlations correlationStore) *metricEvaluator {
+	return &metricEvaluator{
+		pLogs: pLogs,
+		evaluator: &evaluator{
+			logger:        logger,
+			config:        cfg,
+			correlations:  correlations,
+			alreadyLogged: &sync.Map{},
+			// TODO: provide more capable env w/ resource and metric attributes
+			exprEnv: func(pattern string) map[string]any {
+				return map[string]any{"name": pattern}
+			},
+		},
+	}
 }
 
 func (m *metricEvaluator) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{}
 }
 
-func (m *metricEvaluator) ConsumeMetrics(context.Context, pmetric.Metrics) error {
+func (m *metricEvaluator) ConsumeMetrics(_ context.Context, md pmetric.Metrics) error {
+	if pLogs := m.evaluateMetrics(md); pLogs.LogRecordCount() > 0 {
+		m.pLogs <- pLogs
+	}
 	return nil
+}
+
+func (m *metricEvaluator) evaluateMetrics(md pmetric.Metrics) plog.Logs {
+	if ce := m.logger.Check(zapcore.DebugLevel, "evaluating metrics"); ce != nil {
+		if mbytes, err := jsonMarshaler.MarshalMetrics(md); err == nil {
+			ce.Write(zap.ByteString("metrics", mbytes))
+		} else {
+			m.logger.Debug("failed json-marshaling metrics for logging", zap.Error(err))
+		}
+	}
+	pLogs := plog.NewLogs()
+	if md.MetricCount() == 0 {
+		return pLogs
+	}
+
+	receiverID, endpointID := statussources.MetricsToReceiverIDs(md)
+	if receiverID == statussources.NoType || endpointID == "" {
+		m.logger.Debug("unable to evaluate metrics from receiver without corresponding name or Endpoint.ID", zap.Any("metrics", md))
+		return pLogs
+	}
+
+	rEntry, ok := m.config.Receivers[receiverID]
+	if !ok {
+		m.logger.Info("No matching configured receiver for metric status evaluation", zap.String("receiver", receiverID.String()))
+		return pLogs
+	}
+	if rEntry.Status == nil || len(rEntry.Status.Metrics) == 0 {
+		return pLogs
+	}
+	var matchFound bool
+
+	stagePLogs := plog.NewLogs()
+	rLog := stagePLogs.ResourceLogs().AppendEmpty()
+	rAttrs := rLog.Resource().Attributes()
+	m.correlateResourceAttributes(
+		md.ResourceMetrics().At(0).Resource().Attributes(), rAttrs,
+		m.correlations.GetOrCreate(receiverID, endpointID),
+	)
+	rAttrs.InsertString(eventTypeAttr, metricMatch)
+	rAttrs.InsertString(receiverRuleAttr, rEntry.Rule)
+
+	logRecords := rLog.ScopeLogs().AppendEmpty().LogRecords()
+
+	receiverMetrics := map[string][]pmetric.Metric{}
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				m := sm.Metrics().At(k)
+				receiverMetrics[m.Name()] = append(receiverMetrics[m.Name()], m)
+			}
+		}
+	}
+
+	for status, matches := range rEntry.Status.Metrics {
+		for _, match := range matches {
+			for metricName, metrics := range receiverMetrics {
+				for _, metric := range metrics {
+					if shouldLog, err := m.evaluateMatch(match, metricName, status, receiverID, endpointID); err != nil {
+						m.logger.Info(fmt.Sprintf("Error evaluating %s metric match", status), zap.Error(err))
+						continue
+					} else if !shouldLog {
+						continue
+					}
+					matchFound = true
+					logRecord := logRecords.AppendEmpty()
+					desiredRecord := match.Record
+					if desiredRecord == nil {
+						desiredRecord = &LogRecord{}
+					}
+					var desiredBody string
+					if desiredRecord.Body != "" {
+						desiredBody = desiredRecord.Body
+					}
+					logRecord.Body().SetStringVal(desiredBody)
+					for k, v := range desiredRecord.Attributes {
+						logRecord.Attributes().InsertString(k, v)
+					}
+					severityText := desiredRecord.SeverityText
+					if severityText == "" {
+						severityText = "info"
+					}
+					logRecord.SetSeverityText(severityText)
+					logRecord.Attributes().InsertString(metricNameAttr, metricName)
+					logRecord.Attributes().UpsertString(statusAttr, status)
+					if ts := m.timestampFromMetric(metric); ts != nil {
+						logRecord.SetTimestamp(*ts)
+					}
+					logRecord.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+				}
+			}
+		}
+	}
+	if matchFound {
+		pLogs = stagePLogs
+	}
+	return pLogs
+}
+
+func (m *metricEvaluator) timestampFromMetric(metric pmetric.Metric) *pcommon.Timestamp {
+	var ts *pcommon.Timestamp
+	switch dt := metric.DataType(); dt {
+	case pmetric.MetricDataTypeGauge:
+		dps := metric.Gauge().DataPoints()
+		if dps.Len() > 0 {
+			t := dps.At(0).Timestamp()
+			ts = &t
+		}
+	case pmetric.MetricDataTypeSum:
+		dps := metric.Sum().DataPoints()
+		if dps.Len() > 0 {
+			t := dps.At(0).Timestamp()
+			ts = &t
+		}
+	case pmetric.MetricDataTypeHistogram:
+		dps := metric.Histogram().DataPoints()
+		if dps.Len() > 0 {
+			t := dps.At(0).Timestamp()
+			ts = &t
+		}
+	case pmetric.MetricDataTypeExponentialHistogram:
+		dps := metric.ExponentialHistogram().DataPoints()
+		if dps.Len() > 0 {
+			t := dps.At(0).Timestamp()
+			ts = &t
+		}
+	case pmetric.MetricDataTypeSummary:
+		dps := metric.Summary().DataPoints()
+		if dps.Len() > 0 {
+			t := dps.At(0).Timestamp()
+			ts = &t
+		}
+	default:
+		m.logger.Debug("cannot get timestamp from data type", zap.String("data type", dt.String()))
+	}
+	return ts
 }

--- a/internal/receiver/discoveryreceiver/metric_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator_test.go
@@ -1,0 +1,217 @@
+// Copyright  Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoveryreceiver
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestMetricEvaluatorBaseMetricConsumer(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	cfg := &Config{}
+	plogs := make(chan plog.Logs)
+	cStore := newCorrelationStore(logger, time.Hour)
+
+	me := newMetricEvaluator(logger, cfg, plogs, cStore)
+	require.Equal(t, consumer.Capabilities{}, me.Capabilities())
+
+	md := pmetric.NewMetrics()
+	require.NoError(t, me.ConsumeMetrics(context.Background(), md))
+}
+
+func TestMetricEvaluation(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	for _, tc := range []struct {
+		name  string
+		match Match
+	}{
+		{name: "strict", match: Match{Strict: "desired.name"}},
+		{name: "regexp", match: Match{Regexp: "^d[esired]{6}.name$"}},
+		{name: "expr", match: Match{Expr: "name == 'desired.name'"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			match := tc.match
+			match.Record = &LogRecord{
+				Body: "desired body content",
+				Attributes: map[string]string{
+					"one": "one.value", "two": "two.value",
+				},
+			}
+			for _, status := range []string{"successful", "partial", "failed"} {
+				t.Run(status, func(t *testing.T) {
+					for _, firstOnly := range []bool{true, false} {
+						match.FirstOnly = firstOnly
+						t.Run(fmt.Sprintf("FirstOnly:%v", firstOnly), func(t *testing.T) {
+							observerID := config.NewComponentIDWithName("an.observer", "observer.name")
+							cfg := &Config{
+								Receivers: map[config.ComponentID]ReceiverEntry{
+									config.NewComponentIDWithName("a.receiver", "receiver.name"): {
+										Rule:   "a.rule",
+										Status: &Status{Metrics: map[string][]Match{status: {match}}},
+									},
+								},
+								WatchObservers: []config.ComponentID{observerID},
+							}
+							require.NoError(t, cfg.Validate())
+
+							plogs := make(chan plog.Logs)
+							cStore := newCorrelationStore(logger, time.Hour)
+							cStore.UpdateEndpoint(
+								observer.Endpoint{ID: "endpoint.id"},
+								addedState, observerID,
+							)
+
+							me := newMetricEvaluator(logger, cfg, plogs, cStore)
+
+							md := pmetric.NewMetrics()
+							rm := md.ResourceMetrics().AppendEmpty()
+
+							rAttrs := rm.Resource().Attributes()
+							rAttrs.UpsertString("discovery.receiver.type", "a.receiver")
+							rAttrs.UpsertString("discovery.receiver.name", "receiver.name")
+							rAttrs.UpsertString("discovery.endpoint.id", "endpoint.id")
+
+							sm := rm.ScopeMetrics().AppendEmpty()
+							sms := sm.Metrics()
+							sms.AppendEmpty().SetName("undesired.name")
+							sms.AppendEmpty().SetName("another.undesired.name")
+							sms.AppendEmpty().SetName("desired.name")
+							sms.AppendEmpty().SetName("desired.name")
+							sms.AppendEmpty().SetName("desired.name")
+
+							emitted := me.evaluateMetrics(md)
+
+							numExpected := 1
+							if !firstOnly {
+								numExpected = 3
+							}
+							require.Equal(t, numExpected, emitted.LogRecordCount())
+
+							rl := emitted.ResourceLogs().At(0)
+							rAttrs = rl.Resource().Attributes()
+							require.Equal(t, map[string]any{
+								"discovery.endpoint.id":   "endpoint.id",
+								"discovery.event.type":    "metric.match",
+								"discovery.observer.id":   "an.observer/observer.name",
+								"discovery.receiver.name": "receiver.name",
+								"discovery.receiver.rule": "a.rule",
+								"discovery.receiver.type": "a.receiver",
+							}, rAttrs.AsRaw())
+
+							sLogs := rl.ScopeLogs()
+							require.Equal(t, 1, sLogs.Len())
+							sl := sLogs.At(0)
+							lrs := sl.LogRecords()
+							require.Equal(t, numExpected, lrs.Len())
+							for i := 0; i < numExpected; i++ {
+								lr := sl.LogRecords().At(0)
+
+								lrAttrs := lr.Attributes()
+								require.Equal(t, map[string]any{
+									"discovery.status": status,
+									"metric.name":      "desired.name",
+									"one":              "one.value",
+									"two":              "two.value",
+								}, lrAttrs.AsRaw())
+
+								require.Equal(t, "desired body content", lr.Body().AsString())
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestTimestampFromMetric(t *testing.T) {
+	expectedTime := pcommon.NewTimestampFromTime(time.Now())
+	for _, test := range []struct {
+		metricFunc func(pmetric.Metric) (shouldBeNil bool)
+		name       string
+	}{
+		{name: "MetricDataTypeGauge", metricFunc: func(md pmetric.Metric) bool {
+			md.SetDataType(pmetric.MetricDataTypeGauge)
+			md.Gauge().DataPoints().AppendEmpty().SetTimestamp(expectedTime)
+			return false
+		}},
+		{name: "empty MetricDataTypeGauge", metricFunc: func(md pmetric.Metric) bool {
+			md.SetDataType(pmetric.MetricDataTypeGauge)
+			return true
+		}},
+		{name: "MetricDataTypeSum", metricFunc: func(md pmetric.Metric) bool {
+			md.SetDataType(pmetric.MetricDataTypeSum)
+			md.Sum().DataPoints().AppendEmpty().SetTimestamp(expectedTime)
+			return false
+		}},
+		{name: "empty MetricDataTypeSum", metricFunc: func(md pmetric.Metric) bool {
+			md.SetDataType(pmetric.MetricDataTypeSum)
+			return true
+		}},
+		{name: "MetricDataTypeHistogram", metricFunc: func(md pmetric.Metric) bool {
+			md.SetDataType(pmetric.MetricDataTypeHistogram)
+			md.Histogram().DataPoints().AppendEmpty().SetTimestamp(expectedTime)
+			return false
+		}},
+		{name: "empty MetricDataTypeHistogram", metricFunc: func(md pmetric.Metric) bool {
+			md.SetDataType(pmetric.MetricDataTypeHistogram)
+			return true
+		}},
+		{name: "MetricDataTypeExponentialHistogram", metricFunc: func(md pmetric.Metric) bool {
+			md.SetDataType(pmetric.MetricDataTypeExponentialHistogram)
+			md.ExponentialHistogram().DataPoints().AppendEmpty().SetTimestamp(expectedTime)
+			return false
+		}},
+		{name: "empty MetricDataTypeExponentialHistogram", metricFunc: func(md pmetric.Metric) bool {
+			md.SetDataType(pmetric.MetricDataTypeExponentialHistogram)
+			return true
+		}},
+		{name: "MetricDataTypeSummary", metricFunc: func(md pmetric.Metric) bool {
+			md.SetDataType(pmetric.MetricDataTypeSummary)
+			md.Summary().DataPoints().AppendEmpty().SetTimestamp(expectedTime)
+			return false
+		}},
+		{name: "empty MetricDataTypeSummary", metricFunc: func(md pmetric.Metric) bool {
+			md.SetDataType(pmetric.MetricDataTypeSummary)
+			return true
+		}},
+		{name: "MetricDataTypeNone", metricFunc: func(md pmetric.Metric) bool { return true }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			me := newMetricEvaluator(zaptest.NewLogger(t), &Config{}, make(chan plog.Logs), nil)
+			md := pmetric.NewMetrics().ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+			shouldBeNil := test.metricFunc(md)
+			actual := me.timestampFromMetric(md)
+			if shouldBeNil {
+				require.Nil(t, actual)
+			} else {
+				require.NotNil(t, actual)
+				require.Equal(t, expectedTime, *actual)
+			}
+		})
+	}
+}

--- a/internal/receiver/discoveryreceiver/receiver.go
+++ b/internal/receiver/discoveryreceiver/receiver.go
@@ -33,11 +33,13 @@ import (
 
 const (
 	eventTypeAttr             = "discovery.event.type"
+	metricNameAttr            = "metric.name"
 	observerNameAttr          = "discovery.observer.name"
 	observerTypeAttr          = "discovery.observer.type"
 	receiverConfigAttr        = "discovery.receiver.config"
-	receiverUpdatedConfigAttr = "discovery.receiver.updated.config"
 	receiverRuleAttr          = "discovery.receiver.rule"
+	receiverUpdatedConfigAttr = "discovery.receiver.updated.config"
+	statusAttr                = "discovery.status"
 )
 
 var (
@@ -93,7 +95,7 @@ func (d *discoveryReceiver) Start(ctx context.Context, host component.Host) (err
 	d.endpointTracker = newEndpointTracker(d.observables, d.config, d.logger, d.pLogs, correlations)
 	d.endpointTracker.start()
 
-	d.metricEvaluator = newMetricEvaluator()
+	d.metricEvaluator = newMetricEvaluator(d.logger, d.config, d.pLogs, correlations)
 
 	if err = d.createAndSetReceiverCreator(); err != nil {
 		return fmt.Errorf("failed creating internal receiver_creator: %w", err)

--- a/internal/receiver/discoveryreceiver/statussources/metrics.go
+++ b/internal/receiver/discoveryreceiver/statussources/metrics.go
@@ -1,0 +1,40 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statussources
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// MetricsToReceiverIDs extracts the identifiers receiver creator created receivers will embed in their attributes
+func MetricsToReceiverIDs(md pmetric.Metrics) (config.ComponentID, observer.EndpointID) {
+	var receiverType, receiverName, endpointID string
+	if md.ResourceMetrics().Len() > 0 {
+		resourceMetrics := md.ResourceMetrics().At(0)
+		mResAttrs := resourceMetrics.Resource().Attributes()
+		if r, ok := mResAttrs.Get(ReceiverTypeAttr); ok {
+			receiverType = r.AsString()
+		}
+		if r, ok := mResAttrs.Get(ReceiverNameAttr); ok {
+			receiverName = r.AsString()
+		}
+		if r, ok := mResAttrs.Get(EndpointIDAttr); ok {
+			endpointID = r.AsString()
+		}
+	}
+	return config.NewComponentIDWithName(config.Type(receiverType), receiverName), observer.EndpointID(endpointID)
+}

--- a/internal/receiver/discoveryreceiver/statussources/metrics_test.go
+++ b/internal/receiver/discoveryreceiver/statussources/metrics_test.go
@@ -1,0 +1,102 @@
+// Copyright  Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statussources
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestMetricsToReceiverIDs(t *testing.T) {
+	for _, tc := range []struct {
+		rType *string
+		rName *string
+		eID   *string
+		name  string
+	}{
+		{name: "happy path", rType: sPtr("a.type"), rName: sPtr("a.name"), eID: sPtr("an.endpoint")},
+		{name: "empty values", rType: sPtr(""), rName: sPtr(""), eID: sPtr("")},
+		{name: "missing values", rType: nil, rName: nil, eID: nil},
+		{name: "empty receiver type", rType: sPtr(""), rName: sPtr("a.name"), eID: sPtr("an.endpoint")},
+		{name: "missing receiver type", rType: nil, rName: sPtr("a.name"), eID: sPtr("an.endpoint")},
+		{name: "empty receiver name", rType: sPtr("a.type"), rName: sPtr(""), eID: sPtr("an.endpoint")},
+		{name: "missing receiver name", rType: sPtr("a.type"), rName: nil, eID: sPtr("an.endpoint")},
+		{name: "empty endpointID", rType: sPtr("a.type"), rName: sPtr("a.name"), eID: sPtr("")},
+		{name: "missing endpointID", rType: sPtr("a.type"), rName: sPtr("a.name"), eID: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			md := pmetric.NewMetrics()
+			rm := md.ResourceMetrics().AppendEmpty()
+			rAttrs := rm.Resource().Attributes()
+
+			if tc.rType != nil {
+				rAttrs.UpsertString("discovery.receiver.type", *tc.rType)
+			}
+			if tc.rName != nil {
+				rAttrs.UpsertString("discovery.receiver.name", *tc.rName)
+			}
+			if tc.eID != nil {
+				rAttrs.UpsertString("discovery.endpoint.id", *tc.eID)
+			}
+
+			receiverID, endpointID := MetricsToReceiverIDs(md)
+
+			var expectedRType string
+			if tc.rType != nil {
+				expectedRType = *tc.rType
+			}
+			require.Equal(t, config.Type(expectedRType), receiverID.Type())
+
+			var expectedRName string
+			if tc.rName != nil {
+				expectedRName = *tc.rName
+			}
+			require.Equal(t, expectedRName, receiverID.Name())
+
+			var expectedEndpointID string
+			if tc.eID != nil {
+				expectedEndpointID = *tc.eID
+			}
+			require.Equal(t, observer.EndpointID(expectedEndpointID), endpointID)
+		})
+	}
+}
+
+func TestMetricsToReceiverIDsMissingRMetrics(t *testing.T) {
+	md := pmetric.NewMetrics()
+	receiverID, endpointID := MetricsToReceiverIDs(md)
+	require.Equal(t, config.Type(""), receiverID.Type())
+	require.Equal(t, "", receiverID.Name())
+	require.Equal(t, observer.EndpointID(""), endpointID)
+}
+
+func TestMetricsToReceiverIDsMissingRAttributes(t *testing.T) {
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().Clear()
+
+	receiverID, endpointID := MetricsToReceiverIDs(md)
+	require.Equal(t, config.Type(""), receiverID.Type())
+	require.Equal(t, "", receiverID.Name())
+	require.Equal(t, observer.EndpointID(""), endpointID)
+}
+
+func sPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
These changes add metric consumption, evaluation, and log record emission to the discovery receiver. They require https://github.com/signalfx/splunk-otel-collector/pull/1971.