### PR TITLE
testutils: add Testcase.SplunkOtelCollector(Container|Process)

### DIFF
--- a/tests/general/configsources/include_test.go
+++ b/tests/general/configsources/include_test.go
@@ -18,18 +18,14 @@ package tests
 
 import (
 	"fmt"
-	"io"
-	"net/http"
 	"path"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/confmap"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
-	"gopkg.in/yaml.v2"
 
 	"github.com/signalfx/splunk-otel-collector/tests/testutils"
 )
@@ -114,22 +110,6 @@ func TestCollectorProcessWithMultipleTemplateConfigs(t *testing.T) {
 			},
 		},
 	}
-	for _, tc := range []struct {
-		expected map[string]any
-		endpoint string
-	}{
-		{expected: expectedConfig, endpoint: "effective"},
-	} {
-		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/debug/configz/%s", csPort, tc.endpoint))
-		require.NoError(t, err)
 
-		body, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-
-		actual := map[string]any{}
-		require.NoError(t, yaml.Unmarshal(body, &actual))
-
-		require.Equal(t, tc.expected, confmap.NewFromStringMap(actual).ToStringMap())
-	}
-
+	require.Equal(t, expectedConfig, collector.EffectiveConfig(t, csPort))
 }

--- a/tests/general/container_test.go
+++ b/tests/general/container_test.go
@@ -31,8 +31,7 @@ import (
 )
 
 func TestDefaultContainerConfigRequiresEnvVars(t *testing.T) {
-	image := (&testutils.Testcase{T: t}).SkipIfNotContainer()
-
+	image := testutils.GetCollectorImageOrSkipTest(t)
 	tests := []struct {
 		name    string
 		env     map[string]string
@@ -76,9 +75,7 @@ func TestSpecifiedContainerConfigDefaultsToCmdLineArgIfEnvVarConflict(t *testing
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()
 
-	tc.SkipIfNotContainer()
-
-	_, shutdown := tc.SplunkOtelCollector(
+	_, shutdown := tc.SplunkOtelCollectorContainer(
 		"hostmetrics_cpu.yaml",
 		func(collector testutils.Collector) testutils.Collector {
 			return collector.WithArgs("--config", "/etc/config.yaml")
@@ -91,7 +88,6 @@ func TestSpecifiedContainerConfigDefaultsToCmdLineArgIfEnvVarConflict(t *testing
 			)
 		},
 	)
-
 	defer shutdown()
 
 	require.Eventually(t, func() bool {
@@ -118,9 +114,7 @@ func TestConfigYamlEnvVar(t *testing.T) {
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()
 
-	tc.SkipIfNotContainer()
-
-	_, shutdown := tc.SplunkOtelCollector(
+	_, shutdown := tc.SplunkOtelCollectorContainer(
 		"", func(collector testutils.Collector) testutils.Collector {
 			return collector.WithEnv(
 				map[string]string{
@@ -171,14 +165,12 @@ func TestNonDefaultGIDCanAccessJavaInAgentBundle(t *testing.T) {
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()
 
-	tc.SkipIfNotContainer()
-
 	_, stop := tc.Containers(testutils.NewContainer().WithContext(
 		filepath.Join("..", "receivers", "smartagent", "collectd-activemq", "testdata", "server"),
 	).WithExposedPorts("1099:1099").WithName("activemq").WillWaitForPorts("1099"))
 	defer stop()
 
-	_, shutdown := tc.SplunkOtelCollector(
+	_, shutdown := tc.SplunkOtelCollectorContainer(
 		"activemq_config.yaml",
 		func(collector testutils.Collector) testutils.Collector {
 			cc := collector.(*testutils.CollectorContainer)
@@ -197,8 +189,6 @@ func TestNonDefaultGIDCanAccessPythonInAgentBundle(t *testing.T) {
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()
 
-	tc.SkipIfNotContainer()
-
 	_, stop := tc.Containers(testutils.NewContainer().WithContext(
 		filepath.Join("..", "receivers", "smartagent", "collectd-solr", "testdata", "server"),
 	).WithExposedPorts("8983:8983").WithName(
@@ -206,7 +196,7 @@ func TestNonDefaultGIDCanAccessPythonInAgentBundle(t *testing.T) {
 	).WillWaitForPorts("8983").WillWaitForLogs("example launched successfully"))
 	defer stop()
 
-	_, shutdown := tc.SplunkOtelCollector(
+	_, shutdown := tc.SplunkOtelCollectorContainer(
 		"solr_config.yaml",
 		func(collector testutils.Collector) testutils.Collector {
 			cc := collector.(*testutils.CollectorContainer)

--- a/tests/general/discoverymode/configd_test.go
+++ b/tests/general/discoverymode/configd_test.go
@@ -32,9 +32,7 @@ func TestConfigDInitialAndEffectiveConfig(t *testing.T) {
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()
 
-	tc.SkipIfNotContainer()
-
-	collector, shutdown := tc.SplunkOtelCollector(
+	cc, shutdown := tc.SplunkOtelCollectorContainer(
 		"config-to-merge-with.yaml",
 		func(c testutils.Collector) testutils.Collector {
 			cc := c.(*testutils.CollectorContainer)
@@ -55,7 +53,6 @@ func TestConfigDInitialAndEffectiveConfig(t *testing.T) {
 
 	defer shutdown()
 
-	cc := collector.(*testutils.CollectorContainer)
 	expected := map[string]any{
 		"file": map[string]any{
 			"exporters": map[string]any{
@@ -195,9 +192,7 @@ func TestStandaloneConfigD(t *testing.T) {
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()
 
-	tc.SkipIfNotContainer()
-
-	_, shutdown := tc.SplunkOtelCollector(
+	_, shutdown := tc.SplunkOtelCollectorContainer(
 		"empty-config.yaml",
 		func(c testutils.Collector) testutils.Collector {
 			cc := c.(*testutils.CollectorContainer)

--- a/tests/general/discoverymode/docker_observer_discovery_test.go
+++ b/tests/general/discoverymode/docker_observer_discovery_test.go
@@ -39,8 +39,6 @@ func TestDockerObserver(t *testing.T) {
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()
 
-	tc.SkipIfNotContainer()
-
 	finfo, err := os.Stat("/var/run/docker.sock")
 	require.NoError(t, err)
 	fsys := finfo.Sys()
@@ -48,7 +46,7 @@ func TestDockerObserver(t *testing.T) {
 	require.True(t, ok)
 	dockerGID := stat.Gid
 
-	c, shutdown := tc.SplunkOtelCollector(
+	cc, shutdown := tc.SplunkOtelCollectorContainer(
 		"otlp-exporter-no-internal-prometheus.yaml",
 		func(c testutils.Collector) testutils.Collector {
 			cc := c.(*testutils.CollectorContainer)
@@ -70,7 +68,6 @@ func TestDockerObserver(t *testing.T) {
 		},
 	)
 	defer shutdown()
-	cc := c.(*testutils.CollectorContainer)
 
 	_, shutdownPrometheus := tc.Containers(
 		testutils.NewContainer().WithImage("bitnami/prometheus").WithLabel("test.id", tc.ID).WillWaitForLogs("Server is ready to receive web requests."),

--- a/tests/general/discoverymode/host_observer_discovery_test.go
+++ b/tests/general/discoverymode/host_observer_discovery_test.go
@@ -47,11 +47,9 @@ func TestHostObserver(t *testing.T) {
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()
 
-	tc.SkipIfNotContainer()
-
 	promPort := testutils.GetAvailablePort(t)
 
-	c, shutdown := tc.SplunkOtelCollector(
+	cc, shutdown := tc.SplunkOtelCollectorContainer(
 		"otlp-exporter-no-internal-prometheus.yaml",
 		func(c testutils.Collector) testutils.Collector {
 			cc := c.(*testutils.CollectorContainer)
@@ -77,7 +75,7 @@ func TestHostObserver(t *testing.T) {
 		},
 	)
 	defer shutdown()
-	cc := c.(*testutils.CollectorContainer)
+
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	sc, r, err := cc.Container.Exec(ctx, []string{
 		// no config server to prevent port collisions

--- a/tests/general/process_test.go
+++ b/tests/general/process_test.go
@@ -18,18 +18,14 @@ package tests
 
 import (
 	"fmt"
-	"io"
-	"net/http"
 	"path"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/confmap"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
-	"gopkg.in/yaml.v2"
 
 	"github.com/signalfx/splunk-otel-collector/tests/testutils"
 )
@@ -120,23 +116,6 @@ func TestCollectorProcessWithMultipleConfigs(t *testing.T) {
 			},
 		},
 	}
-	for _, tc := range []struct {
-		expected map[string]any
-		endpoint string
-	}{
-		{expected: map[string]any{"file": expectedConfig}, endpoint: "initial"},
-		{expected: expectedConfig, endpoint: "effective"},
-	} {
-		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/debug/configz/%s", csPort, tc.endpoint))
-		require.NoError(t, err)
 
-		body, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-
-		actual := map[string]any{}
-		require.NoError(t, yaml.Unmarshal(body, &actual))
-
-		require.Equal(t, tc.expected, confmap.NewFromStringMap(actual).ToStringMap())
-	}
-
+	require.Equal(t, expectedConfig, collector.EffectiveConfig(t, csPort))
 }

--- a/tests/receivers/filelog/filelog_test.go
+++ b/tests/receivers/filelog/filelog_test.go
@@ -32,9 +32,7 @@ func TestFilelogReceiverSyslogFormat(t *testing.T) {
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()
 
-	tc.SkipIfNotContainer()
-
-	_, shutdown := tc.SplunkOtelCollector(
+	_, shutdown := tc.SplunkOtelCollectorContainer(
 		"syslog_config.yaml",
 		func(c testutils.Collector) testutils.Collector {
 			cc := c.(*testutils.CollectorContainer)

--- a/tests/receivers/oracledb/oracledb_test.go
+++ b/tests/receivers/oracledb/oracledb_test.go
@@ -42,10 +42,13 @@ func TestOracleDBIntegration(t *testing.T) {
 
 	_, stop := tc.Containers(oracledb...)
 	defer stop()
-	env := map[string]string{}
-	env["ORACLEDB_URL"] = "oracle://otel:password@localhost:1521/XE"
 
-	_, shutdown := tc.SplunkOtelCollectorWithEnv("all_metrics_config.yaml", env)
+	_, shutdown := tc.SplunkOtelCollector(
+		"all_metrics_config.yaml",
+		func(collector testutils.Collector) testutils.Collector {
+			return collector.WithEnv(map[string]string{"ORACLEDB_URL": "oracle://otel:password@localhost:1521/XE"})
+		},
+	)
 	defer shutdown()
 
 	expectedResourceMetrics := tc.ResourceMetrics("all.yaml")

--- a/tests/testutils/assert_no_error_host.go
+++ b/tests/testutils/assert_no_error_host.go
@@ -26,7 +26,7 @@ import (
 // there were no errors.
 type assertNoErrorHost struct {
 	component.Host
-	t *testing.T
+	t testing.TB
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
@@ -34,7 +34,7 @@ var _ component.Host = (*assertNoErrorHost)(nil)
 // NewAssertNoErrorHost returns a new instance of a component.Host. This instance
 // asserts if an error is received.
 // TODO: Remove this code when equivalent is available from OpenTelemetry Collector repo.
-func NewAssertNoErrorHost(t *testing.T) component.Host {
+func NewAssertNoErrorHost(t testing.TB) component.Host {
 	return &assertNoErrorHost{
 		componenttest.NewNopHost(),
 		t,

--- a/tests/testutils/collector.go
+++ b/tests/testutils/collector.go
@@ -15,6 +15,8 @@
 package testutils
 
 import (
+	"testing"
+
 	"go.uber.org/zap"
 )
 
@@ -28,4 +30,6 @@ type Collector interface {
 	Build() (Collector, error)
 	Start() error
 	Shutdown() error
+	InitialConfig(t testing.TB, port uint16) map[string]any
+	EffectiveConfig(t testing.TB, port uint16) map[string]any
 }

--- a/tests/testutils/endpoint.go
+++ b/tests/testutils/endpoint.go
@@ -35,7 +35,7 @@ type portpair struct {
 // describing it. The port is available for opening when this function returns
 // provided that there is no race by some other code to grab the same port
 // immediately.
-func getAvailableLocalAddress(t *testing.T) string {
+func getAvailableLocalAddress(t testing.TB) string {
 	ln, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err, "Failed to get a free local port")
 	// There is a possible race if something else takes this same port before
@@ -47,7 +47,7 @@ func getAvailableLocalAddress(t *testing.T) string {
 // GetAvailablePort finds an available local port and returns it. The port is
 // available for opening when this function returns provided that there is no
 // race by some other code to grab the same port immediately.
-func GetAvailablePort(t *testing.T) uint16 {
+func GetAvailablePort(t testing.TB) uint16 {
 	// Retry has been added for windows as net.Listen can return a port that is not actually available. Details can be
 	// found in https://github.com/docker/for-win/issues/3171 but to summarize Hyper-V will reserve ranges of ports
 	// which do not show up under the "netstat -ano" but can only be found by
@@ -83,7 +83,7 @@ func GetAvailablePort(t *testing.T) uint16 {
 }
 
 // Get excluded ports on Windows from the command: netsh interface ipv4 show excludedportrange protocol=tcp
-func getExclusionsList(t *testing.T) []portpair {
+func getExclusionsList(t testing.TB) []portpair {
 	cmd := exec.Command("netsh", "interface", "ipv4", "show", "excludedportrange", "protocol=tcp")
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err)
@@ -92,7 +92,7 @@ func getExclusionsList(t *testing.T) []portpair {
 	return exclusions
 }
 
-func createExclusionsList(exclusionsText string, t *testing.T) []portpair {
+func createExclusionsList(exclusionsText string, t testing.TB) []portpair {
 	exclusions := []portpair{}
 
 	parts := strings.Split(exclusionsText, "--------")

--- a/tests/testutils/otlp_receiver_sink.go
+++ b/tests/testutils/otlp_receiver_sink.go
@@ -169,7 +169,7 @@ func (otlp *OTLPReceiverSink) Reset() {
 	}
 }
 
-func (otlp *OTLPReceiverSink) AssertAllLogsReceived(t *testing.T, expectedResourceLogs telemetry.ResourceLogs, waitTime time.Duration) error {
+func (otlp *OTLPReceiverSink) AssertAllLogsReceived(t testing.TB, expectedResourceLogs telemetry.ResourceLogs, waitTime time.Duration) error {
 	if err := otlp.assertBuilt("AssertAllLogsReceived"); err != nil {
 		return err
 	}
@@ -209,7 +209,7 @@ func (otlp *OTLPReceiverSink) AssertAllLogsReceived(t *testing.T, expectedResour
 	return err
 }
 
-func (otlp *OTLPReceiverSink) AssertAllMetricsReceived(t *testing.T, expectedResourceMetrics telemetry.ResourceMetrics, waitTime time.Duration) error {
+func (otlp *OTLPReceiverSink) AssertAllMetricsReceived(t testing.TB, expectedResourceMetrics telemetry.ResourceMetrics, waitTime time.Duration) error {
 	if err := otlp.assertBuilt("AssertAllMetricsReceived"); err != nil {
 		return err
 	}


### PR DESCRIPTION
The current pattern of `Testcase.SkipIfNotContainer()` and then type asserting the resulting collector from `SplunkOtelCollector` or `SplunkOtelCollectorWithEnv` to a `*CollectorContainer` is a little unintuitive. These changes add new helper methods that incorporate this logic and remove `SplunkOtelCollectorWithEnv`, opting for the builder options.

These changes also promote the initial and effective config helpers to testutils.Collector interface by adding the method to `CollectorProcess`, incorporating existing test logic that was repeated.