### PR TITLE
adopt signalfx exporter system.cpu.time fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.73.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.73.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.73.1-0.20230318040901-6b0c2cca999c
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarder v0.73.0
@@ -247,7 +247,7 @@ require (
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/cadvisor v0.46.0 // indirect
 	github.com/google/flatbuffers v2.0.8+incompatible // indirect
@@ -318,7 +318,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/karrick/godirwalk v1.17.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/klauspost/compress v1.16.0 // indirect
+	github.com/klauspost/compress v1.16.3 // indirect
 	github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165 // indirect
@@ -465,7 +465,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230223222841-637eb2293923 // indirect
 	google.golang.org/grpc v1.53.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
+	google.golang.org/protobuf v1.29.1 // indirect
 	gopkg.in/fatih/set.v0 v0.1.0 // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -610,8 +610,9 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
-github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -985,8 +986,8 @@ github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.14.4/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
-github.com/klauspost/compress v1.16.0 h1:iULayQNOReoYUe+1qtKOqw9CwJv3aNQu8ivo7lw1HU4=
-github.com/klauspost/compress v1.16.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/compress v1.16.3 h1:XuJt9zzcnaz6a16/OU53ZjWp/v7/42WcR5t2a0PcNQY=
+github.com/klauspost/compress v1.16.3/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/knadh/koanf v1.5.0 h1:q2TSd/3Pyc/5yP9ldIrSdIz26MCcyNQzW0pEAugLPNs=
 github.com/knadh/koanf v1.5.0/go.mod h1:Hgyjp4y8v44hpZtPzs7JZfRAW5AhN7KfZcwv1RYggDs=
 github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b h1:udzkj9S/zlT5X367kqJis0QP7YMxobob6zhzq6Yre00=
@@ -1201,8 +1202,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.73.0 h1:cXEco83q8RbY9BGRETOmrgjzYL0UEh0//XiQpNY393U=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.73.0 h1:677WECKPOWdh///cabvEnMELQYjjVofrFz82mbZwEgc=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.73.0/go.mod h1:tvhidi7HEclwzXeG4LxPlsUVfio23n/ByKudAQKCqSM=
-github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.73.0 h1:jBZdQf9LHT/hzQD0hHZkF7lZfVMNm/n4mTp2UznSyr0=
-github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.73.0/go.mod h1:nVCFzUwoRxLkmHMnu4jGkScbWYOJ8o1jigJmlk0YmBs=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.73.1-0.20230318040901-6b0c2cca999c h1:V5Bu10ESEjKIuoZjNs24pjcF1xGQzIWMH2fT++/mS/s=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.73.1-0.20230318040901-6b0c2cca999c/go.mod h1:7RL+UhpImK31czLyjifFl9weBzKZfutIXJWqAo9GiNo=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.73.0 h1:S/Mtd33vmMuwbSd1nQkktqu8j6RGPJ+HC6hkLGazkik=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.73.0/go.mod h1:FQAPJ5wC3/pYJNbHNbTIKzNPQPQ4+9Ctjn/tuOqC/cg=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.73.0 h1:DwaIQgfpwnvcqRPClcE+6wJIwu3GX4rLcvTaTKCYedI=
@@ -2319,8 +2320,9 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.29.1 h1:7QBf+IK2gx70Ap/hDsOmam3GE0v9HicjfEdAxE62UoM=
+google.golang.org/protobuf v1.29.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/tests/exporters/signalfx/testdata/cpu_translations_config.yaml
+++ b/tests/exporters/signalfx/testdata/cpu_translations_config.yaml
@@ -11,6 +11,10 @@ exporters:
     access_token: token
     ingest_url: http://127.0.0.1:9943
     api_url: http://127.0.0.1:9943
+    include_metrics:
+      - metric_name: system.cpu.time
+        dimensions:
+          state: [user]
   otlp:
     endpoint: "${OTLP_ENDPOINT}"
     tls:

--- a/tests/exporters/signalfx/testdata/resource_metrics/cpu_translations.yaml
+++ b/tests/exporters/signalfx/testdata/resource_metrics/cpu_translations.yaml
@@ -1,6 +1,11 @@
 resource_metrics:
   - scope_metrics:
       - metrics:
+          - name: system.cpu.time
+            type: DoubleMonotonicCumulativeSum
+            attributes:
+              cpu: cpu0
+              state: user
           - name: cpu.utilization
             type: DoubleGauge
           - name: cpu.num_processors


### PR DESCRIPTION
These changes pick up https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/6b0c2cca999c0ab87491049b57769dfdaca591e7 and update the integration test to ensure we can include the `system.cpu.time` metric with default translation rules.