### PR TITLE
Update installer script for generate_service_name option

### DIFF
--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -685,6 +685,10 @@ Options:
                                         on this host with '<name>'.
                                         Only applicable if the '--with-instrumentation' option is also specified.
                                         (default: empty)
+  --[no-]generate-service-name          Specify '--no-generate-service-name' to prevent the preloader from setting the
+                                        OTEL_SERVICE_NAME environment variable.
+                                        Only applicable if the '--with-instrumentation' option is also specified.
+                                        (default: --generate-service-name)
   --[enable|disable]-telemetry          Enable or disable the instrumentation preloader from sending the
                                         'splunk.linux-autoinstr.executions' metric to the collector.
                                         Only applicable if the '--with-instrumentation' option is also specified.
@@ -880,8 +884,13 @@ parse_args_and_install() {
         ;;
       --service-name)
         service_name="$2"
-        generate_service_name="false"
         shift 1
+        ;;
+      --generate-service-name)
+        generate_service_name="true"
+        ;;
+      --no-generate-service-name)
+        generate_service_name="false"
         ;;
       --enable-telemetry)
         disable_telemetry="false"

--- a/internal/buildscripts/packaging/tests/installer_test.py
+++ b/internal/buildscripts/packaging/tests/installer_test.py
@@ -368,6 +368,7 @@ def test_installer_with_instrumentation_options(distro, version):
     install_cmd = f"{install_cmd} --deployment-environment test"
     install_cmd = f"{install_cmd} --disable-telemetry"
     install_cmd = f"{install_cmd} --service-name test"
+    install_cmd = f"{install_cmd} --no-generate-service-name"
     install_cmd = f"{install_cmd} --enable-profiler"
     install_cmd = f"{install_cmd} --enable-profiler-memory"
     install_cmd = f"{install_cmd} --enable-metrics"


### PR DESCRIPTION
Follow-up to #2718.

Add option to configure `generate_service_name` instead of inferring based on `service_name`.
