### PR TITLE
Use DOCKER_HUB for libsplunk builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,7 +134,8 @@ libsplunk:
     matrix:
       - ARCH: ["amd64", "arm64"]
   script:
-    - make -C instrumentation dist ARCH=${ARCH}
+    - *docker-reader-role
+    - make -C instrumentation dist ARCH=${ARCH} DOCKER_REPO=${DOCKER_HUB_REPO}
   artifacts:
     paths:
       - instrumentation/dist/libsplunk_*.so

--- a/instrumentation/Dockerfile
+++ b/instrumentation/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:11
+ARG DOCKER_REPO=docker.io
+FROM ${DOCKER_REPO}/debian:11
 
 RUN apt-get update && \
     apt-get install -y build-essential

--- a/instrumentation/Makefile
+++ b/instrumentation/Makefile
@@ -1,6 +1,9 @@
 ARCH=amd64
 INSTALL_DIR=/usr/lib/splunk-instrumentation
 
+# Docker repository used.
+DOCKER_REPO?=docker.io
+
 .PHONY: all
 all: so/libsplunk.so
 
@@ -47,7 +50,7 @@ test: tests
 .PHONY: dist
 dist:
 	@mkdir -p dist
-	docker buildx build --platform linux/$(ARCH) -o type=image,name=libsplunk-builder:$(ARCH),push=false .
+	docker buildx build --platform linux/$(ARCH) --build-arg DOCKER_REPO=$(DOCKER_REPO) -o type=image,name=libsplunk-builder:$(ARCH),push=false .
 	docker rm -f libsplunk-builder 2>/dev/null || true
 	docker run -d --platform linux/$(ARCH) --name libsplunk-builder libsplunk-builder:$(ARCH) sleep inf
 	docker exec libsplunk-builder make test all


### PR DESCRIPTION
Helps avoid docker rate limiting failures in gitlab.