### PR TITLE
dependabot: Ignore otel dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,50 +8,86 @@ updates:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/"
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/open-telemetry/*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/examples/prometheus-federation/prom-counter"
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/open-telemetry/*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/examples/splunk-hec-traces/tracing"
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/open-telemetry/*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/examples/splunk-hec/logging"
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/open-telemetry/*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/internal/tools"
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/open-telemetry/*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/pkg/extension/smartagentextension"
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/open-telemetry/*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/pkg/processor/timestampprocessor"
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/open-telemetry/*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/pkg/receiver/smartagentreceiver"
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/open-telemetry/*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/pkg/signalfx-agent"
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/open-telemetry/*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/pkg/signalfx-agent/pkg/apm"
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/open-telemetry/*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/tests"
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/open-telemetry/*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/tests/tools"
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/open-telemetry/*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "pip"

--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,10 @@ gendependabot:
 	@echo "Add github-actions entry for \"/\""
 	@echo "  - package-ecosystem: \"github-actions\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"" >> ${DEPENDABOT_PATH}
 	@echo "Add gomod entry for \"/\""
-	@echo "  - package-ecosystem: \"gomod\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"" >> ${DEPENDABOT_PATH}
+	@echo "  - package-ecosystem: \"gomod\"\n    directory: \"/\"\n    ignore:\n      - dependency-name: \"go.opentelemetry.io/*\"\n      - dependency-name: \"github.com/open-telemetry/*\"\n    schedule:\n      interval: \"weekly\"" >> ${DEPENDABOT_PATH}
 	@set -e; for dir in $(ALL_GO_MODULES); do \
 		(echo "Add gomod entry for \"$${dir:1}\"" && \
-		  echo "  - package-ecosystem: \"gomod\"\n    directory: \"$${dir:1}\"\n    schedule:\n      interval: \"weekly\"" >> ${DEPENDABOT_PATH} ); \
+		  echo "  - package-ecosystem: \"gomod\"\n    directory: \"$${dir:1}\"\n    ignore:\n      - dependency-name: \"go.opentelemetry.io/*\"\n      - dependency-name: \"github.com/open-telemetry/*\"\n    schedule:\n      interval: \"weekly\"" >> ${DEPENDABOT_PATH} ); \
 	done
 	@set -e; for dir in $(ALL_PYTHON_DEPS); do \
 		(echo "Add pip entry for \"$${dir:1}\"" && \


### PR DESCRIPTION
We usually need to handle these manually or with the `update-deps` script/workflow.