### PR TITLE
Adopt discovery receiver

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -58,7 +58,7 @@ new release. In addition, any of these components may be removed prior to the
 These components should not be considered stable. They are made available
 for testing and validation purposes.
 
-| Receivers | Processors                                                                                                                 | Exporters                                     | Extensions |
-|-----------|----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|------------|
-|           | [span_metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/spanmetricsprocessor) | [pulsar](../internal/exporter/pulsarexporter) |            |
-|           | [timestamp](../pkg/processor/timestamp)                                                                                    |                                               |            | 
+| Receivers                                           | Processors                                                                                                                 | Exporters                                     | Extensions |
+|-----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|------------|
+| [discovery](../internal/receiver/discoveryreceiver) | [span_metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/spanmetricsprocessor) | [pulsar](../internal/exporter/pulsarexporter) |            |
+|                                                     | [timestamp](../pkg/processor/timestamp)                                                                                    |                                               |            |

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -84,6 +84,7 @@ import (
 	"github.com/signalfx/splunk-otel-collector/internal/exporter/httpsinkexporter"
 	"github.com/signalfx/splunk-otel-collector/internal/exporter/pulsarexporter"
 	"github.com/signalfx/splunk-otel-collector/internal/receiver/databricksreceiver"
+	"github.com/signalfx/splunk-otel-collector/internal/receiver/discoveryreceiver"
 	"github.com/signalfx/splunk-otel-collector/processor/timestampprocessor"
 	"github.com/signalfx/splunk-otel-collector/receiver/smartagentreceiver"
 )
@@ -113,6 +114,7 @@ func Get() (component.Factories, error) {
 		cloudfoundryreceiver.NewFactory(),
 		collectdreceiver.NewFactory(),
 		databricksreceiver.NewFactory(),
+		discoveryreceiver.NewFactory(),
 		fluentforwardreceiver.NewFactory(),
 		filelogreceiver.NewFactory(),
 		hostmetricsreceiver.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -44,6 +44,7 @@ func TestDefaultComponents(t *testing.T) {
 		"cloudfoundry",
 		"collectd",
 		"databricks",
+		"discovery",
 		"filelog",
 		"fluentforward",
 		"hostmetrics",

--- a/internal/receiver/discoveryreceiver/README.md
+++ b/internal/receiver/discoveryreceiver/README.md
@@ -148,28 +148,28 @@ receivers:
          config:
            type: collectd/redis
            // the metric or log statement
-           status:
-             metrics:
-               successful:
-                 - regexp: '.*'
-                   // Only emit a single log record for this status entry instead of one for each matching received metric (`false`, the default)
-                   first_only: true
-                   record:
-                     severity_text: info
-                     body: Successfully able to connect to Redis container.
-             statements:
-               partial:
-                 - regexp: (WRONGPASS|NOAUTH|ERR AUTH)
-                   first_only: true
-                   record:
-                     severity_text: warn
-                     body: Container appears to be accepting redis connections but the default auth setting is incorrect. 
-               failed:
-                 - regexp: ConnectionRefusedError
-                   first_only: true
-                   record:
-                     severity_text: debug
-                     body: Container appears to not be accepting redis connections.
+         status:
+           metrics:
+             successful:
+               - regexp: '.*'
+                 // Only emit a single log record for this status entry instead of one for each matching received metric (`false`, the default)
+                 first_only: true
+                 log_record:
+                   severity_text: info
+                   body: Successfully able to connect to Redis container.
+           statements:
+             partial:
+               - regexp: (WRONGPASS|NOAUTH|ERR AUTH)
+                 first_only: true
+                 log_record:
+                   severity_text: warn
+                   body: Container appears to be accepting redis connections but the default auth setting is incorrect.
+             failed:
+               - regexp: ConnectionRefusedError
+                 first_only: true
+                 log_record:
+                   severity_text: debug
+                   body: Container appears to not be accepting redis connections.
 exporters:
   logging:
     logLevel: debug

--- a/internal/receiver/discoveryreceiver/evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/evaluator_test.go
@@ -147,7 +147,7 @@ func TestCorrelateResourceAttrs(t *testing.T) {
 
 			expectedAttrs := map[string]string{}
 			if embed {
-				expectedAttrs["discovery.receiver.updated.config"] = encodedWatchObserver
+				expectedAttrs["discovery.receiver.updated.config.type/name"] = encodedWatchObserver
 			}
 
 			require.Equal(t, expectedAttrs, attrs)
@@ -202,7 +202,7 @@ func TestCorrelateResourceAttrsWithExistingConfig(t *testing.T) {
 			expectedAttrs := map[string]string{}
 
 			if embed {
-				expectedAttrs["discovery.receiver.updated.config"] = receiverConfig
+				expectedAttrs["discovery.receiver.updated.config.type/name"] = receiverConfig
 			}
 
 			require.Equal(t, expectedAttrs, attrs)

--- a/tests/receivers/discovery/discovery_test.go
+++ b/tests/receivers/discovery/discovery_test.go
@@ -1,0 +1,35 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/signalfx/splunk-otel-collector/tests/testutils"
+)
+
+func TestDiscoveryReceiverWithHostObserverProvidesEndpointLogs(t *testing.T) {
+	testutils.AssertAllLogsReceived(
+		t, "host_observer_endpoints.yaml",
+		"host_observer_endpoints_config.yaml", nil,
+	)
+}
+
+func TestDiscoveryReceiverWithHostObserverAndSimplePrometheusReceiverProvideStatusLogs(t *testing.T) {
+	testutils.AssertAllLogsReceived(
+		t, "host_observer_simple_prometheus_statuses.yaml",
+		"host_observer_simple_prometheus_config.yaml", nil,
+	)
+}

--- a/tests/receivers/discovery/testdata/host_observer_endpoints_config.yaml
+++ b/tests/receivers/discovery/testdata/host_observer_endpoints_config.yaml
@@ -1,0 +1,28 @@
+extensions:
+  host_observer:
+  host_observer/with_name:
+  host_observer/with/another/name:
+
+receivers:
+  discovery:
+    log_endpoints: true
+    watch_observers:
+      - host_observer
+      - host_observer/with_name
+      - host_observer/with/another/name
+
+exporters:
+  otlp:
+    endpoint: "${OTLP_ENDPOINT}"
+    tls:
+      insecure: true
+
+service:
+  extensions:
+    - host_observer
+    - host_observer/with_name
+    - host_observer/with/another/name
+  pipelines:
+    logs:
+      receivers: [discovery]
+      exporters: [otlp]

--- a/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
+++ b/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
@@ -4,6 +4,11 @@ extensions:
   host_observer/with/another/name:
 
 receivers:
+  # set up otlp receiver to use its endpoints as assertion material
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
   discovery:
     embed_receiver_config: true
     receivers:
@@ -55,6 +60,9 @@ service:
     - host_observer/with_name
     - host_observer/with/another/name
   pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [otlp]
     logs:
       receivers: [discovery]
       processors: [attributes]

--- a/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
+++ b/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
@@ -1,0 +1,61 @@
+extensions:
+  host_observer:
+  host_observer/with_name:
+  host_observer/with/another/name:
+
+receivers:
+  discovery:
+    embed_receiver_config: true
+    receivers:
+      prometheus_simple:
+        rule: type == "hostport"
+        resource_attributes:
+          one.key: one.value
+          two.key: two.value
+        status:
+          metrics:
+            successful:
+                - regexp: ^otelcol_receiver_accepted_metric_points$
+                  first_only: true
+                  log_record:
+                    severity_text: info
+                    body: Successfully connected to prometheus server
+          statements:
+            failed:
+              - strict: Failed to scrape Prometheus endpoint
+                first_only: true
+                log_record:
+                  severity_text: debug
+                  body: Port appears to not be serving prometheus metrics
+
+    watch_observers:
+      - host_observer
+      - host_observer/with_name
+      - host_observer/with/another/name
+
+# drop scrape_timestamp attributes until we can accept arbitrary values
+processors:
+  attributes:
+    actions:
+      - action: delete
+        key: scrape_timestamp
+
+exporters:
+  otlp:
+    endpoint: "${OTLP_ENDPOINT}"
+    tls:
+      insecure: true
+
+service:
+  telemetry:
+    logs:
+      level: debug
+  extensions:
+    - host_observer
+    - host_observer/with_name
+    - host_observer/with/another/name
+  pipelines:
+    logs:
+      receivers: [discovery]
+      processors: [attributes]
+      exporters: [otlp]

--- a/tests/receivers/discovery/testdata/resource_logs/host_observer_endpoints.yaml
+++ b/tests/receivers/discovery/testdata/resource_logs/host_observer_endpoints.yaml
@@ -1,0 +1,85 @@
+resource_logs:
+  - attributes:
+      discovery.event.type: endpoint.added
+      discovery.observer.type: host_observer
+      discovery.observer.name: ""
+    scope_logs:
+      - logs:
+          - body: endpoint.added hostport endpoint (host_observer)127.0.0.1-55554-TCP-1
+            severity_text: info
+            attributes:
+              command: /otelcol --config /etc/config.yaml
+              endpoint: 127.0.0.1:55554
+              id: (host_observer)127.0.0.1-55554-TCP-1
+              is_ipv6: false
+              port: 55554
+              process_name: otelcol
+              transport: TCP
+              type: hostport
+          - body: endpoint.added hostport endpoint (host_observer)[::]-8888-TCP-1
+            severity_text: info
+            attributes:
+              command: /otelcol --config /etc/config.yaml
+              endpoint: '[::]:8888'
+              id: (host_observer)[::]-8888-TCP-1
+              is_ipv6: true
+              port: 8888
+              process_name: otelcol
+              transport: TCP
+              type: hostport
+  - attributes:
+      discovery.event.type: endpoint.added
+      discovery.observer.type: host_observer
+      discovery.observer.name: with_name
+    scope_logs:
+      - logs:
+          - body: endpoint.added hostport endpoint (host_observer/with_name)127.0.0.1-55554-TCP-1
+            severity_text: info
+            attributes:
+              command: /otelcol --config /etc/config.yaml
+              endpoint: 127.0.0.1:55554
+              id: (host_observer/with_name)127.0.0.1-55554-TCP-1
+              is_ipv6: false
+              port: 55554
+              process_name: otelcol
+              transport: TCP
+              type: hostport
+          - body: endpoint.added hostport endpoint (host_observer/with_name)[::]-8888-TCP-1
+            severity_text: info
+            attributes:
+              command: /otelcol --config /etc/config.yaml
+              endpoint: '[::]:8888'
+              id: (host_observer/with_name)[::]-8888-TCP-1
+              is_ipv6: true
+              port: 8888
+              process_name: otelcol
+              transport: TCP
+              type: hostport
+  - attributes:
+      discovery.event.type: endpoint.added
+      discovery.observer.type: host_observer
+      discovery.observer.name: with/another/name
+    scope_logs:
+      - logs:
+          - body: endpoint.added hostport endpoint (host_observer/with/another/name)127.0.0.1-55554-TCP-1
+            severity_text: info
+            attributes:
+              command: /otelcol --config /etc/config.yaml
+              endpoint: 127.0.0.1:55554
+              id: (host_observer/with/another/name)127.0.0.1-55554-TCP-1
+              is_ipv6: false
+              port: 55554
+              process_name: otelcol
+              transport: TCP
+              type: hostport
+          - body: endpoint.added hostport endpoint (host_observer/with/another/name)[::]-8888-TCP-1
+            severity_text: info
+            attributes:
+              command: /otelcol --config /etc/config.yaml
+              endpoint: '[::]:8888'
+              id: (host_observer/with/another/name)[::]-8888-TCP-1
+              is_ipv6: true
+              port: 8888
+              process_name: otelcol
+              transport: TCP
+              type: hostport

--- a/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
+++ b/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
@@ -1,0 +1,121 @@
+resource_logs:
+  - attributes:
+      discovery.endpoint.id: (host_observer)[::]-8888-TCP-1
+      discovery.event.type: metric.match
+      discovery.observer.id: host_observer
+      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyCg==
+      discovery.receiver.rule: type == "hostport"
+      discovery.receiver.type: prometheus_simple
+      http.scheme: http
+      net.host.port: "8888"
+      one.key: one.value
+      service.instance.id: '[::]:8888'
+      service.name: prometheus_simple/[::]:8888
+      two.key: two.value
+    scope_logs:
+      - logs:
+          - body: Successfully connected to prometheus server
+            attributes:
+              discovery.status: successful
+              metric.name: otelcol_receiver_accepted_metric_points
+            severity: 0
+            severity_text: info
+  - attributes:
+      discovery.endpoint.id: (host_observer)127.0.0.1-631-UDP
+      discovery.event.type: statement.match
+      discovery.observer.id: host_observer
+      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyCg==
+      discovery.receiver.name: ""
+      discovery.receiver.rule: type == "hostport"
+      discovery.receiver.type: prometheus_simple
+    scope_logs:
+      - logs:
+          - body: Port appears to not be serving prometheus metrics
+            attributes:
+              caller: internal/transaction.go:111
+              discovery.status: failed
+              kind: receiver
+              name: prometheus_simple//receiver_creator/discovery{endpoint="127.0.0.1:631"}/(host_observer)127.0.0.1-631-UDP
+              target_labels: '{__name__="up", instance="127.0.0.1:631", job="prometheus_simple/127.0.0.1:631"}'
+            severity: 0
+            severity_text: debug
+  - attributes:
+      discovery.endpoint.id: (host_observer/with_name)[::]-8888-TCP-1
+      discovery.event.type: metric.match
+      discovery.observer.id: host_observer/with_name
+      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyL3dpdGhfbmFtZQo=
+      discovery.receiver.rule: type == "hostport"
+      discovery.receiver.type: prometheus_simple
+      http.scheme: http
+      net.host.port: "8888"
+      one.key: one.value
+      service.instance.id: '[::]:8888'
+      service.name: prometheus_simple/[::]:8888
+      two.key: two.value
+    scope_logs:
+      - logs:
+          - body: Successfully connected to prometheus server
+            attributes:
+              discovery.status: successful
+              metric.name: otelcol_receiver_accepted_metric_points
+            severity: 0
+            severity_text: info
+  - attributes:
+      discovery.endpoint.id: (host_observer/with_name)127.0.0.1-631-UDP
+      discovery.event.type: statement.match
+      discovery.observer.id: host_observer/with_name
+      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyL3dpdGhfbmFtZQo=
+      discovery.receiver.name: ""
+      discovery.receiver.rule: type == "hostport"
+      discovery.receiver.type: prometheus_simple
+    scope_logs:
+      - logs:
+          - body: Port appears to not be serving prometheus metrics
+            attributes:
+              caller: internal/transaction.go:111
+              discovery.status: failed
+              kind: receiver
+              name: prometheus_simple//receiver_creator/discovery{endpoint="127.0.0.1:631"}/(host_observer/with_name)127.0.0.1-631-UDP
+              target_labels: '{__name__="up", instance="127.0.0.1:631", job="prometheus_simple/127.0.0.1:631"}'
+            severity: 0
+            severity_text: debug
+  - attributes:
+      discovery.endpoint.id: (host_observer/with/another/name)[::]-8888-TCP-1
+      discovery.event.type: metric.match
+      discovery.observer.id: host_observer/with/another/name
+      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyL3dpdGgvYW5vdGhlci9uYW1lCg==
+      discovery.receiver.rule: type == "hostport"
+      discovery.receiver.type: prometheus_simple
+      http.scheme: http
+      net.host.port: "8888"
+      one.key: one.value
+      service.instance.id: '[::]:8888'
+      service.name: prometheus_simple/[::]:8888
+      two.key: two.value
+    scope_logs:
+      - logs:
+          - body: Successfully connected to prometheus server
+            attributes:
+              discovery.status: successful
+              metric.name: otelcol_receiver_accepted_metric_points
+            severity: 0
+            severity_text: info
+  - attributes:
+      discovery.endpoint.id: (host_observer/with/another/name)127.0.0.1-631-UDP
+      discovery.event.type: statement.match
+      discovery.observer.id: host_observer/with/another/name
+      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyL3dpdGgvYW5vdGhlci9uYW1lCg==
+      discovery.receiver.name: ""
+      discovery.receiver.rule: type == "hostport"
+      discovery.receiver.type: prometheus_simple
+    scope_logs:
+      - logs:
+          - body: Port appears to not be serving prometheus metrics
+            attributes:
+              caller: internal/transaction.go:111
+              discovery.status: failed
+              kind: receiver
+              name: prometheus_simple//receiver_creator/discovery{endpoint="127.0.0.1:631"}/(host_observer/with/another/name)127.0.0.1-631-UDP
+              target_labels: '{__name__="up", instance="127.0.0.1:631", job="prometheus_simple/127.0.0.1:631"}'
+            severity: 0
+            severity_text: debug

--- a/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
+++ b/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
@@ -21,7 +21,7 @@ resource_logs:
             severity: 0
             severity_text: info
   - attributes:
-      discovery.endpoint.id: (host_observer)127.0.0.1-631-UDP
+      discovery.endpoint.id: (host_observer)[::]-4318-TCP-1
       discovery.event.type: statement.match
       discovery.observer.id: host_observer
       discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyCg==
@@ -35,8 +35,8 @@ resource_logs:
               caller: internal/transaction.go:111
               discovery.status: failed
               kind: receiver
-              name: prometheus_simple//receiver_creator/discovery{endpoint="127.0.0.1:631"}/(host_observer)127.0.0.1-631-UDP
-              target_labels: '{__name__="up", instance="127.0.0.1:631", job="prometheus_simple/127.0.0.1:631"}'
+              name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer)[::]-4318-TCP-1
+              target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
             severity: 0
             severity_text: debug
   - attributes:
@@ -61,7 +61,7 @@ resource_logs:
             severity: 0
             severity_text: info
   - attributes:
-      discovery.endpoint.id: (host_observer/with_name)127.0.0.1-631-UDP
+      discovery.endpoint.id: (host_observer/with_name)[::]-4318-TCP-1
       discovery.event.type: statement.match
       discovery.observer.id: host_observer/with_name
       discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyL3dpdGhfbmFtZQo=
@@ -75,8 +75,8 @@ resource_logs:
               caller: internal/transaction.go:111
               discovery.status: failed
               kind: receiver
-              name: prometheus_simple//receiver_creator/discovery{endpoint="127.0.0.1:631"}/(host_observer/with_name)127.0.0.1-631-UDP
-              target_labels: '{__name__="up", instance="127.0.0.1:631", job="prometheus_simple/127.0.0.1:631"}'
+              name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer/with_name)[::]-4318-TCP-1
+              target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
             severity: 0
             severity_text: debug
   - attributes:
@@ -101,7 +101,7 @@ resource_logs:
             severity: 0
             severity_text: info
   - attributes:
-      discovery.endpoint.id: (host_observer/with/another/name)127.0.0.1-631-UDP
+      discovery.endpoint.id: (host_observer/with/another/name)[::]-4318-TCP-1
       discovery.event.type: statement.match
       discovery.observer.id: host_observer/with/another/name
       discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyL3dpdGgvYW5vdGhlci9uYW1lCg==
@@ -115,7 +115,7 @@ resource_logs:
               caller: internal/transaction.go:111
               discovery.status: failed
               kind: receiver
-              name: prometheus_simple//receiver_creator/discovery{endpoint="127.0.0.1:631"}/(host_observer/with/another/name)127.0.0.1-631-UDP
-              target_labels: '{__name__="up", instance="127.0.0.1:631", job="prometheus_simple/127.0.0.1:631"}'
+              name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer/with/another/name)[::]-4318-TCP-1
+              target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
             severity: 0
             severity_text: debug


### PR DESCRIPTION
These changes include the discovery receiver in the Splunk distribution and include new integration tests. Also corrected the example yaml in the readme and updated to fix a race condition the tests uncovered where empty observer IDs are used in the embedded config.