### PR TITLE
Use memory ballast extension

### DIFF
--- a/deployments/salt/templates/agent_config.yaml
+++ b/deployments/salt/templates/agent_config.yaml
@@ -15,9 +15,12 @@ receivers:
           static_configs:
             - targets: ['127.0.0.1:8888']
 
+extensions:
+  memory_ballast:
+    size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
+
 processors:
   memory_limiter:
-    ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     check_interval: 2s
     limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
 
@@ -28,6 +31,7 @@ exporters:
     loglevel: info
 
 service:
+  extensions: [memory_ballast]
   pipelines:
     metrics:
       receivers: [otlp, prometheus]


### PR DESCRIPTION
This fixes a warning showing that setting the ballast memory size must happen under an extension memory_ballast rather than under the memory_limiter processor.