### PR TITLE
add properties.discovery.yaml support

### DIFF
--- a/internal/confmapprovider/discovery/README.md
+++ b/internal/confmapprovider/discovery/README.md
@@ -102,3 +102,49 @@ successfully started observers.
 
 
 By default, the Discovery mode is provided with pre-made discovery config components in [`bundle.d`](./bundle/README.md).
+
+
+### Discovery properties
+
+Configuring discovery components is performed by merging discovery properties with the config.d receivers
+and extensions `*.discovery.yaml` files. Discovery properties are of the form:
+
+```yaml
+splunk.discovery.receivers.<receiver-type(/name)>.config.<field>(<::subfield>)*: <value>
+splunk.discovery.extensions.<observer-type(/name)>.config.<field>(<::subfield>)*: <value>
+splunk.discovery.receivers.<receiver-type(/name)>.enabled: <true or false>
+splunk.discovery.extensions.<observer-type(/name)>.enabled: <true or false>
+
+# Examples
+splunk.discovery.receivers.prometheus_simple.config.labels::my_label: my_label_value
+splunk.discovery.receivers.prometheus_simple.enabled: true
+
+splunk.discovery.extensions.docker_observer.config.endpoint: tcp://localhost:8080
+splunk.discovery.extensions.k8s_observer.enabled: false
+```
+
+These properties can be in `config.d/properties.discovery.yaml` or specified at run time with `--set` command line options.
+
+Each discovery property also has an equivalent environment variable form using `_x<hex pair>_` encoded delimiters for
+non-word characters `[^a-zA-Z0-9_]`:
+
+```bash
+SPLUNK_DISCOVERY_RECEIVERS_receiver_x2d_type_x2f_receiver_x2d_name_CONFIG_field_x3a__x3a_subfield=value
+SPLUNK_DISCOVERY_EXTENSIONS_observer_x2d_type_x2f_observer_x2d_name_CONFIG_field_x3a__x3a_subfield=value
+SPLUNK_DISCOVERY_RECEIVERS_receiver_x2d_type_x2f_receiver_x2d_name_ENABLED=<true or false>
+SPLUNK_DISCOVERY_EXTENSIONS_observer_x2d_type_x2f_observer_x2d_name_ENABLED=<true or false>
+
+# Examples
+SPLUNK_DISCOVERY_RECEIVERS_prometheus_simple_CONFIG_labels_x3a__x3a_my_label="my_username"
+SPLUNK_DISCOVERY_RECEIVERS_prometheus_simple_ENABLED=true
+
+SPLUNK_DISCOVERY_EXTENSIONS_docker_observer_CONFIG_endpoint="tcp://localhost:8080"
+SPLUNK_DISCOVERY_EXTENSIONS_k8s_observer_ENABLED=false
+```
+
+The priority order for discovery config content from lowest to highest is:
+
+1. `config.d/<receivers or extensions>/*.discovery.yaml` file content (lowest).
+2. `config.d/properties.discovery.yaml` file content.
+3. `SPLUNK_DISCOVERY_<xyz>` environment variables available to the collector process.
+4. `--set splunk.discovery.<xyz>` commandline options (highest).

--- a/internal/confmapprovider/discovery/config_test.go
+++ b/internal/confmapprovider/discovery/config_test.go
@@ -31,10 +31,14 @@ func TestServiceEntryPath(t *testing.T) {
 	assert.True(t, isServiceEntryPath(fmt.Sprintf("%cservice.yaml", os.PathSeparator)))
 	assert.True(t, isServiceEntryPath(fmt.Sprintf(".%cservice.yml", os.PathSeparator)))
 	assert.True(t, isServiceEntryPath(fmt.Sprintf(".%cservice.yaml", os.PathSeparator)))
-	assert.True(t, isServiceEntryPath(fmt.Sprintf("dir%cservice.yml", os.PathSeparator)))
-	assert.True(t, isServiceEntryPath(fmt.Sprintf("dir%cservice.yaml", os.PathSeparator)))
+	assert.True(t, isServiceEntryPath(fmt.Sprintf("config.d%cservice.yml", os.PathSeparator)))
+	assert.True(t, isServiceEntryPath(fmt.Sprintf("config.d%cservice.yaml", os.PathSeparator)))
+	assert.False(t, isServiceEntryPath(fmt.Sprintf("%cnot-service.yml", os.PathSeparator)))
+	assert.False(t, isServiceEntryPath(fmt.Sprintf("%cnot-service.yaml", os.PathSeparator)))
 	assert.False(t, isServiceEntryPath(fmt.Sprintf("%cs.yml", os.PathSeparator)))
 	assert.False(t, isServiceEntryPath(fmt.Sprintf("%cs.yaml", os.PathSeparator)))
+	assert.False(t, isServiceEntryPath(fmt.Sprintf("config.d%cdir%cservice.yml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isServiceEntryPath(fmt.Sprintf("config.d%cdic%cservice.yaml", os.PathSeparator, os.PathSeparator)))
 }
 
 func TestExporterEntryPaths(t *testing.T) {
@@ -42,10 +46,14 @@ func TestExporterEntryPaths(t *testing.T) {
 	assert.True(t, isExporterEntryPath(fmt.Sprintf("%cexporters%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator)))
 	assert.True(t, isExporterEntryPath(fmt.Sprintf(".%cexporters%cany.yml", os.PathSeparator, os.PathSeparator)))
 	assert.True(t, isExporterEntryPath(fmt.Sprintf(".%cexporters%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isExporterEntryPath(fmt.Sprintf("config.d%cexporters%cany.yml", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isExporterEntryPath(fmt.Sprintf("config.d%cexporters%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator)))
 	assert.False(t, isExporterEntryPath(fmt.Sprintf("%cservice.yml", os.PathSeparator)))
 	assert.False(t, isExporterEntryPath(fmt.Sprintf("%cextensions%cs.yml", os.PathSeparator, os.PathSeparator)))
 	assert.False(t, isExporterEntryPath(fmt.Sprintf("%cprocessors%cs.yml", os.PathSeparator, os.PathSeparator)))
 	assert.False(t, isExporterEntryPath(fmt.Sprintf("%creceivers%cs.yml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isExporterEntryPath(fmt.Sprintf("config.d%cdir%cexporters%cany.yml", os.PathSeparator, os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isExporterEntryPath(fmt.Sprintf("config.d%cdir%cexporters%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator, os.PathSeparator)))
 }
 
 func TestExtensionEntryPaths(t *testing.T) {
@@ -53,10 +61,14 @@ func TestExtensionEntryPaths(t *testing.T) {
 	assert.True(t, isExtensionEntryPath(fmt.Sprintf("%cextensions%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator)))
 	assert.True(t, isExtensionEntryPath(fmt.Sprintf(".%cextensions%cany.yml", os.PathSeparator, os.PathSeparator)))
 	assert.True(t, isExtensionEntryPath(fmt.Sprintf(".%cextensions%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isExtensionEntryPath(fmt.Sprintf("config.d%cextensions%cany.yml", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isExtensionEntryPath(fmt.Sprintf("config.d%cextensions%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator)))
 	assert.False(t, isExtensionEntryPath(fmt.Sprintf("%cservice.yml", os.PathSeparator)))
 	assert.False(t, isExtensionEntryPath(fmt.Sprintf("%cexporters%cs.yml", os.PathSeparator, os.PathSeparator)))
 	assert.False(t, isExtensionEntryPath(fmt.Sprintf("%cprocessors%cs.yml", os.PathSeparator, os.PathSeparator)))
 	assert.False(t, isExtensionEntryPath(fmt.Sprintf("%creceivers%cs.yml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isExtensionEntryPath(fmt.Sprintf("config.d%cdir%cextensions%cany.yml", os.PathSeparator, os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isExtensionEntryPath(fmt.Sprintf("config.d%cdir%cextensions%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator, os.PathSeparator)))
 }
 
 func TestProcessorEntryPaths(t *testing.T) {
@@ -64,10 +76,14 @@ func TestProcessorEntryPaths(t *testing.T) {
 	assert.True(t, isProcessorEntryPath(fmt.Sprintf("%cprocessors%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator)))
 	assert.True(t, isProcessorEntryPath(fmt.Sprintf(".%cprocessors%cany.yml", os.PathSeparator, os.PathSeparator)))
 	assert.True(t, isProcessorEntryPath(fmt.Sprintf(".%cprocessors%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isProcessorEntryPath(fmt.Sprintf("config.d%cprocessors%cany.yml", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isProcessorEntryPath(fmt.Sprintf("config.d%cprocessors%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator)))
 	assert.False(t, isProcessorEntryPath(fmt.Sprintf("%cservice.yml", os.PathSeparator)))
 	assert.False(t, isProcessorEntryPath(fmt.Sprintf("%cexporters%cs.yml", os.PathSeparator, os.PathSeparator)))
 	assert.False(t, isProcessorEntryPath(fmt.Sprintf("%cextensions%cs.yml", os.PathSeparator, os.PathSeparator)))
 	assert.False(t, isProcessorEntryPath(fmt.Sprintf("%creceivers%cs.yml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isProcessorEntryPath(fmt.Sprintf("config.d%cdir%cprocessors%cany.yml", os.PathSeparator, os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isProcessorEntryPath(fmt.Sprintf("config.d%cdir%cprocessors%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator, os.PathSeparator)))
 }
 
 func TestReceiverEntryPaths(t *testing.T) {
@@ -75,12 +91,31 @@ func TestReceiverEntryPaths(t *testing.T) {
 	assert.True(t, isReceiverEntryPath(fmt.Sprintf("%creceivers%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator)))
 	assert.True(t, isReceiverEntryPath(fmt.Sprintf(".%creceivers%cany.yml", os.PathSeparator, os.PathSeparator)))
 	assert.True(t, isReceiverEntryPath(fmt.Sprintf(".%creceivers%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isReceiverEntryPath(fmt.Sprintf("config.d%creceivers%cany.yml", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isReceiverEntryPath(fmt.Sprintf("config.d%creceivers%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator)))
 	assert.False(t, isReceiverEntryPath(fmt.Sprintf("%cservice.yml", os.PathSeparator)))
 	assert.False(t, isReceiverEntryPath(fmt.Sprintf("%cexporters%cs.yml", os.PathSeparator, os.PathSeparator)))
 	assert.False(t, isReceiverEntryPath(fmt.Sprintf("%cextensions%cs.yml", os.PathSeparator, os.PathSeparator)))
 	assert.False(t, isReceiverEntryPath(fmt.Sprintf("%cprocessors%cs.yml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isReceiverEntryPath(fmt.Sprintf("config.d%cdir%creceivers%cany.yml", os.PathSeparator, os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isReceiverEntryPath(fmt.Sprintf("config.d%cdir%creceivers%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator, os.PathSeparator)))
 	assert.True(t, isReceiverEntryPath(fmt.Sprintf(".%creceivers%cany.thing.at.all.discovery.yml", os.PathSeparator, os.PathSeparator)))
 	assert.True(t, isReceiverEntryPath(fmt.Sprintf(".%creceivers%cany.thing.at.all.discovery.yaml", os.PathSeparator, os.PathSeparator)))
+}
+func TestDiscoveryObserverEntryPaths(t *testing.T) {
+	assert.False(t, isDiscoveryObserverEntryPath(fmt.Sprintf("%cextensions%cany.yml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isDiscoveryObserverEntryPath(fmt.Sprintf("%cextensions%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isDiscoveryObserverEntryPath(fmt.Sprintf(".%cextensions%cany.yml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isDiscoveryObserverEntryPath(fmt.Sprintf(".%cextensions%cany.thing.at.all.yaml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isDiscoveryObserverEntryPath(fmt.Sprintf("%cservice.yml", os.PathSeparator)))
+	assert.False(t, isDiscoveryObserverEntryPath(fmt.Sprintf("%cexporters%cs.yml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isDiscoveryObserverEntryPath(fmt.Sprintf("%cextensions%cs.yml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isDiscoveryObserverEntryPath(fmt.Sprintf("%cprocessors%cs.yml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isDiscoveryObserverEntryPath(fmt.Sprintf("%cextensions%cdir%cany.thing.at.all.discovery.yml", os.PathSeparator, os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isDiscoveryObserverEntryPath(fmt.Sprintf("%cextensions%cdir%cany.thing.at.all.discovery.yaml", os.PathSeparator, os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isDiscoveryObserverEntryPath(fmt.Sprintf("%cextensions%cany.thing.at.all.discovery.yml", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isDiscoveryObserverEntryPath(fmt.Sprintf("%cextensions%cany.thing.at.all.discovery.yaml", os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isDiscoveryObserverEntryPath(fmt.Sprintf("bundle.d%cextensions%ck8s-observer.discovery.yaml", os.PathSeparator, os.PathSeparator)))
 }
 
 func TestReceiverToDiscoverEntryPaths(t *testing.T) {
@@ -94,6 +129,26 @@ func TestReceiverToDiscoverEntryPaths(t *testing.T) {
 	assert.False(t, isReceiverToDiscoverEntryPath(fmt.Sprintf("%cprocessors%cs.yml", os.PathSeparator, os.PathSeparator)))
 	assert.True(t, isReceiverToDiscoverEntryPath(fmt.Sprintf(".%creceivers%cany.thing.at.all.discovery.yml", os.PathSeparator, os.PathSeparator)))
 	assert.True(t, isReceiverToDiscoverEntryPath(fmt.Sprintf(".%creceivers%cany.thing.at.all.discovery.yaml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isReceiverToDiscoverEntryPath(fmt.Sprintf(".%cdir%creceivers%cany.thing.at.all.discovery.yml", os.PathSeparator, os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isReceiverToDiscoverEntryPath(fmt.Sprintf(".%cdir%creceivers%cany.thing.at.all.discovery.yaml", os.PathSeparator, os.PathSeparator, os.PathSeparator)))
+	assert.True(t, isReceiverToDiscoverEntryPath(fmt.Sprintf("bundle.d%creceivers%csmartagent-postgresql.discovery.yaml", os.PathSeparator, os.PathSeparator)))
+}
+
+func TestDiscoveryPropertiesEntryPath(t *testing.T) {
+	assert.True(t, isDiscoveryPropertiesEntryPath("properties.discovery.yml"))
+	assert.True(t, isDiscoveryPropertiesEntryPath("properties.discovery.yaml"))
+	assert.True(t, isDiscoveryPropertiesEntryPath(fmt.Sprintf("%cproperties.discovery.yml", os.PathSeparator)))
+	assert.True(t, isDiscoveryPropertiesEntryPath(fmt.Sprintf("%cproperties.discovery.yaml", os.PathSeparator)))
+	assert.True(t, isDiscoveryPropertiesEntryPath(fmt.Sprintf("config.d%cproperties.discovery.yml", os.PathSeparator)))
+	assert.True(t, isDiscoveryPropertiesEntryPath(fmt.Sprintf("config.d%cproperties.discovery.yaml", os.PathSeparator)))
+	assert.False(t, isDiscoveryPropertiesEntryPath(fmt.Sprintf("config.d%cdir%cproperties.discovery.yml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isDiscoveryPropertiesEntryPath(fmt.Sprintf("config.d%cdir%cproperties.discovery.yaml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isDiscoveryPropertiesEntryPath(fmt.Sprintf("%cnot-properties.discovery.yml", os.PathSeparator)))
+	assert.False(t, isDiscoveryPropertiesEntryPath(fmt.Sprintf("%cnot-properties.discovery.yaml", os.PathSeparator)))
+	assert.False(t, isDiscoveryPropertiesEntryPath(fmt.Sprintf("%creceivers%cproperties.discovery.yml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isDiscoveryPropertiesEntryPath(fmt.Sprintf("%cextensions%cproperties.discovery.yml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isDiscoveryPropertiesEntryPath(fmt.Sprintf("%cexporters%cproperties.discovery.yml", os.PathSeparator, os.PathSeparator)))
+	assert.False(t, isDiscoveryPropertiesEntryPath(fmt.Sprintf("%cprocessors%cproperties.discovery.yml", os.PathSeparator, os.PathSeparator)))
 }
 
 var expectedConfig = Config{
@@ -276,6 +331,12 @@ var expectedConfig = Config{
 			},
 		},
 	},
+	DiscoveryProperties: PropertiesEntry{
+		Entry: map[string]any{
+			"splunk.discovery.receivers.smartagent/postgresql.config.params.unused_param": "param_value",
+			"splunk.discovery.extensions.docker_observer.config.timeout":                  "1s",
+		},
+	},
 }
 
 func TestConfig(t *testing.T) {
@@ -330,13 +391,29 @@ func TestToServiceConfig(t *testing.T) {
 	require.Equal(t, expectedServiceConfig, sc)
 }
 
-func TestConfigWithTwoReceiversInOneFile(t *testing.T) {
-	configDir := filepath.Join(".", "testdata", "double-receiver-item-config.d")
-	logger := zap.NewNop()
-	cfg := NewConfig(logger)
-	require.NotNil(t, cfg)
-	err := cfg.Load(configDir)
-	require.Contains(t, err.Error(), "must contain a single mapping of ComponentID to component but contained [otlp otlp/disallowed]")
-	cfg.logger = nil // unset for equality check
-	require.Equal(t, Config{}, *cfg)
+func TestInvalidConfigDirContents(t *testing.T) {
+	for _, test := range []struct {
+		configDir     string
+		expectedError string
+	}{
+		{
+			configDir:     "double-receiver-item-config.d",
+			expectedError: "must contain a single mapping of ComponentID to component but contained [otlp otlp/disallowed]",
+		},
+		{
+			configDir:     "invalid-properties.d",
+			expectedError: "failed loading discovery.properties from properties.discovery.yaml: failed unmarshalling component discovery.properties: failed parsing \"properties.discovery.yaml\" as yaml",
+		},
+	} {
+		t.Run(test.configDir, func(t *testing.T) {
+			configDir := filepath.Join(".", "testdata", test.configDir)
+			logger := zap.NewNop()
+			cfg := NewConfig(logger)
+			require.NotNil(t, cfg)
+			err := cfg.Load(configDir)
+			require.Contains(t, err.Error(), test.expectedError)
+			cfg.logger = nil // unset for equality check
+			require.Equal(t, Config{}, *cfg)
+		})
+	}
 }

--- a/internal/confmapprovider/discovery/testdata/config.d/properties.discovery.yaml
+++ b/internal/confmapprovider/discovery/testdata/config.d/properties.discovery.yaml
@@ -1,0 +1,2 @@
+splunk.discovery.receivers.smartagent/postgresql.config.params.unused_param: param_value
+splunk.discovery.extensions.docker_observer.config.timeout: 1s

--- a/internal/confmapprovider/discovery/testdata/invalid-properties.d/properties.discovery.yaml
+++ b/internal/confmapprovider/discovery/testdata/invalid-properties.d/properties.discovery.yaml
@@ -1,0 +1,1 @@
+invalid

--- a/tests/general/discoverymode/testdata/docker-observer-config.d/properties.discovery.yaml
+++ b/tests/general/discoverymode/testdata/docker-observer-config.d/properties.discovery.yaml
@@ -1,0 +1,3 @@
+splunk.discovery.receivers.prometheus_simple.config.labels::label_three: overwritten by --set property
+splunk.discovery.receivers.prometheus_simple.config.labels::label_four: overwritten by env var property
+splunk.discovery.receivers.prometheus_simple.config.labels::label_five: actual.label.five.value

--- a/tests/general/discoverymode/testdata/docker-observer-config.d/receivers/internal-prometheus.discovery.yaml
+++ b/tests/general/discoverymode/testdata/docker-observer-config.d/receivers/internal-prometheus.discovery.yaml
@@ -10,6 +10,8 @@ prometheus_simple:
       collection_interval: 1s
       labels:
         label_two: ${LABEL_TWO_VALUE}
+        label_three: overwritten by --set property
+        label_four: overwritten by env var property
   status:
     metrics:
       successful:


### PR DESCRIPTION
These changes add the ability to specify discovery properties in a single `config.d/properties.discovery.yaml` file that are merged w/ env/cli set properties.


edit: these changes also fix a [bug I introduced](https://github.com/signalfx/splunk-otel-collector/blob/cb4e27e2dc4010d93ed3e8abbe1d5e9e790ace7e/internal/confmapprovider/discovery/config.go#L497) where `configDirRootRegex` was using a group in a range exclusion.