### PR TITLE
Update installer script for amazonlinux 2023 and rhel 9

### DIFF
--- a/.github/workflows/installer-script-test.yml
+++ b/.github/workflows/installer-script-test.yml
@@ -19,14 +19,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  installer-test-matrix:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Get distros
+        id: get-matrix
+        run: |
+          # create test matrix for distro images
+          dockerfiles=$(ls internal/buildscripts/packaging/tests/images/deb/Dockerfile.* internal/buildscripts/packaging/tests/images/rpm/Dockerfile.* | cut -d '.' -f2- | sort -u)
+          if [ -z "$dockerfiles" ]; then
+            echo "Failed to get dockerfiles from internal/buildscripts/packaging/tests/images!" >&2
+            exit 1
+          fi
+          distro=$(for d in $dockerfiles; do echo -n "\"$d\","; done)
+          matrix="{\"DISTRO\": [${distro%,}]}"
+          echo "$matrix" | jq
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+    outputs:
+      matrix: ${{ steps.get-matrix.outputs.matrix }}
+
   linux-installer-script-test:
-    name: linux-installer-script-test
     # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
     runs-on: ubuntu-20.04
+    needs: installer-test-matrix
     strategy:
-      matrix:
-        PACKAGE_TYPE: [ "deb", "rpm" ]
-        INSTRUMENTATION: [ "true", "false" ]
+      matrix: ${{ fromJSON(needs.installer-test-matrix.outputs.matrix) }}
+      fail-fast: false
     env:
       PYTHON_VERSION: '3.10'
       PIP_VERSION: '22.0.4'
@@ -57,12 +78,12 @@ jobs:
         timeout-minutes: 45
         run: |
           mkdir -p ${{ env.RESULT_PATH }}
-          if [ "${{ matrix.INSTRUMENTATION }}" = "true" ]; then
-            markers="${{ matrix.PACKAGE_TYPE }} and instrumentation"
-          else
-            markers="${{ matrix.PACKAGE_TYPE }} and not instrumentation"
+          distro="${{ matrix.DISTRO }}"
+          if [[ "$distro" = "amazonlinux-2" ]]; then
+            # workaround for pytest substring matching
+            distro="amazonlinux-2 and not amazonlinux-2023"
           fi
-          pytest -n2 --verbose -m "$markers" \
+          pytest -n auto --verbose -k "$distro" \
             --junitxml=${{ env.RESULT_PATH }}/results.xml \
             --html=${{ env.RESULT_PATH }}/results.html \
             --self-contained-html \
@@ -71,5 +92,5 @@ jobs:
       - name: Uploading artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: linux-installer-script-test-${{ matrix.PACKAGE_TYPE }}-${{ matrix.INSTRUMENTATION }}-result
+          name: linux-installer-script-test-${{ matrix.DISTRO }}-result
           path: ${{ env.RESULT_PATH }}

--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -5,10 +5,10 @@
 For non-containerized Linux environments, an installer script is available. The
 script deploys and configures:
 
-- Splunk OpenTelemetry Collector for Linux
+- Splunk OpenTelemetry Collector for Linux (**x86_64/amd64 and aarch64/arm64 platforms only**)
 - [SignalFx Smart Agent and collectd bundle](https://github.com/signalfx/signalfx-agent/releases) (**x86_64/amd64 platforms only**)
 - [Fluentd (via the TD Agent)](https://www.fluentd.org/)
-  - Optional, **enabled** by default
+  - Optional, **enabled** by default for supported Linux distributions
   - See the [Fluentd Configuration](#fluentd-configuration) section for additional information, including how to skip installation.
 - [Splunk OpenTelemetry Auto Instrumentation for Java](https://github.com/signalfx/splunk-otel-collector/tree/main/instrumentation#linux-java-auto-instrumentation)
   - Optional, **disabled** by default
@@ -18,8 +18,8 @@ script deploys and configures:
 
 Currently, the following Linux distributions and versions are supported:
 
-- Amazon Linux: 2
-- CentOS / Red Hat / Oracle: 7, 8
+- Amazon Linux: 2, 2023 (**Note:** Log collection with Fluentd not currently supported for Amazon Linux 2023.)
+- CentOS / Red Hat / Oracle: 7, 8, 9
 - Debian: 9, 10, 11
 - SUSE: 12, 15 (**Note:** Only for Collector versions v0.34.0 or higher.  Log collection with Fluentd not currently supported.)
 - Ubuntu: 16.04, 18.04, 20.04, 22.04

--- a/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.amazonlinux-2
+++ b/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.amazonlinux-2
@@ -4,7 +4,7 @@ FROM amazonlinux:2
 
 ENV container docker
 
-RUN yum install -y curl procps initscripts systemd wget
+RUN yum install -y curl procps initscripts systemd wget tar
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \

--- a/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.amazonlinux-2023
+++ b/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.amazonlinux-2023
@@ -1,10 +1,10 @@
-# A centos8 image with systemd enabled.  Must be run with:
+# A amazonlinux2023 image with systemd enabled.  Must be run with:
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
-FROM quay.io/centos/centos:stream8
+FROM amazonlinux:2023
 
 ENV container docker
 
-RUN dnf install -y procps initscripts systemd wget
+RUN yum install -y procps initscripts systemd wget tar
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \

--- a/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.centos-9
+++ b/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.centos-9
@@ -1,6 +1,6 @@
-# A centos8 image with systemd enabled.  Must be run with:
+# A centos9 image with systemd enabled.  Must be run with:
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 ENV container docker
 

--- a/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.oraclelinux-9
+++ b/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.oraclelinux-9
@@ -1,10 +1,10 @@
-# A centos8 image with systemd enabled.  Must be run with:
+# A oraclelinux9 image with systemd enabled.  Must be run with:
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
-FROM quay.io/centos/centos:stream8
+FROM oraclelinux:9
 
 ENV container docker
 
-RUN dnf install -y procps initscripts systemd wget
+RUN dnf install -y curl procps initscripts systemd wget
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \


### PR DESCRIPTION
Note: Fluentd is not yet supported for Amazon Linux 2023 since there are currently [no packages available](https://td-agent-package-browser.herokuapp.com/4/amazon) (the packages for Amazon Linux 2 are incompatible on 2023).