### PR TITLE
Add -f to curl downloads

### DIFF
--- a/instrumentation/packaging/fpm/common.sh
+++ b/instrumentation/packaging/fpm/common.sh
@@ -63,7 +63,7 @@ download_java_agent() {
 
     echo "Downloading $dl_url ..."
     mkdir -p "$( dirname $dest )"
-    curl -sL "$dl_url" -o "$dest"
+    curl -sfL "$dl_url" -o "$dest"
 }
 
 setup_files_and_permissions() {

--- a/internal/buildscripts/packaging/fpm/common.sh
+++ b/internal/buildscripts/packaging/fpm/common.sh
@@ -77,7 +77,7 @@ download_smart_agent() {
     local dl_url=""
 
     if [ "$tag" = "latest" ]; then
-        tag=$( curl -sL "$SMART_AGENT_RELEASE_URL/latest" | jq -r '.tag_name' )
+        tag=$( curl -sfL "$SMART_AGENT_RELEASE_URL/latest" | jq -r '.tag_name' )
         if [ -z "$tag" ]; then
             echo "Failed to get tag_name for latest release from $SMART_AGENT_RELEASE_URL/latest" >&2
             exit 1
@@ -87,7 +87,7 @@ download_smart_agent() {
     dl_url="$SMART_AGENT_DOWNLOAD_URL/$tag/signalfx-agent-${tag#v}.tar.gz"
 
     echo "Downloading $dl_url ..."
-    curl -sL "$dl_url" -o "$buildroot/signalfx-agent.tar.gz"
+    curl -sfL "$dl_url" -o "$buildroot/signalfx-agent.tar.gz"
 
     mkdir -p "$buildroot/$BUNDLE_BASE_DIR"
     tar -xzf "$buildroot/signalfx-agent.tar.gz" -C "$buildroot/$BUNDLE_BASE_DIR"

--- a/internal/buildscripts/packaging/fpm/tar/build.sh
+++ b/internal/buildscripts/packaging/fpm/tar/build.sh
@@ -35,7 +35,7 @@ tar_download_smart_agent() {
     local dl_url=""
 
     if [ "$tag" = "latest" ]; then
-        tag=$( curl -sL "$SMART_AGENT_RELEASE_URL/latest" | jq -r '.tag_name' )
+        tag=$( curl -sfL "$SMART_AGENT_RELEASE_URL/latest" | jq -r '.tag_name' )
         if [ -z "$tag" ]; then
             echo "Failed to get tag_name for latest release from $SMART_AGENT_RELEASE_URL/latest" >&2
             exit 1
@@ -47,7 +47,7 @@ tar_download_smart_agent() {
 
 
     echo "Downloading $dl_url ..."
-    curl -sL "$dl_url" -o "$buildroot/signalfx-agent.tar.gz"
+    curl -sfL "$dl_url" -o "$buildroot/signalfx-agent.tar.gz"
 
     mkdir -p "$buildroot/$BUNDLE_BASE_DIR"
     tar -xzf "$buildroot/signalfx-agent.tar.gz" -C "$buildroot/"

--- a/internal/buildscripts/packaging/msi/msi-builder/build.sh
+++ b/internal/buildscripts/packaging/msi/msi-builder/build.sh
@@ -190,7 +190,7 @@ download_and_extract_smart_agent() {
     local output_dir="$3/agent-bundle"
 
     if [ "$version" = "latest" ]; then
-        version=$( curl -sL "$SMART_AGENT_LATEST_URL" )
+        version=$( curl -sfL "$SMART_AGENT_LATEST_URL" )
         if [ -z "$version" ]; then
             echo "Failed to get version for latest release from ${SMART_AGENT_LATEST_URL}" >&2
             exit 1
@@ -199,7 +199,7 @@ download_and_extract_smart_agent() {
 
     dl_url="$SMART_AGENT_RELEASE_URL/SignalFxAgent-$version-win64.zip"
     echo "Downloading ${dl_url}..."
-    curl -sL "$dl_url" -o "${build_dir}/signalfx-agent.zip"
+    curl -sfL "$dl_url" -o "${build_dir}/signalfx-agent.zip"
 
     unzip -d "$build_dir" "${build_dir}/signalfx-agent.zip"
     mv "${build_dir}/SignalFxAgent" "$output_dir"


### PR DESCRIPTION
Add the -f flag to curl downloads in our packaging scripts, so failure to download a component fails the script.