### PR TITLE
Remove handling of unsupported --mem-ballast-size-mib command line argument

### DIFF
--- a/cmd/otelcol/config/collector/upstream_agent_config.yaml
+++ b/cmd/otelcol/config/collector/upstream_agent_config.yaml
@@ -25,8 +25,7 @@ extensions:
   zpages:
     #endpoint: 0.0.0.0:55679
   memory_ballast:
-    # In general, the ballast should be set to 1/3 of the collector's memory, the limit
-    # should be 90% of the collector's memory.
+    # In general, the ballast should be set to 1/3 of the collector's memory.
     # The simplest way to specify the ballast size is set the value of SPLUNK_BALLAST_SIZE_MIB env variable.
     size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
 
@@ -87,10 +86,8 @@ processors:
   batch:
   # Enabling the memory_limiter is strongly recommended for every pipeline.
   # Configuration is based on the amount of memory allocated to the collector.
-  # In general, the ballast should be set to 1/3 of the collector's memory, the limit
-  # should be 90% of the collector's memory. The simplest way to specify the
-  # ballast size is set the value of SPLUNK_BALLAST_SIZE_MIB env variable. Alternatively, the
-  # --mem-ballast-size-mib command line flag can be passed and take priority.
+  # In general, the limit should be 90% of the collector's memory. The simplest way to specify the
+  # ballast size is set the value of SPLUNK_BALLAST_SIZE_MIB env variable.
   # For more information about memory limiter, see
   # https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiter/README.md
   memory_limiter:

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -92,7 +92,6 @@ func TestNewSettingsNoConvertConfig(t *testing.T) {
 		"--no-convert-config",
 		"--config", configPath,
 		"--config", anotherConfigPath,
-		"--mem-ballast-size-mib", "100",
 		"--set", "foo",
 		"--set", "bar",
 		"--set", "baz",
@@ -104,7 +103,6 @@ func TestNewSettingsNoConvertConfig(t *testing.T) {
 	f := settingsToFlags(t, settings)
 	require.True(t, f.noConvertConfig)
 
-	require.Equal(t, 100, f.memBallastSizeMiB)
 	require.Equal(t, []string{configPath, anotherConfigPath}, f.configPaths.value)
 	require.Equal(t, []string{"foo", "bar", "baz"}, f.setProperties.value)
 
@@ -116,7 +114,6 @@ func TestNewSettingsNoConvertConfig(t *testing.T) {
 	require.Equal(t, []string{
 		"--config", configPath,
 		"--config", anotherConfigPath,
-		"--mem-ballast-size-mib", "100",
 		"--set", "foo", "--set", "bar", "--set", "baz",
 		"--feature-gates", "foo", "--feature-gates", "-bar",
 	}, settings.ServiceArgs())
@@ -127,7 +124,6 @@ func TestNewSettingsConvertConfig(t *testing.T) {
 	settings, err := New([]string{
 		"--config", configPath,
 		"--config", anotherConfigPath,
-		"--mem-ballast-size-mib", "100",
 		"--set", "foo",
 		"--set", "bar",
 		"--set", "baz",
@@ -141,7 +137,6 @@ func TestNewSettingsConvertConfig(t *testing.T) {
 	require.False(t, f.versionFlag)
 	require.False(t, f.noConvertConfig)
 
-	require.Equal(t, 100, f.memBallastSizeMiB)
 	require.Equal(t, []string{configPath, anotherConfigPath}, f.configPaths.value)
 	require.Equal(t, []string{"foo", "bar", "baz"}, f.setProperties.value)
 
@@ -157,7 +152,6 @@ func TestNewSettingsConvertConfig(t *testing.T) {
 	require.Equal(t, []string{
 		"--config", configPath,
 		"--config", anotherConfigPath,
-		"--mem-ballast-size-mib", "100",
 		"--set", "foo", "--set", "bar", "--set", "baz",
 		"--feature-gates", "foo", "--feature-gates", "-bar",
 	}, settings.ServiceArgs())
@@ -291,17 +285,6 @@ func TestCheckRuntimeParams_MemTotalLimitAndBallastEnvs(t *testing.T) {
 	require.NotNil(t, settings)
 	require.Equal(t, "50", os.Getenv(BallastEnvVar))
 	require.Equal(t, "150", os.Getenv(MemLimitMiBEnvVar))
-}
-
-func TestCheckRuntimeParams_MemTotalEnvAndBallastFlag(t *testing.T) {
-	t.Cleanup(setRequiredEnvVars(t))
-	require.NoError(t, os.Setenv(MemTotalEnvVar, "200"))
-
-	settings, err := New([]string{"--mem-ballast-size-mib=90"})
-	require.NoError(t, err)
-	require.NotNil(t, settings)
-	require.Equal(t, "90", os.Getenv(BallastEnvVar))
-	require.Equal(t, "180", os.Getenv(MemLimitMiBEnvVar))
 }
 
 func TestUseConfigPathsFromEnvVar(t *testing.T) {


### PR DESCRIPTION
The argument was removed from the core collector in v0.36.0. We kept supporting it in our distro but the support is broken. We never remove that argument as we do for others and it's being passed to the core collector in https://github.com/signalfx/splunk-otel-collector/blob/main/cmd/otelcol/main.go#L105 where it fails with the following error:

```
2022/12/08 16:25:34 main.go:106: application run finished with error: unknown flag: --mem-ballast-size-mib
```

So I don't think it makes sense to bring back support of it.