### PR TITLE
Remove workflow cleanup for closed PRs

### DIFF
--- a/.github/workflows/cleanup-closed-pr.yml
+++ b/.github/workflows/cleanup-closed-pr.yml
@@ -12,28 +12,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Workflow Cleanup
-        if: ${{ github.event.pull_request.merged == false }}
-        run: |
-          REPO=${{ github.repository }}
-          BRANCH="${{ github.head_ref }}"
-
-          echo "Fetching list of workflow runs for the $BRANCH branch"
-          runIdsForBranch=$(gh run list -R $REPO -b $BRANCH --json databaseId -q '.[].databaseId')
-
-          ## Setting this to not fail the workflow while cancelling workflow runs.
-          set +e
-          for id in $runIdsForBranch
-          do
-              if [[ "${{ github.run_id }}" != "$id" ]]; then
-                echo "Cancelling workflow run ${{ github.server_url }}/${REPO}/actions/runs/${id} ..."
-                gh run cancel -R $REPO $id
-              fi
-          done
-          echo "Done"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Cache Cleanup
         run: |
           gh extension install actions/gh-actions-cache


### PR DESCRIPTION
No longer necessary, and avoid unexpectedly canceling workflows from automated PRs.