### PR TITLE
Add --not-latest option to release script

### DIFF
--- a/internal/buildscripts/packaging/release/helpers/release_args.py
+++ b/internal/buildscripts/packaging/release/helpers/release_args.py
@@ -138,6 +138,17 @@ def get_args_and_asset():
         """,
     )
     parser.add_argument(
+        "--not-latest",
+        action="store_true",
+        default=False,
+        required=False,
+        help="""
+            Only applicable if the --path option is specified for a MSI file.
+            By default, the latest.txt file on dl.signalfx.com is automatically updated with the version of the MSI.
+            If uploading an older version of the MSI, specify this option to skip this step.
+        """,
+    )
+    parser.add_argument(
         "--timeout",
         type=int,
         default=DEFAULT_TIMEOUT,


### PR DESCRIPTION
In case we need to upload an older version of the MSI.