### PR TITLE
Add splunk_skip_repo option to ansible

### DIFF
--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -123,6 +123,10 @@ $> ansible-playbook playbook.yaml -e start_service=false
 - `splunk_ballast_size_mib`: Memory ballast size in MiB that will be set to the Splunk 
   OTel Collector. (**default:** 1/3 of `splunk_memory_total_mib`)
 
+- `splunk_skip_repo` (Linux only): If installing the collector from a custom or self-hosted
+  apt/yum repo, set to `true` to skip the installation of the default repo
+  (**default:** `false`)
+
 - `start_service`: Whether to restart the services installed by the playbook. (**default:** true)
 
 #### Windows Proxy

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -35,7 +35,8 @@ install_fluentd: true
 # Whether to start the services installed by the role (splunk-otel-collector and td-agent).
 start_service: true
 
-sfx_skip_repo: false
+# Disable setting the official Splunk Debian or RPM repository.
+splunk_skip_repo: false
 
 # Explicitly set version of td-agent,
 # By default: 3.7.1 for Debian stretch and 4.3.2 for other distros.

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -35,6 +35,8 @@ install_fluentd: true
 # Whether to start the services installed by the role (splunk-otel-collector and td-agent).
 start_service: true
 
+sfx_skip_repo: false
+
 # Explicitly set version of td-agent,
 # By default: 3.7.1 for Debian stretch and 4.3.2 for other distros.
 td_agent_version: ""

--- a/deployments/ansible/roles/collector/tasks/apt_install_otel_collector.yml
+++ b/deployments/ansible/roles/collector/tasks/apt_install_otel_collector.yml
@@ -19,6 +19,7 @@
     repo: "deb {{ splunk_repo_base_url }}/otel-collector-deb release main"
     filename: splunk-otel-collector.list
     state: present
+  when: not (splunk_skip_repo | bool)
 
 - name: Install Splunk OpenTelemetry Collector via apt package manager
   ansible.builtin.apt:

--- a/deployments/ansible/roles/collector/tasks/yum_install_otel_collector.yml
+++ b/deployments/ansible/roles/collector/tasks/yum_install_otel_collector.yml
@@ -15,7 +15,7 @@
     gpgkey: "{{ splunk_repo_base_url }}/otel-collector-rpm/splunk-B3CD4420.pub"
     gpgcheck: yes
     enabled: yes
-  when: not (sfx_skip_repo | bool)
+  when: not (splunk_skip_repo | bool)
 
 - name: Install Splunk OpenTelemetry Collector via yum package manager
   ansible.builtin.yum:

--- a/deployments/ansible/roles/collector/tasks/yum_install_otel_collector.yml
+++ b/deployments/ansible/roles/collector/tasks/yum_install_otel_collector.yml
@@ -15,6 +15,7 @@
     gpgkey: "{{ splunk_repo_base_url }}/otel-collector-rpm/splunk-B3CD4420.pub"
     gpgcheck: yes
     enabled: yes
+  when: not (sfx_skip_repo | bool)
 
 - name: Install Splunk OpenTelemetry Collector via yum package manager
   ansible.builtin.yum:


### PR DESCRIPTION
Hello team,
Can you please review PR for skipping use of Splunk repo for installing otel package.
We would like to utilize your role, though we can't rely on external repo and would like to keep rpm locally.
Since we are using RH satellite, we can't just provide splunk_repo_base_url var as url is different.
As a reference there is a parity of this in Smart Agent role: https://github.com/signalfx/signalfx-agent/issues/1628
Thanks.