### PR TITLE
Rework command line arguments parsing

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 
+	flag "github.com/spf13/pflag"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"
@@ -44,6 +45,10 @@ func main() {
 
 	collectorSettings, err := settings.New(os.Args[1:])
 	if err != nil {
+		// Exit if --help flag was supplied and usage help was displayed.
+		if err == flag.ErrHelp {
+			os.Exit(0)
+		}
 		log.Fatalf(`invalid settings detected: %v. Use "--help" to show valid usage`, err)
 	}
 
@@ -101,7 +106,7 @@ func main() {
 		ConfigProvider: serviceConfigProvider,
 	}
 
-	os.Args = append(os.Args[:1], collectorSettings.ServiceArgs()...)
+	os.Args = append(os.Args[:1], collectorSettings.ColCoreArgs()...)
 	if err = run(serviceSettings); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This PR solves two problems:

1. In the current implementation, command flags specific to the Splunk distro are dropped from the arguments list passed to the collector core service by their names. It means that all the flag values are unintentionally passed downstream. Also, flags with `=` are not removed from the list and cause failures downstream. For example, `./bin/otelcol --config-dir=/tmp/conf ...` fails with:

```
2022/12/10 19:15:52 main.go:106: application run finished with error: unknown flag: --config-dir
```

And `removeFlag` function is called from methods that are not expected to be mutating by their definition like `ResolverURIs`.

2. Currently, we rely on the downstream collector core service to display `--help` flag output and get the following:

```
Usage:
  otelcol [flags]

Flags:
      --config --config=file:/path/to/first --config=file:path/to/second   Locations to the config file(s), note that only a single location can be set per flag entry e.g. --config=file:/path/to/first --config=file:path/to/second. (default [])
      --feature-gates Flag                                                 Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature.
  -h, --help                                                               help for otelcol
      --set func                                                           Set arbitrary component config property. The component has to be defined in the config file and the flag has a higher precedence. Array config properties are overridden and maps are joined. Example --set=processors.batch.timeout=2s
  -v, --version                                                            version for otelcol
```

It's not just incomplete but also provides a misleading description for `--config` flag: we don't support config schemas, so using any of the provided examples will fail.  This change defines all the flags in our distro and makes the program use that definition in `--help` output instead of relying on the collector core service. Experimental flags like `--configd`, `--config-dir` and `--discovery` are hidden for now, but can be easily enabled. It provides the following output for `--help` flag:

```
Usage of otelcol:
      --config string          Locations to the config file(s), note that only a single location can be set per flag entry e.g. --config=/path/to/first --config=path/to/second. (default "[]")
      --dry-run                Don't run the service, just show the configuration
      --feature-gates string   Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature. (default "[]")
      --no-convert-config      Do not translate old configurations to the new format automatically. By default, old configurations are translated to the new format for backward compatibility.
      --set string             Set arbitrary component config property. The component has to be defined in the config file and the flag has a higher precedence. Array config properties are overridden and maps are joined. Example --set=processors.batch.timeout=2s (default "[]")
  -v, --version                Version of the collector.
```

Now we also explicitly pass all the flags that are handled by the collector core service instead of passing what we don't use. The reason for that is that there are no plans in the collector core to add any new flags. Most of the old flags were migrated to the configuration. And, even if something will be added, it potentially can be incompatible with our distro and introduce some broken flags to the `--help` output without us noticing.

And, as an opportunistic simplification, this change replaces an unnecessary `Settings` interface with a struct.