### PR TITLE
testutils: unify <ANY> and <VERSION_FROM_BUILD> values and checks

### DIFF
--- a/tests/general/discoverymode/testdata/resource_metrics/memory.yaml
+++ b/tests/general/discoverymode/testdata/resource_metrics/memory.yaml
@@ -2,7 +2,7 @@ resource_metrics:
   - scope_metrics:
       - instrumentation_scope:
           name: otelcol/hostmetricsreceiver/memory
-          version: <FROM_BUILD>
+          version: <VERSION_FROM_BUILD>
         metrics:
           - name: system.memory.usage
             type: IntNonmonotonicCumulativeSum

--- a/tests/general/testdata/resource_metrics/cpu.yaml
+++ b/tests/general/testdata/resource_metrics/cpu.yaml
@@ -2,7 +2,7 @@ resource_metrics:
   - scope_metrics:
       - instrumentation_scope:
           name: otelcol/hostmetricsreceiver/cpu
-          version: <FROM_BUILD>
+          version: <VERSION_FROM_BUILD>
         metrics:
           - name: system.cpu.time
             type: DoubleMonotonicCumulativeSum

--- a/tests/general/testdata/resource_metrics/env_config_source_labels.yaml
+++ b/tests/general/testdata/resource_metrics/env_config_source_labels.yaml
@@ -2,7 +2,7 @@ resource_metrics:
   - scope_metrics:
       - instrumentation_scope:
           name: otelcol/hostmetricsreceiver/memory
-          version: <FROM_BUILD>
+          version: <VERSION_FROM_BUILD>
         metrics:
           - name: system.memory.usage
             type: IntNonmonotonicCumulativeSum

--- a/tests/general/testdata/resource_metrics/envvar_labels.yaml
+++ b/tests/general/testdata/resource_metrics/envvar_labels.yaml
@@ -2,7 +2,7 @@ resource_metrics:
   - scope_metrics:
       - instrumentation_scope:
           name: otelcol/hostmetricsreceiver/memory
-          version: <FROM_BUILD>
+          version: <VERSION_FROM_BUILD>
         metrics:
           - name: system.memory.usage
             type: IntNonmonotonicCumulativeSum

--- a/tests/general/testdata/resource_metrics/incompat_env_config_source_labels.yaml
+++ b/tests/general/testdata/resource_metrics/incompat_env_config_source_labels.yaml
@@ -2,7 +2,7 @@ resource_metrics:
   - scope_metrics:
       - instrumentation_scope:
           name: otelcol/hostmetricsreceiver/memory
-          version: <FROM_BUILD>
+          version: <VERSION_FROM_BUILD>
         metrics:
           - name: system.memory.usage
             type: IntNonmonotonicCumulativeSum

--- a/tests/general/testdata/resource_metrics/yaml_from_env.yaml
+++ b/tests/general/testdata/resource_metrics/yaml_from_env.yaml
@@ -2,7 +2,7 @@ resource_metrics:
   - scope_metrics:
       - instrumentation_scope:
           name: otelcol/hostmetricsreceiver/memory
-          version: <FROM_BUILD>
+          version: <VERSION_FROM_BUILD>
         metrics:
           - name: system.memory.usage
             type: IntNonmonotonicCumulativeSum

--- a/tests/receivers/oracledb/testdata/resource_metrics/all.yaml
+++ b/tests/receivers/oracledb/testdata/resource_metrics/all.yaml
@@ -2,7 +2,10 @@ resource_metrics:
   - attributes:
       oracledb.instance.name: localhost:1521
     scope_metrics:
-      - metrics:
+      - instrumentation_scope:
+          name: otelcol/oracledbreceiver
+          version: <VERSION_FROM_BUILD>
+        metrics:
           - name: oracledb.cpu_time
             type: DoubleMonotonicCumulativeSum
           - name: oracledb.enqueue_deadlocks

--- a/tests/testutils/collector_container.go
+++ b/tests/testutils/collector_container.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var configFromArgsPattern = regexp.MustCompile("--config($|[^d]+)")
+var configFromArgsPattern = regexp.MustCompile("--config($|[^d-]+)")
 
 var _ Collector = (*CollectorContainer)(nil)
 var _ testcontainers.LogConsumer = (*collectorLogConsumer)(nil)
@@ -120,10 +120,12 @@ func (collector CollectorContainer) Build() (Collector, error) {
 
 	collector.Container = collector.Container.WithExposedPorts(collector.Ports...)
 
-	if collector.Fail {
-		collector.Container = collector.Container.WillWaitForLogs("")
-	} else {
-		collector.Container = collector.Container.WillWaitForLogs("Everything is ready. Begin running and processing data.")
+	if len(collector.Container.WaitingFor) == 0 {
+		if collector.Fail {
+			collector.Container = collector.Container.WillWaitForLogs("")
+		} else {
+			collector.Container = collector.Container.WillWaitForLogs("Everything is ready. Begin running and processing data.")
+		}
 	}
 
 	if len(collector.Args) > 0 {

--- a/tests/testutils/otlp_receiver_sink.go
+++ b/tests/testutils/otlp_receiver_sink.go
@@ -230,7 +230,7 @@ func (otlp *OTLPReceiverSink) AssertAllMetricsReceived(t *testing.T, expectedRes
 		receivedMetrics = telemetry.FlattenResourceMetrics(receivedMetrics, receivedResourceMetrics)
 
 		var containsAll bool
-		containsAll, err = receivedMetrics.ContainsAll(expectedResourceMetrics, true)
+		containsAll, err = receivedMetrics.ContainsAll(expectedResourceMetrics)
 		return containsAll
 	}, waitTime, 10*time.Millisecond, "Failed to receive expected metrics")
 

--- a/tests/testutils/telemetry/common_test.go
+++ b/tests/testutils/telemetry/common_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestResourceHashFunctionConsistency(t *testing.T) {
-	resource := Resource{Attributes: map[string]any{
+	resource := Resource{Attributes: &map[string]any{
 		"one": "1", "two": 2, "three": 3.000, "four": false, "five": nil,
 	}}
 	for i := 0; i < 100; i++ {
@@ -36,21 +36,24 @@ func TestResourceHashFunctionConsistency(t *testing.T) {
 }
 
 func TestEmptyResourcesAreEqual(t *testing.T) {
-	rOne := Resource{Attributes: map[string]any{}}
-	rTwo := Resource{}
+	rOne := Resource{Attributes: &map[string]any{}}
+	rTwo := Resource{Attributes: &map[string]any{}}
+	rThree := Resource{}
 
 	require.True(t, rOne.Equals(rTwo))
 	require.True(t, rTwo.Equals(rOne))
+	require.True(t, rThree.Equals(rOne))
+	// nil attrs aren't equal to empty map
+	require.False(t, rTwo.Equals(rThree))
 
 	for i := 0; i < 100; i++ {
 		require.Equal(t, rOne.Hash(), rTwo.Hash())
 	}
-
 }
 
 func TestResourceEquivalence(t *testing.T) {
 	resource := func() Resource {
-		return Resource{Attributes: map[string]any{
+		return Resource{Attributes: &map[string]any{
 			"one": 1, "two": "two", "three": nil,
 			"four": []int{1, 2, 3, 4},
 			"five": map[string]any{
@@ -66,10 +69,10 @@ func TestResourceEquivalence(t *testing.T) {
 	assert.True(t, rOne.Equals(rTwo))
 	assert.True(t, rTwo.Equals(rOne))
 
-	rTwo.Attributes["five"].(map[string]any)["another"] = "item"
+	(*rTwo.Attributes)["five"].(map[string]any)["another"] = "item"
 	assert.False(t, rOne.Equals(rTwo))
 	assert.False(t, rTwo.Equals(rOne))
-	rOne.Attributes["five"].(map[string]any)["another"] = "item"
+	(*rOne.Attributes)["five"].(map[string]any)["another"] = "item"
 	assert.True(t, rOne.Equals(rTwo))
 	assert.True(t, rTwo.Equals(rOne))
 }

--- a/tests/testutils/telemetry/pdata_logs.go
+++ b/tests/testutils/telemetry/pdata_logs.go
@@ -30,7 +30,8 @@ func PDataToResourceLogs(pdataLogs ...plog.Logs) (ResourceLogs, error) {
 		for i := 0; i < numRM; i++ {
 			rl := ResourceLog{}
 			pdataRL := pdataRLs.At(i)
-			rl.Resource.Attributes = sanitizeAttributes(pdataRL.Resource().Attributes().AsRaw())
+			sanitizedAttrs := sanitizeAttributes(pdataRL.Resource().Attributes().AsRaw())
+			rl.Resource.Attributes = &sanitizedAttrs
 			pdataSLs := pdataRL.ScopeLogs()
 			for j := 0; j < pdataSLs.Len(); j++ {
 				sls := ScopeLogs{Logs: []Log{}}
@@ -39,7 +40,7 @@ func PDataToResourceLogs(pdataLogs ...plog.Logs) (ResourceLogs, error) {
 				sls.Scope = InstrumentationScope{
 					Name:       pdataSL.Scope().Name(),
 					Version:    pdataSL.Scope().Version(),
-					Attributes: attrs,
+					Attributes: &attrs,
 				}
 				for k := 0; k < pdataSL.LogRecords().Len(); k++ {
 					pdLR := pdataSL.LogRecords().At(k)

--- a/tests/testutils/telemetry/pdata_logs_test.go
+++ b/tests/testutils/telemetry/pdata_logs_test.go
@@ -30,7 +30,7 @@ func TestPDataToResourceLogsHappyPath(t *testing.T) {
 	rls := resourceLogs.ResourceLogs
 	assert.Len(t, rls, 1)
 	rl := rls[0]
-	attrs := rl.Resource.Attributes
+	attrs := *rl.Resource.Attributes
 	assert.True(t, attrs["bool"].(bool))
 	assert.Equal(t, "a_string", attrs["string"].(string))
 	assert.Equal(t, 123, attrs["int"])

--- a/tests/testutils/telemetry/pdata_metrics.go
+++ b/tests/testutils/telemetry/pdata_metrics.go
@@ -30,14 +30,17 @@ func PDataToResourceMetrics(pdataMetrics ...pmetric.Metrics) (ResourceMetrics, e
 		for i := 0; i < numRM; i++ {
 			rm := ResourceMetric{}
 			pdataRM := pdataRMs.At(i)
-			rm.Resource.Attributes = sanitizeAttributes(pdataRM.Resource().Attributes().AsRaw())
+			sanitizedAttrs := sanitizeAttributes(pdataRM.Resource().Attributes().AsRaw())
+			rm.Resource.Attributes = &sanitizedAttrs
 			pdataSMs := pdataRM.ScopeMetrics()
 			for j := 0; j < pdataSMs.Len(); j++ {
 				ISMs := ScopeMetrics{Metrics: []Metric{}}
 				pdataSM := pdataSMs.At(j)
+				attrs := pdataSM.Scope().Attributes().AsRaw()
 				ISMs.Scope = InstrumentationScope{
-					Name:    pdataSM.Scope().Name(),
-					Version: pdataSM.Scope().Version(),
+					Name:       pdataSM.Scope().Name(),
+					Version:    pdataSM.Scope().Version(),
+					Attributes: &attrs,
 				}
 				for k := 0; k < pdataSM.Metrics().Len(); k++ {
 					pdMetric := pdataSM.Metrics().At(k)

--- a/tests/testutils/telemetry/pdata_metrics_test.go
+++ b/tests/testutils/telemetry/pdata_metrics_test.go
@@ -29,7 +29,7 @@ func TestPDataToResourceMetricsHappyPath(t *testing.T) {
 	rms := resourceMetrics.ResourceMetrics
 	assert.Len(t, rms, 1)
 	rm := rms[0]
-	attrs := rm.Resource.Attributes
+	attrs := *rm.Resource.Attributes
 	assert.True(t, attrs["bool"].(bool))
 	assert.Equal(t, "a_string", attrs["string"])
 	assert.Equal(t, 123, attrs["int"])

--- a/tests/testutils/testdata/expected_host_metrics.yaml
+++ b/tests/testutils/testdata/expected_host_metrics.yaml
@@ -2,7 +2,7 @@ resource_metrics:
   - scope_metrics:
     - instrumentation_scope:
         name: otelcol/hostmetricsreceiver/memory
-        version: <FROM_BUILD>
+        version: <VERSION_FROM_BUILD>
       metrics:
         - name: system.memory.usage
           type: IntNonmonotonicCumulativeSum


### PR DESCRIPTION
These changes introduce a central attribute equality helper used by ResourceLogs and ResourceMetrics. They also update resource attributes to be a `*map[string]any` to conform with the resource item attributes and update associated helpers and integration tests as necessary to expand the functionality provided by the `<ANY>` token value from https://github.com/signalfx/splunk-otel-collector/pull/2011

Also including a minor collector container change to respect specified wait conditions. 