### PR TITLE
Add storage to filelog example

### DIFF
--- a/examples/otel-logs-splunk/docker-compose.yml
+++ b/examples/otel-logs-splunk/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - /opt/splunk/etc
   # OpenTelemetry Collector
   otelcollector:
-    image:  quay.io/signalfx/splunk-otel-collector:0.59.1
+    image:  quay.io/signalfx/splunk-otel-collector:0.67.0
     container_name: otelcollector
     command: ["--config=/etc/otel-collector-config.yml"]
     volumes:

--- a/examples/otel-logs-splunk/otel-collector-config.yml
+++ b/examples/otel-logs-splunk/otel-collector-config.yml
@@ -1,6 +1,7 @@
 receivers:
     filelog:
       include: [ /output/file.log ]
+      storage: file_storage/checkpoint
 
 exporters:
     splunk_hec/logs:
@@ -18,9 +19,10 @@ exporters:
         disable_compression: false
         # HTTP timeout when sending data. Defaults to 10s.
         timeout: 10s
-        # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
-        # For this demo, we use a self-signed certificate on the Splunk docker instance, so this flag is set to true.
-        insecure_skip_verify: true
+        tls:
+          # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
+          # For this demo, we use a self-signed certificate on the Splunk docker instance, so this flag is set to true.
+          insecure_skip_verify: true
 
 processors:
     batch:
@@ -32,9 +34,16 @@ extensions:
       endpoint: :1888
     zpages:
       endpoint: :55679
+    file_storage/checkpoint:
+      directory: /output/
+      timeout: 1s
+      compaction:
+        on_start: true
+        directory: /output/
+        max_transaction_size: 65_536
 
 service:
-    extensions: [pprof, zpages, health_check]
+    extensions: [pprof, zpages, health_check, file_storage/checkpoint]
     pipelines:
       logs:
         receivers: [filelog]


### PR DESCRIPTION
Add the file_storage extension to the example to show how checkpointing works.