### PR TITLE
Add default shard ID for Tanzu Tile configuration

### DIFF
--- a/deployments/cloudfoundry/bosh/example/deployment.yaml
+++ b/deployments/cloudfoundry/bosh/example/deployment.yaml
@@ -32,7 +32,7 @@ instance_groups:
           cloudfoundry:
             rlp_gateway:
               endpoint: "https://log-stream.sys.<TAS environment name>.cf-app.com"
-              shard_id: "otelcol"
+              shard_id: "opentelemetry"
               tls:
                 insecure_skip_verify: false
             uaa:

--- a/deployments/cloudfoundry/tile/DEVELOPMENT.md
+++ b/deployments/cloudfoundry/tile/DEVELOPMENT.md
@@ -45,7 +45,6 @@ $ pcf configure splunk-otel-collector tile_config.yaml
 Sample `tile_config.yaml` file contents:
 ```yaml
 ---
-cloudfoundry_rlp_gateway_shard_id: "opentelemetry"
 cloudfoundry_rlp_gateway_tls_insecure_skip_verify: true
 # Note: UAA credentials are from the UAA user created in the Tanzu service setup referenced
 cloudfoundry_uaa_password: { 'secret': <UAA_PASSWORD> }

--- a/deployments/cloudfoundry/tile/tile.yml
+++ b/deployments/cloudfoundry/tile/tile.yml
@@ -61,6 +61,7 @@ forms:
     type: string
     label: RLP gateway shard ID
     description: Metrics are load balanced between receivers that use the same shard ID. Only use if multiple receivers must receive all metrics instead of balancing metrics between them.
+    default: opentelemetry
 
   - name: cloudfoundry_rlp_gateway_tls_insecure_skip_verify
     type: boolean


### PR DESCRIPTION
The shard ID should be filled in automatically with the default collector value to make it easier on the user. This will result in one less variable to fill in for most use-cases.

Use default value as defined in the cloud foundry [receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/cloudfoundryreceiver#configuration).