### PR TITLE
Use include config source with jmx monitor test

### DIFF
--- a/tests/receivers/smartagent/jmx/jmx_test.go
+++ b/tests/receivers/smartagent/jmx/jmx_test.go
@@ -18,7 +18,10 @@ package tests
 
 import (
 	"path"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/signalfx/splunk-otel-collector/tests/testutils"
 )
@@ -31,6 +34,13 @@ var cassandra = []testutils.Container{
 
 func TestJmxReceiverProvidesAllMetrics(t *testing.T) {
 	testutils.AssertAllMetricsReceived(
-		t, "all.yaml", "all_metrics_config.yaml", cassandra, nil,
+		t, "all.yaml", "all_metrics_config.yaml", cassandra,
+		[]testutils.CollectorBuilder{
+			func(collector testutils.Collector) testutils.Collector {
+				p, err := filepath.Abs(filepath.Join(".", "testdata", "script.groovy"))
+				require.NoError(t, err)
+				return collector.WithMount(p, "/opt/script.groovy")
+			},
+		},
 	)
 }

--- a/tests/receivers/smartagent/jmx/testdata/all_metrics_config.yaml
+++ b/tests/receivers/smartagent/jmx/testdata/all_metrics_config.yaml
@@ -1,3 +1,6 @@
+config_sources:
+  include:
+
 receivers:
   smartagent/jmx:
     type: jmx
@@ -6,61 +9,7 @@ receivers:
     username: cassandra
     password: cassandra
     intervalSeconds: 1
-    groovyScript: |
-      ss = util.queryJMX("org.apache.cassandra.db:type=StorageService").first()
-
-      // Copied and modified from https://github.com/apache/cassandra
-      def parseFileSize(String value) {
-        if (!value.matches("\\d+(\\.\\d+)? (GiB|KiB|MiB|TiB|bytes)")) {
-          throw new IllegalArgumentException(
-            String.format("value %s is not a valid human-readable file size", value));
-        }
-        if (value.endsWith(" TiB")) {
-          return Math.round(Double.valueOf(value.replace(" TiB", "")) * 1e12);
-        }
-        else if (value.endsWith(" GiB")) {
-          return Math.round(Double.valueOf(value.replace(" GiB", "")) * 1e9);
-        }
-        else if (value.endsWith(" KiB")) {
-          return Math.round(Double.valueOf(value.replace(" KiB", "")) * 1e3);
-        }
-        else if (value.endsWith(" MiB")) {
-          return Math.round(Double.valueOf(value.replace(" MiB", "")) * 1e6);
-        }
-        else if (value.endsWith(" bytes")) {
-          return Math.round(Double.valueOf(value.replace(" bytes", "")));
-        }
-        else {
-          throw new IllegalStateException(String.format("FileUtils.parseFileSize() reached an illegal state parsing %s", value));
-        }
-      }
-
-      localEndpoint = ss.HostIdToEndpoint.get(ss.LocalHostId)
-      dims = [host_id: ss.LocalHostId, cluster_name: ss.ClusterName]
-
-      // Equivalent of "Up/Down" in the `nodetool status` output.
-      // 1 = Live; 0 = Dead; -1 = Unknown
-      output.sendDatapoint(util.makeGauge(
-        "cassandra.status",
-        ss.LiveNodes.contains(localEndpoint) ? 1 : (ss.DeadNodes.contains(localEndpoint) ? 0 : -1),
-        dims))
-
-      output.sendDatapoint(util.makeGauge(
-        "cassandra.state",
-        ss.JoiningNodes.contains(localEndpoint) ? 3 : (ss.LeavingNodes.contains(localEndpoint) ? 2 : 1),
-        dims))
-
-      output.sendDatapoint(util.makeGauge(
-        "cassandra.load",
-        parseFileSize(ss.LoadString),
-        dims))
-
-      log.info(ss.Ownership.toString())
-      output.sendDatapoint(util.makeGauge(
-        "cassandra.ownership",
-        ss.Ownership.get(InetAddress.getByName(localEndpoint)),
-        dims))
-
+    groovyScript: ${include:/opt/script.groovy}
 exporters:
   otlp:
     endpoint: "${OTLP_ENDPOINT}"

--- a/tests/receivers/smartagent/jmx/testdata/script.groovy
+++ b/tests/receivers/smartagent/jmx/testdata/script.groovy
@@ -1,0 +1,54 @@
+ss = util.queryJMX("org.apache.cassandra.db:type=StorageService").first()
+
+// Copied and modified from https://github.com/apache/cassandra
+def parseFileSize(String value) {
+  if (!value.matches("\\d+(\\.\\d+)? (GiB|KiB|MiB|TiB|bytes)")) {
+    throw new IllegalArgumentException(
+      String.format("value %s is not a valid human-readable file size", value));
+  }
+  if (value.endsWith(" TiB")) {
+    return Math.round(Double.valueOf(value.replace(" TiB", "")) * 1e12);
+  }
+  else if (value.endsWith(" GiB")) {
+    return Math.round(Double.valueOf(value.replace(" GiB", "")) * 1e9);
+  }
+  else if (value.endsWith(" KiB")) {
+    return Math.round(Double.valueOf(value.replace(" KiB", "")) * 1e3);
+  }
+  else if (value.endsWith(" MiB")) {
+    return Math.round(Double.valueOf(value.replace(" MiB", "")) * 1e6);
+  }
+  else if (value.endsWith(" bytes")) {
+    return Math.round(Double.valueOf(value.replace(" bytes", "")));
+  }
+  else {
+    throw new IllegalStateException(String.format("FileUtils.parseFileSize() reached an illegal state parsing %s", value));
+  }
+}
+
+localEndpoint = ss.HostIdToEndpoint.get(ss.LocalHostId)
+dims = [host_id: ss.LocalHostId, cluster_name: ss.ClusterName]
+
+// Equivalent of "Up/Down" in the `nodetool status` output.
+// 1 = Live; 0 = Dead; -1 = Unknown
+output.sendDatapoint(util.makeGauge(
+  "cassandra.status",
+  ss.LiveNodes.contains(localEndpoint) ? 1 : (ss.DeadNodes.contains(localEndpoint) ? 0 : -1),
+  dims))
+
+output.sendDatapoint(util.makeGauge(
+  "cassandra.state",
+  ss.JoiningNodes.contains(localEndpoint) ? 3 : (ss.LeavingNodes.contains(localEndpoint) ? 2 : 1),
+  dims))
+
+output.sendDatapoint(util.makeGauge(
+  "cassandra.load",
+  parseFileSize(ss.LoadString),
+  dims))
+
+log.info(ss.Ownership.toString())
+output.sendDatapoint(util.makeGauge(
+  "cassandra.ownership",
+  ss.Ownership.get(InetAddress.getByName(localEndpoint)),
+  dims))
+


### PR DESCRIPTION
These changes exercise the more likely invocation instead of using an embedded script.