### PR TITLE
rename sign_release.py to release.py

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ fossa:
   except:
     - schedules
 
-.sign-release:
+.deploy-release:
   image: '${DOCKER_CICD_REPO}/ci-container:python-3.9'
   variables:
     PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
@@ -83,7 +83,7 @@ fossa:
           echo "$path not found!"
           exit 1
         fi
-        python3 internal/buildscripts/packaging/release/sign_release.py --force --stage=${STAGE} --path=$path ${OPTIONS:-}
+        python3 internal/buildscripts/packaging/release/release.py --force --stage=${STAGE} --path=$path ${OPTIONS:-}
       done
 
 .go-cache:
@@ -550,7 +550,7 @@ build-push-windows2022-image:
 release-debs:
   extends:
     - .trigger-filter
-    - .sign-release
+    - .deploy-release
   stage: release
   resource_group: artifactory-deb
   dependencies:
@@ -565,7 +565,7 @@ release-debs:
 release-rpms:
   extends:
     - .trigger-filter
-    - .sign-release
+    - .deploy-release
   stage: release
   parallel:
     matrix:

--- a/internal/buildscripts/packaging/release/release.py
+++ b/internal/buildscripts/packaging/release/release.py
@@ -38,13 +38,11 @@ def main():
                 sys.exit(1)
 
         if asset.component == "deb":
-            # Release deb to artifactory and sign metadata
+            # Release deb to artifactory
             release_deb_to_artifactory(asset, args)
         elif asset.component == "rpm":
-            # Sign rpm, release to artifactory, and sign metadata
             release_rpm_to_artifactory(asset, args)
         elif asset.component == "msi":
-            # Sign MSI and release to S3
             release_msi_to_s3(asset, args)
 
     # Release installer scripts to S3


### PR DESCRIPTION
Remove the confusion that the python script has anything to do with signing, which is now handled elsewhere.