### PR TITLE
add gdi-docs to discovery config yaml owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,4 @@
 *.rst @signalfx/gdi-docs @signalfx/gdi-data-collection-approvers
 docs/ @signalfx/gdi-docs @signalfx/gdi-data-collection-approvers
 README* @signalfx/gdi-docs @signalfx/gdi-data-collection-approvers
+internal/confmapprovider/discovery/bundle/bundle.d/**/*.discovery.yaml @signalfx/gdi-docs @signalfx/gdi-data-collection-approvers


### PR DESCRIPTION
The property guidance these files (will) contain is user-facing content and should be verified by our writers.