### PR TITLE
OTL-1747 Document the need for cap_dac_read_search and cap_sys_ptrace

### DIFF
--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -23,6 +23,29 @@ configurations](https://github.com/signalfx/splunk-otel-collector/blob/main/cmd/
 which can be configured via environment variables. How these variables are
 configured depends on the installation method leveraged.
 
+### Permissions
+
+The installers below rely on using the setcap command (installed with libcap2)
+to setup up granular permissions so the Collector doesn't have to be run with
+root permissions to collect telemetry data. When the setcap command is
+available on a Linux host, the Collector will be installed with the
+[capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html) used
+in the setcap command below. These capabilities are what are recommended to
+allow the Collector to run with the least permissions needed regardless of
+which user runs the Collector.
+```sh
+setcap CAP_SYS_PTRACE,CAP_DAC_READ_SEARCH=+eip /usr/bin/otelcol
+```
+**Note:** These permissions work well in most cases, however, a Collector
+could need higher or more custom permission depending on the systems you are
+monitoring.
+
+If a user wanted to set custom permissions after the Collector was installed,
+they could use the setcap command to do so.
+```sh
+setcap {CUSTOM_CAPABILITIES}=+eip /usr/bin/otelcol
+```
+
 ### DEB and RPM Packages
 
 #### Collector Package Repositories

--- a/internal/buildscripts/packaging/fpm/postinstall.sh
+++ b/internal/buildscripts/packaging/fpm/postinstall.sh
@@ -15,6 +15,12 @@
 # limitations under the License.
 
 if command -v setcap >/dev/null 2>&1; then
+    # By default, the Collector will be installed on Linux systems with the
+    # following capabilities below, this will allow the Collector to run with
+    # the least permissions to function properly regardless of what user runs
+    # it.
+    # See: https://man7.org/linux/man-pages/man7/capabilities.7.html
+    # Note: +eip gives the capability to the program regardless of who runs it.
     setcap CAP_SYS_PTRACE,CAP_DAC_READ_SEARCH=+eip /usr/bin/otelcol
 fi
 


### PR DESCRIPTION
Adding documentation about how permissions are setup for the Collector when using a Linux installer.