### PR TITLE
Correct module names for directory locations in examples

### DIFF
--- a/examples/prometheus-federation/prom-counter/go.mod
+++ b/examples/prometheus-federation/prom-counter/go.mod
@@ -1,4 +1,4 @@
-module app
+module github.com/signalfx/splunk-otel-collector/examples/prometheus-federation/prom-counter
 
 go 1.19
 

--- a/examples/splunk-hec-traces/tracing/go.mod
+++ b/examples/splunk-hec-traces/tracing/go.mod
@@ -1,4 +1,4 @@
-module app
+module github.com/signalfx/splunk-otel-collector/examples/splunk-hec-traces/tracing
 
 go 1.19
 

--- a/examples/splunk-hec/logging/go.mod
+++ b/examples/splunk-hec/logging/go.mod
@@ -1,4 +1,4 @@
-module app
+module github.com/signalfx/splunk-otel-collector/examples/splunk-hec/logging
 
 go 1.19
 


### PR DESCRIPTION
This is required for "multimod" tool utility to stop complaining about incorrectly named modules.

Moreover, it's just better practice to name the module after the git repo + module subpath