### PR TITLE
Add workflow for go tests on darwin

### DIFF
--- a/.github/workflows/darwin-test.yml
+++ b/.github/workflows/darwin-test.yml
@@ -1,0 +1,58 @@
+name: darwin-test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '.github/workflows/darwin-test.yml'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'pkg/**'
+      - 'tests/**'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - '!**.md'
+      - '!internal/buildscripts/**'
+
+concurrency:
+  group: darwin-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  darwin-test:
+    name: darwin-test
+    runs-on: ${{ matrix.OS }}
+    strategy:
+      matrix:
+        OS: [ "macos-11", "macos-12" ]
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.6
+
+      - name: Caching dependency
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/bin
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Install golang dependency
+        run: make install-tools
+
+      - name: Unit tests with coverage
+        run: make test-with-cover
+
+      - name: Uploading artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-results-${{ matrix.OS }}
+          path: ./coverage.html

--- a/.github/workflows/darwin-test.yml
+++ b/.github/workflows/darwin-test.yml
@@ -37,14 +37,6 @@ jobs:
         with:
           go-version: 1.19.6
 
-      - name: Caching dependency
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/bin
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-
       - name: Install golang dependency
         run: make install-tools
 

--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,8 @@ end-to-end-test:
 test-with-cover:
 	@echo Verifying that all packages have test files to count in coverage
 	@echo pre-compiling tests
-	@time go test -p $(NUM_CORES) -i $(ALL_PKG_DIRS)
-	$(GO_ACC) $(ALL_PKG_DIRS)
+	@time go test -p $(NUM_CORES) ./...
+	$(GO_ACC) ./...
 	go tool cover -html=coverage.txt -o coverage.html
 
 .PHONY: gendependabot


### PR DESCRIPTION
Similar to [windows-test.yml](https://github.com/signalfx/splunk-otel-collector/blob/main/.github/workflows/windows-test.yml), but for `macos-11` and `macos-12`.

Also, not sure what changed or when, but the `test-with-cover` make target has not been running tests or producing any coverage results. See latest [run](https://github.com/signalfx/splunk-otel-collector/actions/runs/4468999844/jobs/7850537586) for main, compared to the [run](https://github.com/signalfx/splunk-otel-collector/actions/runs/4469517243/jobs/7851783470) from this PR.