### PR TITLE
add support for installing dotnet instrumentation

### DIFF
--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -68,6 +68,9 @@
     (OPTIONAL) Whether to install and configure .NET tracing to forward .NET application traces to the local collector (default: $false)
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -with_dotnet_instrumentation $true
+.PARAMETER instrumentation_exclude_processes
+    (OPTIONAL) A semicolon-delimited list of process names to be excluded from auto-instrumentation (default: Powershell.exe;dotnet.exe)
+    .\install.ps1 -access_token "ACCESSTOKEN" -with_dotnet_instrumentation $true -instrumentation_exclude_processes "Powershell.exe;dotnet.exe;myprogram.exe"
 .PARAMETER signalfx_service_name
     (OPTIONAL) A system-wide SignalFx service name override for .NET tracing. Sets the SIGNALFX_SERVICE_NAME environment variable. Ignored if -with_dotnet_instrumentation is false.
     .EXAMPLE

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -567,7 +567,7 @@ if ($with_dotnet_instrumentation) {
     echo "Installing SignalFx Instrumentation for .NET ..."
     # signalfx-dotnet-tracing github repository API
     $api = "https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/latest"
-    $module_name = "install.psm1"
+    $module_name = "OpenTelemetry.DotNet.Auto.psm1"
     echo "Downloading .NET Instrumentation installer ..."
     $download = (Invoke-WebRequest $api | ConvertFrom-Json).assets | Where-Object { $_.name -like $module_name } | Select-Object -Property browser_download_url,name
     $dotnet_auto_path = Join-Path $env:temp $download.name

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -147,12 +147,14 @@ $old_config_path = "$program_data_path\config.yaml"
 $agent_config_path = "$program_data_path\agent_config.yaml"
 $gateway_config_path = "$program_data_path\gateway_config.yaml"
 $config_path = ""
+
 try {
     Resolve-Path $env:TEMP
     $tempdir = "${env:TEMP}\Splunk\OpenTelemetry Collector"
 } catch {
     $tempdir = "\tmp\Splunk\OpenTelemetry Collector"
 }
+
 $regkey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
 
 $fluentd_msi_name = "td-agent-4.3.2-x64.msi"
@@ -385,6 +387,9 @@ if ($with_fluentd -And (Test-Path -Path "$fluentd_base_dir\bin\fluentd")) {
     throw "$fluentd_base_dir\bin\fluentd is already installed. Remove/Uninstall fluentd and re-run this script."
 }
 
+# create a temporary directory
+$tempdir = create_temp_dir -tempdir $tempdir
+
 if ($with_dotnet_instrumentation) {
     echo "Installing SignalFx Instrumentation for .NET ..."
     $api = "https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/latest"
@@ -433,9 +438,6 @@ if ("$env:VERIFY_ACCESS_TOKEN" -ne "false") {
         echo '- Verified Access Token'
     }
 }
-
-# set up a temporary directory
-$tempdir = create_temp_dir -tempdir $tempdir
 
 if ($collector_msi_url) {
     $collector_msi_name = "splunk-otel-collector.msi"

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -394,8 +394,18 @@ if ($with_fluentd -And (Test-Path -Path "$fluentd_base_dir\bin\fluentd")) {
     throw "$fluentd_base_dir\bin\fluentd is already installed. Remove/Uninstall fluentd and re-run this script."
 }
 
-if ($with_dotnet_instrumentation -and Get-IsSignalFxInstalled) {
-    throw "SignalFx Instrumentation for .NET is already installed. Remove/Uninstall SignalFx Instrumentation for .NET and re-run this script."
+if ($with_dotnet_instrumentation) {
+    echo "Installing SignalFx Instrumentation for .NET ..."
+    $api = "https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/latest"
+    $module_name = "Splunk.SignalFx.DotNet.psm1"
+    echo "Downloading .NET Instrumentation installer ..."
+    $download = (Invoke-WebRequest $api | ConvertFrom-Json).assets | Where-Object { $_.name -like $module_name } | Select-Object -Property browser_download_url,name
+    $dotnet_autoinstr_path = Join-Path $tempdir $download.name
+    Invoke-WebRequest -Uri $download.browser_download_url -OutFile $dotnet_autoinstr_path
+    Import-Module $dotnet_autoinstr_path
+    if (Get-IsSignalFxInstalled) {
+        throw "SignalFx Instrumentation for .NET is already installed. Remove/Uninstall SignalFx Instrumentation for .NET and re-run this script."
+    }
 }
 
 if ($ingest_url -eq "") {
@@ -559,14 +569,6 @@ if ($with_fluentd) {
 }
 
 if ($with_dotnet_instrumentation) {
-    echo "Installing SignalFx Instrumentation for .NET ..."
-    $api = "https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/latest"
-    $module_name = "Splunk.SignalFx.DotNet.psm1"
-    echo "Downloading .NET Instrumentation installer ..."
-    $download = (Invoke-WebRequest $api | ConvertFrom-Json).assets | Where-Object { $_.name -like $module_name } | Select-Object -Property browser_download_url,name
-    $dotnet_auto_path = Join-Path $tempdir $download.name
-    Invoke-WebRequest -Uri $download.browser_download_url -OutFile $dotnet_auto_path
-    Import-Module $dotnet_auto_path
     echo "Installing SignalFx Dotnet Auto Instrumentation..."
     Install-SignalFxDotnet
 

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -576,16 +576,11 @@ if ($with_dotnet_instrumentation) {
     } else {
         # signalfx-dotnet-tracing github repository API
         $api = "https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/latest"
-
         # File pattern to search for
         $pattern = "signalfx-dotnet-tracing-*-x64.msi"
-
-        echo "Finding latest MSI to download ..."
+        echo "Finding latest .NET Instrumentation MSI to download ..."
         $download = (Invoke-WebRequest $api | ConvertFrom-Json).assets | Where-Object { $_.name -like $pattern } | Select-Object -Property browser_download_url,name
-
-        # Download installer MSI to Temp
         $msi = Join-Path $env:temp $download.name
-        echo "Downloading $download.browser_download_url ..."
         Invoke-WebRequest -Uri $download.browser_download_url -OutFile $msi
     }
 

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -68,10 +68,10 @@
     (OPTIONAL) Whether to install and configure .NET tracing to forward .NET application traces to the local collector (default: $false)
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -with_dotnet_instrumentation $true
-.PARAMETER signalfx_env
+.PARAMETER deployment_env
     (OPTIONAL) A system-wide SignalFx "environment" used by .NET instrumentation. Sets the SIGNALFX_ENV environment variable. Ignored if -with_dotnet_instrumentation is false.
     .EXAMPLE
-    .\install.ps1 -access_token "ACCESSTOKEN" -with_dotnet_instrumentation $true -signalfx_env staging
+    .\install.ps1 -access_token "ACCESSTOKEN" -with_dotnet_instrumentation $true -deployment_env staging
 .PARAMETER bundle_dir
     (OPTIONAL) The location of your Smart Agent bundle for monitor functionality (default: C:\Program Files\Splunk\OpenTelemetry Collector\agent-bundle)
     .EXAMPLE
@@ -123,7 +123,7 @@ param (
     [string]$msi_path = "",
     [string]$collector_msi_url = "",
     [string]$fluentd_msi_url = "",
-    [string]$signalfx_env = "",
+    [string]$deployment_env = "",
     [bool]$UNIT_TEST = $false
 )
 
@@ -565,9 +565,9 @@ if ($with_dotnet_instrumentation) {
     echo "Installing SignalFx Dotnet Auto Instrumentation..."
     Install-SignalFxDotnet
 
-    if ($signalfx_env -ne "") {
-        echo "Setting SIGNALFX_ENV environment variable to $signalfx_env ..."
-        update_registry -path "$regkey" -name "SIGNALFX_ENV" -value "$signalfx_env"
+    if ($deployment_env -ne "") {
+        echo "Setting SIGNALFX_ENV environment variable to $deployment_env ..."
+        update_registry -path "$regkey" -name "SIGNALFX_ENV" -value "$deployment_env"
     } else {
         echo "SIGNALFX_ENV environment variable not set. Unless otherwise defined, will appear as 'unknown' in the UI."
     }

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -126,7 +126,7 @@ param (
     [string]$collector_version = "",
     [bool]$with_fluentd = $true,
     [bool]$with_dotnet_instrumentation = $false,
-    [string]$instrumentation_exclude_processes = "Powershell.exe,dotnet.exe",
+    [string]$instrumentation_exclude_processes = "Powershell.exe;dotnet.exe",
     [string]$bundle_dir = "",
     [ValidateSet('test','beta','release')][string]$stage = "release",
     [string]$msi_path = "",

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -176,14 +176,6 @@ $fluentd_config_dir = "$fluentd_base_dir\etc\td-agent"
 $fluentd_config_path = "$fluentd_config_dir\td-agent.conf"
 $fluentd_service_name = "fluentdwinsvc"
 
-$dotnet_tracing_install_dir = "\Program Files\SignalFx\.NET Tracing"
-try {
-    Resolve-Path $env:SYSTEMDRIVE
-    $dotnet_tracing_base_dir = "${env:SYSTEMDRIVE}$dotnet_tracing_install_dir"
-} catch {
-    $dotnet_tracing_base_dir = $dotnet_tracing_install_dir
-}
-
 # check that we're not running with a restricted execution policy
 function check_policy() {
     $executionPolicy  = (Get-ExecutionPolicy)
@@ -400,10 +392,6 @@ if ($with_fluentd -And (service_installed -name "$fluentd_service_name")) {
 
 if ($with_fluentd -And (Test-Path -Path "$fluentd_base_dir\bin\fluentd")) {
     throw "$fluentd_base_dir\bin\fluentd is already installed. Remove/Uninstall fluentd and re-run this script."
-}
-
-if ($with_dotnet_instrumentation -And (Test-Path -Path "$dotnet_tracing_base_dir\SignalFx.Tracing.ClrProfiler.Native.dll")) {
-    throw "SignalFx .NET tracing is already installed. Remove/Uninstall SignalFx .NET tracing and re-run this script."
 }
 
 if ($ingest_url -eq "") {

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -126,6 +126,7 @@ param (
     [string]$collector_version = "",
     [bool]$with_fluentd = $true,
     [bool]$with_dotnet_instrumentation = $false,
+    [string]$instrumentation_exclude_processes = "Powershell.exe,dotnet.exe",
     [string]$bundle_dir = "",
     [ValidateSet('test','beta','release')][string]$stage = "release",
     [string]$msi_path = "",
@@ -597,6 +598,11 @@ if ($with_dotnet_instrumentation) {
     update_registry -path "$regkey" -name "COR_PROFILER" -value "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"
     update_registry -path "$regkey" -name "CORECLR_ENABLE_PROFILING" -value "1"
     update_registry -path "$regkey" -name "CORECLR_PROFILER" -value "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"
+
+    if ($instrumentation_exclude_processes -ne "") {
+      echo "Setting SIGNALFX_PROFILER_EXCLUDE_PROCESSES environment variable to $instrumentation_exclude_processes ..."
+      update_registry -path "$regkey" -name "SIGNALFX_PROFILER_EXCLUDE_PROCESSES" -value "$instrumentation_exclude_processes"
+    }
 
     if ($signalfx_service_name -ne "") {
         echo "Setting SIGNALFX_SERVICE_NAME environment variable to $signalfx_service_name ..."

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -394,6 +394,10 @@ if ($with_fluentd -And (Test-Path -Path "$fluentd_base_dir\bin\fluentd")) {
     throw "$fluentd_base_dir\bin\fluentd is already installed. Remove/Uninstall fluentd and re-run this script."
 }
 
+if ($with_dotnet_instrumentation -and Get-IsSignalFxInstalled) {
+    throw "SignalFx Instrumentation for .NET is already installed. Remove/Uninstall SignalFx Instrumentation for .NET and re-run this script."
+}
+
 if ($ingest_url -eq "") {
     $ingest_url = "https://ingest.$realm.signalfx.com"
 }

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -567,7 +567,7 @@ if ($with_dotnet_instrumentation) {
     echo "Installing SignalFx Instrumentation for .NET ..."
     # signalfx-dotnet-tracing github repository API
     $api = "https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/latest"
-    $module_name = "OpenTelemetry.DotNet.Auto.psm1"
+    $module_name = "Splunk.SignalFx.DotNet.psm1"
     echo "Downloading .NET Instrumentation installer ..."
     $download = (Invoke-WebRequest $api | ConvertFrom-Json).assets | Where-Object { $_.name -like $module_name } | Select-Object -Property browser_download_url,name
     $dotnet_auto_path = Join-Path $env:temp $download.name

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -101,10 +101,10 @@
     (OPTIONAL) Specify the URL to the Fluentd MSI package to install (default: "https://packages.treasuredata.com/4/windows/td-agent-4.1.0-x64.msi")
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -fluentd_msi_url https://my.host/td-agent-4.1.0-x64.msi
-.PARAMETER dotnet_tracing_msi_url
-    (OPTIONAL) Specify the URL to the SignalFx .NET Tracing MSI package to install (default: "https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v0.2.9/signalfx-dotnet-tracing-0.2.9-x64.msi")
+.PARAMETER dotnet_instrumentation_msi_url
+    (OPTIONAL) Specify the URL to the SignalFx .NET Instrumentation MSI package to install (default: "https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v0.2.9/signalfx-dotnet-tracing-0.2.9-x64.msi")
     .EXAMPLE
-    .\install.ps1 -access_token "ACCESSTOKEN" -dotnet_tracing_msi_url https://my.host/signalfx-dotnet-tracing-0.2.9-x64.msi
+    .\install.ps1 -access_token "ACCESSTOKEN" -dotnet_instrumentation_msi_url https://my.host/signalfx-dotnet-tracing-0.2.9-x64.msi
 .PARAMETER msi_path
     (OPTIONAL) Specify a local path to a Splunk OpenTelemetry Collector MSI package to install instead of downloading the package.
     If specified, the -collector_version and -stage parameters will be ignored.
@@ -568,10 +568,10 @@ if ($with_fluentd) {
 
 if ($with_dotnet_instrumentation) {
     echo "Installing SignalFx Instrumentation for .NET ..."
-    if ($dotnet_tracing_msi_url) {
+    if ($dotnet_instrumentation_msi_url) {
         $dotnet_tracing_msi_name = "signalfx-dotnet-tracing.msi"
-        echo "Downloading $dotnet_tracing_msi_url..."
-        download_file -url "$dotnet_tracing_msi_url" -outputDir "$tempdir" -fileName "$dotnet_tracing_msi_name"
+        echo "Downloading $dotnet_instrumentation_msi_url..."
+        download_file -url "$dotnet_instrumentation_msi_url" -outputDir "$tempdir" -fileName "$dotnet_tracing_msi_name"
         $msi = (Join-Path "$tempdir" "$fluentd_msi_name")
     } else {
         # signalfx-dotnet-tracing github repository API
@@ -656,8 +656,8 @@ restarted to apply the changes by restarting the system or running the following
 
 if ($with_dotnet_instrumentation) {
     $message = "
-SignalFx .NET Tracing has been installed and configured to forward traces to the Splunk OpenTelemetry Collector.
-By default, .NET Tracing will automatically generate traces for popular .NET libraries.
+SignalFx .NET Instrumentation has been installed and configured to forward traces to the Splunk OpenTelemetry Collector.
+By default, .NET Instrumentation will automatically generate traces for popular .NET libraries.
 "
     echo "$message"
 }

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -570,9 +570,9 @@ if ($with_dotnet_instrumentation) {
     $module_name = "install.psm1"
     echo "Downloading .NET Instrumentation installer ..."
     $download = (Invoke-WebRequest $api | ConvertFrom-Json).assets | Where-Object { $_.name -like $module_name } | Select-Object -Property browser_download_url,name
-    $tracing_module_path = Join-Path $tempdir $download.name
+    $tracing_module_path = Join-Path "\Users\splunker\Documents\WindowsPowerShell\Modules" $download.name
     Invoke-WebRequest -Uri $download.browser_download_url -OutFile $tracing_module_path
-    Install-Module $tracing_module_path
+    # Install-Module $tracing_module_path
 
     echo "Starting install process ..."
     Install-SignalFxDotnet

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -570,12 +570,13 @@ if ($with_dotnet_instrumentation) {
     $module_name = "install.psm1"
     echo "Downloading .NET Instrumentation installer ..."
     $download = (Invoke-WebRequest $api | ConvertFrom-Json).assets | Where-Object { $_.name -like $module_name } | Select-Object -Property browser_download_url,name
-    $tracing_module_path = Join-Path "\Users\splunker\Documents\WindowsPowerShell\Modules" $download.name
-    Invoke-WebRequest -Uri $download.browser_download_url -OutFile $tracing_module_path
-    # Install-Module $tracing_module_path
-
-    echo "Starting install process ..."
-    Install-SignalFxDotnet
+    $dotnet_auto_path = Join-Path $env:temp $download.name
+    Invoke-WebRequest -Uri $download.browser_download_url -OutFile $dotnet_auto_path
+    Import-Module $dotnet_auto_path
+    echo "Installing OpenTelemetry Core..."
+    Install-OpenTelemetryCore
+    echo "Registering OpenTelemetry for IIS..."
+    Register-OpenTelemetryForIIS
 
     echo "Setting environment variables for instrumentation ..."
     update_registry -path "$regkey" -name "COR_ENABLE_PROFILING" -value "1"

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -565,7 +565,6 @@ if ($with_fluentd) {
 
 if ($with_dotnet_instrumentation) {
     echo "Installing SignalFx Instrumentation for .NET ..."
-    # signalfx-dotnet-tracing github repository API
     $api = "https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/latest"
     $module_name = "Splunk.SignalFx.DotNet.psm1"
     echo "Downloading .NET Instrumentation installer ..."
@@ -573,10 +572,8 @@ if ($with_dotnet_instrumentation) {
     $dotnet_auto_path = Join-Path $env:temp $download.name
     Invoke-WebRequest -Uri $download.browser_download_url -OutFile $dotnet_auto_path
     Import-Module $dotnet_auto_path
-    echo "Installing OpenTelemetry Core..."
-    Install-OpenTelemetryCore
-    echo "Registering OpenTelemetry for IIS..."
-    Register-OpenTelemetryForIIS
+    echo "Installing SignalFx Dotnet Auto Instrumentation..."
+    Install-SignalFxDotnet
 
     echo "Setting environment variables for instrumentation ..."
     update_registry -path "$regkey" -name "COR_ENABLE_PROFILING" -value "1"

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -570,9 +570,9 @@ if ($with_dotnet_instrumentation) {
     $module_name = "install.psm1"
     echo "Downloading .NET Instrumentation installer ..."
     $download = (Invoke-WebRequest $api | ConvertFrom-Json).assets | Where-Object { $_.name -like $module_name } | Select-Object -Property browser_download_url,name
-    $tracing_module_installer_path = Join-Path "${Env:ProgramFiles}\WindowsPowerShell\Modules" $download.name
-    Invoke-WebRequest -Uri $download.browser_download_url -OutFile $tracing_module_installer_path
-    Install-Module $tracing_module_installer_path
+    $tracing_module_path = Join-Path $tempdir $download.name
+    Invoke-WebRequest -Uri $download.browser_download_url -OutFile $tracing_module_path
+    Install-Module $tracing_module_path
 
     echo "Starting install process ..."
     Install-SignalFxDotnet

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -572,7 +572,7 @@ if ($with_dotnet_instrumentation) {
     $module_name = "Splunk.SignalFx.DotNet.psm1"
     echo "Downloading .NET Instrumentation installer ..."
     $download = (Invoke-WebRequest $api | ConvertFrom-Json).assets | Where-Object { $_.name -like $module_name } | Select-Object -Property browser_download_url,name
-    $dotnet_auto_path = Join-Path $env:temp $download.name
+    $dotnet_auto_path = Join-Path $tempdir $download.name
     Invoke-WebRequest -Uri $download.browser_download_url -OutFile $dotnet_auto_path
     Import-Module $dotnet_auto_path
     echo "Installing SignalFx Dotnet Auto Instrumentation..."

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -567,16 +567,15 @@ if ($with_dotnet_instrumentation) {
     echo "Installing SignalFx Instrumentation for .NET ..."
     # signalfx-dotnet-tracing github repository API
     $api = "https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/latest"
-    # File pattern to search for
     $module_name = "install.psm1"
-    echo "Finding latest .NET Instrumentation installer to download ..."
+    echo "Downloading .NET Instrumentation installer ..."
     $download = (Invoke-WebRequest $api | ConvertFrom-Json).assets | Where-Object { $_.name -like $module_name } | Select-Object -Property browser_download_url,name
-    $tracing_module_installer_path = Join-Path $Env:ProgramFiles\WindowsPowerShell\Modules $download.name
+    $tracing_module_installer_path = Join-Path "${Env:ProgramFiles}\WindowsPowerShell\Modules" $download.name
     Invoke-WebRequest -Uri $download.browser_download_url -OutFile $tracing_module_installer_path
+    Install-Module $tracing_module_installer_path
 
-    # Install downloaded MSI
     echo "Starting install process ..."
-    Install-SignalFxDotnet()
+    Install-SignalFxDotnet
 
     echo "Setting environment variables for instrumentation ..."
     update_registry -path "$regkey" -name "COR_ENABLE_PROFILING" -value "1"


### PR DESCRIPTION
This change adds a `with_dotnet_tracing` parameter to the collector install script for windows. When set, the script downloads and installs the dotnet tracing library, and it sets environment variables so that dotnet applications that run on the local machine will be auto-instrumented.