### PR TITLE
Use GITHUB_OUTPUT instead of set-output

### DIFF
--- a/.github/workflows/chef.yml
+++ b/.github/workflows/chef.yml
@@ -32,7 +32,7 @@ jobs:
             echo "Failed to get version from deployments/chef/metadata.rb"
             exit 1
           fi
-          echo "::set-output name=version::${version}"
+          echo "version=${version}" >> $GITHUB_OUTPUT
 
       - name: Push new release tag if it doesn't exist
         uses: actions/github-script@v6

--- a/.github/workflows/deps-test.yml
+++ b/.github/workflows/deps-test.yml
@@ -40,9 +40,9 @@ jobs:
         run: |
           OTEL_VERSION=${{ env.OTEL_VERSION }} ./internal/buildscripts/update-deps 2>&1 | tee -a /tmp/output.txt
           if git diff --exit-code; then
-            echo "::set-output name=has_changes::false"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=has_changes::true"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
       - name: Compile
         shell: bash


### PR DESCRIPTION
`set-output` is being deprecated: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/