### PR TITLE
Increase timeout to 10m for golangci-lint

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,7 @@ on:
       - 'pkg/**'
       - 'tests/**'
       - 'Makefile'
+      - 'Makefile.common'
       - 'go.mod'
       - 'go.sum'
       - '!**.md'

--- a/.github/workflows/darwin-test.yml
+++ b/.github/workflows/darwin-test.yml
@@ -12,6 +12,7 @@ on:
       - 'pkg/**'
       - 'tests/**'
       - 'Makefile'
+      - 'Makefile.common'
       - 'go.mod'
       - 'go.sum'
       - '!**.md'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,6 +12,7 @@ on:
       - 'pkg/**'
       - 'tests/**'
       - 'Makefile'
+      - 'Makefile.common'
       - 'go.mod'
       - 'go.sum'
       - '!**.md'

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -91,7 +91,7 @@ fmt: addlicense misspell-correction
 
 .PHONY: lint
 lint: checklicense misspell
-	$(LINT) run --allow-parallel-runners
+	$(LINT) run --allow-parallel-runners --timeout 10m
 
 .PHONY: tidy
 tidy:

--- a/pkg/signalfx-agent/Makefile
+++ b/pkg/signalfx-agent/Makefile
@@ -25,9 +25,9 @@ vetall:
 lint:
 	go generate ./...
 	@echo 'Linting LINUX code'
-	CGO_ENABLED=0 GOGC=40 golangci-lint run --timeout 10m
+	CGO_ENABLED=0 GOGC=40 golangci-lint run --allow-parallel-runners --timeout 10m
 	@echo 'Linting WINDOWS code'
-	GOOS=windows CGO_ENABLED=0 GOGC=40 golangci-lint run --timeout 10m
+	GOOS=windows CGO_ENABLED=0 GOGC=40 golangci-lint run --allow-parallel-runners --timeout 10m
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
Try to reduce CI failures due to lint timeouts.