### PR TITLE
Document Docker usage and add bundle integration tests

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,32 @@
+# Docker Component Requirements
+
+This distribution includes the [Docker container stats monitor](https://docs.splunk.com/Observability/gdi/docker/docker.html)
+via the [Smart Agent Receiver](../pkg/receiver/smartagent/README.md) to provide the ability to report metrics from containers running on your system.
+It also includes the [Docker Observer Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/dockerobserver) to enable dynamically
+instantiating your receivers using the [Receiver Creator](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/receivercreator/README.md) as target service containers
+are reported by the [Docker daemon](https://docs.docker.com/config/daemon/). Both of these components use a client
+that requires establishing a connection with the daemon similar to using the `docker` cli. In order for this to occur, you'll likely
+need to do one of the following depending on your Docker installation and Collector deployment method.
+
+## Domain Socket
+
+If your daemon is listening to a domain socket (e.g. `/var/run/docker.sock`) then the collector service or executable needs to be granted
+appropriate permissions and access.
+
+### Linux installation
+
+For most manual or scripted Linux installations, the `splunk-otel-collector` user should be added to the `docker` or similar group as configured on your system:
+
+```bash
+$ usermod -aG docker splunk-otel-collector
+```
+
+### Docker image
+
+When using the [`quay.io/signalfx/splunk-otel-collector`](https://quay.io/repository/signalfx/splunk-otel-collector) image, the default container user should be added to the required group as configured on your system, and the domain socket should be bind-mounted:
+
+```bash
+$ docker run -v /var/run/docker.sock:/var/run/docker.sock:ro --group-add $(stat -c '%g' /var/run/docker.sock) quay.io/signalfx/splunk-otel-collector:latest <...>
+# or if specifying the user:group directly
+$ docker run -v /var/run/docker.sock:/var/run/docker.sock:ro --user "splunk-otel-collector:$(stat -c '%g' /var/run/docker.sock)" quay.io/signalfx/splunk-otel-collector:latest <...>
+```

--- a/tests/general/testdata/activemq_config.yaml
+++ b/tests/general/testdata/activemq_config.yaml
@@ -1,0 +1,22 @@
+receivers:
+  smartagent/collectd_activemq:
+    type: collectd/activemq
+    host: localhost
+    port: 1099
+    username: testuser
+    password: testing123
+    extraMetrics: ["*"]
+    intervalSeconds: 1
+
+exporters:
+  otlp:
+    endpoint: "${OTLP_ENDPOINT}"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - smartagent/collectd_activemq
+      exporters: [otlp]

--- a/tests/general/testdata/resource_metrics/activemq.yaml
+++ b/tests/general/testdata/resource_metrics/activemq.yaml
@@ -1,0 +1,7 @@
+resource_metrics:
+  - scope_metrics:
+      - metrics:
+          - name: counter.amq.TotalConnectionsCount
+            type: IntMonotonicCumulativeSum
+          - name: jmx_memory.committed
+            type: IntGauge

--- a/tests/general/testdata/resource_metrics/solr.yaml
+++ b/tests/general/testdata/resource_metrics/solr.yaml
@@ -1,0 +1,5 @@
+resource_metrics:
+  - scope_metrics:
+      - metrics:
+          - name: counter.solr.http_2xx_responses
+            type: IntMonotonicCumulativeSum

--- a/tests/general/testdata/solr_config.yaml
+++ b/tests/general/testdata/solr_config.yaml
@@ -1,0 +1,21 @@
+receivers:
+  smartagent/collectd_solr:
+    type: collectd/solr
+    host: localhost
+    port: 8983
+    extraMetrics: ["*"]
+    intervalSeconds: 1
+
+exporters:
+  otlp:
+    endpoint: "${OTLP_ENDPOINT}"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - smartagent/collectd_solr
+      exporters:
+        - otlp


### PR DESCRIPTION
These changes add a short doc for docker daemon connectivity permissions for linux and containers and two integration tests to make sure that the agent bundle can be interacted with when the container user isn't in the default group.