### PR TITLE
Add test for custom collectd plugin

### DIFF
--- a/tests/receivers/custom_upstat/custom_upstat_test.go
+++ b/tests/receivers/custom_upstat/custom_upstat_test.go
@@ -1,0 +1,45 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package tests
+
+import (
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/signalfx/splunk-otel-collector/tests/testutils"
+)
+
+func TestCustomUpstatIntegration(t *testing.T) {
+	path, err := filepath.Abs(path.Join(".", "testdata", "custom"))
+	require.NoError(t, err)
+	testutils.AssertAllMetricsReceived(t, "all.yaml", "custom_upstat.yaml",
+		nil, []testutils.CollectorBuilder{func(collector testutils.Collector) testutils.Collector {
+			collector, err := collector.WithBoundDirectory(path, "/var/collectd-python/upstat")
+			if err != nil {
+				// we are running in process
+				collector = collector.WithEnv(map[string]string{"PLUGIN_FOLDER": path})
+			} else {
+				// we are running with a container
+				collector = collector.WithEnv(map[string]string{"PLUGIN_FOLDER": "/var/collectd-python/upstat"})
+			}
+			return collector
+		}})
+}

--- a/tests/receivers/custom_upstat/custom_upstat_test.go
+++ b/tests/receivers/custom_upstat/custom_upstat_test.go
@@ -18,6 +18,7 @@
 package tests
 
 import (
+	"errors"
 	"path"
 	"path/filepath"
 	"testing"
@@ -33,7 +34,7 @@ func TestCustomUpstatIntegration(t *testing.T) {
 	testutils.AssertAllMetricsReceived(t, "all.yaml", "custom_upstat.yaml",
 		nil, []testutils.CollectorBuilder{func(collector testutils.Collector) testutils.Collector {
 			collector, err := collector.WithBoundDirectory(path, "/var/collectd-python/upstat")
-			if err != nil {
+			if errors.Is(testutils.ErrUnsupportedFeature, err) {
 				// we are running in process
 				collector = collector.WithEnv(map[string]string{"PLUGIN_FOLDER": path})
 			} else {

--- a/tests/receivers/custom_upstat/testdata/custom/collectd-upstat.py
+++ b/tests/receivers/custom_upstat/testdata/custom/collectd-upstat.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# coding=utf-8
+#
+# upstat-collectd
+
+import sys
+
+class UpStat():
+    def __init__(self, interval=2, count=2):
+        self.interval = interval
+        self.count = count
+
+    def get_upstats(self):
+        return {"up": "1"}
+
+
+class UpMon():
+    def __init__(self):
+        self.plugin_name = 'upstat'
+        self.interval = 10.0
+        self.include = set([])
+
+    def configure_callback(self, conf):
+        collectd.register_read(self.read_callback, self.interval)
+
+    def dispatch_value(self, val_type, type_instance, value):
+        """
+        Dispatch a value to collectd
+        """
+        plugin_instance = "upstat"
+        collectd.info('%s plugin: %s' % (self.plugin_name, 'Sending value: %s-%s.%s=%s' % (
+            self.plugin_name,
+            plugin_instance,
+            '-'.join([val_type, type_instance]),
+            value)))
+
+        val = collectd.Values()
+        val.plugin = self.plugin_name
+        val.plugin_instance = plugin_instance
+        val.type = val_type
+        if len(type_instance):
+            val.type_instance = type_instance
+        val.values = [value]
+        val.meta = {'0': True}
+        val.dispatch()
+
+    def read_callback(self):
+        """
+        Collectd read callback
+        """
+        collectd.info('Read callback called')
+        upstat = UpStat(interval=self.interval)
+        ds = upstat.get_upstats()
+
+        if not ds:
+            collectd.info('%s plugin: No info received.' % self.plugin_name)
+            return
+
+        for name in ds:
+            self.dispatch_value(name, '', ds[name])
+
+
+
+if __name__ == '__main__':
+    upstat = UpStat()
+    ds = upstat.get_upstats()
+
+    for metric in ds:
+        print("%s:%s" % (metric, ds[metric]))
+
+    sys.exit(0)
+else:
+    import collectd
+
+    upmon = UpMon()
+
+    # Register callbacks
+    collectd.register_config(upmon.configure_callback)

--- a/tests/receivers/custom_upstat/testdata/custom/upstat_types.db
+++ b/tests/receivers/custom_upstat/testdata/custom/upstat_types.db
@@ -1,0 +1,1 @@
+up      value:GAUGE:0:U

--- a/tests/receivers/custom_upstat/testdata/custom_upstat.yaml
+++ b/tests/receivers/custom_upstat/testdata/custom_upstat.yaml
@@ -1,0 +1,28 @@
+receivers:
+  smartagent/collectd/custom:
+    type: collectd/custom
+    template: |
+      LoadPlugin "python"
+      TypesDB "${PLUGIN_FOLDER}/upstat_types.db"
+      <Plugin python>
+        ModulePath "${PLUGIN_FOLDER}"
+        Import "collectd-upstat"
+        <Module "collectd-upstat">
+        </Module>
+      </Plugin>
+
+exporters:
+  otlp:
+    endpoint: "${OTLP_ENDPOINT}"
+    tls:
+      insecure: true
+
+service:
+  telemetry:
+    logs:
+      level: "debug"
+  pipelines:
+    metrics:
+      receivers:
+        - smartagent/collectd/custom
+      exporters: [otlp]

--- a/tests/receivers/custom_upstat/testdata/resource_metrics/all.yaml
+++ b/tests/receivers/custom_upstat/testdata/resource_metrics/all.yaml
@@ -1,0 +1,6 @@
+resource_metrics:
+  - attributes:
+    scope_metrics:
+      - metrics:
+          - name: up
+            type: IntGauge

--- a/tests/testutils/collector.go
+++ b/tests/testutils/collector.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	UnsupportedErr = errors.New("unsupported feature")
+	ErrUnsupportedFeature = errors.New("unsupported feature")
 )
 
 type Collector interface {

--- a/tests/testutils/collector.go
+++ b/tests/testutils/collector.go
@@ -15,9 +15,14 @@
 package testutils
 
 import (
+	"errors"
 	"testing"
 
 	"go.uber.org/zap"
+)
+
+var (
+	UnsupportedErr = errors.New("unsupported feature")
 )
 
 type Collector interface {
@@ -27,6 +32,7 @@ type Collector interface {
 	WithLogger(logger *zap.Logger) Collector
 	WithLogLevel(level string) Collector
 	WillFail(fail bool) Collector
+	WithBoundDirectory(path string, mountPoint string) (Collector, error)
 	Build() (Collector, error)
 	Start() error
 	Shutdown() error

--- a/tests/testutils/collector.go
+++ b/tests/testutils/collector.go
@@ -15,14 +15,9 @@
 package testutils
 
 import (
-	"errors"
 	"testing"
 
 	"go.uber.org/zap"
-)
-
-var (
-	ErrUnsupportedFeature = errors.New("unsupported feature")
 )
 
 type Collector interface {
@@ -32,7 +27,7 @@ type Collector interface {
 	WithLogger(logger *zap.Logger) Collector
 	WithLogLevel(level string) Collector
 	WillFail(fail bool) Collector
-	WithBoundDirectory(path string, mountPoint string) (Collector, error)
+	WithMount(path string, mountPoint string) Collector
 	Build() (Collector, error)
 	Start() error
 	Shutdown() error

--- a/tests/testutils/collector_container.go
+++ b/tests/testutils/collector_container.go
@@ -42,6 +42,7 @@ type CollectorContainer struct {
 	contextArchive io.Reader
 	Logger         *zap.Logger
 	logConsumer    collectorLogConsumer
+	Mounts         map[string]string
 	Image          string
 	ConfigPath     string
 	LogLevel       string
@@ -49,7 +50,6 @@ type CollectorContainer struct {
 	Ports          []string
 	Container      Container
 	Fail           bool
-	Mounts         map[string]string
 }
 
 // To be used as a builder whose Build() method provides the actual instance capable of launching the process.

--- a/tests/testutils/collector_container.go
+++ b/tests/testutils/collector_container.go
@@ -102,9 +102,9 @@ func (collector CollectorContainer) WillFail(fail bool) Collector {
 	collector.Fail = fail
 	return &collector
 }
-func (collector CollectorContainer) WithBoundDirectory(path string, mountPoint string) (Collector, error) {
+func (collector CollectorContainer) WithMount(path string, mountPoint string) Collector {
 	collector.Mounts[path] = mountPoint
-	return &collector, nil
+	return &collector
 }
 
 func (collector CollectorContainer) Build() (Collector, error) {

--- a/tests/testutils/collector_process.go
+++ b/tests/testutils/collector_process.go
@@ -49,8 +49,8 @@ type CollectorProcess struct {
 	Fail             bool
 }
 
-func (collector CollectorProcess) WithBoundDirectory(path string, mountPoint string) (Collector, error) {
-	return &collector, ErrUnsupportedFeature
+func (collector CollectorProcess) WithMount(path string, mountPoint string) Collector {
+	return &collector
 }
 
 // To be used as a builder whose Build() method provides the actual instance capable of launching the process.

--- a/tests/testutils/collector_process.go
+++ b/tests/testutils/collector_process.go
@@ -49,6 +49,10 @@ type CollectorProcess struct {
 	Fail             bool
 }
 
+func (collector CollectorProcess) WithBoundDirectory(path string, mountPoint string) (Collector, error) {
+	return &collector, UnsupportedErr
+}
+
 // To be used as a builder whose Build() method provides the actual instance capable of launching the process.
 func NewCollectorProcess() CollectorProcess {
 	return CollectorProcess{Env: map[string]string{}}

--- a/tests/testutils/collector_process.go
+++ b/tests/testutils/collector_process.go
@@ -50,7 +50,7 @@ type CollectorProcess struct {
 }
 
 func (collector CollectorProcess) WithBoundDirectory(path string, mountPoint string) (Collector, error) {
-	return &collector, UnsupportedErr
+	return &collector, ErrUnsupportedFeature
 }
 
 // To be used as a builder whose Build() method provides the actual instance capable of launching the process.


### PR DESCRIPTION
This adds a new integration test that checks explicitly that the smart agent receiver can work with custom collectd plugins.