### PR TITLE
use upstream kind for k8s testing

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -30,7 +30,7 @@ require (
 	k8s.io/cli-runtime v0.25.5
 	k8s.io/client-go v0.25.5
 	k8s.io/kubectl v0.25.5
-	sigs.k8s.io/kind v0.17.0
+	sigs.k8s.io/kind v0.18.0-alpha.0.20221215194558-3c286967842c
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -161,12 +161,8 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-replace (
-	// https://github.com/go-logr/logr/issues/51
-	k8s.io/klog/v2 => k8s.io/klog/v2 v2.80.1
-	// required for local docker image loading: https://github.com/kubernetes-sigs/kind/pull/3013
-	sigs.k8s.io/kind => github.com/rmfitzpatrick/kind v0.0.0-20221201170057-65523387b46c
-)
+// https://github.com/go-logr/logr/issues/51
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.80.1
 
 // security updates
 replace (

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -731,8 +731,6 @@ github.com/prometheus/statsd_exporter v0.22.7 h1:7Pji/i2GuhK6Lu7DHrtTkFmNBCudCPT
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=
-github.com/rmfitzpatrick/kind v0.0.0-20221201170057-65523387b46c h1:Hvt6uDLP1xIZtHJIl5OSzpS86qtTE51+gss9QFURBKQ=
-github.com/rmfitzpatrick/kind v0.0.0-20221201170057-65523387b46c/go.mod h1:Qqp8AiwOlMZmJWs37Hgs31xcbiYXjtXlRBSftcnZXQk=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -1429,6 +1427,8 @@ rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
+sigs.k8s.io/kind v0.18.0-alpha.0.20221215194558-3c286967842c h1:dzqzpcHJoKn5hKaMvGFUjoRg3tNAu29MQH9DH3gx4oc=
+sigs.k8s.io/kind v0.18.0-alpha.0.20221215194558-3c286967842c/go.mod h1:Qqp8AiwOlMZmJWs37Hgs31xcbiYXjtXlRBSftcnZXQk=
 sigs.k8s.io/kustomize/api v0.12.1 h1:7YM7gW3kYBwtKvoY216ZzY+8hM+lV53LUayghNRJ0vM=
 sigs.k8s.io/kustomize/api v0.12.1/go.mod h1:y3JUhimkZkR6sbLNwfJHxvo1TCLwuwm14sCYnkH6S1s=
 sigs.k8s.io/kustomize/kustomize/v4 v4.5.7 h1:cDW6AVMl6t/SLuQaezMET8hgnadZGIAr8tUrxFVOrpg=


### PR DESCRIPTION
bug fix PR has landed so fork is no longer required.