### PR TITLE
[internal/configsource] Fix vault configsource typo in README

### DIFF
--- a/internal/configsource/vaultconfigsource/README.md
+++ b/internal/configsource/vaultconfigsource/README.md
@@ -48,7 +48,7 @@ config_sources:
         role: role
         mount: gcp
         credentials: json_string # This setting is not recommended.
-        jwp_ext: 10m
+        jwt_ext: 10
         service_account: some_account
         project: project_id
 ```


### PR DESCRIPTION
This fixes a typo in the vault config source sample documentation, renaming `jwp_ext` to `jwt_ext` and moving the value to an integer from `10m` to `10`.

See description of the field here: https://github.com/hashicorp/vault-plugin-auth-gcp/blob/e1f6784b379d277038ca0661606aa8d23791e392/plugin/cli.go#L151