### PR TITLE
testutils: add []CollectorBuilder to assertion helpers to reduce boilerplate

### DIFF
--- a/tests/exporters/signalfx/signalfx_translation_test.go
+++ b/tests/exporters/signalfx/signalfx_translation_test.go
@@ -24,12 +24,12 @@ import (
 
 func TestSignalFxExporterTranslatesOTelCPUMetrics(t *testing.T) {
 	testutils.AssertAllMetricsReceived(
-		t, "cpu_translations.yaml", "cpu_translations_config.yaml", nil,
+		t, "cpu_translations.yaml", "cpu_translations_config.yaml", nil, nil,
 	)
 }
 
 func TestSignalFxExporterTranslatesOTelMemoryMetrics(t *testing.T) {
 	testutils.AssertAllMetricsReceived(
-		t, "memory_translations.yaml", "memory_translations_config.yaml", nil,
+		t, "memory_translations.yaml", "memory_translations_config.yaml", nil, nil,
 	)
 }

--- a/tests/general/envvar_expansion_test.go
+++ b/tests/general/envvar_expansion_test.go
@@ -19,7 +19,6 @@ package tests
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -27,79 +26,54 @@ import (
 )
 
 func TestExpandedDollarSignsViaStandardEnvVar(t *testing.T) {
-	tc := testutils.NewTestcase(t)
-	defer tc.PrintLogsOnFailure()
-	defer tc.ShutdownOTLPReceiverSink()
-
-	_, shutdown := tc.SplunkOtelCollectorContainer(
-		"envvar_labels.yaml",
-		func(collector testutils.Collector) testutils.Collector {
-			return collector.WithEnv(map[string]string{"AN_ENVVAR": "an-envvar-value"})
+	testutils.AssertAllMetricsReceived(
+		t, "envvar_labels.yaml", "envvar_labels.yaml",
+		nil, []testutils.CollectorBuilder{
+			func(collector testutils.Collector) testutils.Collector {
+				return collector.WithEnv(map[string]string{"AN_ENVVAR": "an-envvar-value"})
+			},
 		},
 	)
-	defer shutdown()
-
-	expectedResourceMetrics := tc.ResourceMetrics("envvar_labels.yaml")
-	require.NoError(t, tc.OTLPReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
 }
 
 func TestExpandedDollarSignsViaEnvConfigSource(t *testing.T) {
-	tc := testutils.NewTestcase(t)
-	defer tc.PrintLogsOnFailure()
-	defer tc.ShutdownOTLPReceiverSink()
-
-	_, shutdown := tc.SplunkOtelCollectorContainer(
-		"env_config_source_labels.yaml",
-		func(collector testutils.Collector) testutils.Collector {
-			return collector.WithEnv(map[string]string{"AN_ENVVAR": "an-envvar-value"})
+	testutils.AssertAllMetricsReceived(
+		t, "env_config_source_labels.yaml", "env_config_source_labels.yaml",
+		nil, []testutils.CollectorBuilder{
+			func(collector testutils.Collector) testutils.Collector {
+				return collector.WithEnv(map[string]string{"AN_ENVVAR": "an-envvar-value"})
+			},
 		},
 	)
-	defer shutdown()
-
-	expectedResourceMetrics := tc.ResourceMetrics("env_config_source_labels.yaml")
-	require.NoError(t, tc.OTLPReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
 }
 
 func TestIncompatibleExpandedDollarSignsViaEnvConfigSource(t *testing.T) {
-	tc := testutils.NewTestcase(t)
-	defer tc.PrintLogsOnFailure()
-	defer tc.ShutdownOTLPReceiverSink()
-
-	_, shutdown := tc.SplunkOtelCollectorContainer(
-		"env_config_source_labels.yaml",
-		func(collector testutils.Collector) testutils.Collector {
-			return collector.WithEnv(
-				map[string]string{
-					"SPLUNK_DOUBLE_DOLLAR_CONFIG_SOURCE_COMPATIBLE": "false",
-					"AN_ENVVAR": "an-envvar-value",
-				},
-			)
+	testutils.AssertAllMetricsReceived(
+		t, "incompat_env_config_source_labels.yaml", "env_config_source_labels.yaml",
+		nil, []testutils.CollectorBuilder{
+			func(collector testutils.Collector) testutils.Collector {
+				return collector.WithEnv(
+					map[string]string{
+						"SPLUNK_DOUBLE_DOLLAR_CONFIG_SOURCE_COMPATIBLE": "false",
+						"AN_ENVVAR": "an-envvar-value",
+					},
+				)
+			},
 		},
 	)
-	defer shutdown()
-
-	expectedResourceMetrics := tc.ResourceMetrics("incompat_env_config_source_labels.yaml")
-	require.NoError(t, tc.OTLPReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
 }
 
 func TestExpandedYamlViaEnvConfigSource(t *testing.T) {
-	tc := testutils.NewTestcase(t)
-	defer tc.PrintLogsOnFailure()
-	defer tc.ShutdownOTLPReceiverSink()
-
-	_, shutdown := tc.SplunkOtelCollectorContainer(
-		"yaml_from_env.yaml",
-		func(collector testutils.Collector) testutils.Collector {
-			return collector.WithEnv(
-				map[string]string{"YAML": "[{action: update, include: .*, match_type: regexp, operations: [{action: add_label, new_label: yaml-from-env, new_value: value-from-env}]}]"},
-			)
-
+	testutils.AssertAllMetricsReceived(
+		t, "yaml_from_env.yaml", "yaml_from_env.yaml",
+		nil, []testutils.CollectorBuilder{
+			func(collector testutils.Collector) testutils.Collector {
+				return collector.WithEnv(
+					map[string]string{"YAML": "[{action: update, include: .*, match_type: regexp, operations: [{action: add_label, new_label: yaml-from-env, new_value: value-from-env}]}]"},
+				)
+			},
 		},
 	)
-	defer shutdown()
-
-	expectedResourceMetrics := tc.ResourceMetrics("yaml_from_env.yaml")
-	require.NoError(t, tc.OTLPReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
 }
 
 func TestEnvConfigSource(t *testing.T) {

--- a/tests/receivers/discovery/host_observer_test.go
+++ b/tests/receivers/discovery/host_observer_test.go
@@ -25,13 +25,13 @@ import (
 func TestDiscoveryReceiverWithHostObserverProvidesEndpointLogs(t *testing.T) {
 	testutils.AssertAllLogsReceived(
 		t, "host_observer_endpoints.yaml",
-		"host_observer_endpoints_config.yaml", nil,
+		"host_observer_endpoints_config.yaml", nil, nil,
 	)
 }
 
 func TestDiscoveryReceiverWithHostObserverAndSimplePrometheusReceiverProvideStatusLogs(t *testing.T) {
 	testutils.AssertAllLogsReceived(
 		t, "host_observer_simple_prometheus_statuses.yaml",
-		"host_observer_simple_prometheus_config.yaml", nil,
+		"host_observer_simple_prometheus_config.yaml", nil, nil,
 	)
 }

--- a/tests/receivers/filelog/filelog_test.go
+++ b/tests/receivers/filelog/filelog_test.go
@@ -19,7 +19,6 @@ package tests
 import (
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -28,23 +27,15 @@ import (
 )
 
 func TestFilelogReceiverSyslogFormat(t *testing.T) {
-	tc := testutils.NewTestcase(t)
-	defer tc.PrintLogsOnFailure()
-	defer tc.ShutdownOTLPReceiverSink()
-
-	_, shutdown := tc.SplunkOtelCollectorContainer(
-		"syslog_config.yaml",
-		func(c testutils.Collector) testutils.Collector {
-			cc := c.(*testutils.CollectorContainer)
-			syslog, err := filepath.Abs(filepath.Join(".", "testdata", "syslog"))
-			require.NoError(t, err)
-			cc.Container = cc.Container.WithMount(testcontainers.BindMount(syslog, "/opt/syslog"))
-			return cc
+	testutils.AssertAllLogsReceived(t, "syslog.yaml", "syslog_config.yaml",
+		nil, []testutils.CollectorBuilder{
+			func(c testutils.Collector) testutils.Collector {
+				cc := c.(*testutils.CollectorContainer)
+				syslog, err := filepath.Abs(filepath.Join(".", "testdata", "syslog"))
+				require.NoError(t, err)
+				cc.Container = cc.Container.WithMount(testcontainers.BindMount(syslog, "/opt/syslog"))
+				return cc
+			},
 		},
 	)
-
-	defer shutdown()
-
-	expectedResourceLogs := tc.ResourceLogs("syslog.yaml")
-	require.NoError(t, tc.OTLPReceiverSink.AssertAllLogsReceived(t, *expectedResourceLogs, 30*time.Second))
 }

--- a/tests/receivers/prometheus/internal_prometheus_test.go
+++ b/tests/receivers/prometheus/internal_prometheus_test.go
@@ -25,6 +25,6 @@ import (
 
 func TestInternalPrometheusMetrics(t *testing.T) {
 	testutils.AssertAllMetricsReceived(
-		t, "internal.yaml", "internal_metrics_config.yaml", nil,
+		t, "internal.yaml", "internal_metrics_config.yaml", nil, nil,
 	)
 }

--- a/tests/receivers/redis/redisreceiver_test.go
+++ b/tests/receivers/redis/redisreceiver_test.go
@@ -26,12 +26,12 @@ import (
 func TestRedisReceiverProvidesAllMetrics(t *testing.T) {
 	server := testutils.NewContainer().WithContext(path.Join(".", "testdata", "server")).WithExposedPorts("6379:6379").WithName("redis-server").WillWaitForPorts("6379").WillWaitForLogs("Ready to accept connections")
 	containers := []testutils.Container{server}
-	testutils.AssertAllMetricsReceived(t, "all.yaml", "all_metrics_config.yaml", containers)
+	testutils.AssertAllMetricsReceived(t, "all.yaml", "all_metrics_config.yaml", containers, nil)
 }
 
 func TestRedisReceiverProvidesAllMetricsWithServer(t *testing.T) {
 	server := testutils.NewContainer().WithContext(path.Join(".", "testdata", "server")).WithExposedPorts("6379:6379").WithNetworks("redis_network").WithName("redis-server").WillWaitForLogs("Ready to accept connections")
 	client := testutils.NewContainer().WithContext(path.Join(".", "testdata", "client")).WithName("redis-client").WithNetworks("redis_network").WillWaitForLogs("redis client started")
 	containers := []testutils.Container{server, client}
-	testutils.AssertAllMetricsReceived(t, "all.yaml", "all_metrics_config.yaml", containers)
+	testutils.AssertAllMetricsReceived(t, "all.yaml", "all_metrics_config.yaml", containers, nil)
 }

--- a/tests/receivers/smartagent/collectd-activemq/collectd_activemq_test.go
+++ b/tests/receivers/smartagent/collectd-activemq/collectd_activemq_test.go
@@ -29,12 +29,12 @@ var activemq = []testutils.Container{testutils.NewContainer().WithContext(
 
 func TestCollectdActiveMQReceiverProvidesAllMetrics(t *testing.T) {
 	testutils.AssertAllMetricsReceived(
-		t, "all.yaml", "all_metrics_config.yaml", activemq,
+		t, "all.yaml", "all_metrics_config.yaml", activemq, nil,
 	)
 }
 
 func TestCollectdActiveMQReceiverProvidesDefaultMetrics(t *testing.T) {
 	testutils.AssertAllMetricsReceived(
-		t, "default.yaml", "default_metrics_config.yaml", activemq,
+		t, "default.yaml", "default_metrics_config.yaml", activemq, nil,
 	)
 }

--- a/tests/receivers/smartagent/collectd-apache/collectd_apache_test.go
+++ b/tests/receivers/smartagent/collectd-apache/collectd_apache_test.go
@@ -31,12 +31,12 @@ var apache = []testutils.Container{
 
 func TestCollectdApacheReceiverProvidesAllMetrics(t *testing.T) {
 	testutils.AssertAllMetricsReceived(
-		t, "all.yaml", "all_metrics_config.yaml", apache,
+		t, "all.yaml", "all_metrics_config.yaml", apache, nil,
 	)
 }
 
 func TestCollectdApacheReceiverProvidesDefaultMetrics(t *testing.T) {
 	testutils.AssertAllMetricsReceived(
-		t, "default.yaml", "default_metrics_config.yaml", apache,
+		t, "default.yaml", "default_metrics_config.yaml", apache, nil,
 	)
 }

--- a/tests/receivers/smartagent/collectd-cassandra/collectd_cassandra_test.go
+++ b/tests/receivers/smartagent/collectd-cassandra/collectd_cassandra_test.go
@@ -31,12 +31,12 @@ var cassandra = []testutils.Container{
 
 func TestCollectdCassandraReceiverProvidesAllMetrics(t *testing.T) {
 	testutils.AssertAllMetricsReceived(
-		t, "all.yaml", "all_metrics_config.yaml", cassandra,
+		t, "all.yaml", "all_metrics_config.yaml", cassandra, nil,
 	)
 }
 
 func TestCollectdCassandraReceiverProvidesDefaultMetrics(t *testing.T) {
 	testutils.AssertAllMetricsReceived(
-		t, "default.yaml", "default_metrics_config.yaml", cassandra,
+		t, "default.yaml", "default_metrics_config.yaml", cassandra, nil,
 	)
 }

--- a/tests/receivers/smartagent/collectd-couchbase/collectd_couchbase_test.go
+++ b/tests/receivers/smartagent/collectd-couchbase/collectd_couchbase_test.go
@@ -31,6 +31,6 @@ func TestCollectdCouchbaseReceiverProvidesAllMetrics(t *testing.T) {
 	}
 
 	testutils.AssertAllMetricsReceived(
-		t, "all.yaml", "all_metrics_config.yaml", containers,
+		t, "all.yaml", "all_metrics_config.yaml", containers, nil,
 	)
 }

--- a/tests/receivers/smartagent/collectd-elasticsearch/collectd_elasticsearch_test.go
+++ b/tests/receivers/smartagent/collectd-elasticsearch/collectd_elasticsearch_test.go
@@ -35,6 +35,6 @@ func TestCollectdElasticsearchReceiverProvidesAllMetrics(t *testing.T) {
 	}
 
 	testutils.AssertAllMetricsReceived(
-		t, "all.yaml", "all_metrics_config.yaml", containers,
+		t, "all.yaml", "all_metrics_config.yaml", containers, nil,
 	)
 }

--- a/tests/receivers/smartagent/collectd-hadoop/collectd_hadoop_test.go
+++ b/tests/receivers/smartagent/collectd-hadoop/collectd_hadoop_test.go
@@ -36,6 +36,6 @@ func TestCollectdHadoopReceiverProvidesAllMetrics(t *testing.T) {
 	}
 
 	testutils.AssertAllMetricsReceived(
-		t, "all.yaml", "all_metrics_config.yaml", containers,
+		t, "all.yaml", "all_metrics_config.yaml", containers, nil,
 	)
 }

--- a/tests/receivers/smartagent/collectd-kafka/collectd_kafka_test.go
+++ b/tests/receivers/smartagent/collectd-kafka/collectd_kafka_test.go
@@ -19,9 +19,6 @@ package tests
 import (
 	"path"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/signalfx/splunk-otel-collector/tests/testutils"
 )
@@ -71,13 +68,7 @@ func TestCollectdKafkaReceiversProvideAllMetrics(t *testing.T) {
 		{"consumer metrics", "all_consumer.yaml", "all_consumer_metrics_config.yaml"},
 	} {
 		t.Run(args.name, func(tt *testing.T) {
-			ttc := testutils.NewTestcase(tt)
-			expectedResourceMetrics := ttc.ResourceMetrics(args.resourceMetricsFilename)
-
-			_, shutdown := ttc.SplunkOtelCollector(args.collectorConfigFilename)
-			defer shutdown()
-
-			require.NoError(tt, ttc.OTLPReceiverSink.AssertAllMetricsReceived(tt, *expectedResourceMetrics, 30*time.Second))
+			testutils.AssertAllMetricsReceived(tt, args.resourceMetricsFilename, args.collectorConfigFilename, nil, nil)
 		})
 	}
 }

--- a/tests/receivers/smartagent/collectd-nginx/collectd_nginx_test.go
+++ b/tests/receivers/smartagent/collectd-nginx/collectd_nginx_test.go
@@ -31,6 +31,6 @@ func TestCollectdPostgresReceiverProvidesAllMetrics(t *testing.T) {
 	}
 
 	testutils.AssertAllMetricsReceived(
-		t, "all.yaml", "all_metrics_config.yaml", containers,
+		t, "all.yaml", "all_metrics_config.yaml", containers, nil,
 	)
 }

--- a/tests/receivers/smartagent/collectd-postgresql/collectd_postgresql_test.go
+++ b/tests/receivers/smartagent/collectd-postgresql/collectd_postgresql_test.go
@@ -49,6 +49,6 @@ func TestCollectdPostgresReceiverProvidesAllMetrics(t *testing.T) {
 	}
 
 	testutils.AssertAllMetricsReceived(
-		t, "all.yaml", "all_metrics_config.yaml", containers,
+		t, "all.yaml", "all_metrics_config.yaml", containers, nil,
 	)
 }

--- a/tests/receivers/smartagent/collectd-solr/collectd_solr_test.go
+++ b/tests/receivers/smartagent/collectd-solr/collectd_solr_test.go
@@ -33,6 +33,6 @@ func TestCollectdSolrReceiverProvidesAllMetrics(t *testing.T) {
 	}
 
 	testutils.AssertAllMetricsReceived(
-		t, "all.yaml", "all_metrics_config.yaml", containers,
+		t, "all.yaml", "all_metrics_config.yaml", containers, nil,
 	)
 }

--- a/tests/receivers/smartagent/collectd-spark/collectd_spark_test.go
+++ b/tests/receivers/smartagent/collectd-spark/collectd_spark_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"path"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -73,13 +72,7 @@ func TestCollectdSparkReceiverProvidesAllMetrics(t *testing.T) {
 		{"worker metrics", "all_worker.yaml", "all_worker_metrics_config.yaml"},
 	} {
 		t.Run(args.name, func(tt *testing.T) {
-			ttc := testutils.NewTestcase(tt)
-			expectedResourceMetrics := ttc.ResourceMetrics(args.resourceMetricsFilename)
-
-			_, shutdown := ttc.SplunkOtelCollector(args.collectorConfigFilename)
-			defer shutdown()
-
-			require.NoError(tt, ttc.OTLPReceiverSink.AssertAllMetricsReceived(tt, *expectedResourceMetrics, 30*time.Second))
+			testutils.AssertAllMetricsReceived(tt, args.resourceMetricsFilename, args.collectorConfigFilename, nil, nil)
 		})
 	}
 }

--- a/tests/receivers/smartagent/collectd-tomcat/tomcat_test.go
+++ b/tests/receivers/smartagent/collectd-tomcat/tomcat_test.go
@@ -30,6 +30,6 @@ var apache = []testutils.Container{
 
 func TestCollectdTomcatReceiverProvidesDefaultMetrics(t *testing.T) {
 	testutils.AssertAllMetricsReceived(
-		t, "default.yaml", "default_metrics_config.yaml", apache,
+		t, "default.yaml", "default_metrics_config.yaml", apache, nil,
 	)
 }

--- a/tests/receivers/smartagent/haproxy/haproxy_test.go
+++ b/tests/receivers/smartagent/haproxy/haproxy_test.go
@@ -35,6 +35,6 @@ func TestHaproxyReceiverProvidesAllMetrics(t *testing.T) {
 	}
 
 	testutils.AssertAllMetricsReceived(
-		t, "all.yaml", "all_metrics_config.yaml", containers,
+		t, "all.yaml", "all_metrics_config.yaml", containers, nil,
 	)
 }

--- a/tests/receivers/smartagent/jmx/jmx_test.go
+++ b/tests/receivers/smartagent/jmx/jmx_test.go
@@ -31,6 +31,6 @@ var cassandra = []testutils.Container{
 
 func TestJmxReceiverProvidesAllMetrics(t *testing.T) {
 	testutils.AssertAllMetricsReceived(
-		t, "all.yaml", "all_metrics_config.yaml", cassandra,
+		t, "all.yaml", "all_metrics_config.yaml", cassandra, nil,
 	)
 }

--- a/tests/receivers/smartagent/postgresql/postgresql_test.go
+++ b/tests/receivers/smartagent/postgresql/postgresql_test.go
@@ -35,5 +35,5 @@ func TestPostgresReceiverProvidesAllMetrics(t *testing.T) {
 	).WithName("postgres-client").WithNetworks("postgres").WillWaitForLogs("Beginning psql requests")
 	containers := []testutils.Container{server, client}
 
-	testutils.AssertAllMetricsReceived(t, "all.yaml", "all_metrics_config.yaml", containers)
+	testutils.AssertAllMetricsReceived(t, "all.yaml", "all_metrics_config.yaml", containers, nil)
 }

--- a/tests/receivers/smartagent/telegraf-procstat/telegraf_procstat_test.go
+++ b/tests/receivers/smartagent/telegraf-procstat/telegraf_procstat_test.go
@@ -23,5 +23,5 @@ import (
 )
 
 func TestTelegrafProcstatReceiverProvidesAllMetrics(t *testing.T) {
-	testutils.AssertAllMetricsReceived(t, "all.yaml", "all_metrics_config.yaml", nil)
+	testutils.AssertAllMetricsReceived(t, "all.yaml", "all_metrics_config.yaml", nil, nil)
 }

--- a/tests/receivers/smartagent/telegraf-sqlserver/telegraf_sqlserver_test.go
+++ b/tests/receivers/smartagent/telegraf-sqlserver/telegraf_sqlserver_test.go
@@ -36,5 +36,5 @@ func TestTelegrafSQLServerReceiverProvidesAllMetrics(t *testing.T) {
 	).WithName("sql-client").WithNetworks("mssql").WillWaitForLogs("name", "signalfxagent")
 	containers := []testutils.Container{server, client}
 
-	testutils.AssertAllMetricsReceived(t, "all.yaml", "all_metrics_config.yaml", containers)
+	testutils.AssertAllMetricsReceived(t, "all.yaml", "all_metrics_config.yaml", containers, nil)
 }

--- a/tests/testutils/README.md
+++ b/tests/testutils/README.md
@@ -181,6 +181,6 @@ func MyTest(t *testing.T) {
     // ./testdata/resource_metrics/my_resource_metrics.yaml ResourceMetrics instance, CollectorProcess with
     // ./testdata/my_collector_config.yaml config, and build and start all specified containers before calling
     // OTLPReceiverSink.AssertAllMetricsReceived() with a 30s wait duration.
-    testutils.AssertAllMetricsReceived(t, "my_resource_metrics.yaml", "my_collector_config.yaml", containers)
+    testutils.AssertAllMetricsReceived(t, "my_resource_metrics.yaml", "my_collector_config.yaml", containers, nil)
 }
 ```

--- a/tests/testutils/testcase.go
+++ b/tests/testutils/testcase.go
@@ -238,11 +238,14 @@ func GetCollectorImageOrSkipTest(t testing.TB) string {
 	return image
 }
 
-// AssertAllLogsReceived is a central helper, designed to avoid most boilerplate.  Using the desired
-// ResourceLogs and Collector Config filenames and a slice of Container builders, AssertAllLogsReceived
-// creates a Testcase, builds and starts all Container and CollectorProcess instances, and asserts that all
-// expected ResourceLogs are received before running validated cleanup functionality.
-func AssertAllLogsReceived(t testing.TB, resourceLogsFilename, collectorConfigFilename string, containers []Container) {
+// AssertAllLogsReceived is a central helper, designed to avoid most boilerplate. Using the desired
+// ResourceLogs and Collector Config filenames, a slice of Container builders, and a slice of CollectorBuilder
+// AssertAllLogsReceived creates a Testcase, builds and starts all Container and CollectorBuilder-determined Collector
+// instances, and asserts that all expected ResourceLogs are received before running validated cleanup functionality.
+func AssertAllLogsReceived(
+	t testing.TB, resourceLogsFilename, collectorConfigFilename string,
+	containers []Container, builders []CollectorBuilder,
+) {
 	tc := NewTestcase(t)
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()
@@ -252,17 +255,20 @@ func AssertAllLogsReceived(t testing.TB, resourceLogsFilename, collectorConfigFi
 	_, stop := tc.Containers(containers...)
 	defer stop()
 
-	_, shutdown := tc.SplunkOtelCollector(collectorConfigFilename)
+	_, shutdown := tc.SplunkOtelCollector(collectorConfigFilename, builders...)
 	defer shutdown()
 
 	require.NoError(t, tc.OTLPReceiverSink.AssertAllLogsReceived(t, *expectedResourceLogs, 30*time.Second))
 }
 
-// AssertAllMetricsReceived is a central helper, designed to avoid most boilerplate.  Using the desired
-// ResourceMetrics and Collector Config filenames and a slice of Container builders, AssertAllMetricsReceived
-// creates a Testcase, builds and starts all Container and CollectorProcess instances, and asserts that all
-// expected ResourceMetrics are received before running validated cleanup functionality.
-func AssertAllMetricsReceived(t testing.TB, resourceMetricsFilename, collectorConfigFilename string, containers []Container) {
+// AssertAllMetricsReceived is a central helper, designed to avoid most boilerplate. Using the desired
+// ResourceMetrics and Collector Config filenames, a slice of Container builders, and a slice of CollectorBuilder
+// AssertAllMetricsReceived creates a Testcase, builds and starts all Container and CollectorBuilder-determined Collector
+// instances, and asserts that all expected ResourceMetrics are received before running validated cleanup functionality.
+func AssertAllMetricsReceived(
+	t testing.TB, resourceMetricsFilename, collectorConfigFilename string,
+	containers []Container, builders []CollectorBuilder,
+) {
 	tc := NewTestcase(t)
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()
@@ -272,7 +278,7 @@ func AssertAllMetricsReceived(t testing.TB, resourceMetricsFilename, collectorCo
 	_, stop := tc.Containers(containers...)
 	defer stop()
 
-	_, shutdown := tc.SplunkOtelCollector(collectorConfigFilename)
+	_, shutdown := tc.SplunkOtelCollector(collectorConfigFilename, builders...)
 	defer shutdown()
 
 	require.NoError(t, tc.OTLPReceiverSink.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))


### PR DESCRIPTION
Forcing us to reimplement the core helpers to specify collector builders is a nuisance, so best not to do that imo.