### PR TITLE
Fix example config for Pulsar exporter, units are nanoseconds

### DIFF
--- a/internal/exporter/pulsarexporter/testdata/config.yaml
+++ b/internal/exporter/pulsarexporter/testdata/config.yaml
@@ -23,10 +23,12 @@ exporters:
       compression_level: default
       batch_builder_type: 1
       disable_batching: false
-      batching_max_publish_delay: 10
+      # unit is nanoseconds (10^-9), set to 10 milliseconds in nanoseconds
+      batching_max_publish_delay: 10000000
       batching_max_messages: 1000
       batching_max_size: 128000
-      partitions_auto_discovery_interval: 1
+      # unit is nanoseconds (10^-9), set to 1 minute in nanoseconds
+      partitions_auto_discovery_interval: 60000000000
 
 service:
   pipelines:


### PR DESCRIPTION
- setting `partitions_auto_discovery_interval` to `1` causes a flood of `CommandPartitionedTopicMetadata` requests to brokers. The broker doesn't log these requests with info level, and it's hard to detect the issue. 
  - [The default value in pulsar-client-go is 1 minute](https://github.com/apache/pulsar-client-go/blob/v0.8.1/pulsar/producer_impl.go#L47) which is 60*10^9. Set the example value to the default.

- setting `batching_max_publish_delay` to `10` will make batching ineffective since the unit is nanoseconds. 
  - [The default value in pulsar-client-go is 10 milliseconds](https://github.com/apache/pulsar-client-go/blob/v0.8.1/pulsar/producer_impl.go#L38) which is 10^7. Set the example value to the default.