### PR TITLE
ansible: add splunk_otel_collector_no_proxy variable

### DIFF
--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -117,6 +117,12 @@ $> ansible-playbook playbook.yaml -e start_service=false
   `http://user:pass@10.0.0.42`. Notice this proxy is not used by ansible
   itself during deployment. (**default:** ``)
 
+- `splunk_otel_collector_no_proxy` (Linux only): Set the ip and/or hosts that
+  will not use `splunk_otel_collector_proxy_http` or
+  `splunk_otel_collector_proxy_https`. This variable is only used if
+  `splunk_otel_collector_proxy_http` or `splunk_otel_collector_proxy_https` is
+  defined. (**default:** `localhost,127.0.0.1,::1`)
+
 - `splunk_memory_total_mib`: Amount of memory in MiB allocated to the Splunk OTel 
   Collector. (**default:** `512`)
 

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -58,6 +58,7 @@ splunk_collectd_dir: ""
 # Configure otel collector service to use a proxy
 splunk_otel_collector_proxy_http: ""
 splunk_otel_collector_proxy_https: ""
+splunk_otel_collector_no_proxy: "localhost,127.0.0.1,::1"
 
 install_splunk_otel_auto_instrumentation: false
 splunk_otel_auto_instrumentation_version: latest

--- a/deployments/ansible/roles/collector/templates/collector-service-proxy.conf.j2
+++ b/deployments/ansible/roles/collector/templates/collector-service-proxy.conf.j2
@@ -1,4 +1,4 @@
 [Service] 
 Environment="HTTP_PROXY={{ splunk_otel_collector_proxy_http }}"
 Environment="HTTPS_PROXY={{ splunk_otel_collector_proxy_https }}" 
-Environment="NO_PROXY=localhost,127.0.0.1,::1"
+Environment="NO_PROXY={{ splunk_otel_collector_no_proxy }}"


### PR DESCRIPTION
IFAIK when you need to monitor an https vhost on localhost on a proxied environment you need to add the vhost on the NO_PROXY environment variable (event if localhost is used).

```
    smartagent/http_toto:
      type: http
      host: 127.0.0.1
      port: 443
      useHTTPS: true
      noRedirects: true
      sniServerName: www.toto.com
      httpHeaders:
        Host: www.toto.com
      path: /up.php
      desiredCode: 200
      regex: '^OK$'
```
will not worked on a proxied environment if `NO_PROXY=localhost,127.0.0.1,::1` ; for it to work we need `NO_PROXY=localhost,127.0.0.1,::1,www.toto.com`
So we need a way to set NO_PROXY.