### PR TITLE
Split build and integration test into separate jobs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,6 +20,9 @@ concurrency:
   group: integration-test-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  GO_VERSION: "1.19.4"
+
 jobs:
   docker-otelcol:
     name: docker-otelcol
@@ -31,7 +34,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.4
+          go-version: ${{ env.GO_VERSION }}
       - id: module-cache
         uses: actions/cache@v3
         env:
@@ -44,7 +47,39 @@ jobs:
       - run: make docker-otelcol
         env:
           DOCKER_BUILDKIT: '1'
+      - run: docker save -o ./bin/image.tar otelcol:latest
+      - uses: actions/upload-artifact@v3
+        with:
+          name: otelcol
+          path: ./bin
+
+  integration-test:
+    name: integration-test
+    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
+    runs-on: ubuntu-20.04
+    needs: [docker-otelcol]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - id: module-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-go-modules
+        with:
+          path: |
+            /home/runner/go/pkg/mod
+            /home/runner/.cache/go-build
+          key: v1-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: otelcol
+          path: ./bin
+      - run: docker load -i ./bin/image.tar
+      - run: chmod a+x ./bin/*
       - run: make integration-test
         env:
           SPLUNK_OTEL_COLLECTOR_IMAGE: 'otelcol:latest'
-


### PR DESCRIPTION
Avoid unnecessary rebuilds when re-running failed tests.