### PR TITLE
Add windows support to ansible tests

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -109,6 +109,9 @@ jobs:
   windows-test:
     name: Windows Test
     needs: lint
+    # Need to run on macos-12 since it is the only image with native support for ansible, vagrant, and virtualbox.
+    # https://docs.ansible.com/ansible/latest/os_guide/windows_faq.html#windows-faq-ansible
+    # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
     runs-on: macos-12
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -139,6 +139,7 @@ jobs:
           path: "${{ github.workspace }}/requirements.txt"
           contents: |
             ${{ matrix.ansible }}
+            ansible-compat==2.2.7
             ansible-lint==5.4.0
             molecule==4.0.4
             molecule-vagrant==2.0.0

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -17,6 +17,10 @@ on:
       - '.github/workflows/ansible.yml'
       - 'deployments/ansible/**'
 
+concurrency:
+  group: ansible-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 
@@ -45,8 +49,8 @@ jobs:
       - name: Lint code.
         run: yamllint .
 
-  test:
-    name: Test
+  linux-test:
+    name: Linux Test
     needs: lint
     # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
     runs-on: ubuntu-20.04
@@ -75,19 +79,25 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v3
 
+      - uses: DamianReeves/write-file-action@v1.2
+        with:
+          path: "${{ github.workspace }}/requirements.txt"
+          contents: |
+            ${{ matrix.ansible }}
+            molecule==3.3.0
+            molecule-docker==0.2.4
+            docker==5.0.0
+            ansible-lint==5.4.0
+
       - name: Set up Python 3.
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: "${{ github.workspace }}/requirements.txt"
 
       - name: Install test dependencies.
-        run: >
-          pip3 install 
-          ${{ matrix.ansible }}
-          molecule==3.3.0 
-          molecule-docker==0.2.4 
-          docker==5.0.0
-          ansible-lint==5.4.0
+        run: pip3 install --use-pep517 -r ${GITHUB_WORKSPACE}/requirements.txt
 
       - name: Run Molecule tests.
         run: molecule --base-config ./molecule/config/docker.yml test --all
@@ -96,9 +106,60 @@ jobs:
           ANSIBLE_FORCE_COLOR: '1'
           MOLECULE_DISTRO: ${{ matrix.distro }}
 
+  windows-test:
+    name: Windows Test
+    needs: lint
+    runs-on: macos-12
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        ansible:
+          - ansible~=2.10.0
+          - ansible~=3.0
+          - ansible~=4.0
+        distro:
+          - "2012"
+          - "2016"
+          - "2019"
+          - "2022"
+        scenario:
+          - default
+          - custom_vars
+          - without_fluentd
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - uses: DamianReeves/write-file-action@v1.2
+        with:
+          path: "${{ github.workspace }}/requirements.txt"
+          contents: |
+            ${{ matrix.ansible }}
+            ansible-lint==5.4.0
+            molecule==4.0.4
+            molecule-vagrant==2.0.0
+            pywinrm==0.4.3
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: "${{ github.workspace }}/requirements.txt"
+
+      - name: Install test dependencies.
+        run: pip3 install --use-pep517 -r ${GITHUB_WORKSPACE}/requirements.txt
+
+      - name: Run Molecule tests.
+        run: molecule --debug -v --base-config ./molecule/config/windows.yml test -s ${{ matrix.scenario }} -p ${{ matrix.distro }}
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+
   push-release-tag:
     name: Push Release Tag
-    needs: test
+    needs: lint
     # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/main' 

--- a/deployments/ansible/README.md
+++ b/deployments/ansible/README.md
@@ -23,6 +23,7 @@ Currently, the following Windows versions are supported:
 - Windows Server 2012 64-bit
 - Windows Server 2016 64-bit
 - Windows Server 2019 64-bit
+- Windows Server 2022 64-bit
 
 Ansible requires PowerShell 3.0 or newer and at least .NET 4.0 to be installed on Windows host.
 A WinRM listener should be created and activeted. 

--- a/deployments/ansible/contributing/README.md
+++ b/deployments/ansible/contributing/README.md
@@ -25,14 +25,17 @@ following software is installed:
   - molecule
   - molecule-vagrant
   - python-vagrant
+  - pywinrm
 
 Installation steps for MacOS:
 
 ```sh
 brew tap hashicorp/tap
-brew install virtualbox vagrant python3
+brew install virtualbox6 vagrant python3
 pip3 install -r requirements-dev-macos.txt
 ```
+
+#### Linux Testing
 
 Use the following arguments with every molecule command 
 `--base-config ./molecule/config/vagrant.yml`.
@@ -51,6 +54,43 @@ To run the full test suite:
 ```sh
 molecule --base-config ./molecule/config/vagrant.yml test --all
 ```
+
+#### Windows Testing
+
+Use the following arguments with every molecule command
+`--base-config ./molecule/config/windows.yml`.
+
+To run a test suite scenario for *all* supported Windows versions:
+```sh
+molecule --base-config ./molecule/config/windows.yml test -s <scenario>
+```
+
+To run a test scenario for a single Windows version, use the
+`--platform [2012|2016|2019|2022]` argument (requires `molecule` >= 4.0.0):
+```sh
+molecule --base-config ./molecule/config/windows.yml test -s <scenario> --platform <windows version>
+```
+
+To add a new test scenario for Windows:
+1. Create the subdirectory for the new scenario, e.g.
+   `mkdir ./molecule/new_scenario`.
+2. Create and populate the `./molecule/new_scenario/windows-converge.yml` and
+   `./molecule/new_scenario/windows-verify.yml` files.
+3. Test the new scenario, e.g.
+   `molecule --base-config ./molecule/config/windows.yml test -s new_scenario`.
+4. Add the new scenario name to the `windows-test` matrix in the
+   [ansible GitHub workflow](../../../.github/workflows/ansible.yml) when the
+   changes are ready for review.
+
+To add new Windows platform definitions or to modify/remove existing ones:
+1. Update the `platforms` list in
+   [windows.yml](../molecule/config/windows.yml).
+2. Test the new/modified platform, e.g.
+   `molecule --base-config ./molecule/config/windows.yml test -s <scenario> -p <platform_name>`.
+3. If adding/removing a Windows platform, add/remove the platform name for the
+   `windows-test` matrix in the
+   [ansible GitHub workflow](../../../.github/workflows/ansible.yml) when the
+   changes are ready for review.
 
 ### Linux setup
 

--- a/deployments/ansible/contributing/requirements-dev-macos.txt
+++ b/deployments/ansible/contributing/requirements-dev-macos.txt
@@ -1,4 +1,5 @@
 ansible~=2.10.0
+ansible-compat==2.2.7
 ansible-lint==5.4.0
 molecule==4.0.4
 molecule-vagrant==2.0.0

--- a/deployments/ansible/contributing/requirements-dev-macos.txt
+++ b/deployments/ansible/contributing/requirements-dev-macos.txt
@@ -1,4 +1,5 @@
-ansible==3.4.0
-molecule==3.3.0
-molecule-vagrant==0.6.1
-python-vagrant==0.5.15
+ansible~=2.10.0
+ansible-lint==5.4.0
+molecule==4.0.4
+molecule-vagrant==2.0.0
+pywinrm==0.4.3

--- a/deployments/ansible/molecule/config/windows.yml
+++ b/deployments/ansible/molecule/config/windows.yml
@@ -1,0 +1,67 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ./molecule/requirements.yml
+driver:
+  name: vagrant
+  provider:
+    name: virtualbox
+platforms:
+  - name: "2012"
+    box: devopsgroup-io/windows_server-2012r2-standard-amd64-nocm
+    box_version: 1.67.0
+    cpus: 2
+    memory: 4096
+    instance_raw_config_args: &vagrant_args
+      - "vm.boot_timeout = 1200"
+      - "vm.communicator = 'winrm'"
+      - "vm.network 'forwarded_port', guest: 5985, host: 55985"
+      - "winrm.basic_auth_only = true"
+      - "winrm.transport = 'plaintext'"
+      - "winrm.username = 'vagrant'"
+      - "winrm.password = 'vagrant'"
+      - "winrm.retry_limit = 50"
+      - "winrm.retry_delay = 10"
+  - name: "2016"
+    box: cdaf/WindowsServer
+    box_version: 2022.09.01
+    cpus: 2
+    memory: 4096
+    instance_raw_config_args: *vagrant_args
+  - name: "2019"
+    box: gusztavvargadr/windows-server-2019-standard
+    box_version: 1809.0.2211
+    cpus: 2
+    memory: 4096
+    instance_raw_config_args: *vagrant_args
+  - name: "2022"
+    box: gusztavvargadr/windows-server-2022-standard
+    box_version: 2102.0.2211
+    cpus: 2
+    memory: 4096
+    instance_raw_config_args: *vagrant_args
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_ROLES_PATH: ../../roles
+    OBJC_DISABLE_INITIALIZE_FORK_SAFETY: 'YES'
+  connection_options:
+    ansible_connection: winrm
+    ansible_host: 127.0.0.1
+    ansible_port: 55985
+    ansible_become_method: runas
+    ansible_become_user: vagrant
+    ansible_password: vagrant
+    ansible_user: vagrant
+    ansible_winrm_scheme: http
+    ansible_winrm_transport: basic
+    ansible_winrm_server_cert_validation: ignore
+    ansible_winrm_operation_timeout_sec: 60
+    ansible_winrm_read_timeout_sec: 90
+  playbooks:
+    converge: windows-converge.yml
+    prepare: ../default/windows-prepare.yml
+    verify: windows-verify.yml
+  options:
+    vvv: true

--- a/deployments/ansible/molecule/custom_vars/converge.yml
+++ b/deployments/ansible/molecule/custom_vars/converge.yml
@@ -4,8 +4,8 @@
   become: yes
   vars:
     splunk_access_token: fake-token
-    splunk_ingest_url: https://fake-ingest.com
-    splunk_api_url: https://fake-api.com
+    splunk_ingest_url: https://fake-splunk-ingest.com
+    splunk_api_url: https://fake-splunk-api.com
     splunk_otel_collector_version: 0.48.0
     splunk_otel_collector_config: /etc/otel/collector/custom_config.yml
     splunk_otel_collector_config_source: ./custom_collector_config.yml

--- a/deployments/ansible/molecule/custom_vars/verify.yml
+++ b/deployments/ansible/molecule/custom_vars/verify.yml
@@ -25,28 +25,28 @@
 
     - name: Assert SPLUNK_INGEST_URL env var is set
       ansible.builtin.lineinfile:
-        line: SPLUNK_INGEST_URL=https://fake-ingest.com
+        line: SPLUNK_INGEST_URL=https://fake-splunk-ingest.com
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
 
     - name: Assert SPLUNK_API_URL env var is set
       ansible.builtin.lineinfile:
-        line: SPLUNK_INGEST_URL=https://fake-api.com
+        line: SPLUNK_INGEST_URL=https://fake-splunk-api.com
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
 
     - name: Assert SPLUNK_TRACE_URL env var is set
       ansible.builtin.lineinfile:
-        line: SPLUNK_TRACE_URL=https://fake-ingest.com/v2/trace
+        line: SPLUNK_TRACE_URL=https://fake-splunk-ingest.com/v2/trace
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
 
     - name: Assert SPLUNK_HEC_URL env var is set
       ansible.builtin.lineinfile:
-        line: SPLUNK_HEC_URL=https://fake-ingest.com/v1/log
+        line: SPLUNK_HEC_URL=https://fake-splunk-ingest.com/v1/log
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes

--- a/deployments/ansible/molecule/custom_vars/windows-converge.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-converge.yml
@@ -1,0 +1,21 @@
+---
+- name: Converge scenario with custom variables
+  hosts: all
+  become: no
+  vars:
+    splunk_access_token: fake-token
+    splunk_ingest_url: https://fake-ingest.com
+    splunk_api_url: https://fake-api.com
+    splunk_hec_url: https://fake-hec.com
+    splunk_hec_token: fake-hec-token
+    splunk_otel_collector_version: 0.48.0
+    splunk_otel_collector_config: '{{ansible_env.ProgramData}}\Splunk\OpenTelemetry Collector\custom_config.yml'
+    splunk_otel_collector_config_source: ./custom_collector_config.yml
+    splunk_memory_total_mib: 256
+    splunk_ballast_size_mib: 100
+    splunk_fluentd_config: '{{ansible_env.ProgramFiles}}\Splunk\OpenTelemetry Collector\fluentd\custom_config.conf'
+    splunk_fluentd_config_source: ./custom_fluentd_config.conf
+  tasks:
+    - name: "Include signalfx.splunk_otel_collector.collector role"
+      include_role:
+        name: "collector"

--- a/deployments/ansible/molecule/custom_vars/windows-converge.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-converge.yml
@@ -4,9 +4,9 @@
   become: no
   vars:
     splunk_access_token: fake-token
-    splunk_ingest_url: https://fake-ingest.com
-    splunk_api_url: https://fake-api.com
-    splunk_hec_url: https://fake-hec.com
+    splunk_ingest_url: https://fake-splunk-ingest.com
+    splunk_api_url: https://fake-splunk-api.com
+    splunk_hec_url: https://fake-splunk-hec.com
     splunk_hec_token: fake-hec-token
     splunk_otel_collector_version: 0.48.0
     splunk_otel_collector_config: '{{ansible_env.ProgramData}}\Splunk\OpenTelemetry Collector\custom_config.yml'

--- a/deployments/ansible/molecule/custom_vars/windows-verify.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-verify.yml
@@ -1,0 +1,185 @@
+---
+- name: Verify scenario with custom variables
+  hosts: all
+  gather_facts: true
+  become: no
+  tasks:
+    - name: Check splunk-otel-collector service
+      ansible.windows.win_service:
+        name: splunk-otel-collector
+        state: started
+      check_mode: yes
+      register: service_status
+
+    - name: Assert splunk-otel-collector service status
+      assert:
+        that: not service_status.changed
+
+    - name: Check fluentdwinsvc service
+      ansible.windows.win_service:
+        name: fluentdwinsvc
+        state: started
+      check_mode: yes
+      register: service_status
+
+    - name: Assert fluentdwinsvc service status
+      assert:
+        that: not service_status.changed
+
+    - name: Download splunk-otel-collector 0.48.0 MSI
+      ansible.windows.win_get_url:
+        url: https://dl.signalfx.com/splunk-otel-collector/msi/release/splunk-otel-collector-0.48.0-amd64.msi
+        dest: "{{ansible_env.TEMP}}"
+      register: otel_msi_package
+
+    - name: Install splunk-otel-collector 0.48.0 MSI
+      ansible.windows.win_package:
+        path: "{{otel_msi_package.dest}}"
+        state: present
+      check_mode: yes
+      register: msi_installed
+
+    - name: Assert splunk-otel-collector 0.48.0 MSI is already installed
+      assert:
+        that: not msi_installed.changed
+
+    - name: Check custom_config.yml
+      ansible.windows.win_stat:
+        path: '{{ansible_env.ProgramData}}\Splunk\OpenTelemetry Collector\custom_config.yml'
+      register: custom_collector_config
+
+    - name: Assert custom_config.yml exists
+      assert:
+        that: custom_collector_config.stat.exists
+
+    - name: Check SPLUNK_CONFIG custom value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_CONFIG
+        data: '{{ansible_env.ProgramData}}\Splunk\OpenTelemetry Collector\custom_config.yml'
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert custom value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_INGEST_URL custom value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_INGEST_URL
+        data: https://fake-ingest.com
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert custom value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_API_URL custom value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_API_URL
+        data: https://fake-api.com
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert custom value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_TRACE_URL custom value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_TRACE_URL
+        data: https://fake-ingest.com/v2/trace
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert custom value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_HEC_URL custom value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_HEC_URL
+        data: https://fake-hec.com
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert custom value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_HEC_TOKEN custom value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_HEC_TOKEN
+        data: fake-hec-token
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert custom value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_MEMORY_TOTAL_MIB custom value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_MEMORY_TOTAL_MIB
+        data: 256
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert custom value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_BALLAST_SIZE_MIB custom value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_BALLAST_SIZE_MIB
+        data: 100
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert custom value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check fluentd custom_config.conf
+      ansible.windows.win_stat:
+        path: '{{ansible_env.ProgramFiles}}\Splunk\OpenTelemetry Collector\fluentd\custom_config.conf'
+        get_checksum: yes
+      register: custom_fluentd_config
+
+    - name: Assert fluentd custom_config.conf exists
+      assert:
+        that: custom_fluentd_config.stat.exists
+
+    - name: Check td-agent.conf exists
+      ansible.windows.win_stat:
+        path: '{{ansible_env.SystemDrive}}\opt\td-agent\etc\td-agent\td-agent.conf'
+        get_checksum: yes
+      register: td_agent_config
+
+    - name: Assert fluentd custom_config.conf is used
+      assert:
+        that: custom_fluentd_config.stat.checksum == td_agent_config.stat.checksum

--- a/deployments/ansible/molecule/custom_vars/windows-verify.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-verify.yml
@@ -71,7 +71,7 @@
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
         state: present
         name: SPLUNK_INGEST_URL
-        data: https://fake-ingest.com
+        data: https://fake-splunk-ingest.com
         type: string
       check_mode: yes
       register: reg_value
@@ -85,7 +85,7 @@
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
         state: present
         name: SPLUNK_API_URL
-        data: https://fake-api.com
+        data: https://fake-splunk-api.com
         type: string
       check_mode: yes
       register: reg_value
@@ -99,7 +99,7 @@
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
         state: present
         name: SPLUNK_TRACE_URL
-        data: https://fake-ingest.com/v2/trace
+        data: https://fake-splunk-ingest.com/v2/trace
         type: string
       check_mode: yes
       register: reg_value
@@ -113,7 +113,7 @@
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
         state: present
         name: SPLUNK_HEC_URL
-        data: https://fake-hec.com
+        data: https://fake-splunk-hec.com
         type: string
       check_mode: yes
       register: reg_value

--- a/deployments/ansible/molecule/default/windows-converge.yml
+++ b/deployments/ansible/molecule/default/windows-converge.yml
@@ -1,0 +1,11 @@
+---
+- name: Converge scenario with the default configuration on Windows
+  hosts: all
+  become: no
+  vars:
+    splunk_access_token: fake-token
+    splunk_realm: fake-realm
+  tasks:
+    - name: "Include signalfx.splunk_otel_collector.collector role"
+      include_role:
+        name: "collector"

--- a/deployments/ansible/molecule/default/windows-prepare.yml
+++ b/deployments/ansible/molecule/default/windows-prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  become: no
+  tasks:
+    - name: Bypass prepare stage
+      debug:
+        msg: Bypassing the prepare stage since the client is a Windows box
+      changed_when: false

--- a/deployments/ansible/molecule/default/windows-verify.yml
+++ b/deployments/ansible/molecule/default/windows-verify.yml
@@ -1,0 +1,125 @@
+---
+- name: Verify scenario with the default configuration
+  hosts: all
+  gather_facts: true
+  become: no
+  tasks:
+    - name: Check splunk-otel-collector service
+      ansible.windows.win_service:
+        name: splunk-otel-collector
+        state: started
+      check_mode: yes
+      register: service_status
+
+    - name: Assert splunk-otel-collector service status
+      assert:
+        that: not service_status.changed
+
+    - name: Check fluentdwinsvc service
+      ansible.windows.win_service:
+        name: fluentdwinsvc
+        state: started
+      check_mode: yes
+      register: service_status
+
+    - name: Assert fluentdwinsvc service status
+      assert:
+        that: not service_status.changed
+
+    - name: Check SPLUNK_ACCESS_TOKEN registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_ACCESS_TOKEN
+        data: fake-token
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_REALM registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_REALM
+        data: fake-realm
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_API_URL registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_API_URL
+        data: https://api.fake-realm.signalfx.com
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_HEC_TOKEN registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_HEC_TOKEN
+        data: fake-token
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_HEC_URL registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_HEC_URL
+        data: https://ingest.fake-realm.signalfx.com/v1/log
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_INGEST_URL registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_INGEST_URL
+        data: https://ingest.fake-realm.signalfx.com
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_TRACE_URL registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_TRACE_URL
+        data: https://ingest.fake-realm.signalfx.com/v2/trace
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed

--- a/deployments/ansible/molecule/without_fluentd/windows-converge.yml
+++ b/deployments/ansible/molecule/without_fluentd/windows-converge.yml
@@ -1,0 +1,12 @@
+---
+- name: Converge scenario without fluentd on Windows
+  hosts: all
+  become: no
+  vars:
+    splunk_access_token: fake-token
+    splunk_realm: fake-realm
+    install_fluentd: no
+  tasks:
+    - name: "Include signalfx.splunk_otel_collector.collector role"
+      include_role:
+        name: "collector"

--- a/deployments/ansible/molecule/without_fluentd/windows-verify.yml
+++ b/deployments/ansible/molecule/without_fluentd/windows-verify.yml
@@ -1,0 +1,27 @@
+---
+- name: Verify scenario without fluentd installation
+  hosts: all
+  gather_facts: true
+  become: no
+  tasks:
+    - name: Check splunk-otel-collector service
+      ansible.windows.win_service:
+        name: splunk-otel-collector
+        state: started
+      check_mode: yes
+      register: service_status
+
+    - name: Assert splunk-otel-collector service status
+      assert:
+        that: not service_status.changed
+
+    - name: Check fluentdwinsvc service
+      ansible.windows.win_service:
+        name: fluentdwinsvc
+        state: absent
+      check_mode: yes
+      register: service_status
+
+    - name: Assert fluentdwinsvc service does not exist
+      assert:
+        that: not service_status.exists


### PR DESCRIPTION
- Update molecule for vagrant/virtualbox to support windows
- Add test scenarios for windows based on existing linux scenarios, excluding `with_instrumentation`
- Add github matrix job to run on `macos-12` since it has vagrant/virtualbox support

Issues/Limitations:
- New github test jobs could take up to 1 hour to complete a single scenario per Windows version (mostly to download, boot, and provision the vagrant boxes)
- Windows vagrant boxes are too big to cache in github (10GB cache limit per repo)
- Molecule/vagrant/virtualbox flakiness and system load may cause timeouts/failures