### PR TITLE
Update nomad tests

### DIFF
--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - 'deployments/nomad/**'
+      - '.github/workflows/nomad.yml'
 
 permissions:
   contents: write
@@ -21,6 +22,10 @@ jobs:
     name: Test
     # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        nomad: [ "1.1.0", "1.2.0" ]
+      fail-fast: false
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v3
@@ -30,8 +35,14 @@ jobs:
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add - 
           sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
           sudo apt-get update 
-          sudo apt-get install nomad
+          sudo apt-get install nomad=${{ matrix.nomad }}
           sudo apt-get install consul
+
+      - name: Validate otel-agent.nomad
+        run: nomad job validate otel-agent.nomad
+
+      - name: Validate otel-gateway.nomad
+        run: nomad job validate otel-gateway.nomad
 
       - name: Start Nomad Service.
         run: |

--- a/deployments/nomad/README.md
+++ b/deployments/nomad/README.md
@@ -8,7 +8,7 @@ The Splunk OpenTelemetry Collector for HashiCorp Nomad is an orchestrator deploy
 
 To run the job files you need:
 
-- Access to a Nomad cluster
+- Access to a Nomad cluster (**version < 1.3.0**)
 - (Optional) Access to a Consul cluster
 
 To start a local dev agent for Nomad and Consul, download the

--- a/deployments/nomad/otel-agent.nomad
+++ b/deployments/nomad/otel-agent.nomad
@@ -2,6 +2,12 @@ job "otel-agent" {
   datacenters = ["dc1"]
   type        = "system"
 
+  constraint {
+    attribute = "${attr.nomad.version}"
+    operator  = "semver"
+    value     = "< 1.3.0"
+  }
+
   group "otel-agent" {
     network {
       port "metrics" {

--- a/deployments/nomad/otel-gateway.nomad
+++ b/deployments/nomad/otel-gateway.nomad
@@ -2,6 +2,12 @@ job "otel-gateway" {
   datacenters = ["dc1"]
   type        = "service"
 
+  constraint {
+    attribute = "${attr.nomad.version}"
+    operator  = "semver"
+    value     = "< 1.3.0"
+  }
+
   group "otel-gateway" {
     count = 1
 


### PR DESCRIPTION
Current tests fail because our sample job files are incompatible with nomad versions >= 1.3.0.
- Update tests for nomad versions 1.1.0 and 1.2.0
- Add validation checks for the sample job files
- Add constraint for nomad version < 1.3.0 to the sample job files