### PR TITLE
fix image filter to regex match the tag

### DIFF
--- a/deployments/fargate/README.md
+++ b/deployments/fargate/README.md
@@ -32,7 +32,7 @@ JSON.
     },
     {
       "name": "ECS_METADATA_EXCLUDED_IMAGES",
-      "value": "[\"quay.io/signalfx/splunk-otel-collector\"]"
+      "value": "[\"quay.io/signalfx/splunk-otel-collector:*\"]"
     }
   ],
   "image": "quay.io/signalfx/splunk-otel-collector:0.33.0",


### PR DESCRIPTION
OTEL agent task is not filtering out OTEL container metrics when using this example https://github.com/signalfx/splunk-otel-collector/blame/main/deployments/fargate/README.md#L35
the string we are trying to match against is 
```
quay.io/signalfx/splunk-otel-collector:0.36.0
```
based on https://github.com/signalfx/signalfx-agent/blob/c295133b4a52b2fff071c8070536183a48e403fc/pkg/utils/filter/overridable.go#L14 and running it through the unit test, a * is needed to get a match.
```
"value": "[\"quay.io/signalfx/splunk-otel-collector:*\"]"
```

Signed-off-by: Dani Louca <dlouca@splunk.com>