### PR TITLE
Changes to the pulsarexporter configuration to prepare with using upstream

### DIFF
--- a/internal/exporter/pulsarexporter/config.go
+++ b/internal/exporter/pulsarexporter/config.go
@@ -46,22 +46,20 @@ type Config struct {
 
 // Producer defines configuration for producer
 type Producer struct {
-	// Deprecated: properties are not used in creating the producer
 	Properties                      map[string]string `mapstructure:"producer_properties"`
 	MaxReconnectToBroker            *uint             `mapstructure:"max_reconnect_broker"`
-	HashingScheme                   string            `mapstructure:"hashing_scheme"`
-	CompressionLevel                string            `mapstructure:"compression_level"`
-	CompressionType                 string            `mapstructure:"compression_type"`
-	MaxPendingMessages              int               `mapstructure:"max_pending_messages"`
+	SendTimeout                     *time.Duration    `mapstructure:"send_timeout"`
 	BatcherBuilderType              string            `mapstructure:"batch_builder_type"`
+	CompressionType                 string            `mapstructure:"compression_type"`
+	CompressionLevel                string            `mapstructure:"compression_level"`
+	HashingScheme                   string            `mapstructure:"hashing_scheme"`
+	MaxPendingMessages              int               `mapstructure:"max_pending_messages"`
 	PartitionsAutoDiscoveryInterval time.Duration     `mapstructure:"partitions_auto_discovery_interval"`
 	BatchingMaxPublishDelay         time.Duration     `mapstructure:"batching_max_publish_delay"`
 	BatchingMaxMessages             uint              `mapstructure:"batching_max_messages"`
 	BatchingMaxSize                 uint              `mapstructure:"batching_max_size"`
-	// Deprecated: this setting is moved to the main Config struct to reflect the OpenTelemetry contrib exporter.
-	SendTimeout             *time.Duration `mapstructure:"send_timeout"`
-	DisableBlockIfQueueFull bool           `mapstructure:"disable_block_if_queue_full"`
-	DisableBatching         bool           `mapstructure:"disable_batching"`
+	DisableBlockIfQueueFull         bool              `mapstructure:"disable_block_if_queue_full"`
+	DisableBatching                 bool              `mapstructure:"disable_batching"`
 }
 
 var _ component.Config = (*Config)(nil)

--- a/internal/exporter/pulsarexporter/pulsar_exporter.go
+++ b/internal/exporter/pulsarexporter/pulsar_exporter.go
@@ -41,7 +41,7 @@ func newMetricsExporter(config Config, set exporter.CreateSettings, marshalers m
 	if marshaler == nil {
 		return nil, errUnrecognizedEncoding
 	}
-	producer, err := newPulsarProducer(config)
+	producer, err := newPulsarProducer(config, set.Logger)
 
 	if err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func newMetricsExporter(config Config, set exporter.CreateSettings, marshalers m
 	}, nil
 }
 
-func newPulsarProducer(config Config) (pulsar.Producer, error) {
+func newPulsarProducer(config Config, logger *zap.Logger) (pulsar.Producer, error) {
 	// Get pulsar client options
 	clientOptions, clientOptionsErr := config.getClientOptions()
 	if clientOptionsErr != nil {
@@ -68,8 +68,8 @@ func newPulsarProducer(config Config) (pulsar.Producer, error) {
 		return nil, clientErr
 	}
 
-	// Get pulsar pruducer options
-	producerOptions, producerOptionsErr := config.getProducerOptions()
+	// Get pulsar producer options
+	producerOptions, producerOptionsErr := config.getProducerOptions(logger)
 	if producerOptionsErr != nil {
 		return nil, producerOptionsErr
 	}

--- a/internal/exporter/pulsarexporter/testdata/config.yaml
+++ b/internal/exporter/pulsarexporter/testdata/config.yaml
@@ -8,6 +8,7 @@ exporters:
   pulsar:
     topic: otlp_metrics
     broker: pulsar+ssl://localhost:6651
+    timeout: 0
     auth:
       tls:
         ca_file: "/path/to/cacert"
@@ -15,13 +16,12 @@ exporters:
         key_file: "/path/to/key"
         insecure_skip_verify: true
     producer:
-      send_timeout: 0
       disable_block_if_queue_full: false
       max_pending_messages: 100
       hashing_scheme: java_string_hash
       compression_type: zstd
       compression_level: default
-      batch_builder_type: 1
+      batch_builder_type: key_based
       disable_batching: false
       # unit is nanoseconds (10^-9), set to 10 milliseconds in nanoseconds
       batching_max_publish_delay: 10000000


### PR DESCRIPTION
These configuration changes sync the options with what is offered by the upstream pulsar exporter offered by the contrib project. Along with the changes from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/19184, these changes will allow down the road to move to the upstream exporter.