### PR TITLE
simplify Makefile further, load lazily tests list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ integration-vet:
 
 .PHONY: integration-test
 integration-test:
-	@set -e; for dir in $(ALL_TESTS_DIRS); do \
+	@set -e; for dir in $(shell find tests -name '*_test.go' | xargs -L 1 dirname | uniq | sort -r); do \
 	  echo "go test ./... in $${dir}"; \
 	  (cd "$${dir}" && \
 	   $(GOTEST) $(BUILD_INFO_TESTS) -v -timeout 5m -count 1 ./... ); \

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -17,8 +17,6 @@ IMPI=impi
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release
 
-ALL_TESTS_DIRS := $(shell find tests -name '*_test.go' | xargs -L 1 dirname | uniq | sort -r)
-
 ALL_PKG_DIRS := $(shell $(GOCMD) list -f '{{ .Dir }}' ./... | sort)
 
 ALL_SRC := $(shell find $(ALL_PKG_DIRS) -name '*.go' \


### PR DESCRIPTION
Remove a constant that is not used in Makefile.Common and inline it in Makefile to avoid computing the list of tests every time we run make.