### PR TITLE
Update upstream_agent_config.yaml

### DIFF
--- a/cmd/otelcol/config/collector/upstream_agent_config.yaml
+++ b/cmd/otelcol/config/collector/upstream_agent_config.yaml
@@ -125,6 +125,7 @@ exporters:
     # Use instead when sending to gateway
     #api_url: http://${SPLUNK_GATEWAY_URL}:6060
     #ingest_url: http://${SPLUNK_GATEWAY_URL}:9943
+    sync_host_metadata: true
     correlation:
   # Logs
   splunk_hec:


### PR DESCRIPTION
added "sync_host_metadata: true" to enable sync of host meta_data - tested with upstream