### PR TITLE
Provide unexpanded configs in discovery mode

### DIFF
--- a/internal/confmapprovider/discovery/discoverer.go
+++ b/internal/confmapprovider/discovery/discoverer.go
@@ -406,7 +406,7 @@ func (c *Config) observersForDiscoveryMode() []component.ID {
 }
 
 func (d *discoverer) addUnexpandedReceiverConfig(receiverID, observerID component.ID, cfg map[string]any) {
-	d.logger.Info(fmt.Sprintf("adding unexpanded config[%s][%s]: %v\n", receiverID.String(), observerID.String(), cfg))
+	d.logger.Debug(fmt.Sprintf("adding unexpanded config[%s][%s]: %v\n", receiverID.String(), observerID.String(), cfg))
 	observerMap, ok := d.unexpandedReceiverEntries[receiverID]
 	if !ok {
 		observerMap = map[component.ID]map[string]any{}
@@ -422,7 +422,7 @@ func (d *discoverer) getUnexpandedReceiverConfig(receiverID, observerID componen
 	if hasReceiver {
 		cfg, found = observerMap[observerID]
 	}
-	d.logger.Info(fmt.Sprintf("getting unexpanded config[%s][%s](%v): %v\n", receiverID.String(), observerID.String(), found, cfg))
+	d.logger.Debug(fmt.Sprintf("getting unexpanded config[%s][%s](%v): %v\n", receiverID.String(), observerID.String(), found, cfg))
 	return cfg, found
 }
 

--- a/tests/general/discoverymode/k8s_observer_discovery_test.go
+++ b/tests/general/discoverymode/k8s_observer_discovery_test.go
@@ -1,0 +1,378 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/signalfx/splunk-otel-collector/tests/testutils"
+	"github.com/signalfx/splunk-otel-collector/tests/testutils/kubeutils"
+	"github.com/signalfx/splunk-otel-collector/tests/testutils/kubeutils/manifests"
+)
+
+func TestK8sObserver(t *testing.T) {
+	tc := testutils.NewTestcase(t, testutils.OTLPReceiverSinkAllInterfaces)
+	defer tc.PrintLogsOnFailure()
+	defer tc.ShutdownOTLPReceiverSink()
+
+	cluster := kubeutils.NewKindCluster(tc)
+	defer cluster.Delete()
+	cluster.Create()
+	cluster.LoadLocalCollectorImageIfNecessary()
+
+	namespace, serviceAccount := createNamespaceAndServiceAccount(cluster)
+
+	configMap, configMapManifest := configToConfigMapManifest(t, "otlp-exporter-no-internal-prometheus.yaml", namespace)
+	sout, serr, err := cluster.Apply(configMapManifest)
+	tc.Logger.Debug("applying ConfigMap", zap.String("stdout", sout.String()), zap.String("stderr", serr.String()))
+	require.NoError(t, err)
+
+	redis := createRedis(cluster, "target.redis", namespace, serviceAccount)
+
+	crManifest, crbManifest := clusterRoleAndBindingManifests(t, namespace, serviceAccount)
+	sout, serr, err = cluster.Apply(crManifest)
+	tc.Logger.Debug("applying ClusterRole", zap.String("stdout", sout.String()), zap.String("stderr", serr.String()))
+	require.NoError(t, err)
+
+	sout, serr, err = cluster.Apply(crbManifest)
+	tc.Logger.Debug("applying ClusterRoleBinding", zap.String("stdout", sout.String()), zap.String("stderr", serr.String()))
+	require.NoError(t, err)
+
+	daemonSet, dsManifest := daemonSetManifest(cluster, namespace, serviceAccount, configMap)
+	sout, serr, err = cluster.Apply(dsManifest)
+	tc.Logger.Debug("applying DaemonSet", zap.String("stdout", sout.String()), zap.String("stderr", serr.String()))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		rPod, err := cluster.Clientset.CoreV1().Pods(namespace).Get(ctx, redis, metav1.GetOptions{})
+		require.NoError(t, err)
+		tc.Logger.Debug(fmt.Sprintf("redis is: %s\n", rPod.Status.Phase))
+		return rPod.Status.Phase == corev1.PodRunning
+	}, 5*time.Minute, 1*time.Second)
+
+	var collectorPodName string
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		dsPods, err := cluster.Clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("name = %s", daemonSet),
+		})
+		require.NoError(t, err)
+		if len(dsPods.Items) > 0 {
+			collectorPod := dsPods.Items[0]
+			tc.Logger.Debug(fmt.Sprintf("collector is: %s\n", collectorPod.Status.Phase))
+			cPod, err := cluster.Clientset.CoreV1().Pods(collectorPod.Namespace).Get(ctx, collectorPod.Name, metav1.GetOptions{})
+			collectorPodName = cPod.Name
+			require.NoError(t, err)
+			return cPod.Status.Phase == corev1.PodRunning
+		}
+		return false
+	}, 5*time.Minute, 1*time.Second)
+
+	expectedMetrics := tc.ResourceMetrics("k8s-observer-smart-agent-redis.yaml")
+	require.NoError(t, tc.OTLPReceiverSink.AssertAllMetricsReceived(t, *expectedMetrics, 30*time.Second))
+
+	stdout, stderr, err := cluster.Kubectl("exec", "-n", namespace, collectorPodName, "--", "bash", "-c", "SPLUNK_DEBUG_CONFIG_SERVER=false /otelcol --config=/config/config.yaml --config-dir=/config.d --discovery --dry-run")
+	require.NoError(t, err)
+	require.Equal(t, `exporters:
+  otlp:
+    endpoint: ${OTLP_ENDPOINT}
+    tls:
+      insecure: true
+extensions:
+  k8s_observer:
+    auth_type: serviceAccount
+receivers:
+  receiver_creator/discovery:
+    receivers:
+      smartagent:
+        config:
+          type: collectd/redis
+        resource_attributes:
+          one.key: one.value
+          two.key: two.value
+        rule: type == "port" && pod.name == "${TARGET_POD_NAME}"
+    watch_observers:
+    - k8s_observer
+service:
+  extensions:
+  - k8s_observer
+  pipelines:
+    metrics:
+      exporters:
+      - otlp
+      receivers:
+      - receiver_creator/discovery
+  telemetry:
+    metrics:
+      address: ""
+      level: none
+`, stdout.String())
+	require.Contains(t, stderr.String(), "Discovering for next 10s...\nDiscovery complete.\n")
+}
+
+func createRedis(cluster *kubeutils.KindCluster, name, namespace, serviceAccount string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	redis, err := cluster.Clientset.CoreV1().Pods(namespace).Create(
+		ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"another.annotation": "another.annotation.value",
+				},
+				Labels: map[string]string{
+					"another.label": "another.label.value",
+				},
+				Name: name,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Image:           "redis",
+						Name:            "redis",
+						Ports:           []corev1.ContainerPort{{ContainerPort: 6379}},
+						ImagePullPolicy: corev1.PullIfNotPresent,
+					},
+				},
+				ServiceAccountName: serviceAccount,
+				HostNetwork:        true,
+			},
+		}, metav1.CreateOptions{},
+	)
+	require.NoError(cluster.Testcase, err)
+	return redis.Name
+}
+
+func createNamespaceAndServiceAccount(cluster *kubeutils.KindCluster) (string, string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ns, err := cluster.Clientset.CoreV1().Namespaces().Create(
+		ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}},
+		metav1.CreateOptions{},
+	)
+	require.NoError(cluster.Testcase, err)
+	namespace := ns.Name
+
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	serviceAccount, err := cluster.Clientset.CoreV1().ServiceAccounts(namespace).Create(
+		ctx, &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: "some.serviceaccount"},
+		},
+		metav1.CreateOptions{})
+	require.NoError(cluster.Testcase, err)
+	return namespace, serviceAccount.Name
+}
+
+func configToConfigMapManifest(t testing.TB, _, namespace string) (name, manifest string) {
+	config, err := os.ReadFile(filepath.Join(".", "testdata", "otlp-exporter-no-internal-prometheus.yaml"))
+	configStore := map[string]any{"config": string(config)}
+
+	k8sObserver, err := os.ReadFile(filepath.Join(".", "testdata", "k8s-observer-config.d", "extensions", "k8s-observer.discovery.yaml"))
+	configStore["extensions"] = string(k8sObserver)
+
+	saReceiver, err := os.ReadFile(filepath.Join(".", "testdata", "k8s-observer-config.d", "receivers", "smart-agent-redis.discovery.yaml"))
+	configStore["receivers"] = string(saReceiver)
+
+	configYaml, err := yaml.Marshal(configStore)
+	require.NoError(t, err)
+
+	cm := manifests.ConfigMap{
+		Name: "collector.config", Namespace: namespace,
+		Data: string(configYaml),
+	}
+	cmm, err := cm.Render()
+	require.NoError(t, err)
+	return cm.Name, cmm
+}
+
+func clusterRoleAndBindingManifests(t testing.TB, namespace, serviceAccount string) (string, string) {
+	cr := manifests.ClusterRole{
+		Name:      "cluster-role",
+		Namespace: namespace,
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{
+					"events",
+					"namespaces",
+					"namespaces/status",
+					"nodes",
+					"nodes/spec",
+					"nodes/stats",
+					"nodes/proxy",
+					"pods",
+					"pods/status",
+					"persistentvolumeclaims",
+					"persistentvolumes",
+					"replicationcontrollers",
+					"replicationcontrollers/status",
+					"resourcequotas",
+					"services",
+				},
+				Verbs: []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{
+					"daemonsets",
+					"deployments",
+					"replicasets",
+					"statefulsets",
+				},
+				Verbs: []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"extensions"},
+				Resources: []string{
+					"daemonsets",
+					"deployments",
+					"replicasets",
+				},
+				Verbs: []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"batch"},
+				Resources: []string{
+					"jobs",
+					"cronjobs",
+				},
+				Verbs: []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"autoscaling"},
+				Resources: []string{
+					"horizontalpodautoscalers",
+				},
+				Verbs: []string{"get", "list", "watch"},
+			},
+			{
+				NonResourceURLs: []string{"/metrics"},
+				Verbs:           []string{"get", "list", "watch"},
+			},
+		},
+	}
+	crManifest, err := cr.Render()
+	require.NoError(t, err)
+
+	crb := manifests.ClusterRoleBinding{
+		Namespace:          namespace,
+		Name:               "cluster-role-binding",
+		ClusterRoleName:    cr.Name,
+		ServiceAccountName: serviceAccount,
+	}
+	crbManifest, err := crb.Render()
+	require.NoError(t, err)
+
+	return crManifest, crbManifest
+}
+
+func daemonSetManifest(cluster *kubeutils.KindCluster, namespace, serviceAccount, configMap string) (name, manifest string) {
+	splat := strings.Split(cluster.Testcase.OTLPEndpoint, ":")
+	port := splat[len(splat)-1]
+	var hostFromContainer string
+	if runtime.GOOS == "darwin" {
+		hostFromContainer = "host.docker.internal"
+	} else {
+		hostFromContainer = cluster.GetDefaultGatewayIP()
+	}
+	otlpEndpoint := fmt.Sprintf("%s:%s", hostFromContainer, port)
+
+	ds := manifests.DaemonSet{
+		Name:           "an.agent.daemonset",
+		Namespace:      namespace,
+		ServiceAccount: serviceAccount,
+		Labels:         map[string]string{"label.key": "label.value"},
+		Containers: []corev1.Container{
+			{
+				Image:   testutils.GetCollectorImageOrSkipTest(cluster.Testcase),
+				Command: []string{"/otelcol", "--config=/config/config.yaml", "--config-dir=/config.d", "--discovery"},
+				Env: []corev1.EnvVar{
+					{Name: "OTLP_ENDPOINT", Value: otlpEndpoint},
+					{Name: "TARGET_POD_NAME", Value: "target.redis"},
+				},
+				Name:            "otel-collector",
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name: "config-map-volume", MountPath: "/config",
+					},
+					{
+						Name: "config-d-volume", MountPath: "/config.d",
+					},
+				},
+			},
+		},
+		Volumes: []corev1.Volume{
+			{
+				Name: "config-map-volume",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: configMap,
+						},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  "config",
+								Path: "config.yaml",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "config-d-volume",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: configMap,
+						},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  "extensions",
+								Path: "extensions/k8s-observer.discovery.yaml",
+							},
+							{
+								Key:  "receivers",
+								Path: "receivers/smart-agent-redis.discovery.yaml",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	dsm, err := ds.Render()
+	require.NoError(cluster.Testcase, err)
+	return ds.Name, dsm
+}

--- a/tests/general/discoverymode/testdata/docker-observer-config.d/extensions/docker-observer.discovery.yaml
+++ b/tests/general/discoverymode/testdata/docker-observer-config.d/extensions/docker-observer.discovery.yaml
@@ -1,2 +1,2 @@
 docker_observer:
-  endpoint: unix:///var/run/dock.e.r.sock
+  endpoint: ${DOCKER_DOMAIN_SOCKET}

--- a/tests/general/discoverymode/testdata/docker-observer-config.d/receivers/internal-prometheus.discovery.yaml
+++ b/tests/general/discoverymode/testdata/docker-observer-config.d/receivers/internal-prometheus.discovery.yaml
@@ -4,8 +4,12 @@ prometheus_simple:
   config:
     default:
       collection_interval: invalid
+      labels:
+        label.one: ${LABEL_ONE_VALUE}
     docker_observer:
       collection_interval: 1s
+      labels:
+        label.two: ${LABEL_TWO_VALUE}
   status:
     metrics:
       successful:

--- a/tests/general/discoverymode/testdata/host-observer-config.d/receivers/internal-prometheus.discovery.yaml
+++ b/tests/general/discoverymode/testdata/host-observer-config.d/receivers/internal-prometheus.discovery.yaml
@@ -4,8 +4,12 @@ prometheus_simple:
   config:
     default:
       collection_interval: invalid
+      labels:
+        label.one: ${LABEL_ONE_VALUE}
     host_observer:
       collection_interval: 1s
+      labels:
+        label.two: ${LABEL_TWO_VALUE}
   status:
     metrics:
       successful:

--- a/tests/general/discoverymode/testdata/k8s-observer-config.d/extensions/k8s-observer.discovery.yaml
+++ b/tests/general/discoverymode/testdata/k8s-observer-config.d/extensions/k8s-observer.discovery.yaml
@@ -1,0 +1,2 @@
+k8s_observer:
+  auth_type: serviceAccount

--- a/tests/general/discoverymode/testdata/k8s-observer-config.d/receivers/smart-agent-redis.discovery.yaml
+++ b/tests/general/discoverymode/testdata/k8s-observer-config.d/receivers/smart-agent-redis.discovery.yaml
@@ -1,0 +1,24 @@
+smartagent:
+  rule:
+    k8s_observer: type == "port" && pod.name == "${TARGET_POD_NAME}"
+  config:
+    default:
+      type: collectd/redis
+  resource_attributes:
+    one.key: one.value
+    two.key: two.value
+  status:
+    metrics:
+      successful:
+          - strict: bytes.used_memory_rss
+            first_only: true
+            log_record:
+              severity_text: info
+              body: Successfully scraped metrics from redis pod
+    statements:
+      failed:
+        - regexp: "^redis_info plugin: Error connecting to .* - ConnectionRefusedError.*$"
+          first_only: true
+          log_record:
+            severity_text: debug
+            body: Port appears to not be from redis server

--- a/tests/general/discoverymode/testdata/otlp-exporter-no-internal-prometheus.yaml
+++ b/tests/general/discoverymode/testdata/otlp-exporter-no-internal-prometheus.yaml
@@ -1,7 +1,8 @@
 exporters:
   otlp:
     endpoint: "${OTLP_ENDPOINT}"
-    insecure: true
+    tls:
+      insecure: true
 service:
   telemetry:
     metrics:

--- a/tests/general/discoverymode/testdata/resource_metrics/host-observer-internal-prometheus.yaml
+++ b/tests/general/discoverymode/testdata/resource_metrics/host-observer-internal-prometheus.yaml
@@ -10,6 +10,8 @@ resource_metrics:
             type: DoubleMonotonicCumulativeSum
             attributes:
               exporter: logging
+              label.one: actual.label.one.value
+              label.two: actual.label.two.value
               service_instance_id: <ANY>
               service_name: otelcol
               service_version: <VERSION_FROM_BUILD>

--- a/tests/general/discoverymode/testdata/resource_metrics/k8s-observer-smart-agent-redis.yaml
+++ b/tests/general/discoverymode/testdata/resource_metrics/k8s-observer-smart-agent-redis.yaml
@@ -1,0 +1,16 @@
+resource_metrics:
+  - attributes:
+      k8s.namespace.name: test-namespace
+      k8s.pod.name: target.redis
+      k8s.pod.uid: <ANY>
+      one.key: one.value
+      two.key: two.value
+    scope_metrics:
+      - metrics:
+          - name: gauge.connected_clients
+            type: IntGauge
+            attributes:
+              dsname: value
+              plugin: redis_info
+              plugin_instance: <ANY>
+              system.type: redis

--- a/tests/testutils/container_test.go
+++ b/tests/testutils/container_test.go
@@ -515,4 +515,9 @@ func TestTestcontainersContainerMethods(t *testing.T) {
 		"/tmp/afile", 655,
 	)
 	require.NoError(t, err)
+
+	sc, stdout, stderr := alpine.AssertExec(t, 5*time.Second, "sh", "-c", "echo stdout > /dev/stdout && echo stderr > /dev/stderr")
+	require.Equal(t, "stdout\n", stdout)
+	require.Equal(t, "stderr\n", stderr)
+	require.Zero(t, sc)
 }


### PR DESCRIPTION
In the same vein as https://github.com/signalfx/splunk-otel-collector/pull/2439 these changes ensure that successfully discovered target entities don't report their expanded config values from the discovery confmap provider* (and by extension `--dry-run`), which would make any configs using env vars only valid for running on a matching environment.

They also update all discovery mode integration tests to vet this w/ a new docker exec helper and add a new k8s integration test (the bulk of the changes).