### PR TITLE
[Prototyping] Add workspace env vars

### DIFF
--- a/.github/workflows/actions-test-playground.yml
+++ b/.github/workflows/actions-test-playground.yml
@@ -1,0 +1,51 @@
+name: build-and-test
+
+on:
+  push:
+    branches:
+      - 'test_actions*'
+  pull_request:
+    paths:
+      - '.github/workflows/actions-test-playground.yml'
+      - 'internal/buildscripts/packaging/temp-gh-actions-test/**'
+      - 'Makefile'
+
+concurrency:
+  group: build-and-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: '3.10'
+  PIP_VERSION: '22.0.4'
+  GO_VERSION: 1.19.0
+
+jobs:
+  setup-environment:
+    name: setup-environment
+    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Caching dependency
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Test env vars
+        run: |
+          echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+          echo "GITHUB_REF_NAME=$GITHUF_REF_NAME"
+          echo "REF_TYPE=$REF_TYPE"
+          make install-tools
+          make test-gh-actions

--- a/Makefile
+++ b/Makefile
@@ -225,3 +225,13 @@ endif
 .PHONY: update-examples
 update-examples:
 	cd examples && $(MAKE) update-examples
+
+.PHONY: test-gh-actions
+test-gh-actions:
+	echo "In makefile for github actions"
+	echo "$GITHUB_WORKSPACE"
+	echo "$GITHUB_REF"
+	echo "$GITHUB_REF_NAME"
+	echo "$REF_TYPE"
+	echo "$VERSION"
+	./internal/buildscripts/packaging/temp-gh-actions-test/installer_script_test.sh

--- a/internal/buildscripts/packaging/temp-gh-actions-test/test-gh-actions-shell-script.sh
+++ b/internal/buildscripts/packaging/temp-gh-actions-test/test-gh-actions-shell-script.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+echo "starting tests!"
+set -euxo pipefail
+# Tests that github actions env vars are set as expected.  Likely to fail on first few pushes, as we will be validating
+# an error case to start with.
+
+echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"
+echo "REF_TYPE=$REF_TYPE"
+echo "exiting test.."


### PR DESCRIPTION
For security reasons we cannot test github actions in PRs, so add new workflow which will only trigger on non-main branch and test on said non-main branch.

Also set this particular workflow to run "downstream" (non-`.github/workflows/*.yml`) changes to shell scripts in our specific folder