### PR TITLE
Improve error handling for windows installers

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -451,17 +451,29 @@ jobs:
           path: ./dist
 
       - name: Installation test
+        env:
+          token: fake-token
+          realm: fake-realm
+          memory: "256"
         run: |
           $ErrorActionPreference = 'Stop'
           Set-PSDebug -Trace 1
           $msi_path = Resolve-Path .\dist\splunk-otel-collector*.msi
           $env:VERIFY_ACCESS_TOKEN = "false"
-          .\internal\buildscripts\packaging\installer\install.ps1 -access_token "testing123" -realm "test" -msi_path "$msi_path" -mode "${{ matrix.MODE }}" -with_fluentd $${{ matrix.WITH_FLUENTD }}
+          .\internal\buildscripts\packaging\installer\install.ps1 -access_token "${{ env.token }}" -realm "${{ env.realm }}" -msi_path "$msi_path" -mode "${{ matrix.MODE }}" -memory "${{ env.memory }}" -with_fluentd $${{ matrix.WITH_FLUENTD }}
           Start-Sleep -s 30
-          powershell.exe -File .github\workflows\scripts\win-test-services.ps1 -mode "${{ matrix.MODE }}" -with_fluentd "${{ matrix.WITH_FLUENTD }}"
-          powershell.exe -File .github\workflows\scripts\win-test-support-bundle.ps1 -mode "${{ matrix.MODE }}" -with_fluentd "${{ matrix.WITH_FLUENTD }}"
+          & ${{ github.workspace }}\.github\workflows\scripts\win-test-services.ps1 -mode "${{ matrix.MODE }}" -access_token "${{ env.token }}" -realm "${{ env.realm }}" -memory "${{ env.memory }}" -with_fluentd "${{ matrix.WITH_FLUENTD }}"
+          & ${{ github.workspace }}\.github\workflows\scripts\win-test-support-bundle.ps1 -mode "${{ matrix.MODE }}" -with_fluentd "${{ matrix.WITH_FLUENTD }}"
           Test-Path -Path "$env:ProgramFiles\Splunk\OpenTelemetry Collector\agent-bundle\python\python.exe"
           Test-Path -Path "$env:ProgramFiles\Splunk\OpenTelemetry Collector\agent-bundle\collectd-python"
+
+      - name: splunk-otel-collector logs
+        if: ${{ always() }}
+        run: Get-WinEvent -ProviderName splunk-otel-collector | Sort-Object -Property TimeCreated | Select-Object -Property Message | Format-List
+
+      - name: fluentd logs
+        if: ${{ always() && matrix.WITH_FLUENTD == 'true' }}
+        run: Get-Content -Path "${env:SYSTEMDRIVE}\opt\td-agent\td-agent.log"
 
   windows-choco:
     name: windows-choco
@@ -489,6 +501,19 @@ jobs:
           .\internal\buildscripts\packaging\choco\make.ps1 build_choco -MSIFile $msi_file_path -Version $version | Tee-Object -file .\dist\build_logs.log
           Test-Path -Path ".\dist\splunk-otel-collector.$version.nupkg"
 
+      - name: Test install without parameters
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Set-PSDebug -Trace 1
+          choco install splunk-otel-collector -s=".\dist" -y
+          if ($LASTEXITCODE -ne 0) {
+            throw "choco install failed!"
+          }
+          # the collector service should not be running if installed without the SPLUNK_ACCESS_TOKEN parameter
+          if ((Get-CimInstance -ClassName win32_service -Filter "Name = 'splunk-otel-collector'" | Select Name, State).State -Eq "Running") {
+            throw "splunk-otel-collector is running"
+          }
+
       - name: Uploading choco build artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -504,6 +529,8 @@ jobs:
         OS: [ "windows-2019", "windows-2022" ]
         MODE: [ "agent", "gateway" ]
         WITH_FLUENTD: [ "true", "false" ]
+        SCENARIO: [ "install", "upgrade" ]
+      fail-fast: false
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v3
@@ -514,31 +541,57 @@ jobs:
           name: choco-build
           path: ./dist
 
-      - name: Chocolatey test
+      - name: Chocolatey ${{ matrix.SCENARIO }} test
+        env:
+          token: fake-token
+          realm: fake-realm
+          memory: "256"
         run: |
           $ErrorActionPreference = 'Stop'
           Set-PSDebug -Trace 1
           $choco_file_name = Resolve-Path .\dist\splunk-otel-collector*.nupkg
-          write-host "Installing $choco_file_name..."
-          choco install splunk-otel-collector -s="$choco_file_name" --params="'/SPLUNK_ACCESS_TOKEN=12345 /SPLUNK_REALM=test /MODE:${{ matrix.MODE }} /WITH_FLUENTD:${{ matrix.WITH_FLUENTD }}'" -y
-          Start-Sleep -s 30
-          powershell.exe -File .github\workflows\scripts\win-test-services.ps1 -mode "${{ matrix.MODE }}" -with_fluentd "${{ matrix.WITH_FLUENTD }}"
-          powershell.exe -File .github\workflows\scripts\win-test-support-bundle.ps1 -mode "${{ matrix.MODE }}" -with_fluentd "${{ matrix.WITH_FLUENTD }}"
-          write-host "Reinstalling choco package..."
-          choco install splunk-otel-collector -s="$choco_file_name" --params="'/MODE:${{ matrix.MODE }} /WITH_FLUENTD:${{ matrix.WITH_FLUENTD }}'" --force -y
-          Start-Sleep -s 30
-          powershell.exe -File .github\workflows\scripts\win-test-services.ps1 -mode "${{ matrix.MODE }}" -with_fluentd "${{ matrix.WITH_FLUENTD }}"
-          write-host "Uninstalling choco package..."
-          choco uninstall -y splunk-otel-collector
-          if (!((Get-CimInstance -ClassName win32_service -Filter "Name = 'splunk-otel-collector'" | Select Name, State).State -Eq "Running")) {
-            write-host "splunk-otel-collector has been successfully uninstalled and service is not running."
+          $params = "/SPLUNK_ACCESS_TOKEN=${{ env.token }} /SPLUNK_REALM=${{ env.realm }} /SPLUNK_MEMORY_TOTAL_MIB=${{ env.memory }} /MODE:${{ matrix.MODE }} /WITH_FLUENTD:${{ matrix.WITH_FLUENTD }}"
+          if ("${{ matrix.SCENARIO }}" -eq "install") {
+            write-host "Installing $choco_file_name ..."
+            choco install splunk-otel-collector -s=".\dist" --params="'$params'" -y
+            if ($LASTEXITCODE -ne 0) {
+              throw "choco install failed!"
+            }
           } else {
-            throw "Failed to uninstall splunk-otel-collector chocolatey package."
+            write-host "Installing splunk-otel-collector 0.74.0 ..."
+            choco feature enable -n=useRememberedArgumentsForUpgrades
+            choco install splunk-otel-collector --no-progress --version=0.74.0 --params="'$params'" -y
+            if ($LASTEXITCODE -ne 0) {
+              throw "choco install failed!"
+            }
+            Start-Sleep 30
+            write-host "Upgrading $choco_file_name ..."
+            choco upgrade splunk-otel-collector -s=".\dist" -y
+            if ($LASTEXITCODE -ne 0) {
+              throw "choco upgrade failed!"
+            }
           }
-          if (!((Get-CimInstance -ClassName win32_service -Filter "Name = 'fluentdwinsvc'" | Select Name, State).State -Eq "Running")) {
-            write-host "fluentdwinsvc has been successfully uninstalled and service is not running."
-          } else {
-            throw "Failed to uninstall fluentdwinsvc."
+          Start-Sleep -s 30
+          & ${{ github.workspace }}\.github\workflows\scripts\win-test-services.ps1 -mode "${{ matrix.MODE }}" -access_token "${{ env.token }}" -realm "${{ env.realm }}" -memory "${{ env.memory }}" -with_fluentd "${{ matrix.WITH_FLUENTD }}"
+          & ${{ github.workspace }}\.github\workflows\scripts\win-test-support-bundle.ps1 -mode "${{ matrix.MODE }}" -with_fluentd "${{ matrix.WITH_FLUENTD }}"
+
+      - name: splunk-otel-collector logs
+        if: ${{ always() }}
+        run: Get-WinEvent -ProviderName splunk-otel-collector | Sort-Object -Property TimeCreated | Select-Object -Property Message | Format-List
+
+      - name: fluentd logs
+        if: ${{ always() && matrix.WITH_FLUENTD == 'true' }}
+        run: Get-Content -Path "${env:SYSTEMDRIVE}\opt\td-agent\td-agent.log"
+
+      - name: Uninstall test
+        run: |
+          choco uninstall splunk-otel-collector -y
+          if ($LASTEXITCODE -ne 0) {
+            throw "choco uninstall failed!"
+          }
+          Start-Sleep -s 30
+          if ((Get-CimInstance -ClassName win32_service -Filter "Name = 'splunk-otel-collector'" | Select Name, State).State -Eq "Running") {
+            throw "splunk-otel-collector service is still running"
           }
 
   windows-zeroconfig-sources:

--- a/.github/workflows/scripts/win-test-services.ps1
+++ b/.github/workflows/scripts/win-test-services.ps1
@@ -1,32 +1,53 @@
 param (
     [string]$mode = "agent",
+    [string]$access_token = "testing123",
+    [string]$realm = "test",
+    [string]$memory = "512",
     [string]$with_fluentd = "true"
 )
 
 $ErrorActionPreference = 'Stop'
 Set-PSDebug -Trace 1
 
-$SPLUNK_CONFIG = Get-ItemPropertyValue -PATH "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" -name "SPLUNK_CONFIG"
-$SPLUNK_CONFIG_FILE = Split-Path $SPLUNK_CONFIG -leaf
-if ( "$SPLUNK_CONFIG_FILE" -ne "${mode}_config.yaml" ) {
-    write-host "Environment variable SPLUNK_CONFIG is not properly set."
-    exit 1
+function check_regkey([string]$name, [string]$value) {
+    $actual = Get-ItemPropertyValue -PATH "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" -name "$name"
+    if ( "$value" -ne "$actual" ) {
+        throw "Environment variable $name is not properly set. Found: '$actual', Expected '$value'"
+    }
 }
 
-if ((Get-CimInstance -ClassName win32_service -Filter "Name = 'splunk-otel-collector'" | Select Name, State).State -Eq "Running") {
+function service_running([string]$name) {
+    return ((Get-CimInstance -ClassName win32_service -Filter "Name = '$name'" | Select Name, State).State -Eq "Running")
+}
+
+$api_url = "https://api.${realm}.signalfx.com"
+$ingest_url = "https://ingest.${realm}.signalfx.com"
+
+check_regkey -name "SPLUNK_CONFIG" -value "${env:PROGRAMDATA}\Splunk\OpenTelemetry Collector\${mode}_config.yaml"
+check_regkey -name "SPLUNK_ACCESS_TOKEN" -value "$access_token"
+check_regkey -name "SPLUNK_REALM" -value "$realm"
+check_regkey -name "SPLUNK_API_URL" -value "$api_url"
+check_regkey -name "SPLUNK_INGEST_URL" -value "$ingest_url"
+check_regkey -name "SPLUNK_TRACE_URL" -value "${ingest_url}/v2/trace"
+check_regkey -name "SPLUNK_HEC_URL" -value "${ingest_url}/v1/log"
+check_regkey -name "SPLUNK_HEC_TOKEN" -value "$access_token"
+check_regkey -name "SPLUNK_BUNDLE_DIR" -value "${env:PROGRAMFILES}\Splunk\OpenTelemetry Collector\agent-bundle"
+check_regkey -name "SPLUNK_MEMORY_TOTAL_MIB" -value  "$memory"
+
+if ((service_running -name "splunk-otel-collector")) {
     write-host "splunk-otel-collector service is running."
 } else {
-    throw "Failed to install splunk-otel-collector using chocolatey."
+    throw "splunk-otel-collector service is not running."
 }
 
 if ("$with_fluentd" -eq "true") {
-    if ((Get-CimInstance -ClassName win32_service -Filter "Name = 'fluentdwinsvc'" | Select Name, State).State -Eq "Running") {
+    if ((service_running -name "fluentdwinsvc")) {
         write-host "fluentdwinsvc service is running."
     } else {
-        throw "Failed to install fluentdwinsvc using chocolatey."
+        throw "fluentdwinsvc service is not running."
     }
 } else {
-    if ((Get-CimInstance -ClassName win32_service -Filter "Name = 'fluentdwinsvc'" | Select Name, State).State -Eq "Running") {
+    if ((service_running -name "fluentdwinsvc")) {
         throw "fluentdwinsvc service is running."
     } else {
         write-host "fluentdwinsvc service is not running."

--- a/.github/workflows/win-installer-script-test.yml
+++ b/.github/workflows/win-installer-script-test.yml
@@ -1,0 +1,46 @@
+name: win-installer-script-test
+
+# Only run tests for main branch or if the PR has relevant changes
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '.github/workflows/win-installer-script-test.yml'
+      - '.github/workflows/scripts/**'
+      - 'internal/buildscripts/packaging/installer/install.ps1'
+
+concurrency:
+  group: win-installer-script-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ${{ matrix.OS }}
+    strategy:
+      matrix:
+        OS: [ "windows-2019", "windows-2022" ]
+        MODE: [ "agent", "gateway" ]
+        WITH_FLUENTD: [ "true", "false" ]
+      fail-fast: false
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Installation test
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $env:VERIFY_ACCESS_TOKEN = "false"
+          .\internal\buildscripts\packaging\installer\install.ps1 -access_token "testing123" -realm "test" -mode "${{ matrix.MODE }}" -memory "256" -with_fluentd $${{ matrix.WITH_FLUENTD }}
+          Start-Sleep -s 30
+          & ${{ github.workspace }}\.github\workflows\scripts\win-test-services.ps1 -mode "${{ matrix.MODE }}" -access_token "testing123" -realm "test" -memory "256" -with_fluentd "${{ matrix.WITH_FLUENTD }}"
+          & ${{ github.workspace }}\.github\workflows\scripts\win-test-support-bundle.ps1 -mode "${{ matrix.MODE }}" -with_fluentd "${{ matrix.WITH_FLUENTD }}"
+
+      - name: splunk-otel-collector logs
+        if: ${{ always() }}
+        run: Get-WinEvent -ProviderName splunk-otel-collector | Sort-Object -Property TimeCreated | Select-Object -Property Message | Format-List
+
+      - name: fluentd logs
+        if: ${{ always() && matrix.WITH_FLUENTD == 'true' }}
+        run: Get-Content -Path "${env:SYSTEMDRIVE}\opt\td-agent\td-agent.log"

--- a/internal/buildscripts/packaging/choco/splunk-otel-collector/tools/chocolateyinstall.ps1
+++ b/internal/buildscripts/packaging/choco/splunk-otel-collector/tools/chocolateyinstall.ps1
@@ -6,6 +6,7 @@ write-host "Checking configuration parameters ..."
 $pp = Get-PackageParameters
 
 [bool]$WITH_FLUENTD = $TRUE
+[bool]$SkipFluentd = $FALSE
 
 $MODE = $pp['MODE']
 
@@ -138,10 +139,12 @@ catch {
 }
 
 # remove orphaned service or when upgrading from bundle installation
-try {
-    stop_service
-} catch {
-    write-host "$_"
+if (service_installed -name "$service_name") {
+    try {
+        stop_service -name "$service_name"
+    } catch {
+        write-host "$_"
+    }
 }
 
 # remove orphaned registry entries or when upgrading from bundle installation
@@ -190,21 +193,52 @@ elseif ($MODE -eq "gateway"){
 
 update_registry -path "$regkey" -name "SPLUNK_CONFIG" -value "$config_path"
 
-if (!$SPLUNK_ACCESS_TOKEN) {
-    write-host ""
-    write-host "*NOTICE*: SPLUNK_ACCESS_TOKEN not detected. This is required for the default configuration to reach Splunk Observability Suite and can be specified via"
-    write-host "Set-ItemProperty -path `"HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment`" -name `"SPLUNK_ACCESS_TOKEN`" -value `"ACTUAL_ACCESS_TOKEN`""
-    write-host "before starting the splunk-otel-collector service:"
-    write-host "Start-Service -Name `"splunk-otel-collector`""
-    write-host ""
-} else {
-    write-host "Starting splunk-otel-collector service..."
-    start_service -config_path "$config_path"
-    wait_for_service -timeout 60
-    write-host "- Started"
-}
-
 # Install and configure fluentd to forward log events to the collector.
 if ($WITH_FLUENTD) {
-    . $toolsDir\fluentd.ps1
+    # Skip installation of fluentd if already installed
+    if ((service_installed -name "$fluentd_service_name") -OR (Test-Path -Path "$fluentd_base_dir\bin\fluentd")) {
+        $SkipFluentd = $TRUE
+        Write-Host "The $fluentd_service_name service is already installed. Skipping fluentd installation."
+    } else {
+        . $toolsDir\fluentd.ps1
+    }
+}
+
+# Try starting the service(s) only after all components were successfully installed and SPLUNK_ACCESS_TOKEN was found.
+if (!$SPLUNK_ACCESS_TOKEN) {
+    write-host ""
+    write-host "*NOTICE*: SPLUNK_ACCESS_TOKEN was not specified as an installation parameter and not found in the Windows Registry."
+    write-host "This is required for the default configuration to reach Splunk Observability Cloud and can be configured with:"
+    write-host "  PS> Set-ItemProperty -path `"HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment`" -name `"SPLUNK_ACCESS_TOKEN`" -value `"ACTUAL_ACCESS_TOKEN`""
+    write-host "before starting the $service_name service with:"
+    write-host "  PS> Start-Service -Name `"${service_name}`""
+    if ($WITH_FLUENTD) {
+        write-host "Then restart the fluentd service to ensure collected log events are forwarded to the $service_name service with:"
+        write-host "  PS> Stop-Service -Name `"${fluentd_service_name}`""
+        write-host "  PS> Start-Service -Name `"${fluentd_service_name}`""
+    }
+    write-host ""
+} else {
+    try {
+        write-host "Starting $service_name service..."
+        start_service -name "$service_name" -config_path "$config_path"
+        write-host "- Started"
+        if ($WITH_FLUENTD -and !$SkipFluentd) {
+            # The fluentd service is automatically started after msi installation.
+            # Wait for it to be running before trying to restart it with our custom config.
+            Write-Host "Restarting $fluentd_service_name service..."
+            wait_for_service -name "$fluentd_service_name"
+            stop_service -name "$fluentd_service_name"
+            start_service -name "$fluentd_service_name" -config_path "$fluentd_config_path"
+            Write-Host "- Started"
+        }
+        write-host ""
+    } catch {
+        $err = $_.Exception.Message
+        # Don't fail if all components were installed successfully but service(s) fail to start.
+        # Otherwise, chocolatey may leave the system in a weird state.
+        Write-Warning "Installation completed, but one or more services failed to start:"
+        Write-Warning "$err"
+        continue
+    }
 }

--- a/internal/buildscripts/packaging/choco/splunk-otel-collector/tools/common.ps1
+++ b/internal/buildscripts/packaging/choco/splunk-otel-collector/tools/common.ps1
@@ -4,6 +4,17 @@ $config_path = "$program_data_path\"
 
 $service_name = "splunk-otel-collector"
 
+try {
+    Resolve-Path $env:SYSTEMDRIVE 2>&1>$null
+    $fluentd_base_dir = "${env:SYSTEMDRIVE}\opt\td-agent"
+} catch {
+    $fluentd_base_dir = "\opt\td-agent"
+}
+$fluentd_config_dir = "$fluentd_base_dir\etc\td-agent"
+$fluentd_config_path = "$fluentd_config_dir\td-agent.conf"
+$fluentd_service_name = "fluentdwinsvc"
+$fluentd_log_path = "$fluentd_base_dir\td-agent.log"
+
 # whether the service is running
 function service_running([string]$name) {
     return ((Get-CimInstance -ClassName win32_service -Filter "Name = '$name'" | Select Name, State).State -Eq "Running")
@@ -14,31 +25,73 @@ function service_installed([string]$name) {
     return ((Get-CimInstance -ClassName win32_service -Filter "Name = '$name'" | Select Name, State).Name -Eq "$name")
 }
 
+function get_service_log_path([string]$name) {
+    $log_path = "the Windows Event Viewer"
+    if (($name -eq $fluentd_service_name) -and (Test-Path -Path "$fluentd_log_path")) {
+        $log_path = $fluentd_log_path
+    }
+    return $log_path
+}
+
+# wait for the service to start
+function wait_for_service([string]$name, [int]$timeout=60) {
+    $startTime = Get-Date
+    while (!(service_running -name "$name")){
+        if ((New-TimeSpan -Start $startTime -End (Get-Date)).TotalSeconds -gt $timeout) {
+            $err = "Timed out waiting for the $name service to be running."
+            $log_path = get_service_log_path -name "$name"
+            Write-Warning "$err"
+            Write-Warning "Please check $log_path for more details."
+            throw "$err"
+        }
+        # give windows a second to synchronize service status
+        Start-Sleep -Seconds 1
+    }
+}
+
+# wait for the service to stop
+function wait_for_service_stop([string]$name, [int]$timeout=60) {
+    $startTime = Get-Date
+    while ((service_running -name "$name")){
+        if ((New-TimeSpan -Start $startTime -End (Get-Date)).TotalSeconds -gt $timeout) {
+            $err = "Timed out waiting for the $name service to be stopped."
+            $log_path = get_service_log_path -name "$name"
+            Write-Warning "$err"
+            Write-Warning "Please check $log_path for more details."
+            throw "$err"
+        }
+        # give windows a second to synchronize service status
+        Start-Sleep -Seconds 1
+    }
+}
+
 # start the service if it's stopped
-function start_service([string]$name=$service_name, [string]$config_path=$config_path) {
+function start_service([string]$name, [string]$config_path=$config_path, [int]$max_attempts=3, [int]$timeout=60) {
+    if (!(service_installed -name "$name")) {
+        throw "The $name service does not exist!"
+    }
     if (!(service_running -name "$name")) {
         if (Test-Path -Path $config_path) {
-            try {
-                Start-Service -Name "$name"
-            } catch {
-                $err = $_.Exception.Message
-                $message = "
-                An error occurred while trying to start the $name service
-                $err
-                "
-                throw "$message"
-            }
-
-            # wait for the service to start
-            $startTime = Get-Date
-            while (!(service_running -name "$name")) {
-                # timeout after 60 seconds
-                if ((New-TimeSpan -Start $startTime -End (Get-Date)).TotalSeconds -gt 60){
-                    throw "The $name service is not running.  Something went wrong during the installation.  Please check the Windows Event Viewer and rerun the installer if necessary."
+            for ($i=1; $i -le $max_attempts; $i++) {
+                try {
+                    Start-Service -Name "$name"
+                    break
+                } catch {
+                    $err = $_.Exception.Message
+                    if ($i -eq $max_attempts) {
+                        $log_path = get_service_log_path -name "$name"
+                        Write-Warning "An error occurred while trying to start the $name service:"
+                        Write-Warning "$err"
+                        Write-Warning "Please check $log_path for more details."
+                        throw "$err"
+                    } else {
+                        Stop-Service -Name "$name" -ErrorAction Ignore
+                        Start-Sleep -Seconds 10
+                        continue
+                    }
                 }
-                # give windows a second to synchronize service status
-                Start-Sleep -Seconds 1
             }
+            wait_for_service -name "$name" -timeout $timeout
         } else {
             throw "$config_path does not exist and is required to start the $name service"
         }
@@ -46,17 +99,27 @@ function start_service([string]$name=$service_name, [string]$config_path=$config
 }
 
 # stop the service if it's running
-function stop_service([string]$name) {
-    if (service_running -name "$name") {
-        try {
-            Stop-Service -Name "$name"
-        } catch {
-            $err = $_.Exception.Message
-            $message = "
-            An error occurred while trying to stop the $name service
-            $message
-            "
+function stop_service([string]$name, [int]$max_attempts=3, [int]$timeout=60) {
+    if ((service_running -name "$name")) {
+        for ($i=1; $i -le $max_attempts; $i++) {
+            try {
+                Stop-Service -Name "$name"
+                break
+            } catch {
+                $err = $_.Exception.Message
+                if ($i -eq $max_attempts) {
+                    $log_path = get_service_log_path -name "$name"
+                    Write-Warning "An error occurred while trying to start the $name service:"
+                    Write-Warning "$err"
+                    Write-Warning "Please check $log_path for more details."
+                    throw "$err"
+                } else {
+                    Start-Sleep -Seconds 10
+                    continue
+                }
+            }
         }
+        wait_for_service_stop -name "$name" -timeout $timeout
     }
 }
 
@@ -81,18 +144,6 @@ function update_registry([string]$path, [string]$name, [string]$value) {
     Set-ItemProperty -path "$path" -name "$name" -value "$value"
 }
 
-# wait for the service to start
-function wait_for_service([string]$name=$service_name, [int]$timeout=60) {
-    $startTime = Get-Date
-    while (!(service_running -name "$name")){
-        if ((New-TimeSpan -Start $startTime -End (Get-Date)).TotalSeconds -gt $timeout){
-            throw "Service is not running.  Something went wrong durring the installation.  Please rerun the installer"
-        }
-        # give windows a second to synchronize service status
-        Start-Sleep -Seconds 1
-    }
-}
-
 # check that we're not running with a restricted execution policy
 function check_policy() {
     $executionPolicy  = (Get-ExecutionPolicy)
@@ -106,6 +157,49 @@ For more information execute:
         PS> Get-Help about_execution_policies
 "@
     }
+}
+
+# download a file to a given destination
+function download_file([string]$url, [string]$outputDir, [string]$fileName) {
+    try {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        (New-Object System.Net.WebClient).DownloadFile($url, "$outputDir\$fileName")
+    } catch {
+        $err = $_.Exception.Message
+        $message = "
+        An error occurred while downloading $url
+        $err
+        "
+        throw "$message"
+    }
+}
+
+# create the temp directory if it doesn't exist
+function create_temp_dir($tempdir) {
+    if ((Test-Path -Path "$tempdir")) {
+        Remove-Item -Recurse -Force "$tempdir"
+    }
+    mkdir "$tempdir" -ErrorAction Ignore
+}
+
+function install_msi([string]$path) {
+    Write-Host "Installing $path ..."
+    $startTime = Get-Date
+    $proc = (Start-Process msiexec.exe -Wait -PassThru -ArgumentList "/qn /norestart /i `"$path`"")
+    if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
+        Write-Warning "The installer failed with error code ${proc.ExitCode}."
+        try {
+            $events = (Get-WinEvent -ProviderName "MsiInstaller" | Where-Object { $_.TimeCreated -ge $startTime })
+            ForEach ($event in $events) {
+                ($event | Select -ExpandProperty Message | Out-String).TrimEnd() | Write-Host
+            }
+        } catch {
+            Write-Warning "Please check the Windows Event Viewer for more details."
+            continue
+        }
+        Exit $proc.ExitCode
+    }
+    Write-Host "- Done"
 }
 
 $ErrorActionPreference = 'Stop'; # stop on all errors

--- a/internal/buildscripts/packaging/choco/splunk-otel-collector/tools/fluentd.ps1
+++ b/internal/buildscripts/packaging/choco/splunk-otel-collector/tools/fluentd.ps1
@@ -1,94 +1,43 @@
-[bool]$SkipFluend = $FALSE
-
-$fluentd_msi_name = "td-agent-4.3.0-x64.msi"
+$fluentd_msi_name = "td-agent-4.3.2-x64.msi"
 $fluentd_dl_url = "https://packages.treasuredata.com/4/windows/$fluentd_msi_name"
-try {
-    Resolve-Path $env:SYSTEMDRIVE
-    $fluentd_base_dir = "${env:SYSTEMDRIVE}\opt\td-agent"
-} catch {
-    $fluentd_base_dir = "\opt\td-agent"
-}
-$fluentd_config_dir = "$fluentd_base_dir\etc\td-agent"
-$fluentd_config_path = "$fluentd_config_dir\td-agent.conf"
-$fluentd_service_name = "fluentdwinsvc"
 
 try {
-    Resolve-Path $env:TEMP
+    Resolve-Path $env:TEMP 2>&1>$null
     $tempdir = "${env:TEMP}\Fluentd"
 } catch {
     $tempdir = "\tmp\Fluentd"
 }
 
-#Skipping installation of fluentd if already installed
-if ((service_installed -name "$fluentd_service_name") -OR (Test-Path -Path "$fluentd_base_dir\bin\fluentd")) {
-    $SkipFluend = $TRUE
-    Write-Host "The $fluentd_service_name service is already installed. Skipping fluentd installation."
+create_temp_dir -tempdir $tempdir
+$default_fluentd_config = "$installation_path\fluentd\td-agent.conf"
+$default_confd_dir = "$installation_path\fluentd\conf.d"
+
+# copy the default fluentd config to $fluentd_config_path if it does not already exist
+if (!(Test-Path -Path "$fluentd_config_path") -And (Test-Path -Path "$default_fluentd_config")) {
+    $default_fluentd_config = Resolve-Path "$default_fluentd_config"
+    Write-Host "Copying $default_fluentd_config to $fluentd_config_path"
+    mkdir "$fluentd_config_dir" -ErrorAction Ignore | Out-Null
+    Copy-Item "$default_fluentd_config" "$fluentd_config_path"
 }
 
-if (!$SkipFluend) {
-
-    # download a file to a given destination
-    function download_file([string]$url, [string]$outputDir, [string]$fileName) {
-        try {
-            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-            (New-Object System.Net.WebClient).DownloadFile($url, "$outputDir\$fileName")
-        } catch {
-            $err = $_.Exception.Message
-            $message = "
-            An error occurred while downloading $url
-            $err
-            "
-            throw "$message"
+# copy the default source configs to $fluentd_config_dir\conf.d if it does not already exist
+if (Test-Path -Path "$default_confd_dir\*.conf") {
+    mkdir "$fluentd_config_dir\conf.d" -ErrorAction Ignore | Out-Null
+    $confFiles = (Get-Item "$default_confd_dir\*.conf")
+    foreach ($confFile in $confFiles) {
+        $name = $confFile.Name
+        $path = $confFile.FullName
+        if (!(Test-Path -Path "$fluentd_config_dir\conf.d\$name")) {
+            Write-Host "Copying $path to $fluentd_config_dir\conf.d\$name"
+            Copy-Item "$path" "$fluentd_config_dir\conf.d\$name"
         }
     }
-
-    # create the temp directory if it doesn't exist
-    function create_temp_dir($tempdir=$tempdir) {
-        if ((Test-Path -Path "$tempdir")) {
-            Remove-Item -Recurse -Force "$tempdir"
-        }
-        mkdir "$tempdir" -ErrorAction Ignore
-    }
-
-    $tempdir = create_temp_dir -tempdir $tempdir
-    $default_fluentd_config = "$installation_path\fluentd\td-agent.conf"
-    $default_confd_dir = "$installation_path\fluentd\conf.d"
-
-    # copy the default fluentd config to $fluentd_config_path if it does not already exist
-    if (!(Test-Path -Path "$fluentd_config_path") -And (Test-Path -Path "$default_fluentd_config")) {
-        $default_fluentd_config = Resolve-Path "$default_fluentd_config"
-        Write-Host "Copying $default_fluentd_config to $fluentd_config_path"
-        mkdir "$fluentd_config_dir" -ErrorAction Ignore | Out-Null
-        Copy-Item "$default_fluentd_config" "$fluentd_config_path"
-    }
-
-    # copy the default source configs to $fluentd_config_dir\conf.d if it does not already exist
-    if (Test-Path -Path "$default_confd_dir\*.conf") {
-        mkdir "$fluentd_config_dir\conf.d" -ErrorAction Ignore | Out-Null
-        $confFiles = (Get-Item "$default_confd_dir\*.conf")
-        foreach ($confFile in $confFiles) {
-            $name = $confFile.Name
-            $path = $confFile.FullName
-            if (!(Test-Path -Path "$fluentd_config_dir\conf.d\$name")) {
-                Write-Host "Copying $path to $fluentd_config_dir\conf.d\$name"
-                Copy-Item "$path" "$fluentd_config_dir\conf.d\$name"
-            }
-        }
-    }
-    Write-Host "Downloading $fluentd_dl_url..."
-    download_file -url "$fluentd_dl_url" -outputDir "$tempdir" -fileName "$fluentd_msi_name"
-    $fluentd_msi_path = (Join-Path "$tempdir" "$fluentd_msi_name")
-
-    Write-Host "Installing $fluentd_msi_path ..."
-    Start-Process msiexec.exe -Wait -ArgumentList "/qn /norestart /i `"$fluentd_msi_path`""
-    Write-Host "- Done"
-
-    stop_service -name "$fluentd_service_name"
-
-    Write-Host "Starting $fluentd_service_name service..."
-    start_service -name "$fluentd_service_name" -config_path "$fluentd_config_path"
-    Write-Host "- Started"
-
-    # remove the temporary directory
-    Remove-Item -Recurse -Force "$tempdir"
 }
+Write-Host "Downloading $fluentd_dl_url..."
+download_file -url "$fluentd_dl_url" -outputDir "$tempdir" -fileName "$fluentd_msi_name"
+$fluentd_msi_path = (Join-Path "$tempdir" "$fluentd_msi_name")
+
+install_msi -path "$fluentd_msi_path"
+
+# remove the temporary directory
+Remove-Item -Recurse -Force "$tempdir"


### PR DESCRIPTION
For the windows installer script and chocolatey installer:
- Add retries (max of 3) when starting/stopping the collector and fluentd services
- Check the exit code when installing MSI's
- Move service starts to the end, after all components have been installed
- Update failure messages
- Add new workflow to test windows installer script
- Update installation tests

Known issue:
- CI tests may occasionally fail when the installers try to start the collector service with our default configs, e.g. https://github.com/signalfx/splunk-otel-collector/actions/runs/4872776707/jobs/8691911641
  ```
  failed to start service: failed to start extensions: listen tcp 0.0.0.0:55679: bind: An attempt was made to 
  access a socket in a way forbidden by its access permissions.; failed to shutdown pipelines: no existing 
  monitoring routine is running; no existing monitoring routine is running; no existing monitoring routine is 
  running; no existing monitoring routine is running
  ```
  Still unsure if it's an environmental issue with github runners, or with the collector service itself.