### PR TITLE
Hard set latest-tag if absent to triage build trying to install an "older version" than in the test. TODO need to fix root cause once triage has been verified

### DIFF
--- a/instrumentation/packaging/fpm/common.sh
+++ b/instrumentation/packaging/fpm/common.sh
@@ -39,11 +39,13 @@ get_version() {
     commit_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --tags --exact-match --match 'v[0-9]*' 2>/dev/null || true )"
     if [[ -z "$commit_tag" ]]; then
         latest_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true )"
-        if [[ -n "$latest_tag" ]]; then
-            echo "${latest_tag}-post"
-        else
-            echo "0.0.1-post"
-        fi
+        # DIRTY DIRTY TRIAGE HACK THAT TODO NEEDS TO BE FIXED ASAP
+        echo "${latest_tag:-v0.67.0}-post"
+        #if [[ -n "$latest_tag" ]]; then
+        #    echo "${latest_tag}-post"
+        #else
+        #    echo "0.0.1-post"
+        #fi
     else
         echo "$commit_tag"
     fi


### PR DESCRIPTION
See https://splunk.slack.com/archives/C02C8GVHL1Z/p1671053023635889?thread_ts=1671041001.488629&cid=C02C8GVHL1Z for more details

TL;DR 

this code block is hitting the `0.0.1` part for some reason.  No idea why, so for now, force out the version we're trying to push to at least vet the rpm build since we cannot reproduce locally due to https://splunk.slack.com/archives/C02C8GVHL1Z/p1671054594215009
```
get_version() {
    commit_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --tags --exact-match --match 'v[0-9]*' 2>/dev/null || true )"
    if [[ -z "$commit_tag" ]]; then
        latest_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true )"
        if [[ -n "$latest_tag" ]]; then
            echo "${latest_tag}-post"
        else
            echo "0.0.1-post"
        fi
    else
        echo "$commit_tag"
    fi
}
```