### PR TITLE
Cherry-pick fluentforward receiver performance regression fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### 🧰 Bug fixes 🧰
+
+- Cherry-pick [fluentforward receiver fix](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/20721)
+  from upstream which fixes a performance regression introduced in v0.73.0.
+
 ## v0.74.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.74.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.74.0) and the [opentelemetry-collector-contrib v0.74.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.74.0) releases where appropriate.

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver v0.75.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver v0.75.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.75.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.75.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.75.1-0.20230405204547-23c6e57b5d78
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.75.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.75.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.75.0

--- a/go.sum
+++ b/go.sum
@@ -1594,8 +1594,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdrecei
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver v0.75.0/go.mod h1:Eu2reTIOo3iKPiX6J0oi4eoaihHK3mz8LaagNQJpH1k=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.75.0 h1:y/oz4+USvnaxeKDwtxa/XXgGKb+txWXVxNW7wd743pA=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.75.0/go.mod h1:HnxMZFJaRQKW6liorsvLThsc5qqkqMpal6R3kABz4TA=
-github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.75.0 h1:ZQIarx2B2CDbzvcvMsI2Oo753qS5Xj4dCT0mb8cvc5w=
-github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.75.0/go.mod h1:3TAJLKO1hBwmL3XFmqHEAU7LL4u9grfhmPRFb0JyaUA=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.75.1-0.20230405204547-23c6e57b5d78 h1:mN/XDejfF7277ZgEYsshMUY1gs5j/TqLV11nORTQ4IE=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.75.1-0.20230405204547-23c6e57b5d78/go.mod h1:XrYGUm9G04WgGfP2mtUIWXv9ZDnLAZ4A2VgLjJLLH78=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.75.0 h1:3pVqXvWLjksmZhWUyiWUKqcZpoxhCjXTGArP3KNqfk8=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.75.0/go.mod h1:JjUsuCj2MY98IiRpRWyBORa0X9hcJt0Br1oosWdfIG4=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.75.0 h1:yjFdQHXoKeLuJcfBtt3LJ3g8h/U/DQRrwki7/RRyqTM=


### PR DESCRIPTION
This needs to be included in the next release of our distro since we rely on this receiver for the logs collection. It will be released upstream only in 0.76.0