### PR TITLE
Fix latest git tag detection

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -358,7 +358,7 @@ jobs:
             echo "TAG_NAME=" >> $GITHUB_ENV
           fi
           export VERSION_TAG="${TAG_NAME#v}"
-          make msi SKIP_COMPILE=true VERSION="${VERSION_TAG:-0.67.0.${{ github.run_number }}}"
+          make msi SKIP_COMPILE=true VERSION="${VERSION_TAG:-0.0.1.${{ github.run_number }}}"
       
       - name: Uploading msi build artifacts
         uses: actions/upload-artifact@v3

--- a/internal/buildscripts/packaging/choco/make.ps1
+++ b/internal/buildscripts/packaging/choco/make.ps1
@@ -28,7 +28,7 @@ $scriptDir = split-path -parent $MyInvocation.MyCommand.Definition
 $repoDir = "$scriptDir\..\..\..\.."
 
 function build_choco(
-        [string]$Version="0.67.0",
+        [string]$Version="0.0.1",
         [string]$MSIFile="",
         [string]$BuildDir="$repoDir\dist",
         [string]$ChocoDir="$scriptDir\splunk-otel-collector") {

--- a/internal/buildscripts/packaging/fpm/common.sh
+++ b/internal/buildscripts/packaging/fpm/common.sh
@@ -52,7 +52,7 @@ PREUNINSTALL_PATH="$FPM_DIR/preuninstall.sh"
 get_version() {
     commit_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --tags --exact-match --match 'v[0-9]*' 2>/dev/null || true )"
     if [[ -z "$commit_tag" ]]; then
-        latest_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true )"
+        latest_tag="$( git ls-remote --refs --tags -q | tail -n 1 | awk -F/ '{ print $3 }' )"
         if [[ -n "$latest_tag" ]]; then
             echo "${latest_tag}-post"
         else

--- a/internal/buildscripts/packaging/fpm/common.sh
+++ b/internal/buildscripts/packaging/fpm/common.sh
@@ -53,13 +53,11 @@ get_version() {
     commit_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --tags --exact-match --match 'v[0-9]*' 2>/dev/null || true )"
     if [[ -z "$commit_tag" ]]; then
         latest_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true )"
-        # DIRTY DIRTY TRIAGE HACK THAT TODO NEEDS TO BE FIXED ASAP
-        echo "${latest_tag:-v0.67.0}-post"
-        #if [[ -n "$latest_tag" ]]; then
-        #    echo "${latest_tag}-post"
-        #else
-        #    echo "0.0.1-post"
-        #fi
+        if [[ -n "$latest_tag" ]]; then
+            echo "${latest_tag}-post"
+        else
+            echo "0.0.1-post"
+        fi
     else
         echo "$commit_tag"
     fi

--- a/internal/buildscripts/packaging/msi/build.sh
+++ b/internal/buildscripts/packaging/msi/build.sh
@@ -13,13 +13,11 @@ get_version() {
     commit_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --tags --exact-match --match 'v[0-9]*' 2>/dev/null || true )"
     if [[ -z "$commit_tag" ]]; then
         latest_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true )"
-        # DIRTY DIRTY TRIAGE HACK THAT TODO NEEDS TO BE FIXED ASAP
-        echo "${latest_tag:-v0.67.0}.1"
-        #if [[ -n "$latest_tag" ]]; then
-        #    echo "${latest_tag}.1"
-        #else
-        #    echo "0.0.1"
-        #fi
+        if [[ -n "$latest_tag" ]]; then
+            echo "${latest_tag}.1"
+        else
+            echo "0.0.1"
+        fi
     else
         echo "$commit_tag"
     fi

--- a/internal/buildscripts/packaging/msi/build.sh
+++ b/internal/buildscripts/packaging/msi/build.sh
@@ -12,7 +12,7 @@ SMART_AGENT_RELEASE="${2:-}"
 get_version() {
     commit_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --tags --exact-match --match 'v[0-9]*' 2>/dev/null || true )"
     if [[ -z "$commit_tag" ]]; then
-        latest_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true )"
+        latest_tag="$( git ls-remote --refs --tags -q | tail -n 1 | awk -F/ '{ print $3 }' )"
         if [[ -n "$latest_tag" ]]; then
             echo "${latest_tag}.1"
         else

--- a/internal/buildscripts/packaging/msi/make.ps1
+++ b/internal/buildscripts/packaging/msi/make.ps1
@@ -42,7 +42,7 @@ function Install-Tools {
 function New-MSI(
     [string]$Otelcol="./bin/otelcol_windows_amd64.exe",
     [string]$Translatesfx="./bin/translatesfx_windows_amd64.exe",
-    [string]$Version="0.67.0",
+    [string]$Version="0.0.1",
     [string]$BuildDir="./dist",
     [string]$Config="./cmd/otelcol/config/collector/agent_config.yaml",
     [string]$FluentdConfig="./internal/buildscripts/packaging/fpm/etc/otel/collector/fluentd/fluent.conf",


### PR DESCRIPTION
Detect the latest tag using `git ls-remote`, as checkouts no longer contain all tags.