### PR TITLE
Remove github api calls, use github's latest link

### DIFF
--- a/instrumentation/packaging/fpm/common.sh
+++ b/instrumentation/packaging/fpm/common.sh
@@ -29,7 +29,7 @@ JAVA_AGENT_INSTALL_PATH="/usr/lib/splunk-instrumentation/splunk-otel-javaagent.j
 CONFIG_INSTALL_PATH="/usr/lib/splunk-instrumentation/instrumentation.conf"
 
 JAVA_AGENT_RELEASE_PATH="${FPM_DIR}/../java-agent-release.txt"
-JAVA_AGENT_RELEASE_URL="https://github.com/signalfx/splunk-otel-java/releases/download/"
+JAVA_AGENT_RELEASE_URL="https://github.com/signalfx/splunk-otel-java/releases/"
 
 POSTINSTALL_PATH="$FPM_DIR/postinstall.sh"
 PREUNINSTALL_PATH="$FPM_DIR/preuninstall.sh"
@@ -56,8 +56,11 @@ download_java_agent() {
     local dest="$2"
     local api_url=""
     local dl_url=""
-
-    dl_url="$JAVA_AGENT_RELEASE_URL/$tag/splunk-otel-javaagent.jar"
+    if [[ "$tag" = "latest" ]]; then
+      dl_url="$JAVA_AGENT_RELEASE_URL/latest/download/splunk-otel-javaagent.jar"
+    else
+      dl_url="$JAVA_AGENT_RELEASE_URL/$tag/download/splunk-otel-javaagent.jar"
+    fi
 
     echo "Downloading $dl_url ..."
     mkdir -p "$( dirname $dest )"

--- a/instrumentation/packaging/fpm/common.sh
+++ b/instrumentation/packaging/fpm/common.sh
@@ -29,7 +29,7 @@ JAVA_AGENT_INSTALL_PATH="/usr/lib/splunk-instrumentation/splunk-otel-javaagent.j
 CONFIG_INSTALL_PATH="/usr/lib/splunk-instrumentation/instrumentation.conf"
 
 JAVA_AGENT_RELEASE_PATH="${FPM_DIR}/../java-agent-release.txt"
-JAVA_AGENT_RELEASE_URL="https://api.github.com/repos/signalfx/splunk-otel-java/releases"
+JAVA_AGENT_RELEASE_URL="https://github.com/signalfx/splunk-otel-java/releases/download/"
 
 POSTINSTALL_PATH="$FPM_DIR/postinstall.sh"
 PREUNINSTALL_PATH="$FPM_DIR/preuninstall.sh"
@@ -57,20 +57,7 @@ download_java_agent() {
     local api_url=""
     local dl_url=""
 
-    if [ "$tag" = "latest" ]; then
-        tag=$( curl -sL "$JAVA_AGENT_RELEASE_URL/latest" | jq -r '.tag_name' )
-        if [ -z "$tag" ]; then
-            echo "Failed to get tag_name for latest release from $JAVA_AGENT_RELEASE_URL/latest" >&2
-            exit 1
-        fi
-    fi
-
-    api_url="$JAVA_AGENT_RELEASE_URL/tags/$tag"
-    dl_url="$( curl -sL "$api_url" | jq -r '.assets[] .browser_download_url' | grep "splunk-otel-javaagent.jar" | grep -v ".asc$" )"
-    if [ -z "$dl_url" ]; then
-        echo "Failed to get the agent download url from $api_url" >&2
-        exit 1
-    fi
+    dl_url="$JAVA_AGENT_RELEASE_URL/$tag/splunk-otel-javaagent.jar"
 
     echo "Downloading $dl_url ..."
     mkdir -p "$( dirname $dest )"

--- a/internal/buildscripts/packaging/fpm/common.sh
+++ b/internal/buildscripts/packaging/fpm/common.sh
@@ -41,6 +41,7 @@ FLUENTD_CONFIG_INSTALL_DIR="/etc/otel/collector/fluentd"
 
 SMART_AGENT_RELEASE_PATH="${FPM_DIR}/../smart-agent-release.txt"
 SMART_AGENT_RELEASE_URL="https://api.github.com/repos/signalfx/signalfx-agent/releases"
+SMART_AGENT_DOWNLOAD_URL="https://github.com/signalfx/signalfx-agent/releases/download/"
 BUNDLE_BASE_DIR="/usr/lib/splunk-otel-collector"
 AGENT_BUNDLE_INSTALL_DIR="$BUNDLE_BASE_DIR/agent-bundle"
 
@@ -81,12 +82,7 @@ download_smart_agent() {
         fi
     fi
 
-    api_url="$SMART_AGENT_RELEASE_URL/tags/$tag"
-    dl_url="$( curl -sL "$api_url" | jq -r '.assets[] .browser_download_url' | grep "signalfx-agent-${tag#v}\.tar\.gz" )"
-    if [ -z "$dl_url" ]; then
-        echo "Failed to get the agent download url from $api_url" >&2
-        exit 1
-    fi
+    dl_url="$SMART_AGENT_DOWNLOAD_URL/$tag/signalfx-agent-${tag#v}.tar.gz"
 
     echo "Downloading $dl_url ..."
     curl -sL "$dl_url" -o "$buildroot/signalfx-agent.tar.gz"

--- a/internal/buildscripts/packaging/fpm/tar/build.sh
+++ b/internal/buildscripts/packaging/fpm/tar/build.sh
@@ -43,11 +43,8 @@ tar_download_smart_agent() {
     fi
 
     api_url="$SMART_AGENT_RELEASE_URL/tags/$tag"
-    dl_url="$( curl -sL "$api_url" | jq -r '.assets[] .browser_download_url' | grep "signalfx-agent-${tag#v}\.tar\.gz" )"
-    if [ -z "$dl_url" ]; then
-        echo "Failed to get the agent download url from $api_url" >&2
-        exit 1
-    fi
+    dl_url="$SMART_AGENT_DOWNLOAD_URL/$tag/signalfx-agent-${tag#v}.tar.gz"
+
 
     echo "Downloading $dl_url ..."
     curl -sL "$dl_url" -o "$buildroot/signalfx-agent.tar.gz"

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -392,12 +392,11 @@ $tempdir = create_temp_dir -tempdir $tempdir
 
 if ($with_dotnet_instrumentation) {
     echo "Installing SignalFx Instrumentation for .NET ..."
-    $api = "https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/latest"
     $module_name = "Splunk.SignalFx.DotNet.psm1"
+    $download = "https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/latest/Splunk.SignalFx.DotNet.psm1"
+    $dotnet_autoinstr_path = Join-Path $tempdir $module_name
     echo "Downloading .NET Instrumentation installer ..."
-    $download = (Invoke-WebRequest $api | ConvertFrom-Json).assets | Where-Object { $_.name -like $module_name } | Select-Object -Property browser_download_url,name
-    $dotnet_autoinstr_path = Join-Path $tempdir $download.name
-    Invoke-WebRequest -Uri $download.browser_download_url -OutFile $dotnet_autoinstr_path
+    Invoke-WebRequest -Uri $download -OutFile $dotnet_autoinstr_path
     Import-Module $dotnet_autoinstr_path
     if (Get-IsSignalFxInstalled) {
         throw "SignalFx Instrumentation for .NET is already installed. Remove/Uninstall SignalFx Instrumentation for .NET and re-run this script."

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -393,7 +393,7 @@ $tempdir = create_temp_dir -tempdir $tempdir
 if ($with_dotnet_instrumentation) {
     echo "Installing SignalFx Instrumentation for .NET ..."
     $module_name = "Splunk.SignalFx.DotNet.psm1"
-    $download = "https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/latest/Splunk.SignalFx.DotNet.psm1"
+    $download = "https://github.com/signalfx/signalfx-dotnet-tracing/releases/latest/download/Splunk.SignalFx.DotNet.psm1"
     $dotnet_autoinstr_path = Join-Path $tempdir $module_name
     echo "Downloading .NET Instrumentation installer ..."
     Invoke-WebRequest -Uri $download -OutFile $dotnet_autoinstr_path


### PR DESCRIPTION
We are being throttled by Github because we call in various places its API from public workers. Instead, use the `latest` release link.