### PR TITLE
Add ResourceLogs and filelog receiver integration test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -39,8 +39,8 @@ func TestMyExampleComponent(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, expectedResourceMetrics)
 
-	// combination OTLP Receiver consumertests.MetricsSink
-	otlp, err := testutils.NewOTLPMetricsReceiverSink().WithEndpoint("localhost:23456").Build()
+	// combination OTLP Receiver, consumertests.MetricsSink, and consumertests.LogsSink
+	otlp, err := testutils.NewOTLPReceiverSink().WithEndpoint("localhost:23456").Build()
 	require.NoError(t, err)
 	require.NoError(t, otlp.Start())
 

--- a/tests/endtoend/authscope_test.go
+++ b/tests/endtoend/authscope_test.go
@@ -86,7 +86,7 @@ func TestIngestAuthScopeTokenGrantsRequiredMetricAndDimensionCapabilities(tt *te
 			tc := testutils.NewTestcase(t)
 			defer tc.PrintLogsOnFailure()
 			// Not used directly since we are sending to backend
-			tc.ShutdownOTLPMetricsReceiverSink()
+			tc.ShutdownOTLPReceiverSink()
 
 			_, stop := tc.Containers(postgresContainers()...)
 			defer stop()
@@ -131,7 +131,7 @@ func TestIngestAuthScopeTokenGrantsRequiredEventCapabilities(tt *testing.T) {
 			tc := testutils.NewTestcase(t)
 			defer tc.PrintLogsOnFailure()
 			// Not used directly since we are sending to backend
-			tc.ShutdownOTLPMetricsReceiverSink()
+			tc.ShutdownOTLPReceiverSink()
 
 			os.Setenv("SPLUNK_ACCESS_TOKEN", run.token)
 			os.Setenv("SPLUNK_API_URL", ts.APIUrl)
@@ -194,7 +194,7 @@ func TestAPIAuthScopeTokenDoesntGrantRequiredMetricAndDimensionCapabilities(t *t
 	ts := secrets(t)
 	tc := testutils.NewTestcase(t)
 	defer tc.PrintLogsOnFailure()
-	tc.ShutdownOTLPMetricsReceiverSink()
+	tc.ShutdownOTLPReceiverSink()
 
 	_, stop := tc.Containers(postgresContainers()...)
 	defer stop()
@@ -220,7 +220,7 @@ func TestAPIAuthScopeTokenDoesntGrantRequiredEventCapabilities(t *testing.T) {
 	ts := secrets(t)
 	tc := testutils.NewTestcase(t)
 	defer tc.PrintLogsOnFailure()
-	tc.ShutdownOTLPMetricsReceiverSink()
+	tc.ShutdownOTLPReceiverSink()
 
 	os.Setenv("SPLUNK_ACCESS_TOKEN", ts.APIToken)
 	os.Setenv("SPLUNK_API_URL", ts.APIUrl)

--- a/tests/general/envvar_expansion_test.go
+++ b/tests/general/envvar_expansion_test.go
@@ -26,7 +26,7 @@ import (
 func TestExpandedDollarSignsViaStandardEnvVar(t *testing.T) {
 	tc := testutils.NewTestcase(t)
 	defer tc.PrintLogsOnFailure()
-	defer tc.ShutdownOTLPMetricsReceiverSink()
+	defer tc.ShutdownOTLPReceiverSink()
 
 	tc.SkipIfNotContainer()
 
@@ -38,13 +38,13 @@ func TestExpandedDollarSignsViaStandardEnvVar(t *testing.T) {
 	defer shutdown()
 
 	expectedResourceMetrics := tc.ResourceMetrics("envvar_labels.yaml")
-	require.NoError(t, tc.OTLPMetricsReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
+	require.NoError(t, tc.OTLPReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
 }
 
 func TestExpandedDollarSignsViaEnvConfigSource(t *testing.T) {
 	tc := testutils.NewTestcase(t)
 	defer tc.PrintLogsOnFailure()
-	defer tc.ShutdownOTLPMetricsReceiverSink()
+	defer tc.ShutdownOTLPReceiverSink()
 
 	tc.SkipIfNotContainer()
 
@@ -56,13 +56,13 @@ func TestExpandedDollarSignsViaEnvConfigSource(t *testing.T) {
 	defer shutdown()
 
 	expectedResourceMetrics := tc.ResourceMetrics("env_config_source_labels.yaml")
-	require.NoError(t, tc.OTLPMetricsReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
+	require.NoError(t, tc.OTLPReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
 }
 
 func TestIncompatibleExpandedDollarSignsViaEnvConfigSource(t *testing.T) {
 	tc := testutils.NewTestcase(t)
 	defer tc.PrintLogsOnFailure()
-	defer tc.ShutdownOTLPMetricsReceiverSink()
+	defer tc.ShutdownOTLPReceiverSink()
 
 	tc.SkipIfNotContainer()
 
@@ -77,13 +77,13 @@ func TestIncompatibleExpandedDollarSignsViaEnvConfigSource(t *testing.T) {
 	defer shutdown()
 
 	expectedResourceMetrics := tc.ResourceMetrics("incompat_env_config_source_labels.yaml")
-	require.NoError(t, tc.OTLPMetricsReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
+	require.NoError(t, tc.OTLPReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
 }
 
 func TestExpandedYamlViaEnvConfigSource(t *testing.T) {
 	tc := testutils.NewTestcase(t)
 	defer tc.PrintLogsOnFailure()
-	defer tc.ShutdownOTLPMetricsReceiverSink()
+	defer tc.ShutdownOTLPReceiverSink()
 
 	tc.SkipIfNotContainer()
 
@@ -95,5 +95,5 @@ func TestExpandedYamlViaEnvConfigSource(t *testing.T) {
 	defer shutdown()
 
 	expectedResourceMetrics := tc.ResourceMetrics("yaml_from_env.yaml")
-	require.NoError(t, tc.OTLPMetricsReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
+	require.NoError(t, tc.OTLPReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
 }

--- a/tests/receivers/filelog/filelog_test.go
+++ b/tests/receivers/filelog/filelog_test.go
@@ -1,0 +1,50 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+
+	"github.com/signalfx/splunk-otel-collector/tests/testutils"
+)
+
+func TestFilelogReceiverSyslogFormat(t *testing.T) {
+	tc := testutils.NewTestcase(t)
+	defer tc.PrintLogsOnFailure()
+	defer tc.ShutdownOTLPReceiverSink()
+
+	tc.SkipIfNotContainer()
+
+	_, shutdown := tc.SplunkOtelCollector(
+		"syslog_config.yaml",
+		func(c testutils.Collector) testutils.Collector {
+			cc := c.(*testutils.CollectorContainer)
+			syslog, err := filepath.Abs(filepath.Join(".", "testdata", "syslog"))
+			require.NoError(t, err)
+			cc.Container = cc.Container.WithMount(testcontainers.BindMount(syslog, "/opt/syslog"))
+			return cc
+		},
+	)
+
+	defer shutdown()
+
+	expectedResourceLogs := tc.ResourceLogs("syslog.yaml")
+	require.NoError(t, tc.OTLPReceiverSink.AssertAllLogsReceived(t, *expectedResourceLogs, 30*time.Second))
+}

--- a/tests/receivers/filelog/testdata/resource_logs/syslog.yaml
+++ b/tests/receivers/filelog/testdata/resource_logs/syslog.yaml
@@ -1,0 +1,88 @@
+resource_logs:
+  - scope_logs:
+      - logs:
+          - body: "<0>Oct  6 14:45:33 debian systemd-udevd[174657]: Using default interface naming scheme 'v247'."
+            severity_text: emerg
+            severity: 21
+            attributes:
+              appname: systemd-udevd
+              facility: 0
+              hostname: debian
+              log.file.name: syslog
+              message: Using default interface naming scheme 'v247'.
+              priority: 0
+              proc_id: "174657"
+          - body: "<1>Oct  6 14:45:33 debian kernel: [17099.341634] docker0: port 1(veth4f642f0) entered disabled state"
+            severity_text: alert
+            severity: 19
+            attributes:
+              appname: kernel
+              facility: 0
+              hostname: debian
+              log.file.name: syslog
+              message: '[17099.341634] docker0: port 1(veth4f642f0) entered disabled state'
+              priority: 1
+          - body: "<2>Oct  6 14:45:33 debian avahi-daemon[564]: Interface veth4f642f0.IPv6 no longer relevant for mDNS."
+            severity_text: crit
+            severity: 18
+            attributes:
+              appname: avahi-daemon
+              facility: 0
+              hostname: debian
+              log.file.name: syslog
+              message: Interface veth4f642f0.IPv6 no longer relevant for mDNS.
+              priority: 2
+              proc_id: "564"
+          - body: "<3>Oct  6 14:45:33 debian avahi-daemon[564]: Leaving mDNS multicast group on interface veth4f642f0.IPv6 with address aa::bb:cc:dd:ee."
+            severity_text: err
+            severity: 17
+            attributes:
+              appname: avahi-daemon
+              facility: 0
+              hostname: debian
+              log.file.name: syslog
+              message: Leaving mDNS multicast group on interface veth4f642f0.IPv6 with address aa::bb:cc:dd:ee.
+              priority: 3
+              proc_id: "564"
+          - body: "<4>Oct  6 14:45:33 debian kernel: [17099.344322] device veth4f642f0 left promiscuous mode"
+            severity_text: warning
+            severity: 13
+            attributes:
+              appname: kernel
+              facility: 0
+              hostname: debian
+              log.file.name: syslog
+              message: '[17099.344322] device veth4f642f0 left promiscuous mode'
+              priority: 4
+          - body: "<5>Oct  6 14:45:33 debian kernel: [17099.344328] docker0: port 1(veth4f642f0) entered disabled state"
+            severity_text: notice
+            severity: 10
+            attributes:
+              appname: kernel
+              facility: 0
+              hostname: debian
+              log.file.name: syslog
+              message: '[17099.344328] docker0: port 1(veth4f642f0) entered disabled state'
+              priority: 5
+          - body: "<6>Oct  6 14:45:33 debian avahi-daemon[564]: Withdrawing address record for aa::bb:cc:dd:ee on veth4f642f0."
+            severity_text: info
+            severity: 9
+            attributes:
+              appname: avahi-daemon
+              facility: 0
+              hostname: debian
+              log.file.name: syslog
+              message: Withdrawing address record for aa::bb:cc:dd:ee on veth4f642f0.
+              priority: 6
+              proc_id: "564"
+          - body: "<7>Oct  6 14:45:33 debian NetworkManager[567]: <info>  [1665081933.1506] device (veth4f642f0): released from master device docker0"
+            severity_text: debug
+            severity: 5
+            attributes:
+              appname: NetworkManager
+              facility: 0
+              hostname: debian
+              log.file.name: syslog
+              message: '<info>  [1665081933.1506] device (veth4f642f0): released from master device docker0'
+              priority: 7
+              proc_id: <info>  [1665081933.1506

--- a/tests/receivers/filelog/testdata/syslog
+++ b/tests/receivers/filelog/testdata/syslog
@@ -1,0 +1,8 @@
+<0>Oct  6 14:45:33 debian systemd-udevd[174657]: Using default interface naming scheme 'v247'.
+<1>Oct  6 14:45:33 debian kernel: [17099.341634] docker0: port 1(veth4f642f0) entered disabled state
+<2>Oct  6 14:45:33 debian avahi-daemon[564]: Interface veth4f642f0.IPv6 no longer relevant for mDNS.
+<3>Oct  6 14:45:33 debian avahi-daemon[564]: Leaving mDNS multicast group on interface veth4f642f0.IPv6 with address aa::bb:cc:dd:ee.
+<4>Oct  6 14:45:33 debian kernel: [17099.344322] device veth4f642f0 left promiscuous mode
+<5>Oct  6 14:45:33 debian kernel: [17099.344328] docker0: port 1(veth4f642f0) entered disabled state
+<6>Oct  6 14:45:33 debian avahi-daemon[564]: Withdrawing address record for aa::bb:cc:dd:ee on veth4f642f0.
+<7>Oct  6 14:45:33 debian NetworkManager[567]: <info>  [1665081933.1506] device (veth4f642f0): released from master device docker0

--- a/tests/receivers/filelog/testdata/syslog_config.yaml
+++ b/tests/receivers/filelog/testdata/syslog_config.yaml
@@ -1,0 +1,22 @@
+receivers:
+  filelog:
+    include: [/opt/syslog]
+    start_at: beginning
+    operators:
+      type: syslog_parser
+      protocol: rfc3164
+
+exporters:
+  otlp:
+    endpoint: "${OTLP_ENDPOINT}"
+    tls:
+      insecure: true
+
+service:
+  telemetry:
+    logs:
+      level: debug
+  pipelines:
+    logs:
+      receivers: [filelog]
+      exporters: [otlp]

--- a/tests/receivers/smartagent/collectd-kafka/collectd_kafka_test.go
+++ b/tests/receivers/smartagent/collectd-kafka/collectd_kafka_test.go
@@ -27,7 +27,7 @@ import (
 func TestCollectdKafkaReceiversProvideAllMetrics(t *testing.T) {
 	tc := testutils.NewTestcase(t)
 	defer tc.PrintLogsOnFailure()
-	defer tc.ShutdownOTLPMetricsReceiverSink()
+	defer tc.ShutdownOTLPReceiverSink()
 
 	kafka := testutils.NewContainer().WithContext(
 		path.Join(".", "testdata", "kafka"),
@@ -75,7 +75,7 @@ func TestCollectdKafkaReceiversProvideAllMetrics(t *testing.T) {
 			_, shutdown := ttc.SplunkOtelCollector(args.collectorConfigFilename)
 			defer shutdown()
 
-			require.NoError(tt, ttc.OTLPMetricsReceiverSink.AssertAllMetricsReceived(tt, *expectedResourceMetrics, 30*time.Second))
+			require.NoError(tt, ttc.OTLPReceiverSink.AssertAllMetricsReceived(tt, *expectedResourceMetrics, 30*time.Second))
 		})
 	}
 }

--- a/tests/receivers/smartagent/collectd-spark/collectd_spark_test.go
+++ b/tests/receivers/smartagent/collectd-spark/collectd_spark_test.go
@@ -28,7 +28,7 @@ import (
 func TestCollectdSparkReceiverProvidesAllMetrics(t *testing.T) {
 	tc := testutils.NewTestcase(t)
 	defer tc.PrintLogsOnFailure()
-	defer tc.ShutdownOTLPMetricsReceiverSink()
+	defer tc.ShutdownOTLPReceiverSink()
 
 	spark := testutils.NewContainer().WithContext(
 		path.Join(".", "testdata", "server"),
@@ -77,7 +77,7 @@ func TestCollectdSparkReceiverProvidesAllMetrics(t *testing.T) {
 			_, shutdown := ttc.SplunkOtelCollector(args.collectorConfigFilename)
 			defer shutdown()
 
-			require.NoError(tt, ttc.OTLPMetricsReceiverSink.AssertAllMetricsReceived(tt, *expectedResourceMetrics, 30*time.Second))
+			require.NoError(tt, ttc.OTLPReceiverSink.AssertAllMetricsReceived(tt, *expectedResourceMetrics, 30*time.Second))
 		})
 	}
 }

--- a/tests/testutils/README.md
+++ b/tests/testutils/README.md
@@ -96,7 +96,7 @@ err = myContainerFromBuildContext.Start(context.Background())
 
 ### OTLP Metrics Receiver Sink
 
-The `OTLPMetricsReceiverSink` is a helper type that will easily stand up an inmemory OTLP Receiver with
+The `OTLPReceiverSink` is a helper type that will easily stand up an inmemory OTLP Receiver with
 `consumertest.MetricsSink` functionality.  It will listen to the configured gRPC endpoint that running Collector
 processes can be configured to reach and provides an `AssertAllMetricsReceived()` test method to confirm that expected
 `ResourceMetrics` are received within the specified window.
@@ -104,7 +104,7 @@ processes can be configured to reach and provides an `AssertAllMetricsReceived()
 ```go
 import "github.com/signafx/splunk-otel-collector/tests/testutils"
 
-otlp, err := testutils.NewOTLPMetricsReceiverSink().WithEndpoint("localhost:23456").Build()
+otlp, err := testutils.NewOTLPReceiverSink().WithEndpoint("localhost:23456").Build()
 require.NoError(t, err)
 
 defer func() {
@@ -160,7 +160,7 @@ defer func() { require.NoError(t, collector.Shutdown()) }()
 ### Testcase
 
 All the above test utilities can be easily configured by the `Testcase` helper to avoid unnecessary boilerplate in
-resource creation and cleanup.  The associated OTLPMetricsReceiverSink for each `Testcase` will have an OS-provided
+resource creation and cleanup.  The associated OTLPReceiverSink for each `Testcase` will have an OS-provided
 endpoint that can be rendered via the `"${OTLP_ENDPOINT}"` environment variable in your tested config. `testutils`
 provides a general `AssertAllMetricsReceived()` function that utilizes this type to stand up all the necessary resources
 associated with a test and assert that all expected metrics are received:
@@ -177,10 +177,10 @@ func MyTest(t *testing.T) {
         testutils.NewContainer().WithImage("my_other_docker_image"),
     }
 
-    // will implicitly create a Testcase with OTLPMetricsReceiverSink listening at $OTLP_ENDPOINT,
+    // will implicitly create a Testcase with OTLPReceiverSink listening at $OTLP_ENDPOINT,
     // ./testdata/resource_metrics/my_resource_metrics.yaml ResourceMetrics instance, CollectorProcess with
     // ./testdata/my_collector_config.yaml config, and build and start all specified containers before calling
-    // otlpMetricsReceiverSink.AssertAllMetricsReceived() with a 30s wait duration.
+    // OTLPReceiverSink.AssertAllMetricsReceived() with a 30s wait duration.
     testutils.AssertAllMetricsReceived(t, "my_resource_metrics.yaml", "my_collector_config.yaml", containers)
 }
 ```

--- a/tests/testutils/collector_process_integration_test.go
+++ b/tests/testutils/collector_process_integration_test.go
@@ -34,7 +34,7 @@ func TestCollectorPath(t *testing.T) {
 }
 
 func TestCollectorProcessConfigSourced(t *testing.T) {
-	otlp, err := NewOTLPMetricsReceiverSink().WithEndpoint("localhost:23456").Build()
+	otlp, err := NewOTLPReceiverSink().WithEndpoint("localhost:23456").Build()
 	require.NoError(t, err)
 	require.NotNil(t, otlp)
 

--- a/tests/testutils/container.go
+++ b/tests/testutils/container.go
@@ -47,6 +47,7 @@ type Container struct {
 	ExposedPorts         []string
 	ContainerNetworks    []string
 	WaitingFor           []wait.Strategy
+	Mounts               []testcontainers.ContainerMount
 }
 
 var _ testcontainers.Container = (*Container)(nil)
@@ -118,6 +119,11 @@ func (container Container) WithExposedPorts(ports ...string) Container {
 	return container
 }
 
+func (container Container) WithMount(mount testcontainers.ContainerMount) Container {
+	container.Mounts = append(container.Mounts, mount)
+	return container
+}
+
 func (container Container) WithName(name string) Container {
 	container.ContainerName = name
 	return container
@@ -172,6 +178,7 @@ func (container Container) Build() *Container {
 		ExposedPorts:   container.ExposedPorts,
 		Name:           container.ContainerName,
 		Networks:       container.ContainerNetworks,
+		Mounts:         container.Mounts,
 		NetworkMode:    networkMode,
 		WaitingFor:     wait.ForAll(container.WaitingFor...).WithStartupTimeout(startupTimeout),
 	}

--- a/tests/testutils/otlp_receiver_sink_test.go
+++ b/tests/testutils/otlp_receiver_sink_test.go
@@ -34,18 +34,20 @@ import (
 )
 
 func TestNewOTLPReceiverSink(t *testing.T) {
-	otlp := NewOTLPMetricsReceiverSink()
+	otlp := NewOTLPReceiverSink()
 	require.NotNil(t, otlp)
 
 	require.Empty(t, otlp.Endpoint)
 	require.Nil(t, otlp.Host)
 	require.Nil(t, otlp.Logger)
-	require.Nil(t, otlp.receiver)
-	require.Nil(t, otlp.sink)
+	require.Nil(t, otlp.logsReceiver)
+	require.Nil(t, otlp.logsSink)
+	require.Nil(t, otlp.metricsReceiver)
+	require.Nil(t, otlp.metricsSink)
 }
 
 func TestBuilderMethods(t *testing.T) {
-	otlp := NewOTLPMetricsReceiverSink()
+	otlp := NewOTLPReceiverSink()
 
 	withEndpoint := otlp.WithEndpoint("myendpoint")
 	require.Equal(t, "myendpoint", withEndpoint.Endpoint)
@@ -63,30 +65,32 @@ func TestBuilderMethods(t *testing.T) {
 }
 
 func TestBuildDefaults(t *testing.T) {
-	otlp, err := NewOTLPMetricsReceiverSink().Build()
+	otlp, err := NewOTLPReceiverSink().Build()
 	require.Error(t, err)
-	assert.EqualError(t, err, "must provide an Endpoint for OTLPMetricsReceiverSink")
+	assert.EqualError(t, err, "must provide an Endpoint for OTLPReceiverSink")
 	assert.Nil(t, otlp)
 
-	otlp, err = NewOTLPMetricsReceiverSink().WithEndpoint("myEndpoint").Build()
+	otlp, err = NewOTLPReceiverSink().WithEndpoint("myEndpoint").Build()
 	require.NoError(t, err)
 	assert.Equal(t, "myEndpoint", otlp.Endpoint)
 	assert.NotNil(t, otlp.Host)
 	assert.NotNil(t, otlp.Logger)
-	assert.NotNil(t, otlp.receiver)
-	assert.NotNil(t, otlp.sink)
+	assert.NotNil(t, otlp.logsReceiver)
+	assert.NotNil(t, otlp.logsSink)
+	assert.NotNil(t, otlp.metricsReceiver)
+	assert.NotNil(t, otlp.metricsSink)
 }
 
 func TestReceiverMethodsWithoutBuildingDisallowed(t *testing.T) {
-	otlp := NewOTLPMetricsReceiverSink()
+	otlp := NewOTLPReceiverSink()
 
 	err := otlp.Start()
 	require.Error(t, err)
-	require.EqualError(t, err, "cannot invoke Start() on an OTLPMetricsReceiverSink that hasn't been built")
+	require.EqualError(t, err, "cannot invoke Start() on an OTLPReceiverSink that hasn't been built")
 
 	err = otlp.Shutdown()
 	require.Error(t, err)
-	require.EqualError(t, err, "cannot invoke Shutdown() on an OTLPMetricsReceiverSink that hasn't been built")
+	require.EqualError(t, err, "cannot invoke Shutdown() on an OTLPReceiverSink that hasn't been built")
 
 	metrics := otlp.AllMetrics()
 	require.Nil(t, metrics)
@@ -99,7 +103,7 @@ func TestReceiverMethodsWithoutBuildingDisallowed(t *testing.T) {
 
 	err = otlp.AssertAllMetricsReceived(t, telemetry.ResourceMetrics{}, 0)
 	require.Error(t, err)
-	require.EqualError(t, err, "cannot invoke AssertAllMetricsReceived() on an OTLPMetricsReceiverSink that hasn't been built")
+	require.EqualError(t, err, "cannot invoke AssertAllMetricsReceived() on an OTLPReceiverSink that hasn't been built")
 }
 
 func otlpExporter(t *testing.T) component.MetricsExporter {
@@ -123,7 +127,7 @@ func otlpExporter(t *testing.T) component.MetricsExporter {
 }
 
 func TestOTLPReceiverMetricsAvailableToSink(t *testing.T) {
-	otlp, err := NewOTLPMetricsReceiverSink().WithEndpoint("localhost:4317").Build()
+	otlp, err := NewOTLPReceiverSink().WithEndpoint("localhost:4317").Build()
 	require.NoError(t, err)
 
 	err = otlp.Start()
@@ -146,7 +150,7 @@ func TestOTLPReceiverMetricsAvailableToSink(t *testing.T) {
 }
 
 func TestAssertAllMetricsReceivedHappyPath(t *testing.T) {
-	otlp, err := NewOTLPMetricsReceiverSink().WithEndpoint("localhost:4317").Build()
+	otlp, err := NewOTLPReceiverSink().WithEndpoint("localhost:4317").Build()
 	require.NoError(t, err)
 
 	err = otlp.Start()

--- a/tests/testutils/telemetry/common_test.go
+++ b/tests/testutils/telemetry/common_test.go
@@ -17,6 +17,7 @@ package telemetry
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,4 +46,60 @@ func TestEmptyResourcesAreEqual(t *testing.T) {
 		require.Equal(t, rOne.Hash(), rTwo.Hash())
 	}
 
+}
+
+func TestResourceEquivalence(t *testing.T) {
+	resource := func() Resource {
+		return Resource{Attributes: map[string]any{
+			"one": 1, "two": "two", "three": nil,
+			"four": []int{1, 2, 3, 4},
+			"five": map[string]any{
+				"true": true, "false": false, "nil": nil,
+			},
+		}}
+	}
+	rOne := resource()
+	rOneSelf := rOne
+	assert.True(t, rOne.Equals(rOneSelf))
+
+	rTwo := resource()
+	assert.True(t, rOne.Equals(rTwo))
+	assert.True(t, rTwo.Equals(rOne))
+
+	rTwo.Attributes["five"].(map[string]any)["another"] = "item"
+	assert.False(t, rOne.Equals(rTwo))
+	assert.False(t, rTwo.Equals(rOne))
+	rOne.Attributes["five"].(map[string]any)["another"] = "item"
+	assert.True(t, rOne.Equals(rTwo))
+	assert.True(t, rTwo.Equals(rOne))
+}
+
+func TestInstrumentationScopeEquivalence(t *testing.T) {
+	il := func() InstrumentationScope {
+		return InstrumentationScope{
+			Name: "an_instrumentation_scope", Version: "an_instrumentation_scope_version",
+		}
+	}
+
+	ilOne := il()
+	ilOneSelf := ilOne
+	assert.True(t, ilOne.Equals(ilOneSelf))
+
+	ilTwo := il()
+	assert.True(t, ilOne.Equals(ilTwo))
+	assert.True(t, ilTwo.Equals(ilOne))
+
+	ilTwo.Version = ""
+	assert.False(t, ilOne.Equals(ilTwo))
+	assert.False(t, ilTwo.Equals(ilOne))
+	ilOne.Version = ""
+	assert.True(t, ilOne.Equals(ilTwo))
+	assert.True(t, ilTwo.Equals(ilOne))
+
+	ilTwo.Name = ""
+	assert.False(t, ilOne.Equals(ilTwo))
+	assert.False(t, ilTwo.Equals(ilOne))
+	ilOne.Name = ""
+	assert.True(t, ilOne.Equals(ilTwo))
+	assert.True(t, ilTwo.Equals(ilOne))
 }

--- a/tests/testutils/telemetry/logs.go
+++ b/tests/testutils/telemetry/logs.go
@@ -1,0 +1,316 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"bytes"
+	"crypto/md5" // #nosec this is not for cryptographic purposes
+	"fmt"
+	"os"
+	"reflect"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+	"gopkg.in/yaml.v2"
+
+	"github.com/signalfx/splunk-otel-collector/tests/internal/version"
+)
+
+// ResourceLogs is a convenience type for testing helpers and assertions.
+// Analogous to pdata form, with the exception that InstrumentationScope.Logs items act as both parent log container
+// and records whose identity is based on differing attributes and other fields.
+type ResourceLogs struct {
+	ResourceLogs []ResourceLog `yaml:"resource_logs"`
+}
+
+// ResourceLog is the top level log type for a given Resource (set of attributes) and its associated ScopeLogs.
+type ResourceLog struct {
+	Resource  Resource    `yaml:",inline,omitempty"`
+	ScopeLogs []ScopeLogs `yaml:"scope_logs"`
+}
+
+// ScopeLogs are the collection of logs produced by a given InstrumentationScope
+type ScopeLogs struct {
+	Scope InstrumentationScope `yaml:"instrumentation_scope,omitempty"`
+	Logs  []Log                `yaml:"logs,omitempty"`
+}
+
+// Log is the log content, representing both the overall definition and a single datapoint.
+type Log struct {
+	ObservedTimestamp time.Time            `yaml:"observed_timestamp,omitempty"`
+	Timestamp         time.Time            `yaml:"timestamp,omitempty"`
+	Body              any                  `yaml:"body,omitempty"`
+	Attributes        *map[string]any      `yaml:"attributes,omitempty"`
+	Severity          *plog.SeverityNumber `yaml:"severity,omitempty"`
+	SeverityText      string               `yaml:"severity_text,omitempty"`
+}
+
+// LoadResourceLogs returns a ResourceLogs instance generated via parsing a valid yaml file at the provided path.
+func LoadResourceLogs(path string) (*ResourceLogs, error) {
+	logFile, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer logFile.Chdir()
+
+	buffer := new(bytes.Buffer)
+	if _, err = buffer.ReadFrom(logFile); err != nil {
+		return nil, err
+	}
+	by := buffer.Bytes()
+
+	var loaded ResourceLogs
+	err = yaml.UnmarshalStrict(by, &loaded)
+	if err != nil {
+		return nil, err
+	}
+	loaded.FillDefaultValues()
+	err = loaded.Validate() // in lieu of json/yaml schema adoption
+	if err != nil {
+		return nil, err
+	}
+	return &loaded, nil
+}
+
+// FillDefaultValues fills ResourceLogs with default values
+func (resourceLogs *ResourceLogs) FillDefaultValues() {
+	for i, rm := range resourceLogs.ResourceLogs {
+		for j, sls := range rm.ScopeLogs {
+			if sls.Scope.Version == buildVersionPlaceholder {
+				resourceLogs.ResourceLogs[i].ScopeLogs[j].Scope.Version = version.Version
+			}
+			for _, sl := range sls.Logs {
+				if sl.Attributes != nil {
+					for k, v := range *sl.Attributes {
+						if v == buildVersionPlaceholder {
+							(*sl.Attributes)[k] = version.Version
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// Determines if all values in ResourceLogs item are valid
+func (resourceLogs ResourceLogs) Validate() error {
+	for _, rm := range resourceLogs.ResourceLogs {
+		for _, sls := range rm.ScopeLogs {
+			for range sls.Logs {
+				continue
+			}
+		}
+	}
+	return nil
+}
+
+func (log Log) String() string {
+	out, err := yaml.Marshal(log)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+// Hash provides an md5 hash determined by Log content.
+func (log Log) Hash() string {
+	return fmt.Sprintf("%x", md5.Sum([]byte(log.String()))) // #nosec
+}
+
+// Equals confirms that all fields, defined or not, in receiver Log are equal to toCompare.
+func (log Log) Equals(toCompare Log) bool {
+	return log.equals(toCompare, true)
+}
+
+// RelaxedEquals confirms that all defined fields in receiver Log are matched in toCompare, ignoring those not
+// set.
+func (log Log) RelaxedEquals(toCompare Log) bool {
+	return log.equals(toCompare, false)
+}
+
+// equals determines if receiver Log is equal to toCompare Log, relaxed if not strict
+func (log Log) equals(toCompare Log, strict bool) bool {
+	if log.Body != toCompare.Body && (strict || log.Body != nil) {
+		return false
+	}
+	if log.SeverityText != toCompare.SeverityText && (strict || log.SeverityText != "") {
+		return false
+	}
+
+	if log.Severity != nil {
+		if toCompare.Severity == nil || (*log.Severity != *toCompare.Severity) {
+			return false
+		}
+	} else {
+		if strict && toCompare.Severity != nil {
+			return false
+		}
+	}
+
+	if log.Attributes != nil {
+		if toCompare.Attributes == nil {
+			return false
+		}
+		return reflect.DeepEqual(*log.Attributes, *toCompare.Attributes)
+	}
+	return true
+}
+
+// FlattenResourceLogs takes multiple instances of ResourceLogs and flattens them
+// to only unique entries by Resource, InstrumentationScope, and Log content.
+// It will preserve order by removing subsequent occurrences of repeated items
+// from the returned flattened ResourceLogs item
+func FlattenResourceLogs(resourceLogs ...ResourceLogs) ResourceLogs {
+	flattened := ResourceLogs{}
+
+	var resourceHashes []string
+	// maps of resource hashes to objects
+	resources := map[string]Resource{}
+	scopeLogs := map[string][]ScopeLogs{}
+
+	// flatten by Resource
+	for _, rms := range resourceLogs {
+		for _, rm := range rms.ResourceLogs {
+			resourceHash := rm.Resource.Hash()
+			if _, ok := resources[resourceHash]; !ok {
+				resources[resourceHash] = rm.Resource
+				resourceHashes = append(resourceHashes, resourceHash)
+			}
+			scopeLogs[resourceHash] = append(scopeLogs[resourceHash], rm.ScopeLogs...)
+		}
+	}
+
+	// flatten by InstrumentationScope
+	for _, resourceHash := range resourceHashes {
+		resource := resources[resourceHash]
+		resourceLog := ResourceLog{
+			Resource: resource,
+		}
+
+		var ilHashes []string
+		// maps of hashes to objects
+		ils := map[string]InstrumentationScope{}
+		ilLogs := map[string][]Log{}
+		for _, ilm := range scopeLogs[resourceHash] {
+			ilHash := ilm.Scope.Hash()
+			if _, ok := ils[ilHash]; !ok {
+				ils[ilHash] = ilm.Scope
+				ilHashes = append(ilHashes, ilHash)
+			}
+			if ilm.Logs == nil {
+				ilm.Logs = []Log{}
+			}
+			ilLogs[ilHash] = append(ilLogs[ilHash], ilm.Logs...)
+		}
+
+		// flatten by Log
+		for _, ilHash := range ilHashes {
+			il := ils[ilHash]
+
+			var logHashes []string
+			logs := map[string]Log{}
+			allILLogs := ilLogs[ilHash]
+			for _, log := range allILLogs {
+				logHash := log.Hash()
+				if _, ok := logs[logHash]; !ok {
+					logs[logHash] = log
+					logHashes = append(logHashes, logHash)
+				}
+			}
+
+			var flattenedLogs []Log
+			for _, logHash := range logHashes {
+				flattenedLogs = append(flattenedLogs, logs[logHash])
+			}
+
+			if flattenedLogs == nil {
+				flattenedLogs = []Log{}
+			}
+
+			sms := ScopeLogs{
+				Scope: il,
+				Logs:  flattenedLogs,
+			}
+			resourceLog.ScopeLogs = append(resourceLog.ScopeLogs, sms)
+		}
+
+		flattened.ResourceLogs = append(flattened.ResourceLogs, resourceLog)
+	}
+
+	return flattened
+}
+
+// ContainsAll determines if everything in expectedResourceLogs ResourceLogs is in the receiver ResourceLogs
+// item (i.e. expected ⊆ received). Neither guarantees equivalence, nor that expected contains all of received
+// (i.e. is not an expected ≣ received nor received ⊆ expected check).
+// Log equivalence is based on RelaxedEquals() check: fields not in expected (e.g. unit, type, value, etc.)
+// are not compared to received, but all labels must match.
+// For better reliability, it's advised that both ResourceLogs items have been flattened by FlattenResourceLogs.
+func (resourceLogs ResourceLogs) ContainsAll(contains ResourceLogs) (bool, error) {
+	var missingResources []string
+	var missingInstrumentationLibraries []string
+	var missingLogs []string
+
+	for _, expectedResourceLog := range contains.ResourceLogs {
+		resourceMatched := false
+		for _, resourceLog := range resourceLogs.ResourceLogs {
+			if resourceLog.Resource.Equals(expectedResourceLog.Resource) {
+				resourceMatched = true
+				for _, expectedILM := range expectedResourceLog.ScopeLogs {
+					InstrumentationScopeMatched := false
+					for _, ilm := range resourceLog.ScopeLogs {
+						if ilm.Scope.Equals(expectedILM.Scope) {
+							InstrumentationScopeMatched = true
+							for _, expectedLog := range expectedILM.Logs {
+								logFound := false
+								for _, log := range ilm.Logs {
+									if expectedLog.RelaxedEquals(log) {
+										logFound = true
+									}
+								}
+								if !logFound {
+									missingLogs = append(missingLogs, expectedLog.String())
+								}
+							}
+							if len(missingLogs) != 0 {
+								return false, fmt.Errorf(
+									"%v doesn't contain all of %v.  Missing Logs: %s",
+									ilm.Logs, expectedILM.Logs, missingLogs)
+							}
+						}
+					}
+					if !InstrumentationScopeMatched {
+						missingInstrumentationLibraries = append(missingInstrumentationLibraries, expectedILM.Scope.String())
+					}
+				}
+				if len(missingInstrumentationLibraries) != 0 {
+					return false, fmt.Errorf(
+						"%v doesn't contain all of  %v.  Missing InstrumentationLibraries: %s",
+						resourceLog.ScopeLogs, expectedResourceLog.ScopeLogs, missingInstrumentationLibraries)
+				}
+			}
+		}
+		if !resourceMatched {
+			missingResources = append(missingResources, expectedResourceLog.Resource.String())
+		}
+	}
+	if len(missingResources) != 0 {
+		return false, fmt.Errorf(
+			"%v doesn't contain all of %v.  Missing resources: %s",
+			resourceLogs.ResourceLogs, contains.ResourceLogs, missingResources,
+		)
+	}
+	return true, nil
+}

--- a/tests/testutils/telemetry/logs_test.go
+++ b/tests/testutils/telemetry/logs_test.go
@@ -1,0 +1,414 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func loadedResourceLogs(t *testing.T) ResourceLogs {
+	resourceLogs, err := LoadResourceLogs(filepath.Join(".", "testdata", "logs", "resource-logs.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, resourceLogs)
+	return *resourceLogs
+}
+
+func TestLoadLogsHappyPath(t *testing.T) {
+	resourceLogs := loadedResourceLogs(t)
+	assert.Equal(t, 2, len(resourceLogs.ResourceLogs))
+
+	firstRL := resourceLogs.ResourceLogs[0]
+	firstRLAttrs := firstRL.Resource.Attributes
+	require.Equal(t, 2, len(firstRLAttrs))
+	require.NotNil(t, firstRLAttrs["one_attr"])
+	assert.Equal(t, "one_value", firstRLAttrs["one_attr"])
+	require.NotNil(t, firstRLAttrs["two_attr"])
+	assert.Equal(t, "two_value", firstRLAttrs["two_attr"])
+
+	assert.Equal(t, 2, len(firstRL.ScopeLogs))
+	firstRLFirstSL := firstRL.ScopeLogs[0]
+	require.NotNil(t, firstRLFirstSL)
+	require.NotNil(t, firstRLFirstSL.Scope)
+	assert.Equal(t, "without_logs", firstRLFirstSL.Scope.Name)
+	assert.Equal(t, "some_version", firstRLFirstSL.Scope.Version)
+	require.Nil(t, firstRLFirstSL.Logs)
+
+	firstRLSecondSL := firstRL.ScopeLogs[1]
+	require.NotNil(t, firstRLSecondSL)
+	require.NotNil(t, firstRLSecondSL.Scope)
+	assert.Empty(t, firstRLSecondSL.Scope.Name)
+	assert.Empty(t, firstRLSecondSL.Scope.Version)
+	require.NotNil(t, firstRLSecondSL.Logs)
+
+	require.Equal(t, 2, len(firstRLSecondSL.Logs))
+	firstRLSecondSLFirstLog := firstRLSecondSL.Logs[0]
+	require.NotNil(t, firstRLSecondSLFirstLog)
+	assert.Equal(t, "a string body", firstRLSecondSLFirstLog.Body)
+	assert.Equal(t, plog.SeverityNumber(1), *firstRLSecondSLFirstLog.Severity)
+	assert.Equal(t, "info", firstRLSecondSLFirstLog.SeverityText)
+	firstRLSecondSLFirstLogAttrs := firstRL.Resource.Attributes
+	require.Equal(t, 2, len(firstRLSecondSLFirstLogAttrs))
+	require.NotNil(t, firstRLSecondSLFirstLogAttrs["one_attr"])
+	assert.Equal(t, "one_value", firstRLSecondSLFirstLogAttrs["one_attr"])
+	require.NotNil(t, firstRLSecondSLFirstLogAttrs["two_attr"])
+	assert.Equal(t, "two_value", firstRLSecondSLFirstLogAttrs["two_attr"])
+
+	firstRLSecondScopeLogSecondLog := firstRLSecondSL.Logs[1]
+	require.NotNil(t, firstRLSecondScopeLogSecondLog)
+	assert.Equal(t, 0, firstRLSecondScopeLogSecondLog.Body)
+	assert.Empty(t, firstRLSecondScopeLogSecondLog.SeverityText)
+	assert.Nil(t, firstRLSecondScopeLogSecondLog.Severity)
+	assert.Nil(t, firstRLSecondScopeLogSecondLog.Attributes)
+
+	secondRL := resourceLogs.ResourceLogs[1]
+	require.Zero(t, len(secondRL.Resource.Attributes))
+
+	assert.Equal(t, 1, len(secondRL.ScopeLogs))
+	secondRLFirstSL := secondRL.ScopeLogs[0]
+	require.NotNil(t, secondRLFirstSL)
+	require.NotNil(t, secondRLFirstSL.Scope)
+	assert.Equal(t, "with_logs", secondRLFirstSL.Scope.Name)
+	assert.Equal(t, "another_version", secondRLFirstSL.Scope.Version)
+	require.NotNil(t, secondRLFirstSL.Logs)
+
+	require.Equal(t, 2, len(secondRLFirstSL.Logs))
+	secondRLFirstSLFirstLog := secondRLFirstSL.Logs[0]
+	require.NotNil(t, secondRLFirstSLFirstLog)
+	assert.Equal(t, true, secondRLFirstSLFirstLog.Body)
+	assert.Equal(t, plog.SeverityNumber(24), *secondRLFirstSLFirstLog.Severity)
+	assert.Equal(t, "arbitrary", secondRLFirstSLFirstLog.SeverityText)
+	assert.Nil(t, secondRLFirstSLFirstLog.Attributes)
+
+	secondRLFirstScopeLogSecondLog := secondRLFirstSL.Logs[1]
+	require.NotNil(t, secondRLFirstScopeLogSecondLog)
+	assert.Equal(t, 0.123, secondRLFirstScopeLogSecondLog.Body)
+	assert.Equal(t, plog.SeverityNumber(9), *secondRLFirstScopeLogSecondLog.Severity)
+	assert.Empty(t, secondRLFirstScopeLogSecondLog.SeverityText)
+	assert.Nil(t, secondRLFirstScopeLogSecondLog.Attributes)
+}
+
+func TestLoadLogsNotAValidPath(t *testing.T) {
+	resourceLogs, err := LoadResourceLogs("notafile")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no such file or directory")
+	require.Nil(t, resourceLogs)
+}
+
+func TestLoadLogsInvalidItems(t *testing.T) {
+	resourceLogs, err := LoadResourceLogs(filepath.Join(".", "testdata", "logs", "invalid-resource-logs.yaml"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "field notAttributesOrScopeLogs not found in type telemetry.ResourceLog")
+	require.Nil(t, resourceLogs)
+}
+
+func TestLogEquivalence(t *testing.T) {
+	sev := plog.SeverityNumberFatal
+	log := func() Log {
+		return Log{
+			Body: "a_log_body", SeverityText: "a_severity_text",
+			Severity: &sev,
+			Attributes: &map[string]any{
+				"one": "one", "two": "two",
+			},
+		}
+	}
+
+	lOne := log()
+	lOneSelf := log()
+	assert.True(t, lOne.Equals(lOneSelf))
+
+	lTwo := log()
+	assert.True(t, lOne.Equals(lTwo))
+	assert.True(t, lTwo.Equals(lOne))
+
+	lTwo.Body = ""
+	assert.False(t, lOne.Equals(lTwo))
+	assert.False(t, lTwo.Equals(lOne))
+	lOne.Body = ""
+	assert.True(t, lOne.Equals(lTwo))
+	assert.True(t, lTwo.Equals(lOne))
+
+	lTwo.SeverityText = ""
+	assert.False(t, lOne.Equals(lTwo))
+	assert.False(t, lTwo.Equals(lOne))
+	lOne.SeverityText = ""
+	assert.True(t, lOne.Equals(lTwo))
+	assert.True(t, lTwo.Equals(lOne))
+
+	sevOne := plog.SeverityNumberError
+	sevTwo := plog.SeverityNumberError
+	lTwo.Severity = &sevOne
+	assert.False(t, lOne.Equals(lTwo))
+	assert.False(t, lTwo.Equals(lOne))
+	lOne.Severity = &sevTwo
+	assert.True(t, lOne.Equals(lTwo))
+	assert.True(t, lTwo.Equals(lOne))
+
+	(*lTwo.Attributes)["three"] = "three"
+	assert.False(t, lOne.Equals(lTwo))
+	assert.False(t, lTwo.Equals(lOne))
+	(*lOne.Attributes)["three"] = "three"
+	assert.True(t, lOne.Equals(lTwo))
+	assert.True(t, lTwo.Equals(lOne))
+}
+
+func TestLogRelaxedEquivalence(t *testing.T) {
+	sevOne := plog.SeverityNumberDebug
+	lacksBodyAndSeverityText := Log{
+		Attributes: &map[string]any{
+			"one": "one", "two": "two",
+		}, Severity: &sevOne,
+	}
+
+	sevTwo := plog.SeverityNumberDebug
+	completeLog := Log{
+		Body: "a_log", SeverityText: "a_description",
+		Attributes: &map[string]any{
+			"one": "one", "two": "two",
+		}, Severity: &sevTwo,
+	}
+
+	require.True(t, lacksBodyAndSeverityText.RelaxedEquals(completeLog))
+	require.False(t, completeLog.RelaxedEquals(lacksBodyAndSeverityText))
+
+	(*lacksBodyAndSeverityText.Attributes)["three"] = "three"
+	require.False(t, lacksBodyAndSeverityText.RelaxedEquals(completeLog))
+	require.False(t, completeLog.RelaxedEquals(lacksBodyAndSeverityText))
+	(*completeLog.Attributes)["three"] = "three"
+	require.True(t, lacksBodyAndSeverityText.RelaxedEquals(completeLog))
+	require.False(t, completeLog.RelaxedEquals(lacksBodyAndSeverityText))
+
+	sev := plog.SeverityNumberTrace
+	lacksBodyAndSeverityText.Severity = &sev
+	require.False(t, lacksBodyAndSeverityText.RelaxedEquals(completeLog))
+	require.False(t, completeLog.RelaxedEquals(lacksBodyAndSeverityText))
+	completeLog.Severity = &sev
+	require.True(t, lacksBodyAndSeverityText.RelaxedEquals(completeLog))
+	require.False(t, completeLog.RelaxedEquals(lacksBodyAndSeverityText))
+
+	completeLog.Body = nil
+	completeLog.SeverityText = ""
+	require.True(t, lacksBodyAndSeverityText.RelaxedEquals(completeLog))
+	require.True(t, completeLog.RelaxedEquals(lacksBodyAndSeverityText))
+}
+
+func TestLogAttributeRelaxedEquivalence(t *testing.T) {
+	sev := plog.SeverityNumberInfo
+	lackingAttributes := Log{
+		Body: "a_log", SeverityText: "severity_text",
+		Severity: &sev,
+	}
+
+	emptyAttributes := Log{
+		Body: "a_log", SeverityText: "severity_text",
+		Severity: &sev, Attributes: &map[string]any{},
+	}
+
+	completeLog := Log{
+		Body: "a_log", SeverityText: "severity_text",
+		Severity: &sev, Attributes: &map[string]any{
+			"one": "one", "two": "two",
+		},
+	}
+
+	require.True(t, lackingAttributes.RelaxedEquals(completeLog))
+	require.False(t, emptyAttributes.RelaxedEquals(completeLog))
+}
+
+func TestLogHashFunctionConsistency(t *testing.T) {
+	sev := plog.SeverityNumberInfo
+	log := Log{
+		Body: "some log", SeverityText: "some severity_texti",
+		Severity: &sev, Attributes: &map[string]any{
+			"attributeOne": "1", "attributeTwo": "two",
+		},
+	}
+	for i := 0; i < 100; i++ {
+		require.Equal(t, "2f160310dd1c038e106ca2a3564ca561", log.Hash())
+	}
+}
+
+func TestFlattenResourceLogsByResourceIdentity(t *testing.T) {
+	resource := Resource{Attributes: map[string]any{"attribute_one": nil, "attribute_two": 123.456}}
+	resourceLogs := ResourceLogs{
+		ResourceLogs: []ResourceLog{
+			{Resource: resource},
+			{Resource: resource},
+			{Resource: resource},
+		},
+	}
+	expectedResourceLogs := ResourceLogs{ResourceLogs: []ResourceLog{{Resource: resource}}}
+	require.Equal(t, expectedResourceLogs, FlattenResourceLogs(resourceLogs))
+}
+
+func TestFlattenResourceLogsByScopeLogsIdentity(t *testing.T) {
+	resource := Resource{Attributes: map[string]any{"attribute_three": true, "attribute_four": 23456}}
+	sm := ScopeLogs{Scope: InstrumentationScope{
+		Name: "an instrumentation library", Version: "an instrumentation library version",
+	}, Logs: []Log{}}
+	resourceLogs := ResourceLogs{
+		ResourceLogs: []ResourceLog{
+			{Resource: resource, ScopeLogs: []ScopeLogs{}},
+			{Resource: resource, ScopeLogs: []ScopeLogs{sm}},
+			{Resource: resource, ScopeLogs: []ScopeLogs{sm, sm}},
+			{Resource: resource, ScopeLogs: []ScopeLogs{sm, sm, sm}},
+		},
+	}
+	expectedResourceLogs := ResourceLogs{
+		ResourceLogs: []ResourceLog{
+			{Resource: resource, ScopeLogs: []ScopeLogs{sm}},
+		},
+	}
+	require.Equal(t, expectedResourceLogs, FlattenResourceLogs(resourceLogs))
+}
+
+func TestFlattenResourceLogsByLogsIdentity(t *testing.T) {
+	sevOne := plog.SeverityNumberTrace
+	sevTwo := plog.SeverityNumberTrace2
+	sevThree := plog.SeverityNumberTrace3
+	resource := Resource{Attributes: map[string]any{}}
+	logs := []Log{
+		{Body: "a log", SeverityText: "a severity_text", Severity: &sevOne},
+		{Body: "another log", SeverityText: "another severity_text", Severity: &sevTwo},
+		{Body: "yet another log", SeverityText: "yet anothe severity_text", Severity: &sevThree},
+	}
+	sm := ScopeLogs{Logs: logs}
+	smRepeated := ScopeLogs{Logs: append(logs, logs...)}
+	smRepeatedTwice := ScopeLogs{Logs: append(logs, append(logs, logs...)...)}
+	smWithoutLogs := ScopeLogs{}
+	resourceLogs := ResourceLogs{
+		ResourceLogs: []ResourceLog{
+			{Resource: resource, ScopeLogs: []ScopeLogs{}},
+			{Resource: resource, ScopeLogs: []ScopeLogs{sm}},
+			{Resource: resource, ScopeLogs: []ScopeLogs{smRepeated}},
+			{Resource: resource, ScopeLogs: []ScopeLogs{smRepeatedTwice}},
+			{Resource: resource, ScopeLogs: []ScopeLogs{smWithoutLogs}},
+		},
+	}
+	expectedResourceLogs := ResourceLogs{
+		ResourceLogs: []ResourceLog{
+			{Resource: resource, ScopeLogs: []ScopeLogs{sm}},
+		},
+	}
+	require.Equal(t, expectedResourceLogs, FlattenResourceLogs(resourceLogs))
+}
+
+func TestFlattenResourceLogsConsistency(t *testing.T) {
+	resourceLogs, err := PDataToResourceLogs(PDataLogs())
+	require.NoError(t, err)
+	require.NotNil(t, resourceLogs)
+	require.Equal(t, resourceLogs, FlattenResourceLogs(resourceLogs))
+	var rms []ResourceLogs
+	for i := 0; i < 100; i++ {
+		rms = append(rms, resourceLogs)
+	}
+	for i := 0; i < 100; i++ {
+		require.Equal(t, resourceLogs, FlattenResourceLogs(rms...))
+	}
+}
+
+func TestLogContainsAllSelfCheck(t *testing.T) {
+	resourceLogs := loadedResourceLogs(t)
+	containsAll, err := resourceLogs.ContainsAll(resourceLogs)
+	require.True(t, containsAll, err)
+	require.NoError(t, err)
+}
+
+func TestLogContainsAllNoBijection(t *testing.T) {
+	received := loadedResourceLogs(t)
+
+	expected, err := LoadResourceLogs(filepath.Join(".", "testdata", "logs", "expected-logs.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, expected)
+
+	containsAll, err := received.ContainsAll(*expected)
+	require.True(t, containsAll, err)
+	require.NoError(t, err)
+
+	// Since expectedLogs specify no severities, they will never find matches with logs w/ them.
+	containsAll, err = expected.ContainsAll(received)
+	require.False(t, containsAll)
+	require.Error(t, err)
+	require.Contains(t, err.Error(),
+		"Missing Logs: [body: true\nseverity: 24\nseverity_text: arbitrary\n body: 0.123\nseverity: 9\n]",
+	)
+}
+
+func TestLogContainsAllSeverityTextNeverReceived(t *testing.T) {
+	received := loadedResourceLogs(t)
+	expected, err := LoadResourceLogs(filepath.Join(".", "testdata", "logs", "never-received-logs.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, expected)
+
+	// neverReceivedLogs.yaml details a Log with a value that isn't in resourceLogs.yaml
+	containsAll, err := received.ContainsAll(*expected)
+	require.False(t, containsAll)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Missing Logs: [body: true\nseverity_text: never received\n]")
+}
+
+func TestLogContainsAllInstrumentationScopeNeverReceived(t *testing.T) {
+	received := loadedResourceLogs(t)
+	expected, err := LoadResourceLogs(filepath.Join(".", "testdata", "logs", "never-received-instrumentation-scope.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, expected)
+
+	// neverReceivedLogs.yaml details an Instrumentation Library that isn't in resourceLogs.yaml
+	containsAll, err := received.ContainsAll(*expected)
+	require.False(t, containsAll)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Missing InstrumentationLibraries: [name: unmatched_instrumentation_scope\n]")
+}
+
+func TestLogContainsAllResourceNeverReceived(t *testing.T) {
+	received := loadedResourceLogs(t)
+	expected, err := LoadResourceLogs(filepath.Join(".", "testdata", "logs", "never-received-resource.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, expected)
+
+	// neverReceivedLogs.yaml details a Resource that isn't in resourceLogs.yaml
+	containsAll, err := received.ContainsAll(*expected)
+	require.False(t, containsAll)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Missing resources: [not: matched\n]")
+}
+
+func TestLogContainsAllWithMissingAndEmptyAttributes(t *testing.T) {
+	received, err := LoadResourceLogs(filepath.Join(".", "testdata", "logs", "attribute-value-resource-logs.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, received)
+
+	unspecified, err := LoadResourceLogs(filepath.Join(".", "testdata", "logs", "unspecified-attributes-allowed.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, unspecified)
+
+	empty, err := LoadResourceLogs(filepath.Join(".", "testdata", "logs", "empty-attributes-required.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, empty)
+
+	containsAll, err := received.ContainsAll(*unspecified)
+	require.True(t, containsAll)
+	require.NoError(t, err)
+
+	containsAll, err = received.ContainsAll(*empty)
+	require.False(t, containsAll)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Missing Logs: [body: a string body\nattributes: {}\nseverity: 1\nseverity_text: info\n]")
+}

--- a/tests/testutils/telemetry/metrics_test.go
+++ b/tests/testutils/telemetry/metrics_test.go
@@ -123,62 +123,6 @@ func TestLoadMetricsInvalidMetricType(t *testing.T) {
 	require.Nil(t, resourceMetrics)
 }
 
-func TestResourceEquivalence(t *testing.T) {
-	resource := func() Resource {
-		return Resource{Attributes: map[string]any{
-			"one": 1, "two": "two", "three": nil,
-			"four": []int{1, 2, 3, 4},
-			"five": map[string]any{
-				"true": true, "false": false, "nil": nil,
-			},
-		}}
-	}
-	rOne := resource()
-	rOneSelf := rOne
-	assert.True(t, rOne.Equals(rOneSelf))
-
-	rTwo := resource()
-	assert.True(t, rOne.Equals(rTwo))
-	assert.True(t, rTwo.Equals(rOne))
-
-	rTwo.Attributes["five"].(map[string]any)["another"] = "item"
-	assert.False(t, rOne.Equals(rTwo))
-	assert.False(t, rTwo.Equals(rOne))
-	rOne.Attributes["five"].(map[string]any)["another"] = "item"
-	assert.True(t, rOne.Equals(rTwo))
-	assert.True(t, rTwo.Equals(rOne))
-}
-
-func TestInstrumentationScopeEquivalence(t *testing.T) {
-	il := func() InstrumentationScope {
-		return InstrumentationScope{
-			Name: "an_instrumentation_scope", Version: "an_instrumentation_scope_version",
-		}
-	}
-
-	ilOne := il()
-	ilOneSelf := ilOne
-	assert.True(t, ilOne.Equals(ilOneSelf))
-
-	ilTwo := il()
-	assert.True(t, ilOne.Equals(ilTwo))
-	assert.True(t, ilTwo.Equals(ilOne))
-
-	ilTwo.Version = ""
-	assert.False(t, ilOne.Equals(ilTwo))
-	assert.False(t, ilTwo.Equals(ilOne))
-	ilOne.Version = ""
-	assert.True(t, ilOne.Equals(ilTwo))
-	assert.True(t, ilTwo.Equals(ilOne))
-
-	ilTwo.Name = ""
-	assert.False(t, ilOne.Equals(ilTwo))
-	assert.False(t, ilTwo.Equals(ilOne))
-	ilOne.Name = ""
-	assert.True(t, ilOne.Equals(ilTwo))
-	assert.True(t, ilTwo.Equals(ilOne))
-}
-
 func TestMetricEquivalence(t *testing.T) {
 	metric := func() Metric {
 		return Metric{
@@ -361,7 +305,7 @@ func TestFlattenResourceMetricsByMetricsIdentity(t *testing.T) {
 	metrics := []Metric{
 		{Name: "a metric", Unit: "a unit", Description: "a description", Value: 123},
 		{Name: "another metric", Unit: "another unit", Description: "another description", Value: 234},
-		{Name: "yet anothert metric", Unit: "yet anothe unit", Description: "yet anothet description", Value: 345},
+		{Name: "yet another metric", Unit: "yet anothe unit", Description: "yet anothet description", Value: 345},
 	}
 	sm := ScopeMetrics{Metrics: metrics}
 	smRepeated := ScopeMetrics{Metrics: append(metrics, metrics...)}
@@ -398,14 +342,14 @@ func TestFlattenResourceMetricsConsistency(t *testing.T) {
 	}
 }
 
-func TestContainsAllSelfCheck(t *testing.T) {
+func TestMetricContainsAllSelfCheck(t *testing.T) {
 	resourceMetrics := loadedResourceMetrics(t)
 	containsAll, err := resourceMetrics.ContainsAll(resourceMetrics)
 	require.True(t, containsAll, err)
 	require.NoError(t, err)
 }
 
-func TestContainsAllNoBijection(t *testing.T) {
+func TestMetricContainsAllNoBijection(t *testing.T) {
 	received := loadedResourceMetrics(t)
 
 	expected, err := LoadResourceMetrics(filepath.Join(".", "testdata", "metrics", "expected-metrics.yaml"))
@@ -425,7 +369,7 @@ func TestContainsAllNoBijection(t *testing.T) {
 	)
 }
 
-func TestContainsAllValueNeverReceived(t *testing.T) {
+func TestMetricContainsAllValueNeverReceived(t *testing.T) {
 	received := loadedResourceMetrics(t)
 	expected, err := LoadResourceMetrics(filepath.Join(".", "testdata", "metrics", "never-received-metrics.yaml"))
 	require.NoError(t, err)
@@ -438,7 +382,7 @@ func TestContainsAllValueNeverReceived(t *testing.T) {
 	require.Contains(t, err.Error(), "Missing Metrics: [name: another_int_gauge\ntype: IntGauge\nvalue: 111\n]")
 }
 
-func TestContainsAllInstrumentationScopeNeverReceived(t *testing.T) {
+func TestMetricContainsAllInstrumentationScopeNeverReceived(t *testing.T) {
 	received := loadedResourceMetrics(t)
 	expected, err := LoadResourceMetrics(filepath.Join(".", "testdata", "metrics", "never-received-instrumentation-scope.yaml"))
 	require.NoError(t, err)
@@ -451,7 +395,7 @@ func TestContainsAllInstrumentationScopeNeverReceived(t *testing.T) {
 	require.Contains(t, err.Error(), "Missing InstrumentationLibraries: [name: unmatched_instrumentation_scope\n]")
 }
 
-func TestContainsAllResourceNeverReceived(t *testing.T) {
+func TestMetricContainsAllResourceNeverReceived(t *testing.T) {
 	received := loadedResourceMetrics(t)
 	expected, err := LoadResourceMetrics(filepath.Join(".", "testdata", "metrics", "never-received-resource.yaml"))
 	require.NoError(t, err)
@@ -464,7 +408,7 @@ func TestContainsAllResourceNeverReceived(t *testing.T) {
 	require.Contains(t, err.Error(), "Missing resources: [not: matched\n]")
 }
 
-func TestContainsAllWithMissingAndEmptyAttributes(t *testing.T) {
+func TestMetricContainsAllWithMissingAndEmptyAttributes(t *testing.T) {
 	received, err := LoadResourceMetrics(filepath.Join(".", "testdata", "metrics", "attribute-value-resource-metrics.yaml"))
 	require.NoError(t, err)
 	require.NotNil(t, received)

--- a/tests/testutils/telemetry/pdata_logs.go
+++ b/tests/testutils/telemetry/pdata_logs.go
@@ -1,0 +1,138 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+// PDataToResourceLogs returns a ResourceLogs item generated from plog.Logs content.
+func PDataToResourceLogs(pdataLogs ...plog.Logs) (ResourceLogs, error) {
+	resourceLogs := ResourceLogs{}
+	for _, pdataLog := range pdataLogs {
+		pdataRLs := pdataLog.ResourceLogs()
+		numRM := pdataRLs.Len()
+		for i := 0; i < numRM; i++ {
+			rl := ResourceLog{}
+			pdataRL := pdataRLs.At(i)
+			rl.Resource.Attributes = sanitizeAttributes(pdataRL.Resource().Attributes().AsRaw())
+			pdataSLs := pdataRL.ScopeLogs()
+			for j := 0; j < pdataSLs.Len(); j++ {
+				sls := ScopeLogs{Logs: []Log{}}
+				pdataSL := pdataSLs.At(j)
+				attrs := pdataSL.Scope().Attributes().AsRaw()
+				sls.Scope = InstrumentationScope{
+					Name:       pdataSL.Scope().Name(),
+					Version:    pdataSL.Scope().Version(),
+					Attributes: attrs,
+				}
+				for k := 0; k < pdataSL.LogRecords().Len(); k++ {
+					pdLR := pdataSL.LogRecords().At(k)
+					log := Log{}
+					log.Body = pdLR.Body().AsRaw()
+					lAttrs := sanitizeAttributes(pdLR.Attributes().AsRaw())
+					log.Attributes = &lAttrs
+					log.Timestamp = pdLR.Timestamp().AsTime()
+					log.ObservedTimestamp = pdLR.ObservedTimestamp().AsTime()
+					sn := pdLR.SeverityNumber()
+					log.Severity = &sn
+					log.SeverityText = pdLR.SeverityText()
+					sls.Logs = append(sls.Logs, log)
+				}
+				rl.ScopeLogs = append(rl.ScopeLogs, sls)
+			}
+			resourceLogs.ResourceLogs = append(resourceLogs.ResourceLogs, rl)
+		}
+	}
+	return resourceLogs, nil
+}
+
+func PDataLogs() plog.Logs {
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	attrs := resourceLogs.Resource().Attributes()
+	attrs.PutBool("bool", true)
+	attrs.PutString("string", "a_string")
+	attrs.PutInt("int", 123)
+	attrs.PutDouble("double", 123.45)
+	attrs.PutEmpty("null")
+
+	scopeLogs := resourceLogs.ScopeLogs()
+	slOne := scopeLogs.AppendEmpty()
+	slOne.Scope().SetName("an_instrumentation_scope_name")
+	slOne.Scope().SetVersion("an_instrumentation_scope_version")
+	slOneLogs := slOne.LogRecords()
+	slOneLogOne := slOneLogs.AppendEmpty()
+
+	slOneLogOne.SetTimestamp(pcommon.NewTimestampFromTime(time.Date(1970, 1, 2, 3, 4, 5, 6, time.UTC)))
+	slOneLogOne.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Date(1990, 1, 2, 3, 4, 5, 6, time.UTC)))
+	slOneLogOne.SetSeverityNumber(plog.SeverityNumberTrace)
+	slOneLogOne.SetSeverityText("severity-text-1")
+	slOneLogOne.Attributes().PutString("attribute_name_1", "attribute_value_1")
+	slOneLogOne.Attributes().PutString("attribute_name_2", "attribute_value_2")
+	slOneLogOne.Body().SetStr("body - string value")
+
+	slOneLogTwo := slOneLogs.AppendEmpty()
+	slOneLogTwo.SetTimestamp(pcommon.NewTimestampFromTime(time.Date(1971, 1, 2, 3, 4, 5, 6, time.UTC)))
+	slOneLogTwo.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Date(1991, 1, 2, 3, 4, 5, 6, time.UTC)))
+	slOneLogTwo.SetSeverityNumber(plog.SeverityNumberDebug)
+	slOneLogTwo.SetSeverityText("severity-text-2")
+	slOneLogTwo.Attributes().PutString("attribute_name_3", "attribute_value_3")
+	slOneLogTwo.Attributes().PutString("attribute_name_4", "attribute_value_4")
+	slOneLogTwo.Body().SetBool(true)
+
+	scopeLogs.AppendEmpty().Scope().SetName("an_instrumentation_scope_without_version_or_logs")
+
+	slThreeLogs := scopeLogs.AppendEmpty().LogRecords()
+	slThreeLogOne := slThreeLogs.AppendEmpty()
+	slThreeLogOne.SetTimestamp(pcommon.NewTimestampFromTime(time.Date(1972, 1, 2, 3, 4, 5, 6, time.UTC)))
+	slThreeLogOne.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Date(1992, 1, 2, 3, 4, 5, 6, time.UTC)))
+	slThreeLogOne.SetSeverityNumber(plog.SeverityNumberInfo)
+	slThreeLogOne.SetSeverityText("severity-text-3")
+	slThreeLogOne.Attributes().PutString("attribute_name_5", "attribute_value_5")
+	slThreeLogOne.Attributes().PutString("attribute_name_6", "attribute_value_6")
+	slThreeLogOne.Body().SetInt(1)
+
+	slThreeLogTwo := slThreeLogs.AppendEmpty()
+	slThreeLogTwo.SetTimestamp(pcommon.NewTimestampFromTime(time.Date(1973, 1, 2, 3, 4, 5, 6, time.UTC)))
+	slThreeLogTwo.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Date(1993, 1, 2, 3, 4, 5, 6, time.UTC)))
+	slThreeLogTwo.SetSeverityNumber(plog.SeverityNumberWarn)
+	slThreeLogTwo.SetSeverityText("severity-text-4")
+	slThreeLogTwo.Attributes().PutString("attribute_name_7", "attribute_value_7")
+	slThreeLogTwo.Attributes().PutString("attribute_name_8", "attribute_value_8")
+	slThreeLogTwo.Body().SetDouble(1.234)
+
+	slThreeLogThree := slThreeLogs.AppendEmpty()
+	slThreeLogThree.SetTimestamp(pcommon.NewTimestampFromTime(time.Date(1974, 1, 2, 3, 4, 5, 6, time.UTC)))
+	slThreeLogThree.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Date(1994, 1, 2, 3, 4, 5, 6, time.UTC)))
+	slThreeLogThree.SetSeverityNumber(plog.SeverityNumberError)
+	slThreeLogThree.SetSeverityText("severity-text-5")
+	slThreeLogThree.Attributes().PutString("attribute_name_9", "attribute_value_9")
+	slThreeLogThree.Attributes().PutString("attribute_name_10", "attribute_value_10")
+	slThreeLogThree.Body().SetEmptyMap().FromRaw(map[string]any{"one.key": "one.val", "two.key": 2})
+
+	slThreeLogFour := slThreeLogs.AppendEmpty()
+	slThreeLogFour.SetTimestamp(pcommon.NewTimestampFromTime(time.Date(1975, 1, 2, 3, 4, 5, 6, time.UTC)))
+	slThreeLogFour.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Date(1995, 1, 2, 3, 4, 5, 6, time.UTC)))
+	slThreeLogFour.SetSeverityNumber(plog.SeverityNumberFatal)
+	slThreeLogFour.SetSeverityText("severity-text-6")
+	slThreeLogFour.Attributes().PutString("attribute_name_11", "attribute_value_11")
+	slThreeLogFour.Attributes().PutString("attribute_name_12", "attribute_value_12")
+	slThreeLogFour.Body().SetEmptyBytes().FromRaw([]byte("bytes"))
+	return logs
+}

--- a/tests/testutils/telemetry/pdata_logs_test.go
+++ b/tests/testutils/telemetry/pdata_logs_test.go
@@ -1,0 +1,108 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestPDataToResourceLogsHappyPath(t *testing.T) {
+	resourceLogs, err := PDataToResourceLogs(PDataLogs())
+	assert.NoError(t, err)
+	require.NotNil(t, resourceLogs)
+
+	rls := resourceLogs.ResourceLogs
+	assert.Len(t, rls, 1)
+	rl := rls[0]
+	attrs := rl.Resource.Attributes
+	assert.True(t, attrs["bool"].(bool))
+	assert.Equal(t, "a_string", attrs["string"].(string))
+	assert.Equal(t, 123, attrs["int"])
+	assert.Equal(t, 123.45, attrs["double"])
+	assert.Nil(t, attrs["null"])
+
+	scopeLogs := rl.ScopeLogs
+	assert.Len(t, scopeLogs, 3)
+	assert.Equal(t, "an_instrumentation_scope_name", scopeLogs[0].Scope.Name)
+	assert.Equal(t, "an_instrumentation_scope_version", scopeLogs[0].Scope.Version)
+
+	require.Len(t, scopeLogs[0].Logs, 2)
+
+	slOneLogOne := scopeLogs[0].Logs[0]
+	assert.Equal(t, "body - string value", slOneLogOne.Body)
+	assert.Equal(t, map[string]any{
+		"attribute_name_1": "attribute_value_1",
+		"attribute_name_2": "attribute_value_2",
+	}, *slOneLogOne.Attributes)
+	assert.Equal(t, "severity-text-1", slOneLogOne.SeverityText)
+	assert.Equal(t, plog.SeverityNumberTrace, *slOneLogOne.Severity)
+
+	slOneLogTwo := scopeLogs[0].Logs[1]
+	assert.Equal(t, true, slOneLogTwo.Body)
+	assert.Equal(t, map[string]any{
+		"attribute_name_3": "attribute_value_3",
+		"attribute_name_4": "attribute_value_4",
+	}, *slOneLogTwo.Attributes)
+	assert.Equal(t, "severity-text-2", slOneLogTwo.SeverityText)
+	assert.Equal(t, plog.SeverityNumberDebug, *slOneLogTwo.Severity)
+
+	assert.Equal(t, "an_instrumentation_scope_without_version_or_logs", scopeLogs[1].Scope.Name)
+	assert.Equal(t, "", scopeLogs[1].Scope.Version)
+	assert.Len(t, scopeLogs[1].Logs, 0)
+
+	assert.Equal(t, "", scopeLogs[2].Scope.Name)
+	assert.Equal(t, "", scopeLogs[2].Scope.Version)
+	require.Len(t, scopeLogs[2].Logs, 4)
+
+	slThreeLogOne := scopeLogs[2].Logs[0]
+	assert.Equal(t, int64(1), slThreeLogOne.Body)
+	assert.Equal(t, map[string]any{
+		"attribute_name_5": "attribute_value_5",
+		"attribute_name_6": "attribute_value_6",
+	}, *slThreeLogOne.Attributes)
+	assert.Equal(t, "severity-text-3", slThreeLogOne.SeverityText)
+	assert.Equal(t, plog.SeverityNumberInfo, *slThreeLogOne.Severity)
+
+	slThreeLogTwo := scopeLogs[2].Logs[1]
+	assert.Equal(t, 1.234, slThreeLogTwo.Body)
+	assert.Equal(t, map[string]any{
+		"attribute_name_7": "attribute_value_7",
+		"attribute_name_8": "attribute_value_8",
+	}, *slThreeLogTwo.Attributes)
+	assert.Equal(t, "severity-text-4", slThreeLogTwo.SeverityText)
+	assert.Equal(t, plog.SeverityNumberWarn, *slThreeLogTwo.Severity)
+
+	slThreeLogThree := scopeLogs[2].Logs[2]
+	assert.Equal(t, map[string]any{"one.key": "one.val", "two.key": int64(2)}, slThreeLogThree.Body)
+	assert.Equal(t, map[string]any{
+		"attribute_name_9":  "attribute_value_9",
+		"attribute_name_10": "attribute_value_10",
+	}, *slThreeLogThree.Attributes)
+	assert.Equal(t, "severity-text-5", slThreeLogThree.SeverityText)
+	assert.Equal(t, plog.SeverityNumberError, *slThreeLogThree.Severity)
+
+	slThreeLogFour := scopeLogs[2].Logs[3]
+	assert.Equal(t, []byte("bytes"), slThreeLogFour.Body)
+	assert.Equal(t, map[string]any{
+		"attribute_name_11": "attribute_value_11",
+		"attribute_name_12": "attribute_value_12",
+	}, *slThreeLogFour.Attributes)
+	assert.Equal(t, "severity-text-6", slThreeLogFour.SeverityText)
+	assert.Equal(t, plog.SeverityNumberFatal, *slThreeLogFour.Severity)
+}

--- a/tests/testutils/telemetry/testdata/logs/attribute-value-resource-logs.yaml
+++ b/tests/testutils/telemetry/testdata/logs/attribute-value-resource-logs.yaml
@@ -1,0 +1,9 @@
+resource_logs:
+  - scope_logs:
+      - logs:
+          - body: a string body
+            severity_text: info
+            severity: 1
+            attributes:
+              attribute_one: value_one
+              attribute_two: value_two

--- a/tests/testutils/telemetry/testdata/logs/empty-attributes-required.yaml
+++ b/tests/testutils/telemetry/testdata/logs/empty-attributes-required.yaml
@@ -1,0 +1,7 @@
+resource_logs:
+  - scope_logs:
+      - logs:
+          - body: a string body
+            severity_text: info
+            severity: 1
+            attributes: {}

--- a/tests/testutils/telemetry/testdata/logs/expected-logs.yaml
+++ b/tests/testutils/telemetry/testdata/logs/expected-logs.yaml
@@ -1,0 +1,9 @@
+resource_logs:
+  - scope_logs:
+      - instrumentation_scope:
+          name: with_logs
+          version: another_version
+        logs:
+          - body: true
+            severity_text: arbitrary
+          - body: 0.123

--- a/tests/testutils/telemetry/testdata/logs/invalid-resource-logs.yaml
+++ b/tests/testutils/telemetry/testdata/logs/invalid-resource-logs.yaml
@@ -1,0 +1,3 @@
+resource_logs:
+  - notAttributesOrScopeLogs:
+      - thing: value

--- a/tests/testutils/telemetry/testdata/logs/never-received-instrumentation-scope.yaml
+++ b/tests/testutils/telemetry/testdata/logs/never-received-instrumentation-scope.yaml
@@ -1,0 +1,13 @@
+resource_logs:
+  - scope_logs:
+      - instrumentation_scope:
+          name: with_logs
+          version: another_version
+        logs:
+          - body: true
+            severity_text: arbitrary
+            severity: 24
+          - body: 0.123
+            severity: 9
+      - instrumentation_scope:
+          name: unmatched_instrumentation_scope

--- a/tests/testutils/telemetry/testdata/logs/never-received-logs.yaml
+++ b/tests/testutils/telemetry/testdata/logs/never-received-logs.yaml
@@ -1,0 +1,9 @@
+resource_logs:
+  - scope_logs:
+      - instrumentation_scope:
+          name: with_logs
+          version: another_version
+        logs:
+          - body: true
+            severity_text: never received
+          - body: 0.123

--- a/tests/testutils/telemetry/testdata/logs/never-received-resource.yaml
+++ b/tests/testutils/telemetry/testdata/logs/never-received-resource.yaml
@@ -1,0 +1,13 @@
+resource_logs:
+  - attributes:
+      not: matched
+  - scope_logs:
+      - instrumentation_scope:
+          name: with_logs
+          version: another_version
+        logs:
+          - body: true
+            severity_text: arbitrary
+            severity: 24
+          - body: 0.123
+            severity: 9

--- a/tests/testutils/telemetry/testdata/logs/resource-logs.yaml
+++ b/tests/testutils/telemetry/testdata/logs/resource-logs.yaml
@@ -1,0 +1,26 @@
+resource_logs:
+  - attributes:
+      one_attr: one_value
+      two_attr: two_value
+    scope_logs:
+      - instrumentation_scope:
+          name: without_logs
+          version: some_version
+      - logs:
+          - body: a string body
+            severity_text: info
+            severity: 1
+            attributes:
+              one_lr_attr: one_lr_value
+              two_lr_attr: two_lr_value
+          - body: 0
+  - scope_logs:
+      - instrumentation_scope:
+          name: with_logs
+          version: another_version
+        logs:
+          - body: true
+            severity_text: arbitrary
+            severity: 24
+          - body: 0.123
+            severity: 9

--- a/tests/testutils/telemetry/testdata/logs/unspecified-attributes-allowed.yaml
+++ b/tests/testutils/telemetry/testdata/logs/unspecified-attributes-allowed.yaml
@@ -1,0 +1,6 @@
+resource_logs:
+  - scope_logs:
+      - logs:
+          - body: a string body
+            severity_text: info
+            severity: 1


### PR DESCRIPTION
In preparation of adding the discovery receiver these changes add a new ResourceLogs test format and associate an otlp logs receiver with the testsuite sink.

Also adding a `WithMount` container helper and `CollectorBuilder` pattern to be able to arbitrarily update the tested collector, which is required for mounting files without adding a more strict signature.

Requires https://github.com/signalfx/splunk-otel-collector/pull/2069