### PR TITLE
Add workflow to tidy dependabot PRs

### DIFF
--- a/.github/workflows/tidy-dependabot-pr.yml
+++ b/.github/workflows/tidy-dependabot-pr.yml
@@ -1,0 +1,29 @@
+name: tidy-dependabot-pr
+on:
+  push:
+    branches:
+      - dependabot/go_modules/**
+
+env:
+  GO_VERSION: 1.19.6
+
+concurrency:
+  group: tidy-dependabot-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  make-tidy:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
+      - run: make for-all CMD='make tidy'
+      - uses: stefanzweifel/git-auto-commit-action@v4.16.0
+        with:
+          commit_message: make tidy
+          branch: ${{ github.head_ref }}


### PR DESCRIPTION
Runs `make for-all CMD='make tidy'` and commits/pushes the changes to dependabot branches.