### PR TITLE
Revert an OTLP exporter config change

### DIFF
--- a/tests/general/container_test.go
+++ b/tests/general/container_test.go
@@ -128,8 +128,8 @@ func TestConfigYamlEnvVar(t *testing.T) {
 exporters:
   otlp:
     endpoint: "${OTLP_ENDPOINT}"
-    tls:
-      insecure: true
+    # This is purposefully misconfigured to ensure config converters properly address it.
+    insecure: true
 
 service:
   pipelines:


### PR DESCRIPTION
This config option was misconfigured in a test on purpose for the sake of testing the config converts to make sure they properly catch it.