### PR TITLE
ensure --dry-run doesn't report expanded config values

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -72,6 +72,7 @@ func main() {
 		log.Fatalf("failed to create discovery provider: %v", err)
 	}
 
+	hooks := []configprovider.Hook{configServer, dryRun}
 	envProvider := envprovider.New()
 	fileProvider := fileprovider.New()
 	serviceConfigProvider, err := otelcol.NewConfigProvider(
@@ -82,16 +83,16 @@ func main() {
 					discovery.ConfigDScheme(): configprovider.NewConfigSourceConfigMapProvider(
 						discovery.ConfigDProvider(),
 						zap.NewNop(), // The service logger is not available yet, setting it to Nop.
-						info, configServer, configsources.Get()...,
+						info, hooks, configsources.Get()...,
 					),
 					discovery.DiscoveryModeScheme(): configprovider.NewConfigSourceConfigMapProvider(
-						discovery.DiscoveryModeProvider(), zap.NewNop(), info, configServer, configsources.Get()...,
+						discovery.DiscoveryModeProvider(), zap.NewNop(), info, hooks, configsources.Get()...,
 					),
 					envProvider.Scheme(): configprovider.NewConfigSourceConfigMapProvider(
-						envProvider, zap.NewNop(), info, configServer, configsources.Get()...,
+						envProvider, zap.NewNop(), info, hooks, configsources.Get()...,
 					),
 					fileProvider.Scheme(): configprovider.NewConfigSourceConfigMapProvider(
-						fileProvider, zap.NewNop(), info, configServer, configsources.Get()...,
+						fileProvider, zap.NewNop(), info, hooks, configsources.Get()...,
 					),
 				}, Converters: confMapConverters,
 			},

--- a/internal/configconverter/config_server_test.go
+++ b/internal/configconverter/config_server_test.go
@@ -38,8 +38,8 @@ func TestConfigServer_RequireEnvVar(t *testing.T) {
 
 	cs := NewConfigServer()
 	require.NotNil(t, cs)
-	cs.Register()
-	t.Cleanup(cs.Unregister)
+	cs.OnNew()
+	t.Cleanup(cs.OnShutdown)
 	require.NoError(t, cs.Convert(context.Background(), confmap.NewFromStringMap(initial)))
 
 	client := &http.Client{}
@@ -92,10 +92,10 @@ func TestConfigServer_EnvVar(t *testing.T) {
 
 			cs := NewConfigServer()
 			require.NotNil(t, cs)
-			cs.Register()
+			cs.OnNew()
 
 			require.NoError(t, cs.Convert(context.Background(), confmap.NewFromStringMap(initial)))
-			defer cs.Unregister()
+			defer cs.OnShutdown()
 
 			endpoint := tt.endpoint
 			if endpoint == "" {
@@ -147,10 +147,10 @@ func TestConfigServer_Serve(t *testing.T) {
 
 	cs := NewConfigServer()
 	require.NotNil(t, cs)
-	cs.Register()
-	t.Cleanup(cs.Unregister)
+	cs.OnNew()
+	t.Cleanup(cs.OnShutdown)
 
-	cs.SetForScheme("scheme", initial)
+	cs.OnRetrieve("scheme", initial)
 	require.NoError(t, cs.Convert(context.Background(), confmap.NewFromStringMap(initial)))
 
 	// Test for the pages to be actually valid YAML files.

--- a/pkg/extension/smartagentextension/config_windows_test.go
+++ b/pkg/extension/smartagentextension/config_windows_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/extension"
 )
 

--- a/pkg/receiver/smartagent/config_windows_test.go
+++ b/pkg/receiver/smartagent/config_windows_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
 
 func TestLoadUnsupportedCollectdMonitorOnWindows(t *testing.T) {

--- a/tests/general/dry_run_test.go
+++ b/tests/general/dry_run_test.go
@@ -1,0 +1,96 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package tests
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/signalfx/splunk-otel-collector/tests/testutils"
+)
+
+func TestDryRunDoesntExpandEnvVars(t *testing.T) {
+	tc := testutils.NewTestcase(t)
+	defer tc.PrintLogsOnFailure()
+	defer tc.ShutdownOTLPReceiverSink()
+
+	config := `config_sources:
+  env:
+    defaults:
+      COLLECTION_INTERVAL: 1s
+      OTLP_EXPORTER: otlp
+exporters:
+  otlp:
+    endpoint: ${OTLP_ENDPOINT}
+    insecure: true
+receivers:
+  hostmetrics:
+    collection_interval: ${env:COLLECTION_INTERVAL}
+    scrapers:
+      cpu: null
+service:
+  pipelines:
+    metrics:
+      exporters:
+      - ${env:OTLP_EXPORTER}
+      receivers:
+      - ${HOST_METRICS_RECEIVER}`
+
+	c, shutdown := tc.SplunkOtelCollectorContainer(
+		"", func(collector testutils.Collector) testutils.Collector {
+			// deferring running service for exec
+			c := collector.WithEnv(
+				map[string]string{
+					"HOST_METRICS_RECEIVER": "hostmetrics",
+					"SPLUNK_CONFIG":         "",
+					"SPLUNK_CONFIG_YAML":    config,
+				},
+			).WithArgs("-c", "trap exit SIGTERM ; echo ok ; while true; do : ; done")
+			cc := c.(*testutils.CollectorContainer)
+			cc.Container = cc.Container.WithEntrypoint("bash").WillWaitForLogs("ok")
+			return cc
+		},
+	)
+
+	defer shutdown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	sc, reader, err := c.Container.Exec(ctx, []string{
+		"bash", "-c", "/otelcol --dry-run 2>/dev/null",
+	})
+	assert.NoError(t, err)
+	require.NotNil(t, reader)
+	dryRun, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.True(t, len(dryRun) >= 8)
+	require.Equal(t, config, string(dryRun[8:len(dryRun)-1])) // strip leading control character
+	require.Zero(t, sc)
+
+	// confirm successful service functionality
+	sc, _, err = c.Container.Exec(ctx, []string{"bash", "-c", "/otelcol &"})
+	assert.NoError(t, err)
+	require.Zero(t, sc)
+
+	expectedResourceMetrics := tc.ResourceMetrics("cpu.yaml")
+	require.NoError(t, tc.OTLPReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
+}

--- a/tests/testutils/container.go
+++ b/tests/testutils/container.go
@@ -45,6 +45,7 @@ type Container struct {
 	Image                string
 	ContainerName        string
 	ContainerNetworkMode string
+	Entrypoint           []string
 	Cmd                  []string
 	ContainerNetworks    []string
 	ExposedPorts         []string
@@ -81,6 +82,11 @@ func (container Container) WithContext(path string) Container {
 
 func (container Container) WithContextArchive(contextArchive io.Reader) Container {
 	container.Dockerfile.ContextArchive = contextArchive
+	return container
+}
+
+func (container Container) WithEntrypoint(entrypoint ...string) Container {
+	container.Entrypoint = entrypoint
 	return container
 }
 
@@ -211,6 +217,7 @@ func (container Container) Build() *Container {
 		Image:          container.Image,
 		FromDockerfile: container.Dockerfile,
 		Cmd:            container.Cmd,
+		Entrypoint:     container.Entrypoint,
 		Env:            container.Env,
 		ExposedPorts:   container.ExposedPorts,
 		Name:           container.ContainerName,

--- a/tests/testutils/container_test.go
+++ b/tests/testutils/container_test.go
@@ -65,6 +65,11 @@ func TestDockerBuilderMethods(t *testing.T) {
 	assert.NotSame(t, builder, withContextArchive)
 	assert.Nil(t, builder.Dockerfile.ContextArchive)
 
+	withEntrypoint := builder.WithEntrypoint("bin", "arg")
+	assert.Equal(t, []string{"bin", "arg"}, withEntrypoint.Entrypoint)
+	assert.NotSame(t, builder, withEntrypoint)
+	assert.Empty(t, builder.Entrypoint)
+
 	withCmd := builder.WithCmd("bash", "-c", "'sleep inf'")
 	assert.Equal(t, []string{"bash", "-c", "'sleep inf'"}, withCmd.Cmd)
 	assert.NotSame(t, builder, withCmd)
@@ -384,8 +389,8 @@ func (lc *logConsumer) Accept(l testcontainers.Log) {
 var _ testcontainers.LogConsumer = (*logConsumer)(nil)
 
 func TestTestcontainersContainerMethods(t *testing.T) {
-	alpine := NewContainer().WithImage("alpine").WithCmd(
-		"sh", "-c", "echo rdy > /tmp/something && tail -f /tmp/something",
+	alpine := NewContainer().WithImage("alpine").WithEntrypoint("sh", "-c").WithCmd(
+		"echo rdy > /tmp/something && tail -f /tmp/something",
 	).WithExposedPorts("12345:12345").WithName("my-alpine").WithNetworks(
 		"bridge", "network_a", "network_b",
 	).WillWaitForLogs("rdy").Build()


### PR DESCRIPTION
Currently `--dry-run` will provide the final config values with all config source and environment variables having been resolved/expanded. This is not desirable for dynamic* content. These changes add a new `configprovider.Hook` mechanism to provide additional components access of pre-resolving config content like* the config server currently does. The config server converter is updated to conform to the new interface.

These also pick up existing missing imports and add an integration test with an additional testutil container helper.  