### PR TITLE
Fix broken Java Agent GitHub download link

### DIFF
--- a/instrumentation/packaging/fpm/common.sh
+++ b/instrumentation/packaging/fpm/common.sh
@@ -58,7 +58,7 @@ download_java_agent() {
     if [[ "$tag" = "latest" ]]; then
       dl_url="$JAVA_AGENT_RELEASE_URL/latest/download/splunk-otel-javaagent.jar"
     else
-      dl_url="$JAVA_AGENT_RELEASE_URL/$tag/download/splunk-otel-javaagent.jar"
+      dl_url="$JAVA_AGENT_RELEASE_URL/download/$tag/splunk-otel-javaagent.jar"
     fi
 
     echo "Downloading $dl_url ..."


### PR DESCRIPTION
The collector downloads the Java agent for instrumentation. The java agent download link is incorrect when a specific tag is provided. This fixes the link.

I tested both the `latest` and `$tag` URLs manually, they're both working now (`latest` wasn't broken).