### PR TITLE
Bump actions/setup-go to v4 in darwin-test.yml

### DIFF
--- a/.github/workflows/darwin-test.yml
+++ b/.github/workflows/darwin-test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.6
 


### PR DESCRIPTION
Missed this update with #2739 