### PR TITLE
discovery receiver: add statement evaluation

### DIFF
--- a/internal/receiver/discoveryreceiver/statement_evaluator.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator.go
@@ -1,0 +1,234 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoveryreceiver
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/signalfx/splunk-otel-collector/internal/receiver/discoveryreceiver/statussources"
+)
+
+var _ zapcore.Core = (*statementEvaluator)(nil)
+
+const (
+	statementMatch      = "statement.match"
+	defaultSeverityText = "INFO"
+)
+
+// statementEvaluator conforms to a zapcore.Core to intercept component log statements and
+// determine if they match any configured Status match rules. If so, they emit log records
+// for the matching statement.
+type statementEvaluator struct {
+	*evaluator
+	pLogs chan plog.Logs
+	// this is the logger to share with other components to evaluate their statements and produce plog.Logs
+	evaluatedLogger *zap.Logger
+	encoder         zapcore.Encoder
+}
+
+func newStatementEvaluator(logger *zap.Logger, config *Config, pLogs chan plog.Logs, correlations correlationStore) (*statementEvaluator, error) {
+	zapConfig := zap.NewProductionConfig()
+	zapConfig.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
+	zapConfig.Sampling.Initial = 1
+	zapConfig.Sampling.Thereafter = 1
+	encoder := statussources.NewZapCoreEncoder()
+
+	se := &statementEvaluator{
+		pLogs: pLogs,
+		evaluator: &evaluator{
+			logger:        logger,
+			config:        config,
+			correlations:  correlations,
+			alreadyLogged: &sync.Map{},
+			// TODO: provide more capable env w/ resource and log record attributes
+			exprEnv: func(pattern string) map[string]any {
+				return map[string]any{"msg": pattern}
+			},
+		},
+		encoder: encoder,
+	}
+	var err error
+	if se.evaluatedLogger, err = zapConfig.Build(
+		// zap.OnFatal must not be WriteThenFatal or WriteThenNoop since it's rewritten to be WriteThenFatal
+		// https://github.com/uber-go/zap/blob/e06e09a6d396031c89b87383eef3cad6f647cf2c/logger.go#L315.
+		// Using an arbitrary action offset.
+		zap.WithFatalHook(zapcore.WriteThenFatal+100),
+		zap.WrapCore(func(core zapcore.Core) zapcore.Core { return se }),
+	); err != nil {
+		return nil, err
+	}
+	return se, nil
+}
+
+// Enabled is a zapcore.Core method. We should be enabled for all
+// levels since we want to intercept all statements.
+func (se *statementEvaluator) Enabled(zapcore.Level) bool {
+	return true
+}
+
+// With is a zapcore.Core method. We clone ourselves so all
+// modified downstream loggers are still evaluated.
+func (se *statementEvaluator) With(fields []zapcore.Field) zapcore.Core {
+	cp := *se
+	cp.encoder = se.encoder.Clone()
+	for i := range fields {
+		fields[i].AddTo(cp.encoder)
+	}
+	return &cp
+}
+
+// Check is a zapcore.Core method. Similar to Enabled() we want to
+// return a valid CheckedEntry for all logging attempts to intercept
+// all statements.
+func (se *statementEvaluator) Check(entry zapcore.Entry, checkedEntry *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	return checkedEntry.AddCore(entry, se)
+}
+
+// Write is a zapcore.Core method. This is where the logged entry
+// is converted to a statussources.Statement, if from a downstream receiver,
+// and its content is evaluated for status matches and plog.Logs translation/submission.
+func (se *statementEvaluator) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	statement, err := statussources.StatementFromZapCoreEntry(se.encoder, entry, fields)
+	if err != nil {
+		return err
+	}
+	if name, ok := statement.Fields["name"]; ok {
+		if cid, err := config.NewComponentIDFromString(fmt.Sprintf("%v", name)); err == nil {
+			if cid.Type() == "receiver_creator" && cid.Name() == se.config.ID().String() {
+				// this is from our internal Receiver Creator and not a generated receiver, so write
+				// it to our logger core without submitting the entry for evaluation
+				if ce := se.logger.Check(entry.Level, ""); ce != nil {
+					// forward to our logger now that we know entry.Level is accepted
+					_ = se.logger.Core().Write(entry, fields)
+				}
+				return nil
+			}
+		}
+	}
+
+	if pLogs := se.evaluateStatement(statement); pLogs.LogRecordCount() > 0 {
+		se.pLogs <- pLogs
+	}
+
+	return nil
+}
+
+// Sync is a zapcore.Core method.
+func (se *statementEvaluator) Sync() error {
+	return nil
+}
+
+// evaluateStatement will convert the provided statussources.Statement into a plog.LogRecord
+// and match it against the applicable configured ReceiverEntry's status Statement.[]Match
+func (se *statementEvaluator) evaluateStatement(statement *statussources.Statement) plog.Logs {
+	se.logger.Debug("evaluating statement", zap.Any("statement", statement))
+	pLogs := plog.NewLogs()
+
+	statementLogRecord := statement.ToLogRecord()
+	receiverID, endpointID, rEntry, shouldEvaluate := se.receiverEntryFromLogRecord(statementLogRecord)
+	if !shouldEvaluate {
+		return pLogs
+	}
+
+	stagePLogs, logRecords := se.prepareMatchingLogs(rEntry, receiverID, endpointID)
+	body := statementLogRecord.Body().AsString()
+
+	var matchFound bool
+	for status, matches := range rEntry.Status.Statements {
+		for _, match := range matches {
+			if shouldLog, err := se.evaluateMatch(match, body, status, receiverID, endpointID); err != nil {
+				se.logger.Info(fmt.Sprintf("Error evaluating %s statement match", status), zap.Error(err))
+				continue
+			} else if !shouldLog {
+				continue
+			}
+			matchFound = true
+			logRecord := logRecords.AppendEmpty()
+			var desiredRecord LogRecord
+			if match.Record != nil {
+				desiredRecord = *match.Record
+			}
+			statementLogRecord.CopyTo(logRecord)
+			if desiredRecord.Body != "" {
+				logRecord.Body().SetStr(desiredRecord.Body)
+			}
+			if len(desiredRecord.Attributes) > 0 {
+				for k, v := range desiredRecord.Attributes {
+					logRecord.Attributes().PutString(k, v)
+				}
+			}
+			severityText := desiredRecord.SeverityText
+			if severityText == "" {
+				severityText = logRecord.SeverityText()
+				if severityText == "" {
+					severityText = defaultSeverityText
+				}
+			}
+			logRecord.SetSeverityText(severityText)
+			logRecord.Attributes().PutString(statusAttr, status)
+			logRecord.SetTimestamp(pcommon.NewTimestampFromTime(statement.Time))
+			logRecord.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		}
+	}
+
+	if matchFound {
+		pLogs = stagePLogs
+	}
+	return pLogs
+}
+
+func (se *statementEvaluator) receiverEntryFromLogRecord(record plog.LogRecord) (config.ComponentID, observer.EndpointID, ReceiverEntry, bool) {
+	receiverID, endpointID := statussources.ReceiverNameToIDs(record)
+	if receiverID == statussources.NoType || endpointID == "" {
+		// statement evaluation requires both a populated receiver.ID and EndpointID
+		se.logger.Debug("unable to evaluate statement from receiver", zap.String("receiver", receiverID.String()))
+		return statussources.NoType, "", ReceiverEntry{}, false
+	}
+
+	rEntry, ok := se.config.Receivers[receiverID]
+	if !ok {
+		se.logger.Info("No matching configured receiver for statement status evaluation", zap.String("receiver", receiverID.String()))
+		return statussources.NoType, "", ReceiverEntry{}, false
+	}
+
+	if rEntry.Status == nil {
+		return statussources.NoType, "", ReceiverEntry{}, false
+	}
+
+	return receiverID, endpointID, rEntry, true
+}
+
+func (se *statementEvaluator) prepareMatchingLogs(rEntry ReceiverEntry, receiverID config.ComponentID, endpointID observer.EndpointID) (plog.Logs, plog.LogRecordSlice) {
+	stagePLogs := plog.NewLogs()
+	rLog := stagePLogs.ResourceLogs().AppendEmpty()
+	rAttrs := rLog.Resource().Attributes()
+	fromAttrs := pcommon.NewMap()
+	fromAttrs.PutString(statussources.ReceiverTypeAttr, string(receiverID.Type()))
+	fromAttrs.PutString(statussources.ReceiverNameAttr, receiverID.Name())
+	fromAttrs.PutString(statussources.EndpointIDAttr, string(endpointID))
+	se.correlateResourceAttributes(fromAttrs, rAttrs, se.correlations.GetOrCreate(receiverID, endpointID))
+	rAttrs.PutString(eventTypeAttr, statementMatch)
+	rAttrs.PutString(receiverRuleAttr, rEntry.Rule)
+	return stagePLogs, rLog.ScopeLogs().AppendEmpty().LogRecords()
+}

--- a/internal/receiver/discoveryreceiver/statement_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator_test.go
@@ -1,0 +1,246 @@
+// Copyright  Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discoveryreceiver
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/signalfx/splunk-otel-collector/internal/receiver/discoveryreceiver/statussources"
+)
+
+func TestStatementEvaluation(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		match Match
+	}{
+		{name: "strict", match: Match{Strict: "desired.statement"}},
+		{name: "regexp", match: Match{Regexp: "^d[esired]{6}.statement$"}},
+		{name: "expr", match: Match{Expr: "msg == 'desired.statement'"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			match := tc.match
+			match.Record = &LogRecord{
+				Body: "desired body content",
+				Attributes: map[string]string{
+					"one": "one.value", "two": "two.value",
+				},
+			}
+			for _, status := range []string{"successful", "partial", "failed"} {
+				t.Run(status, func(t *testing.T) {
+					for _, level := range []string{"debug", "info", "warn", "error", "fatal", "dpanic", "panic"} {
+						t.Run(level, func(t *testing.T) {
+							for _, firstOnly := range []bool{true, false} {
+								match.FirstOnly = firstOnly
+								t.Run(fmt.Sprintf("FirstOnly:%v", firstOnly), func(t *testing.T) {
+									observerID := config.NewComponentIDWithName("an.observer", "observer.name")
+									cfg := &Config{
+										Receivers: map[config.ComponentID]ReceiverEntry{
+											config.NewComponentIDWithName("a.receiver", "receiver.name"): {
+												Rule:   "a.rule",
+												Status: &Status{Statements: map[string][]Match{status: {match}}},
+											},
+										},
+										WatchObservers: []config.ComponentID{observerID},
+									}
+									require.NoError(t, cfg.Validate())
+
+									plogs := make(chan plog.Logs)
+
+									logger := zaptest.NewLogger(t)
+									cStore := newCorrelationStore(logger, time.Hour)
+									cStore.UpdateEndpoint(
+										observer.Endpoint{ID: "endpoint.id"},
+										addedState, observerID,
+									)
+
+									se, err := newStatementEvaluator(logger, cfg, plogs, cStore)
+									require.NoError(t, err)
+
+									evaluatedLogger := se.evaluatedLogger.With(
+										zap.String("name", `a.receiver/receiver.name/receiver_creator/rc.name/{endpoint=""}/endpoint.id`),
+									)
+
+									numExpected := 1
+									if !firstOnly {
+										numExpected = 3
+									}
+
+									emitted := plog.NewLogs()
+									wg := sync.WaitGroup{}
+									wg.Add(numExpected)
+
+									go func() {
+										timer := time.NewTimer(50 * time.Millisecond)
+										for i := 0; i < numExpected; i++ {
+											select {
+											case logs := <-plogs:
+												if emitted.LogRecordCount() == 0 {
+													emitted = logs
+												} else {
+													logs.ResourceLogs().MoveAndAppendTo(emitted.ResourceLogs())
+												}
+												wg.Done()
+											case <-timer.C:
+												return
+											}
+										}
+									}()
+
+									logMethod := map[string]func(string, ...zap.Field){
+										"debug":  evaluatedLogger.Debug,
+										"info":   evaluatedLogger.Info,
+										"warn":   evaluatedLogger.Warn,
+										"error":  evaluatedLogger.Error,
+										"fatal":  evaluatedLogger.Fatal,
+										"dpanic": evaluatedLogger.DPanic,
+										"panic":  evaluatedLogger.Panic,
+									}[level]
+
+									for _, statement := range []string{
+										"undesired.statement",
+										"another.undesired.statement",
+										"desired.statement",
+										"desired.statement",
+										"desired.statement",
+									} {
+										panicCheck := require.NotPanics
+										if level == "panic" {
+											panicCheck = require.Panics
+										}
+										panicCheck(t, func() {
+											logMethod(statement)
+										})
+									}
+
+									require.Eventually(t, func() bool {
+										wg.Wait()
+										return true
+									}, 50*time.Millisecond, time.Millisecond)
+
+									for i := 0; i < numExpected; i++ {
+										rl := emitted.ResourceLogs().At(i)
+										rAttrs := rl.Resource().Attributes()
+										require.Equal(t, map[string]any{
+											"discovery.endpoint.id":   "endpoint.id",
+											"discovery.event.type":    "statement.match",
+											"discovery.observer.id":   "an.observer/observer.name",
+											"discovery.receiver.name": "receiver.name",
+											"discovery.receiver.rule": "a.rule",
+											"discovery.receiver.type": "a.receiver",
+										}, rAttrs.AsRaw())
+
+										sLogs := rl.ScopeLogs()
+										require.Equal(t, 1, sLogs.Len())
+										sl := sLogs.At(0)
+										lrs := sl.LogRecords()
+										require.Equal(t, 1, lrs.Len())
+										lr := sl.LogRecords().At(0)
+
+										lrAttrs := lr.Attributes().AsRaw()
+
+										require.Contains(t, lrAttrs, "caller")
+										_, expectedFile, _, _ := runtime.Caller(0)
+										// runtime doesn't use os.PathSeparator
+										splitPath := strings.Split(expectedFile, "/")
+										expectedCaller := splitPath[len(splitPath)-1]
+										require.Contains(t, lrAttrs["caller"], expectedCaller)
+										delete(lrAttrs, "caller")
+
+										// argOrder doesn't like this for some reason
+										// nolint:gocritic
+										if strings.Contains("error fatal dpanic panic", level) {
+											require.Contains(t, lrAttrs, "stacktrace")
+											delete(lrAttrs, "stacktrace")
+										}
+
+										require.Equal(t, map[string]any{
+											"discovery.status": status,
+											"name":             `a.receiver/receiver.name/receiver_creator/rc.name/{endpoint=""}/endpoint.id`,
+											"one":              "one.value",
+											"two":              "two.value",
+										}, lrAttrs)
+
+										require.Equal(t, "desired body content", lr.Body().AsString())
+										require.Equal(t, level, lr.SeverityText())
+									}
+								})
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestLogRecordDefaultAndArbitrarySeverityText(t *testing.T) {
+	observerID := config.NewComponentIDWithName("an.observer", "observer.name")
+	cfg := &Config{
+		Receivers: map[config.ComponentID]ReceiverEntry{
+			config.NewComponentIDWithName("a.receiver", "receiver.name"): {
+				Rule:   "a.rule",
+				Status: &Status{Statements: map[string][]Match{"successful": {Match{Strict: "match.me"}}}},
+			},
+		},
+		WatchObservers: []config.ComponentID{observerID},
+	}
+	require.NoError(t, cfg.Validate())
+
+	plogs := make(chan plog.Logs)
+
+	logger := zaptest.NewLogger(t)
+	cStore := newCorrelationStore(logger, time.Hour)
+	cStore.UpdateEndpoint(
+		observer.Endpoint{ID: "endpoint.id"},
+		addedState, observerID,
+	)
+
+	se, err := newStatementEvaluator(logger, cfg, plogs, cStore)
+	require.NoError(t, err)
+	require.NotNil(t, se)
+
+	s := &statussources.Statement{
+		Message:    "match.me",
+		Level:      "",
+		Time:       time.Now(),
+		LoggerName: "logger.name",
+		Fields: map[string]any{
+			"name": `a.receiver/receiver.name/receiver_creator/rc.name/{endpoint=""}/endpoint.id`,
+		},
+	}
+
+	logs := se.evaluateStatement(s)
+	require.Equal(t, 1, logs.LogRecordCount())
+	lr := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	require.Equal(t, "INFO", lr.SeverityText())
+
+	s.Level = "arbitrary level used as severity text"
+	logs = se.evaluateStatement(s)
+	require.Equal(t, 1, logs.LogRecordCount())
+	lr = logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	require.Equal(t, "arbitrary level used as severity text", lr.SeverityText())
+}

--- a/internal/receiver/discoveryreceiver/statussources/statements.go
+++ b/internal/receiver/discoveryreceiver/statussources/statements.go
@@ -1,0 +1,159 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statussources
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
+	"go.uber.org/zap/buffer"
+	"go.uber.org/zap/zapcore"
+)
+
+var (
+	ReceiverCreatorRegexp = regexp.MustCompile(`receiver_creator/`)
+	receiverNameRegexp    = regexp.MustCompile(`^(?P<type>[^/]+)/(?P<name>.*)$`)
+	EndpointTargetRegexp  = regexp.MustCompile(`{endpoint=[^}]*}/`)
+	endpointIDRegexp      = regexp.MustCompile(`^.*{endpoint=.*}/(?P<id>.*)$`)
+	undesiredFields       = []string{"ts", "msg", "level"}
+)
+
+// Statement models a zapcore.Entry but defined here for usability/maintainability
+type Statement struct {
+	Message    string
+	Fields     map[string]any
+	Level      string
+	Time       time.Time
+	LoggerName string
+	Caller     zapcore.EntryCaller
+	Stack      string
+}
+
+func NewZapCoreEncoder() zapcore.Encoder {
+	return zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+}
+
+// StatementFromZapCoreEntry converts the Entry to a Statement using the provided encoder, which is assumed to be
+// a JSONEncoder (unexpected from zapcore) to obtain the target Fields.
+func StatementFromZapCoreEntry(encoder zapcore.Encoder, entry zapcore.Entry, fields []zapcore.Field) (*Statement, error) {
+	statement := &Statement{
+		Message:    entry.Message,
+		Level:      entry.Level.String(),
+		Time:       entry.Time,
+		LoggerName: entry.LoggerName,
+		Caller:     entry.Caller,
+		Stack:      entry.Stack,
+	}
+	var err error
+	var entryBuffer *buffer.Buffer
+
+	if entryBuffer, err = encoder.EncodeEntry(entry, fields); err != nil {
+		return nil, fmt.Errorf("failed encoding zapcore.Entry: %w", err)
+	}
+
+	b := entryBuffer.Bytes()
+	if err = json.Unmarshal(b, &statement.Fields); err != nil {
+		return nil, fmt.Errorf("failed representing encoded zapcore.Entry (%s) as json: %w", b, err)
+	}
+
+	for _, undesiredField := range undesiredFields {
+		delete(statement.Fields, undesiredField)
+	}
+
+	return statement, nil
+}
+
+func (s *Statement) ToLogRecord() plog.LogRecord {
+	logRecord := plog.NewLogRecord()
+	if s == nil {
+		return logRecord
+	}
+
+	logRecord.SetTimestamp(pcommon.NewTimestampFromTime(s.Time))
+	logRecord.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	logRecord.Body().SetStr(s.Message)
+	logRecord.SetSeverityText(s.Level)
+	logRecord.Attributes().FromRaw(s.Fields)
+	return logRecord
+}
+
+// ReceiverNameToIDs parses the zap "name" field value according to
+// outcome of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12670
+// where receiver creator receiver names are of the form
+// `<receiver.type>/<receiver.name>/receiver_creator/<receiver-creator.name>{endpoint="<Endpoint.Target>"}/<Endpoint.ID>`.
+// If receiverName argument is not of this form empty Component and Endpoint IDs are returned.
+func ReceiverNameToIDs(record plog.LogRecord) (receiverID config.ComponentID, endpointID observer.EndpointID) {
+	// The receiver creator sets dynamically created receiver names as the zap "name" field for their component logger.
+	nameAttr, ok := record.Attributes().Get("name")
+	if !ok {
+		// there is nothing we can do without a receiver name
+		return NoType, ""
+	}
+	receiverName := nameAttr.AsString()
+
+	// The receiver creator will log an initial start statement not from the underlying receiver's logger.
+	// These statements have an "endpoint_id" field and the "name" field won't include the necessary "receiver_creator/"
+	// and "{endpoint=<endpoint.Target>}" separators. In this case we get the EndpointID, if any, and form a placeholder name of desired form.
+	if endpointIDAttr, hasEndpointID := record.Attributes().Get("endpoint_id"); hasEndpointID {
+		receiverName = fmt.Sprintf(`%s/receiver_creator/<PLACEHOLDER>/{endpoint="PLACEHOLDER"}/%s`, receiverName, endpointIDAttr.AsString())
+	}
+
+	// receiver creator generated and altered initial endpoint handler message names must contain
+	// one "receiver_creator" and one "{endpoint=<Endpoint.Target>}" separator or are unable to be decomposed
+	for _, re := range []*regexp.Regexp{ReceiverCreatorRegexp, EndpointTargetRegexp} {
+		if matches := re.FindAllStringSubmatch(receiverName, -1); len(matches) != 1 {
+			return NoType, ""
+		}
+	}
+
+	var rcIdx int
+	if rcIdx = strings.Index(receiverName, "receiver_creator/"); rcIdx == -1 {
+		// previous check enforces this to not be the case but for good measure
+		return NoType, ""
+	}
+	nameSection := receiverName[:rcIdx]
+	endpointSection := receiverName[rcIdx:]
+
+	var nameMatches []string
+	if nameMatches = receiverNameRegexp.FindStringSubmatch(nameSection); len(nameMatches) < 2 {
+		return NoType, ""
+	}
+	rType := nameMatches[1]
+
+	var nameCandidate string
+	if len(nameMatches) > 2 {
+		nameCandidate = nameMatches[2]
+	}
+	var rName string
+	if nameCandidate != "" {
+		rName = nameCandidate
+		if nameCandidate[len(nameCandidate)-1] == '/' {
+			rName = nameCandidate[0 : len(nameCandidate)-1]
+		}
+	}
+	var eID string
+	if endpointMatches := endpointIDRegexp.FindStringSubmatch(endpointSection); len(endpointMatches) > 1 {
+		eID = endpointMatches[1]
+	}
+	return config.NewComponentIDWithName(config.Type(rType), rName), observer.EndpointID(eID)
+}

--- a/internal/receiver/discoveryreceiver/statussources/statements_test.go
+++ b/internal/receiver/discoveryreceiver/statussources/statements_test.go
@@ -1,0 +1,182 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statussources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestStatementFromZapCoreEntry(t *testing.T) {
+	logger := zaptest.NewLogger(t).Named("logger.name")
+	encoder := NewZapCoreEncoder()
+	ce := logger.Check(zap.DebugLevel, "a.message")
+	entry := ce.Entry
+
+	now := time.Now()
+	entry.Time = now
+	statement, err := StatementFromZapCoreEntry(encoder, entry, []zapcore.Field{
+		zap.String("field.one", "field.value"), zap.String("field.two", "another.field.value"),
+		zap.Int("int", 1), zap.Bool("bool", true),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, statement)
+
+	require.Equal(t, "a.message", statement.Message)
+	require.Equal(t, "debug", statement.Level)
+	require.Equal(t, now, statement.Time)
+	require.Equal(t, "logger.name", statement.LoggerName)
+	require.Equal(t, entry.Caller, statement.Caller)
+	require.Equal(t, map[string]any{
+		"field.one": "field.value", "field.two": "another.field.value",
+		"logger": "logger.name", "bool": true, "int": float64(1), // becomes a float in json unmarshalling
+	}, statement.Fields)
+}
+
+func TestStatementFromZapCoreEntryUnsupportedEncoder(t *testing.T) {
+	logger := zaptest.NewLogger(t).Named("logger.name")
+	encoder := zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig())
+
+	ce := logger.Check(zap.DebugLevel, "a.message")
+	entry := ce.Entry
+
+	statement, err := StatementFromZapCoreEntry(encoder, entry, nil)
+	require.ErrorContains(t, err, "failed representing encoded zapcore.Entry")
+	require.Nil(t, statement)
+}
+
+func TestStatementToLogRecord(t *testing.T) {
+	logger := zaptest.NewLogger(t).Named("logger.name")
+	encoder := NewZapCoreEncoder()
+	ce := logger.Check(zap.DebugLevel, "a.message")
+	entry := ce.Entry
+
+	now := time.Now()
+	entry.Time = now
+	statement, err := StatementFromZapCoreEntry(encoder, entry, []zapcore.Field{
+		zap.String("field.one", "field.value"), zap.String("field.two", "another.field.value"),
+		zap.Int("int", 1), zap.Bool("bool", true),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, statement)
+
+	t0 := time.Now()
+	lr := statement.ToLogRecord()
+
+	require.Equal(t, "a.message", lr.Body().AsString())
+	require.Equal(t, "debug", lr.SeverityText())
+	require.Equal(t, now.UTC(), lr.Timestamp().AsTime())
+	require.GreaterOrEqual(t, lr.ObservedTimestamp().AsTime(), t0)
+	require.Equal(t, map[string]any{
+		"field.one": "field.value", "field.two": "another.field.value",
+		"logger": "logger.name", "bool": true, "int": float64(1), // becomes a float in json unmarshalling
+	}, lr.Attributes().AsRaw())
+
+}
+
+func TestReceiverNameToIDs(t *testing.T) {
+	for _, test := range []struct {
+		name               string
+		receiverName       string
+		expectedReceiverID config.ComponentID
+		expectedEndpointID observer.EndpointID
+	}{
+		{name: "happy path",
+			receiverName:       `<receiver.type>/<receiver.name>/receiver_creator/<receiver-creator.name>{endpoint="<Endpoint.Target>"}/<Endpoint.ID>`,
+			expectedReceiverID: config.NewComponentIDWithName("<receiver.type>", "<receiver.name>"),
+			expectedEndpointID: observer.EndpointID("<Endpoint.ID>"),
+		},
+		{name: "missing receiver_creator separator",
+			receiverName:       `<receiver.type>/<receiver.name>/<receiver-creator.name>{endpoint="<Endpoint.Target>"}/<Endpoint.ID>`,
+			expectedReceiverID: config.NewComponentID(""),
+			expectedEndpointID: observer.EndpointID(""),
+		},
+		{name: "multiple receiver_creator separators",
+			receiverName:       `<receiver.type>/<receiver.name>/receiver_creator/receiver_creator/{endpoint="<Endpoint.Target>"}/<Endpoint.ID>`,
+			expectedReceiverID: config.NewComponentID(""),
+			expectedEndpointID: observer.EndpointID(""),
+		},
+		{name: "missing endpoint separator",
+			receiverName:       `<receiver.type>/<receiver.name>/receiver_creator/<receiver-creator.name>/<Endpoint.ID>`,
+			expectedReceiverID: config.NewComponentID(""),
+			expectedEndpointID: observer.EndpointID(""),
+		},
+		{name: "multiple endpoint separators",
+			receiverName:       `<receiver.type>/<receiver.name>/receiver_creator/<receiver-creator.name>/{endpoint="<Endpoint.Target>"}/{endpoint="<Endpoint.Target>"}/<Endpoint.ID>`,
+			expectedReceiverID: config.NewComponentID(""),
+			expectedEndpointID: observer.EndpointID(""),
+		},
+		{name: "missing name with forward slash hostport",
+			receiverName:       `debug//receiver_creator/discovery/discovery_name{endpoint="127.0.0.53:53"}/(host_observer/host)127.0.0.53-53-TCP)`,
+			expectedReceiverID: config.NewComponentID("debug"),
+			expectedEndpointID: observer.EndpointID("(host_observer/host)127.0.0.53-53-TCP)"),
+		},
+		{name: "missing name without forward slash hostport",
+			receiverName:       `debug/receiver_creator/discovery/discovery_name{endpoint="127.0.0.53:53"}/(host_observer/host)127.0.0.53-53-TCP)`,
+			expectedReceiverID: config.NewComponentID("debug"),
+			expectedEndpointID: observer.EndpointID("(host_observer/host)127.0.0.53-53-TCP)"),
+		},
+		{name: "docker observer",
+			receiverName:       `smartagent/redis/with/additional/slashes/receiver_creator/discovery/discovery_name{endpoint="172.17.0.2:6379"}/d2ee077a262e23bf3fccdd6422f88ce3ec6ed2403bfe67c1d25fb3e5647a0bb7:6379`,
+			expectedReceiverID: config.NewComponentIDWithName("smartagent", "redis/with/additional/slashes"),
+			expectedEndpointID: observer.EndpointID("d2ee077a262e23bf3fccdd6422f88ce3ec6ed2403bfe67c1d25fb3e5647a0bb7:6379"),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			lr := plog.NewLogRecord()
+			lr.Attributes().PutString("name", test.receiverName)
+			receiverID, endpointID := ReceiverNameToIDs(lr)
+			require.Equal(t, test.expectedReceiverID, receiverID)
+			require.Equal(t, test.expectedEndpointID, endpointID)
+		})
+	}
+}
+
+func FuzzReceiverNameToIDs(f *testing.F) {
+	for _, receiverName := range []string{
+		`invalid`, `<receiver.type>/<receiver.name>/<receiver-creator.name>{endpoint="<Endpoint.Target>"}/<Endpoint.ID>`,
+		`<receiver.type>/<receiver.name>/receiver_creator/<receiver-creator.name>/<Endpoint.ID>`,
+		`<receiver.type>/<receiver.name>/receiver_creator/<receiver-creator.name>/{endpoint="<Endpoint.Target>"}/{endpoint="<Endpoint.Target>"}/<Endpoint.ID>`,
+		`<receiver.type>/<receiver.name>/receiver_creator/<receiver-creator.name>/{endpoint="<Endpoint.Target>"}/<Endpoint.ID>`,
+		`<receiver.type>/<receiver.name>/receiver_creator/receiver_creator/{endpoint="<Endpoint.Target>"}/<Endpoint.ID>`,
+		`debug//receiver_creator/discovery/discovery_name{endpoint="127.0.0.53:53"}/(host_observer/host)127.0.0.53-53-TCP)`,
+		`debug/receiver_creator/discovery/discovery_name{endpoint="127.0.0.53:53"}/(host_observer/host)127.0.0.53-53-TCP`,
+		`smartagent/redis/receiver_creator/discovery/discovery_name{endpoint="172.17.0.2:6379"}/d2ee077a262e23bf3fccdd6422f88ce3ec6ed2403bfe67c1d25fb3e5647a0bb7:6379`,
+	} {
+		f.Add(receiverName)
+	}
+	f.Fuzz(func(t *testing.T, receiverName string) {
+		require.NotPanics(t, func() {
+			lr := plog.NewLogRecord()
+			lr.Attributes().PutString("name", receiverName)
+			receiverID, endpointID := ReceiverNameToIDs(lr)
+			// if we can't find a receiver we should never return an EndpointID
+			if receiverID == NoType {
+				require.Equal(t, observer.EndpointID(""), endpointID)
+			} else if receiverID.Type() == config.Type("") {
+				// if the receiver type is empty the name should also be empty
+				require.Equal(t, "", receiverID.Name())
+			}
+		})
+	})
+}


### PR DESCRIPTION
These changes add component log statement evaluation with an intercepting `zapcore.Core` to the discovery receiver. Current target will be updated to main when https://github.com/signalfx/splunk-otel-collector/pull/1980 lands.