### PR TITLE
Update OTLP TLS insecure config option formatting

### DIFF
--- a/docs/apm-infra-correlation.md
+++ b/docs/apm-infra-correlation.md
@@ -176,7 +176,8 @@ exporters:
   # Traces
   otlp:
     endpoint: "${SPLUNK_GATEWAY_URL}:4317"
-    insecure: true
+    tls:
+      insecure: true
   # Metrics + Events + APM correlation calls
   signalfx:
     access_token: "${SPLUNK_ACCESS_TOKEN}"

--- a/examples/nomad/otel-demo.nomad
+++ b/examples/nomad/otel-demo.nomad
@@ -366,7 +366,8 @@ processors:
 exporters:
   otlp:
     endpoint: "{{ with service "otlp.otel-gateway" }}{{ with index . 0 }}{{ .Address }}:{{ .Port }}{{ end }}{{ end }}"
-    insecure: true
+    tls:
+      insecure: true
   logging:
     loglevel: debug
 service:

--- a/tests/general/container_test.go
+++ b/tests/general/container_test.go
@@ -128,7 +128,8 @@ func TestConfigYamlEnvVar(t *testing.T) {
 exporters:
   otlp:
     endpoint: "${OTLP_ENDPOINT}"
-    insecure: true
+    tls:
+      insecure: true
 
 service:
   pipelines:

--- a/tests/general/discoverymode/testdata/standalone-config.d/exporters/otlp.yaml
+++ b/tests/general/discoverymode/testdata/standalone-config.d/exporters/otlp.yaml
@@ -1,3 +1,4 @@
 otlp:
   endpoint: "${OTLP_ENDPOINT}"
-  insecure: true
+  tls:
+    insecure: true

--- a/tests/general/dry_run_test.go
+++ b/tests/general/dry_run_test.go
@@ -38,7 +38,8 @@ func TestDryRunDoesntExpandEnvVars(t *testing.T) {
 exporters:
   otlp:
     endpoint: ${OTLP_ENDPOINT}
-    insecure: true
+    tls:
+      insecure: true
 receivers:
   hostmetrics:
     collection_interval: ${env:COLLECTION_INTERVAL}

--- a/tests/general/testdata/env_config_source_labels.yaml
+++ b/tests/general/testdata/env_config_source_labels.yaml
@@ -83,7 +83,8 @@ processors:
 exporters:
   otlp:
     endpoint: "${OTLP_ENDPOINT}"
-    insecure: true
+    tls:
+      insecure: true
 service:
   pipelines:
     metrics:

--- a/tests/general/testdata/envvar_labels.yaml
+++ b/tests/general/testdata/envvar_labels.yaml
@@ -80,7 +80,8 @@ processors:
 exporters:
   otlp:
     endpoint: "${OTLP_ENDPOINT}"
-    insecure: true
+    tls:
+      insecure: true
 service:
   pipelines:
     metrics:

--- a/tests/general/testdata/hostmetrics_cpu.yaml
+++ b/tests/general/testdata/hostmetrics_cpu.yaml
@@ -7,7 +7,8 @@ receivers:
 exporters:
   otlp:
     endpoint: "${OTLP_ENDPOINT}"
-    insecure: true
+    tls:
+      insecure: true
 
 service:
   pipelines:

--- a/tests/general/testdata/yaml_from_env.yaml
+++ b/tests/general/testdata/yaml_from_env.yaml
@@ -27,7 +27,8 @@ processors:
 exporters:
   otlp:
     endpoint: "${OTLP_ENDPOINT}"
-    insecure: true
+    tls:
+      insecure: true
 service:
   pipelines:
     traces:

--- a/tests/receivers/redis/testdata/all_metrics_config.yaml
+++ b/tests/receivers/redis/testdata/all_metrics_config.yaml
@@ -4,7 +4,8 @@ receivers:
 exporters:
   otlp:
     endpoint: "${OTLP_ENDPOINT}"
-    insecure: true
+    tls:
+      insecure: true
 
 service:
   pipelines:


### PR DESCRIPTION
Configuration for the OTLP exporter "insecure" option changed a long time ago to move under the "tls" map item. We have a lot of tests using the old format, so this updates them to match the new.