### PR TITLE
nil check when looking for the type of a value

### DIFF
--- a/internal/configconverter/k8s_tagger.go
+++ b/internal/configconverter/k8s_tagger.go
@@ -53,8 +53,8 @@ func (RenameK8sTagger) Convert(_ context.Context, in *confmap.Conf) error {
 			found = true
 		} else {
 			if serviceEntryRe.MatchString(k) {
-				kind := reflect.TypeOf(v).Kind()
-				if kind == reflect.Slice {
+				t := reflect.TypeOf(v)
+				if t != nil && t.Kind() == reflect.Slice {
 					if sliceOfInterfaces, ok := v.([]any); ok {
 						for i, val := range sliceOfInterfaces {
 							if strVal, ok := val.(string); ok {


### PR DESCRIPTION
Fixes #2465

Somehow the value of a k8s attribute is nil, and we panic on this. The fix is to check for nil before we look for the type of the attribute.