### PR TITLE
Mark our internal pulsar exporter as deprecated

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,3 +107,11 @@ linters:
     - staticcheck
     - unconvert
     - unparam
+
+issues:
+  exclude:
+    - ^G104
+  exclude-rules:
+    - linters:
+        - staticcheck
+      text: "SA1019:"

--- a/docs/components.md
+++ b/docs/components.md
@@ -86,7 +86,7 @@ The distribution offers support for the following components.
 | [logging](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter)              | [in development] |
 | [otlp](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter)                    | [stable]         |
 | [otlphttp](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter)            | [stable]         |
-| [pulsar](../internal/exporter/pulsarexporter)                                                                        | [in development] |
+| [pulsar](../internal/exporter/pulsarexporter)                                                                        | [deprecated]     |
 | [signalfx](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter)    | [beta]           |
 | [sapm](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sapmexporter)            | [beta]           |
 | [splunk_hec](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/splunkhecexporter) | [beta]           |

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -93,6 +93,7 @@ import (
 	"go.uber.org/multierr"
 
 	"github.com/signalfx/splunk-otel-collector/internal/exporter/httpsinkexporter"
+	//lint:ignore SA1019 We will replace the exporter in future versions
 	"github.com/signalfx/splunk-otel-collector/internal/exporter/pulsarexporter"
 	"github.com/signalfx/splunk-otel-collector/internal/receiver/databricksreceiver"
 	"github.com/signalfx/splunk-otel-collector/internal/receiver/discoveryreceiver"
@@ -174,6 +175,7 @@ func Get() (otelcol.Factories, error) {
 		signalfxexporter.NewFactory(),
 		splunkhecexporter.NewFactory(),
 		httpsinkexporter.NewFactory(),
+		//lint:ignore SA1019 We will replace the exporter in future versions
 		pulsarexporter.NewFactory(),
 	)
 	if err != nil {

--- a/internal/exporter/pulsarexporter/README.md
+++ b/internal/exporter/pulsarexporter/README.md
@@ -1,3 +1,12 @@
 # Pulsar Exporter
 
-Pulsar exporter exports metrics to Pulsar.
+| Status                   |                       |
+| ------------------------ |-----------------------|
+| Stability                | [deprecated]          |
+| Supported pipeline types | metrics |
+
+The Pulsar exporter is used to export metrics to Apache Pulsar.
+
+The exporter is deprecated and will be replaced by the [OpenTelemetry Collector upstream exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/pulsarexporter).
+
+[deprecated]:https://github.com/open-telemetry/opentelemetry-collector#deprecated

--- a/internal/exporter/pulsarexporter/doc.go
+++ b/internal/exporter/pulsarexporter/doc.go
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Deprecated: This exporter will be replaced by github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter
 // Package pulsarexporter exports trace data to Pulsar.
 package pulsarexporter

--- a/internal/exporter/pulsarexporter/factory.go
+++ b/internal/exporter/pulsarexporter/factory.go
@@ -37,6 +37,7 @@ const (
 // FactoryOption applies changes to pulsarExporterFactory.
 type FactoryOption func(factory *pulsarExporterFactory)
 
+// Deprecated: This exporter will be replaced by github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter
 // NewFactory creates pulsar exporter factory.
 func NewFactory(options ...FactoryOption) exporter.Factory {
 	f := &pulsarExporterFactory{

--- a/internal/exporter/pulsarexporter/factory.go
+++ b/internal/exporter/pulsarexporter/factory.go
@@ -82,6 +82,7 @@ func (f *pulsarExporterFactory) createMetricsExporter(
 	settings exporter.CreateSettings,
 	cfg component.Config,
 ) (exporter.Metrics, error) {
+	settings.Logger.Warn("the pulsarexporter component is deprecated and will be replaced by github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter")
 	oCfg := cfg.(*Config)
 	if oCfg.Encoding == "otlp_json" {
 		settings.Logger.Info("otlp_json is considered experimental and should not be used in a production environment")


### PR DESCRIPTION
This PR updates the component status of the pulsar exporter we host in this repository as deprecated in favor of using the upstream pulsar exporter.
