### PR TITLE
Update golang to 1.19.6

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ env:
   PIP_VERSION: '22.0.4'
   REQUIREMENTS_PATH: "internal/buildscripts/packaging/tests/requirements.txt"
   RESULT_PATH: "~/testresults"
-  GO_VERSION: 1.19.4
+  GO_VERSION: 1.19.6
 
 jobs:
   setup-environment:

--- a/.github/workflows/deps-test.yml
+++ b/.github/workflows/deps-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.4
+          go-version: 1.19.6
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.19.4"
+  GO_VERSION: "1.19.6"
   GOTESPLIT_TOTAL: "10"
 
 jobs:

--- a/.github/workflows/trivy-scans.yml
+++ b/.github/workflows/trivy-scans.yml
@@ -10,7 +10,7 @@ on:
       - '.trivyignore'
 
 env:
-  GO_VERSION: '1.19.4'
+  GO_VERSION: '1.19.6'
 
 jobs:
   trivy-fs-scan:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.4
+          go-version: 1.19.6
 
       - name: Install golang dependency
         run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,7 +87,7 @@ fossa:
       done
 
 .go-cache:
-  image: '${DOCKER_HUB_REPO}/golang:1.19.4'
+  image: '${DOCKER_HUB_REPO}/golang:1.19.6'
   variables:
     GOPATH: "$CI_PROJECT_DIR/.go"
   before_script:


### PR DESCRIPTION
For CVE-2022-41723 (https://pkg.go.dev/vuln/GO-2023-1571)