### PR TITLE
minor integration test helper improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ for-all:
 
 .PHONY: integration-vet
 integration-vet:
-	@set -e; cd tests && go vet -tags integration,endtoend,testutils ./... && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) -tags testutils -v -timeout 5m -count 1 ./...
+	@set -e; cd tests && go vet -tags integration,testutilsintegration,endtoend,testutils ./... && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) -tags testutils,testutilsintegration -v -timeout 5m -count 1 ./...
 
 .PHONY: integration-test
 integration-test: integration-vet

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,1 +1,4 @@
 include ../Makefile.Common
+
+GOTEST_OPT+=-count 1
+GO_BUILD_TAGS="testutils"

--- a/tests/general/configsources/testdata/vault_config.yaml
+++ b/tests/general/configsources/testdata/vault_config.yaml
@@ -1,6 +1,6 @@
 config_sources:
   vault:
-    endpoint: http://vault:8200
+    endpoint: http://${VAULT_HOSTNAME}:8200
     path: secret/data/kv
     auth:
       token: token

--- a/tests/general/configsources/vault_test.go
+++ b/tests/general/configsources/vault_test.go
@@ -42,6 +42,7 @@ func TestBasicSecretAccess(t *testing.T) {
 		}).WillWaitForLogs("Development mode should NOT be used in production installations!")
 
 	if !testutils.CollectorImageIsSet() {
+		// otelcol subprocess needs vault to be exposed and resolvable
 		vault = vault.WithExposedPorts("8200:8200")
 		vaultHostname = "localhost"
 	}

--- a/tests/testutils/collector_container.go
+++ b/tests/testutils/collector_container.go
@@ -35,7 +35,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const CollectorImageEnvVar = "SPLUNK_OTEL_COLLECTOR_IMAGE"
+const collectorImageEnvVar = "SPLUNK_OTEL_COLLECTOR_IMAGE"
 
 var configFromArgsPattern = regexp.MustCompile("--config($|[^d-]+)")
 
@@ -301,7 +301,7 @@ func (collector *CollectorContainer) execConfigRequest(t testing.TB, uri string)
 }
 
 func GetCollectorImage() string {
-	return strings.TrimSpace(os.Getenv(CollectorImageEnvVar))
+	return strings.TrimSpace(os.Getenv(collectorImageEnvVar))
 }
 
 func CollectorImageIsSet() bool {

--- a/tests/testutils/collector_container_integration_test.go
+++ b/tests/testutils/collector_container_integration_test.go
@@ -1,0 +1,165 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build testutils && testutilsintegration
+
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTestcontainersContainerMethods(t *testing.T) {
+	alpine := NewContainer().WithImage("alpine").WithEntrypoint("sh", "-c").WithCmd(
+		"echo rdy > /tmp/something && tail -f /tmp/something",
+	).WithExposedPorts("12345:12345").WithName("my-alpine").WithNetworks(
+		"bridge", "network_a", "network_b",
+	).WillWaitForLogs("rdy").Build()
+
+	defer func() {
+		require.NoError(t, alpine.Stop(context.Background(), nil))
+		require.NoError(t, alpine.Terminate(context.Background()))
+		err := alpine.Terminate(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "No such container")
+	}()
+
+	err := alpine.Start(context.Background())
+	log := ""
+	if err != nil {
+		if logs, e := alpine.Logs(context.Background()); logs != nil && e == nil {
+			buf := new(strings.Builder)
+			io.Copy(buf, logs)
+			log = buf.String()
+		}
+	}
+	require.NoError(t, err, fmt.Sprintf("failed to start container: %q", log))
+
+	assert.NotEmpty(t, alpine.GetContainerID())
+
+	endpoint, err := alpine.Endpoint(context.Background(), "localhost")
+	assert.Equal(t, "localhost://localhost:12345", endpoint)
+	require.NoError(t, err)
+
+	endpoint, err = alpine.PortEndpoint(context.Background(), "12345", "localhost")
+	assert.Equal(t, "localhost://localhost:12345", endpoint)
+	require.NoError(t, err)
+
+	host, err := alpine.Host(context.Background())
+	assert.Equal(t, "localhost", host)
+	require.NoError(t, err)
+
+	port, err := alpine.MappedPort(context.Background(), "12345")
+	assert.EqualValues(t, "12345/tcp", port)
+	require.NoError(t, err)
+
+	portMap, err := alpine.Ports(context.Background())
+
+	assert.True(t, func() bool {
+		expectedPorts := []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "12345"}}
+		expectedPortMap := nat.PortMap(map[nat.Port][]nat.PortBinding{
+			"12345/tcp": expectedPorts,
+		})
+
+		if assert.ObjectsAreEqual(expectedPortMap, portMap) {
+			return true
+		}
+
+		expectedPorts = append(expectedPorts, nat.PortBinding{HostIP: "::", HostPort: "12345"})
+		expectedPortMap = nat.PortMap(map[nat.Port][]nat.PortBinding{
+			"12345/tcp": expectedPorts,
+		})
+		return assert.ObjectsAreEqual(expectedPortMap, portMap)
+	}())
+	require.NoError(t, err)
+
+	sid := alpine.SessionID()
+	assert.NotEmpty(t, sid)
+
+	rc, err := alpine.Logs(context.Background())
+	require.NoError(t, err)
+	assert.NotNil(t, rc)
+
+	b := make([]byte, 15)
+	rc.Read(b)
+	assert.Contains(t, string(b), "rdy")
+	assert.NotContains(t, string(b), "sleep inf") // confirm this isn't a bash error logging command
+
+	lc := logConsumer{}
+	alpine.FollowOutput(&lc)
+
+	err = alpine.StartLogProducer(context.Background())
+	require.NoError(t, err)
+
+	ec, _, err := alpine.Exec(context.Background(), []string{"sh", "-c", "echo 'some message' >> /tmp/something"})
+	assert.Equal(t, 0, ec)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		lc.Lock()
+		defer lc.Unlock()
+		for _, statement := range lc.statements {
+			if statement == "some message" {
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 1*time.Millisecond)
+
+	require.Contains(t, lc.statements, "some message")
+
+	err = alpine.StopLogProducer()
+	require.NoError(t, err)
+
+	name, err := alpine.Name(context.Background())
+	assert.Equal(t, "/my-alpine", name)
+	require.NoError(t, err)
+
+	networks, err := alpine.Networks(context.Background())
+	sort.Strings(networks)
+	assert.Equal(t, []string{"bridge", "network_a", "network_b"}, networks)
+	require.NoError(t, err)
+
+	aliases, err := alpine.NetworkAliases(context.Background())
+	assert.NotEmpty(t, aliases)
+	require.NoError(t, err)
+
+	cip, err := alpine.ContainerIP(context.Background())
+	assert.NotEmpty(t, cip)
+	require.NoError(t, err)
+
+	ips, err := alpine.ContainerIPs(context.Background())
+	assert.NotEmpty(t, ips)
+	require.NoError(t, err)
+
+	err = alpine.CopyFileToContainer(
+		context.Background(), path.Join(".", "testdata", "file_to_transfer"),
+		"/tmp/afile", 655,
+	)
+	require.NoError(t, err)
+
+	sc, stdout, stderr := alpine.AssertExec(t, 5*time.Second, "sh", "-c", "echo stdout > /dev/stdout && echo stderr > /dev/stderr")
+	require.Equal(t, "stdout\n", stdout)
+	require.Equal(t, "stderr\n", stderr)
+	require.Zero(t, sc)
+}

--- a/tests/testutils/collector_container_test.go
+++ b/tests/testutils/collector_container_test.go
@@ -141,19 +141,19 @@ func TestCollectorContainerLogging(t *testing.T) {
 }
 
 func clearEnvVar(t testing.TB) {
-	if currentVal, ok := os.LookupEnv(CollectorImageEnvVar); ok {
+	if currentVal, ok := os.LookupEnv(collectorImageEnvVar); ok {
 		t.Cleanup(func() {
-			os.Setenv(CollectorImageEnvVar, currentVal)
+			os.Setenv(collectorImageEnvVar, currentVal)
 		})
 	}
-	os.Unsetenv(CollectorImageEnvVar)
+	os.Unsetenv(collectorImageEnvVar)
 }
 
 func TestGetCollectorImage(t *testing.T) {
 	clearEnvVar(t)
 	require.False(t, CollectorImageIsSet())
 	require.Empty(t, GetCollectorImage())
-	os.Setenv(CollectorImageEnvVar, "    some.image\t")
+	os.Setenv(collectorImageEnvVar, "    some.image\t")
 	require.True(t, CollectorImageIsSet())
 	require.Equal(t, "some.image", GetCollectorImage())
 }

--- a/tests/testutils/collector_process.go
+++ b/tests/testutils/collector_process.go
@@ -172,7 +172,7 @@ func requestConfig(t testing.TB, uri string) map[string]any {
 		if err == nil {
 			break
 		}
-		time.Sleep(2 * time.Second)
+		time.Sleep(5 * time.Second)
 	}
 	require.NoError(t, err)
 

--- a/tests/testutils/collector_process.go
+++ b/tests/testutils/collector_process.go
@@ -172,7 +172,7 @@ func requestConfig(t testing.TB, uri string) map[string]any {
 		if err == nil {
 			break
 		}
-		time.Sleep(1 * time.Second)
+		time.Sleep(2 * time.Second)
 	}
 	require.NoError(t, err)
 

--- a/tests/testutils/collector_process_integration_test.go
+++ b/tests/testutils/collector_process_integration_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build testutils
+//go:build testutils && testutilsintegration
 
 package testutils
 
@@ -32,6 +32,14 @@ func TestCollectorPath(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, p)
 	assert.True(t, strings.HasSuffix(p, "/bin/otelcol"))
+}
+
+func TestConfigPathNotRequiredUponBuildWithArgs(t *testing.T) {
+	withArgs := NewCollectorProcess().WithArgs("arg_one", "arg_two")
+
+	collector, err := withArgs.Build()
+	require.NoError(t, err)
+	require.NotNil(t, collector)
 }
 
 func TestCollectorProcessConfigSourced(t *testing.T) {

--- a/tests/testutils/collector_process_test.go
+++ b/tests/testutils/collector_process_test.go
@@ -71,14 +71,6 @@ func TestConfigPathRequiredUponBuildWithoutArgs(t *testing.T) {
 	assert.EqualError(t, err, "you must specify a ConfigPath for your CollectorProcess before building")
 }
 
-func TestConfigPathNotRequiredUponBuildWithArgs(t *testing.T) {
-	withArgs := NewCollectorProcess().WithArgs("arg_one", "arg_two")
-
-	collector, err := withArgs.Build()
-	require.NoError(t, err)
-	require.NotNil(t, collector)
-}
-
 func TestCollectorProcessBuildDefaults(t *testing.T) {
 	// specifying Path to avoid built otelcol requirement
 	builder := NewCollectorProcess().WithPath("somepath").WithConfigPath("someconfigpath")

--- a/tests/testutils/container_test.go
+++ b/tests/testutils/container_test.go
@@ -18,18 +18,14 @@ package testutils
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"path"
 	"reflect"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 	"unsafe"
 
-	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -389,137 +385,3 @@ func (lc *logConsumer) Accept(l testcontainers.Log) {
 }
 
 var _ testcontainers.LogConsumer = (*logConsumer)(nil)
-
-func TestTestcontainersContainerMethods(t *testing.T) {
-	alpine := NewContainer().WithImage("alpine").WithEntrypoint("sh", "-c").WithCmd(
-		"echo rdy > /tmp/something && tail -f /tmp/something",
-	).WithExposedPorts("12345:12345").WithName("my-alpine").WithNetworks(
-		"bridge", "network_a", "network_b",
-	).WillWaitForLogs("rdy").Build()
-
-	defer func() {
-		require.NoError(t, alpine.Stop(context.Background(), nil))
-		require.NoError(t, alpine.Terminate(context.Background()))
-		err := alpine.Terminate(context.Background())
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "No such container")
-	}()
-
-	err := alpine.Start(context.Background())
-	log := ""
-	if err != nil {
-		if logs, e := alpine.Logs(context.Background()); logs != nil && e == nil {
-			buf := new(strings.Builder)
-			io.Copy(buf, logs)
-			log = buf.String()
-		}
-	}
-	require.NoError(t, err, fmt.Sprintf("failed to start container: %q", log))
-
-	assert.NotEmpty(t, alpine.GetContainerID())
-
-	endpoint, err := alpine.Endpoint(context.Background(), "localhost")
-	assert.Equal(t, "localhost://localhost:12345", endpoint)
-	require.NoError(t, err)
-
-	endpoint, err = alpine.PortEndpoint(context.Background(), "12345", "localhost")
-	assert.Equal(t, "localhost://localhost:12345", endpoint)
-	require.NoError(t, err)
-
-	host, err := alpine.Host(context.Background())
-	assert.Equal(t, "localhost", host)
-	require.NoError(t, err)
-
-	port, err := alpine.MappedPort(context.Background(), "12345")
-	assert.EqualValues(t, "12345/tcp", port)
-	require.NoError(t, err)
-
-	portMap, err := alpine.Ports(context.Background())
-
-	assert.True(t, func() bool {
-		expectedPorts := []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "12345"}}
-		expectedPortMap := nat.PortMap(map[nat.Port][]nat.PortBinding{
-			"12345/tcp": expectedPorts,
-		})
-
-		if assert.ObjectsAreEqual(expectedPortMap, portMap) {
-			return true
-		}
-
-		expectedPorts = append(expectedPorts, nat.PortBinding{HostIP: "::", HostPort: "12345"})
-		expectedPortMap = nat.PortMap(map[nat.Port][]nat.PortBinding{
-			"12345/tcp": expectedPorts,
-		})
-		return assert.ObjectsAreEqual(expectedPortMap, portMap)
-	}())
-	require.NoError(t, err)
-
-	sid := alpine.SessionID()
-	assert.NotEmpty(t, sid)
-
-	rc, err := alpine.Logs(context.Background())
-	require.NoError(t, err)
-	assert.NotNil(t, rc)
-
-	b := make([]byte, 15)
-	rc.Read(b)
-	assert.Contains(t, string(b), "rdy")
-	assert.NotContains(t, string(b), "sleep inf") // confirm this isn't a bash error logging command
-
-	lc := logConsumer{}
-	alpine.FollowOutput(&lc)
-
-	err = alpine.StartLogProducer(context.Background())
-	require.NoError(t, err)
-
-	ec, _, err := alpine.Exec(context.Background(), []string{"sh", "-c", "echo 'some message' >> /tmp/something"})
-	assert.Equal(t, 0, ec)
-	require.NoError(t, err)
-	require.Eventually(t, func() bool {
-		lc.Lock()
-		defer lc.Unlock()
-		for _, statement := range lc.statements {
-			if statement == "some message" {
-				return true
-			}
-		}
-		return false
-	}, 10*time.Second, 1*time.Millisecond)
-
-	require.Contains(t, lc.statements, "some message")
-
-	err = alpine.StopLogProducer()
-	require.NoError(t, err)
-
-	name, err := alpine.Name(context.Background())
-	assert.Equal(t, "/my-alpine", name)
-	require.NoError(t, err)
-
-	networks, err := alpine.Networks(context.Background())
-	sort.Strings(networks)
-	assert.Equal(t, []string{"bridge", "network_a", "network_b"}, networks)
-	require.NoError(t, err)
-
-	aliases, err := alpine.NetworkAliases(context.Background())
-	assert.NotEmpty(t, aliases)
-	require.NoError(t, err)
-
-	cip, err := alpine.ContainerIP(context.Background())
-	assert.NotEmpty(t, cip)
-	require.NoError(t, err)
-
-	ips, err := alpine.ContainerIPs(context.Background())
-	assert.NotEmpty(t, ips)
-	require.NoError(t, err)
-
-	err = alpine.CopyFileToContainer(
-		context.Background(), path.Join(".", "testdata", "file_to_transfer"),
-		"/tmp/afile", 655,
-	)
-	require.NoError(t, err)
-
-	sc, stdout, stderr := alpine.AssertExec(t, 5*time.Second, "sh", "-c", "echo stdout > /dev/stdout && echo stderr > /dev/stderr")
-	require.Equal(t, "stdout\n", stdout)
-	require.Equal(t, "stderr\n", stderr)
-	require.Zero(t, sc)
-}

--- a/tests/testutils/kubeutils/kind_cluster_integration_test.go
+++ b/tests/testutils/kubeutils/kind_cluster_integration_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build testutils
+//go:build testutils && testutilsintegration
 
 package kubeutils
 

--- a/tests/testutils/testcase.go
+++ b/tests/testutils/testcase.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	docker "github.com/docker/docker/client"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -228,30 +227,6 @@ func (t *Testcase) PrintLogsOnFailure() {
 // Validating shutdown helper for the Testcase's OTLPReceiverSink
 func (t *Testcase) ShutdownOTLPReceiverSink() {
 	require.NoError(t, t.OTLPReceiverSink.Shutdown())
-}
-
-func GetCollectorImageOrSkipTest(t testing.TB) string {
-	image := os.Getenv("SPLUNK_OTEL_COLLECTOR_IMAGE")
-	if strings.TrimSpace(image) == "" {
-		t.Skipf("skipping container-only test (set SPLUNK_OTEL_COLLECTOR_IMAGE env var).")
-		return ""
-	}
-	return image
-}
-
-func CollectorImageIsForArm(t testing.TB) bool {
-	image := os.Getenv("SPLUNK_OTEL_COLLECTOR_IMAGE")
-	if strings.TrimSpace(image) != "" {
-		client, err := docker.NewClientWithOpts(docker.FromEnv)
-		require.NoError(t, err)
-		client.NegotiateAPIVersion(context.Background())
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		inspect, _, err := client.ImageInspectWithRaw(ctx, image)
-		require.NoError(t, err)
-		return inspect.Architecture == "arm64"
-	}
-	return false
 }
 
 // AssertAllLogsReceived is a central helper, designed to avoid most boilerplate. Using the desired


### PR DESCRIPTION
These tests add a new `testutilsintegration` build tag for integration-vet and relocate* the collector container image helpers to the collector container package.

Also updating the vault integration test to use a new `CollectorImageIsSet()` helper and fix subprocess target validation in preparation of https://github.com/signalfx/splunk-otel-collector/pull/2893.