### PR TITLE
support .env file to load env

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 
+	_ "github.com/joho/godotenv/autoload"
 	flag "github.com/spf13/pflag"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-gcp v0.15.0
 	github.com/hashicorp/vault/api v1.9.0
 	github.com/jaegertracing/jaeger v1.41.0
+	github.com/joho/godotenv v1.3.0
 	github.com/knadh/koanf v1.5.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.72.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.72.0


### PR DESCRIPTION
Fixes #2643

This adds an autoload of any .env file located in the working directory when invoking the collector.

A .env file may contain environment variables that then get loaded as part of the env vars seen by the collector.

This is a lightweight approach to fixing the issue.