### PR TITLE
[BUG_FIX] Watch for changes in the configsource implementations

### DIFF
--- a/internal/configprovider/builder_test.go
+++ b/internal/configprovider/builder_test.go
@@ -40,7 +40,7 @@ func TestConfigSourceBuild(t *testing.T) {
 		configSettings     map[string]Source
 		factories          Factories
 		expectedCfgSources map[string]ConfigSource
-		wantErr            error
+		wantErr            string
 		name               string
 	}{
 		{
@@ -51,7 +51,7 @@ func TestConfigSourceBuild(t *testing.T) {
 				},
 			},
 			factories: testFactories,
-			wantErr:   &errUnknownType{},
+			wantErr:   "unknown unknown_config_source config source type for tstcfgsrc",
 		},
 		{
 			name: "creation_error",
@@ -65,7 +65,7 @@ func TestConfigSourceBuild(t *testing.T) {
 					ErrOnCreateConfigSource: errors.New("forced test error"),
 				},
 			},
-			wantErr: &errConfigSourceCreation{},
+			wantErr: "failed to create config source tstcfgsrc: forced test error",
 		},
 		{
 			name: "factory_return_nil",
@@ -77,7 +77,7 @@ func TestConfigSourceBuild(t *testing.T) {
 			factories: Factories{
 				"tstcfgsrc": &mockNilCfgSrcFactory{},
 			},
-			wantErr: &errFactoryCreatedNil{},
+			wantErr: "factory for \"tstcfgsrc\" produced a nil extension",
 		},
 		{
 			name: "base_case",
@@ -108,7 +108,11 @@ func TestConfigSourceBuild(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			builtCfgSources, err := Build(ctx, tt.configSettings, params, tt.factories)
-			require.IsType(t, tt.wantErr, err)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
 			require.Equal(t, tt.expectedCfgSources, builtCfgSources)
 		})
 	}

--- a/internal/configprovider/component.go
+++ b/internal/configprovider/component.go
@@ -17,22 +17,9 @@ package configprovider
 
 import (
 	"context"
-	"errors"
 
 	"go.opentelemetry.io/collector/confmap"
 )
-
-// ErrSessionClosed is returned by WatchForUpdate functions when its parent Session
-// object is closed.
-// This error can be wrapped with additional information. Callers trying to identify this
-// specific error must use errors.Is.
-var ErrSessionClosed = errors.New("parent session was closed")
-
-// ErrValueUpdated is returned by WatchForUpdate functions when the value being watched
-// was changed or expired and needs to be retrieved again.
-// This error can be wrapped with additional information. Callers trying to identify this
-// specific error must use errors.Is.
-var ErrValueUpdated = errors.New("configuration must retrieve the updated value")
 
 // ConfigSource is the interface to be implemented by objects used by the collector
 // to retrieve external configuration information.


### PR DESCRIPTION
Before, the WatchForChanges was not called, now we pass the same WatcherFunc down to the ConfigSources.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>