### PR TITLE
Fix deb/rpm versioning in github workflows

### DIFF
--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Downloading libsplunk-${{ matrix.ARCH }}
         uses: actions/download-artifact@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -239,6 +239,8 @@ jobs:
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Caching dependency
         uses: actions/cache@v3

--- a/instrumentation/Makefile
+++ b/instrumentation/Makefile
@@ -64,7 +64,7 @@ ifneq ($(SKIP_COMPILE), true)
 endif
 	@mkdir -p dist
 	docker build -t instrumentation-fpm packaging/fpm
-	docker run --rm -v $(CURDIR):/instrumentation -e PACKAGE=$* -e VERSION=$(VERSION) -e ARCH=$(ARCH) instrumentation-fpm
+	docker run --rm -v $(CURDIR)/../:/repo -e PACKAGE=$* -e VERSION=$(VERSION) -e ARCH=$(ARCH) instrumentation-fpm
 
 # Run this to install and enable the auto-instrumentation files. Mostly intended for development.
 .PHONY: install

--- a/instrumentation/packaging/fpm/Dockerfile
+++ b/instrumentation/packaging/fpm/Dockerfile
@@ -1,15 +1,17 @@
 FROM debian:10
 
-VOLUME /instrumentation
-WORKDIR /instrumentation
+VOLUME /repo
+WORKDIR /repo
 
 ENV PACKAGE="deb"
 ENV VERSION=""
 ENV ARCH="amd64"
-ENV OUTPUT_DIR="/instrumentation/dist/"
+ENV OUTPUT_DIR="/repo/instrumentation/dist/"
 
 COPY install-deps.sh Gemfile Gemfile.lock /
 
 RUN /install-deps.sh
 
-CMD ./packaging/fpm/$PACKAGE/build.sh "$VERSION" "$ARCH" "$OUTPUT_DIR"
+RUN git config --global --add safe.directory /repo
+
+CMD ./instrumentation/packaging/fpm/$PACKAGE/build.sh "$VERSION" "$ARCH" "$OUTPUT_DIR"

--- a/instrumentation/packaging/fpm/common.sh
+++ b/instrumentation/packaging/fpm/common.sh
@@ -39,13 +39,11 @@ get_version() {
     commit_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --tags --exact-match --match 'v[0-9]*' 2>/dev/null || true )"
     if [[ -z "$commit_tag" ]]; then
         latest_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true )"
-        # DIRTY DIRTY TRIAGE HACK THAT TODO NEEDS TO BE FIXED ASAP
-        echo "${latest_tag:-v0.67.0}-post"
-        #if [[ -n "$latest_tag" ]]; then
-        #    echo "${latest_tag}-post"
-        #else
-        #    echo "0.0.1-post"
-        #fi
+        if [[ -n "$latest_tag" ]]; then
+            echo "${latest_tag}-post"
+        else
+            echo "0.0.1-post"
+        fi
     else
         echo "$commit_tag"
     fi

--- a/internal/buildscripts/packaging/fpm/Dockerfile
+++ b/internal/buildscripts/packaging/fpm/Dockerfile
@@ -12,4 +12,6 @@ COPY install-deps.sh Gemfile Gemfile.lock /
 
 RUN /install-deps.sh
 
+RUN git config --global --add safe.directory /repo
+
 CMD ./internal/buildscripts/packaging/fpm/$PACKAGE/build.sh "$VERSION" "$ARCH" "$OUTPUT_DIR" "$SMART_AGENT_RELEASE"

--- a/internal/buildscripts/packaging/fpm/common.sh
+++ b/internal/buildscripts/packaging/fpm/common.sh
@@ -53,13 +53,11 @@ get_version() {
     commit_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --tags --exact-match --match 'v[0-9]*' 2>/dev/null || true )"
     if [[ -z "$commit_tag" ]]; then
         latest_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true )"
-        # DIRTY DIRTY TRIAGE HACK THAT TODO NEEDS TO BE FIXED ASAP
-        echo "${latest_tag:-v0.67.0}-post"
-        #if [[ -n "$latest_tag" ]]; then
-        #    echo "${latest_tag}-post"
-        #else
-        #    echo "0.0.1-post"
-        #fi
+        if [[ -n "$latest_tag" ]]; then
+            echo "${latest_tag}-post"
+        else
+            echo "0.0.1-post"
+        fi
     else
         echo "$commit_tag"
     fi

--- a/internal/buildscripts/packaging/msi/build.sh
+++ b/internal/buildscripts/packaging/msi/build.sh
@@ -13,13 +13,11 @@ get_version() {
     commit_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --tags --exact-match --match 'v[0-9]*' 2>/dev/null || true )"
     if [[ -z "$commit_tag" ]]; then
         latest_tag="$( git -C "$REPO_DIR" describe --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true )"
-        # DIRTY DIRTY TRIAGE HACK THAT TODO NEEDS TO BE FIXED ASAP
-        echo "${latest_tag:-v0.67.0}.1"
-        #if [[ -n "$latest_tag" ]]; then
-        #    echo "${latest_tag}.1"
-        #else
-        #    echo "0.0.1"
-        #fi
+        if [[ -n "$latest_tag" ]]; then
+            echo "${latest_tag}.1"
+        else
+            echo "0.0.1"
+        fi
     else
         echo "$commit_tag"
     fi


### PR DESCRIPTION
Workaround for https://github.com/actions/checkout/issues/766 when using `git describe` to get the latest tag for deb/rpm versioning.