### PR TITLE
Use testcase helper for process integration test

### DIFF
--- a/tests/testutils/testdata/collector_process_config.yaml
+++ b/tests/testutils/testdata/collector_process_config.yaml
@@ -6,7 +6,7 @@ receivers:
 
 exporters:
   otlp:
-    endpoint: localhost:23456
+    endpoint: "${OTLP_ENDPOINT}"
     tls:
       insecure: true
 


### PR DESCRIPTION
The current process integration test doesn't specify a logger so exec errors aren't surfaced and deducing the failure is left as an exercise to the user. Updating the test so that issues are clearer:


>{{debug 2023-02-16 15:32:18.284052751 -0500 EST m=+0.011909859  subprocess changed state undefined } [{state 15 0 Errored <nil>}]}
{{error 2023-02-16 15:32:18.284054307 -0500 EST m=+0.011911407  subprocess died undefined } [{error 26 0  fork/exec /splunk-otel-collector/bin/otelcol: permission denied}]}
{{debug 2023-02-16 15:32:18.284061454 -0500 EST m=+0.011918562  subprocess changed state undefined } [{state 15 0 ShuttingDown <nil>}]}
{{debug 2023-02-16 15:32:18.284137259 -0500 EST m=+0.011994373  subprocess changed state undefined } [{state 15 0 Stopped <nil>}]}

Thanks to @jeffreyc-splunk for tracking this down
