### PR TITLE
Break out CI_COMMIT_TAG for windows2022 gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -523,7 +523,8 @@ build-push-windows2022-image:
       $ErrorActionPreference = 'Stop'
       if ($env:CI_COMMIT_TAG) {
         $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows"
-        $IMAGE_TAG = "${env:CI_COMMIT_TAG.TrimStart("v")}-2022"
+        $tagNumber = $env:CI_COMMIT_TAG.TrimStart("v")
+        $IMAGE_TAG = "${tagNumber}-2022"
       } else {
         $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows-dev"
         $IMAGE_TAG = "${env:CI_COMMIT_SHA}-2022"


### PR DESCRIPTION
Seems like `CI_COMMIT_TAG` is not being properly set