### PR TITLE
Update actions/setup-go cache key for hash of all go.sum

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
 
       - name: Installing dependency
         run: |
@@ -61,6 +62,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
 
       - name: gofmt
         run: |
@@ -84,6 +86,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
 
       - name: Lint
         run: |
@@ -103,6 +106,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
 
       - name: Unit tests
         run: |
@@ -130,6 +134,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
 
       - name: Coverage tests
         run: |
@@ -163,6 +168,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
 
       - name: Build Collector
         run: |
@@ -238,13 +244,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Caching dependency
-        uses: actions/cache@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          path: |
-            ~/go/bin
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
 
       - name: Downloading binaries-linux_${{ matrix.ARCH }}
         uses: actions/download-artifact@v3
@@ -342,13 +346,11 @@ jobs:
           name: binaries-windows_amd64
           path: ./bin
 
-      - name: Caching dependency
-        uses: actions/cache@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          path: |
-            ~/go/bin
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
 
       - id: latest
         uses: pozetroninc/github-action-get-latest-release@v0.7.0
@@ -500,6 +502,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
 
       - name: Set up QEMU
         if: ${{ matrix.ARCH != 'amd64' }}

--- a/.github/workflows/darwin-test.yml
+++ b/.github/workflows/darwin-test.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.19.6
+          cache-dependency-path: '**/go.sum'
 
       - name: Install golang dependency
         run: make install-tools

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
       - uses: actions/cache@v3
         with:
           path: .cache/buildx/agent-bundle-${{ matrix.ARCH }}
@@ -76,6 +77,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
       - uses: actions/download-artifact@v3
         with:
           name: otelcol-${{ matrix.ARCH }}
@@ -107,6 +109,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
       - uses: actions/download-artifact@v3
         with:
           name: otelcol-${{ matrix.ARCH }}

--- a/.github/workflows/trivy-scans.yml
+++ b/.github/workflows/trivy-scans.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
       - uses: actions/cache@v3
         with:
           path: .cache/buildx/agent-bundle-${{ matrix.ARCH }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
       - name: Update OpenTelemetry Dependencies to ${{ env.OTEL_VERSION }}
         run: OTEL_VERSION=${{ env.OTEL_VERSION }} ./internal/buildscripts/update-deps
       - name: make tidy

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.19.6
+          cache-dependency-path: '**/go.sum'
 
       - name: Install golang dependency
         run: |


### PR DESCRIPTION
The default cache key is the hash for only the go.sum in the project root dir.