### PR TITLE
Add workflow to create PR for new openjdk release

### DIFF
--- a/.github/workflows/update-openjdk.yml
+++ b/.github/workflows/update-openjdk.yml
@@ -1,0 +1,40 @@
+name: Update Bundled OpenJDK
+on:
+  pull_request:
+    paths:
+      - .github/workflows/update-openjdk.yml
+  schedule:
+    - cron: '0 12 * * 1-5'
+
+concurrency:
+  group: update-openjdk-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update-openjdk:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - id: latest
+        uses: pozetroninc/github-action-get-latest-release@v0.7.0
+        with:
+          repository: adoptium/temurin11-binaries
+          excludes: prerelease, draft
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update JDK_VERSION in pkg/signalfx-agent/bundle/Dockerfile
+        run: |
+          version=$( echo "${{ steps.latest.outputs.release }}" | sed 's|^jdk-\(.*\)|\1|' | tr '+' '_' )
+          if [[ -n "$version" ]]; then
+            echo "$version"
+            sed -i "s|^ARG JDK_VERSION=.*|ARG JDK_VERSION=${version}|" pkg/signalfx-agent/bundle/Dockerfile
+            git diff
+          fi
+      - name: Create Pull Request
+        if: success() && (github.event_name == 'schedule')
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: Update Bundled OpenJDK to latest
+          commit-message: Update Bundled OpenJDK to latest
+          base: main
+          draft: true


### PR DESCRIPTION
Check https://github.com/adoptium/temurin11-binaries for the latest release, update the `JDK_VERSION` arg in the agent bundle [Dockerfile](https://github.com/signalfx/splunk-otel-collector/blob/main/pkg/signalfx-agent/bundle/Dockerfile), and create a draft PR if there are changes.