### PR TITLE
Import gpg key for centos9 test image

### DIFF
--- a/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.centos-9
+++ b/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.centos-9
@@ -4,6 +4,7 @@ FROM quay.io/centos/centos:stream9
 
 ENV container docker
 
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 RUN dnf install -y procps initscripts systemd wget
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \


### PR DESCRIPTION
Workaround for our test failures (e.g. https://github.com/signalfx/splunk-otel-collector/actions/runs/4619591339 and https://github.com/signalfx/splunk-otel-collector/actions/runs/4619591335) until the centos9 image and/or yum repo is updated.