### PR TITLE
Use https apt repos for salt tests

### DIFF
--- a/deployments/salt/Dockerfile
+++ b/deployments/salt/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get upgrade -y -o DPkg::Options::=--force-confold
 RUN apt-get install -y software-properties-common ca-certificates wget curl apt-transport-https python3-pip vim
 
 RUN curl -L https://repo.saltproject.io/py3/ubuntu/20.04/amd64/latest/SALTSTACK-GPG-KEY.pub | apt-key add -
-RUN echo 'deb http://repo.saltproject.io/py3/ubuntu/20.04/amd64/latest focal main' > /etc/apt/sources.list.d/saltstack.list && \
+RUN echo 'deb https://repo.saltproject.io/py3/ubuntu/20.04/amd64/latest focal main' > /etc/apt/sources.list.d/saltstack.list && \
     apt-get update && \
     apt-get install -y salt-minion
 

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.debian-bullseye
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.debian-bullseye
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get upgrade -y -o DPkg::Options::=--force-confold
 RUN apt-get install -y software-properties-common ca-certificates wget curl apt-transport-https python3-pip vim systemd procps
 
 RUN curl -L https://repo.saltproject.io/py3/debian/11/amd64/latest/SALTSTACK-GPG-KEY.pub | apt-key add -
-RUN echo 'deb http://repo.saltproject.io/py3/debian/11/amd64/latest/ bullseye main' > /etc/apt/sources.list.d/saltstack.list && \
+RUN echo 'deb https://repo.saltproject.io/py3/debian/11/amd64/latest/ bullseye main' > /etc/apt/sources.list.d/saltstack.list && \
     apt-get update && \
     apt-get install -y salt-minion
 

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.debian-buster
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.debian-buster
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get upgrade -y -o DPkg::Options::=--force-confold
 RUN apt-get install -y software-properties-common ca-certificates wget curl apt-transport-https python3-pip vim systemd procps
 
 RUN curl -L https://repo.saltproject.io/py3/debian/10/amd64/latest/SALTSTACK-GPG-KEY.pub | apt-key add -
-RUN echo 'deb http://repo.saltproject.io/py3/debian/10/amd64/latest/ buster main' > /etc/apt/sources.list.d/saltstack.list && \
+RUN echo 'deb https://repo.saltproject.io/py3/debian/10/amd64/latest/ buster main' > /etc/apt/sources.list.d/saltstack.list && \
     apt-get update && \
     apt-get install -y salt-minion
 

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.debian-stretch
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.debian-stretch
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get upgrade -y -o DPkg::Options::=--force-confold
 RUN apt-get install -y software-properties-common ca-certificates wget curl apt-transport-https python3-pip vim procps
 
 RUN curl -L https://repo.saltproject.io/py3/debian/9/amd64/latest/SALTSTACK-GPG-KEY.pub | apt-key add -
-RUN echo 'deb http://repo.saltproject.io/py3/debian/9/amd64/latest/ stretch main' > /etc/apt/sources.list.d/saltstack.list && \
+RUN echo 'deb https://repo.saltproject.io/py3/debian/9/amd64/latest/ stretch main' > /etc/apt/sources.list.d/saltstack.list && \
     apt-get update && \
     apt-get install -y salt-minion
 

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.ubuntu-bionic
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.ubuntu-bionic
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get upgrade -y -o DPkg::Options::=--force-confold
 RUN apt-get install -y software-properties-common ca-certificates wget curl apt-transport-https python3-pip vim systemd
 
 RUN curl -L https://repo.saltproject.io/py3/ubuntu/18.04/amd64/latest/SALTSTACK-GPG-KEY.pub | apt-key add -
-RUN echo 'deb http://repo.saltproject.io/py3/ubuntu/18.04/amd64/latest bionic main' > /etc/apt/sources.list.d/saltstack.list && \
+RUN echo 'deb https://repo.saltproject.io/py3/ubuntu/18.04/amd64/latest bionic main' > /etc/apt/sources.list.d/saltstack.list && \
     apt-get update && \
     apt-get install -y salt-minion
 

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.ubuntu-focal
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.ubuntu-focal
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get upgrade -y -o DPkg::Options::=--force-confold
 RUN apt-get install -y software-properties-common ca-certificates wget curl apt-transport-https python3-pip vim
 
 RUN curl -L https://repo.saltproject.io/py3/ubuntu/20.04/amd64/latest/SALTSTACK-GPG-KEY.pub | apt-key add -
-RUN echo 'deb http://repo.saltproject.io/py3/ubuntu/20.04/amd64/latest focal main' > /etc/apt/sources.list.d/saltstack.list && \
+RUN echo 'deb https://repo.saltproject.io/py3/ubuntu/20.04/amd64/latest focal main' > /etc/apt/sources.list.d/saltstack.list && \
     apt-get update && \
     apt-get install -y salt-minion
 

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.ubuntu-jammy
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.ubuntu-jammy
@@ -7,7 +7,7 @@ RUN apt-get install -y software-properties-common ca-certificates wget curl apt-
 
 # salt packages not yet supported for jammy, so install from pypi instead.
 #RUN curl -L https://repo.saltproject.io/py3/ubuntu/22.04/amd64/latest/SALTSTACK-GPG-KEY.pub | apt-key add -
-#RUN echo 'deb http://repo.saltproject.io/py3/ubuntu/22.04/amd64/latest focal main' > /etc/apt/sources.list.d/saltstack.list && \
+#RUN echo 'deb https://repo.saltproject.io/py3/ubuntu/22.04/amd64/latest focal main' > /etc/apt/sources.list.d/saltstack.list && \
 #    apt-get update && \
 #    apt-get install -y salt-minion
 RUN pip install 'Jinja2<3.1' salt


### PR DESCRIPTION
Saltstack recently updated their apt repos to https and deprecated http.  Fixes salt test failures (e.g. https://github.com/signalfx/splunk-otel-collector/actions/runs/4625524016).