### PR TITLE
Add workflow to test changes to release requirements

### DIFF
--- a/.github/workflows/release-requirements.yml
+++ b/.github/workflows/release-requirements.yml
@@ -1,0 +1,27 @@
+name: release-requirements
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/release-requirements.yml'
+      - 'internal/buildscripts/packaging/release/requirements.txt'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install-requirements:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+          cache-dependency-path: 'internal/buildscripts/packaging/release/requirements.txt'
+
+      - run: pip install -r internal/buildscripts/packaging/release/requirements.txt


### PR DESCRIPTION
Simple pip installation test to verify changes to `internal/buildscripts/packaging/release/requirements.txt` (e.g. dependabot PRs).