### PR TITLE
Use windows 2022 runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -501,7 +501,7 @@ build-push-windows2022-image:
   dependencies:
     - sign-exe
   tags:
-    - windows
+    - windows2022
   retry: 2
   before_script:
     - Copy-Item .\dist\signed\otelcol_windows_amd64.exe .\cmd\otelcol\otelcol.exe

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ fossa:
 .trigger-filter:
   only:
     variables:
-      - $CI_COMMIT_BRANCH == "use_windows_2022_runner"
+      - $CI_COMMIT_BRANCH == "main"
       - $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
   except:
     - schedules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ fossa:
 .trigger-filter:
   only:
     variables:
-      - $CI_COMMIT_BRANCH == "main"
+      - $CI_COMMIT_BRANCH == "use_windows_2022_runner"
       - $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
   except:
     - schedules


### PR DESCRIPTION
The Windows 2022 runner is now working correctly and I have used this branch  to push a Windows 2022 docker image out:
https://quay.io/repository/signalfx/splunk-otel-collector-windows-dev?tab=tags&tag=d15a9d9722240111885ab24761c240483eef35e0-2022

