### PR TITLE
httpsinkexporter: add support for metrics and filtering

### DIFF
--- a/internal/exporter/httpsinkexporter/README.md
+++ b/internal/exporter/httpsinkexporter/README.md
@@ -1,17 +1,22 @@
 # HTTP Sink Exporter
 
+**This component is for testing purposes only. It does not redact or filter any telemetry content it exposes and should not be used with production data.**
+
 This exporter makes span data available via a HTTP endpoint. The endpoint
-accepts requests for spans with specific characteristics and blocks until the exporter
-receives such spans or the request times out. Once the requested spans are detected, they're
+accepts requests for spans or metrics with specific characteristics and blocks until the exporter
+receives matching data or the request times out. Once the requested data is detected, it is
 returned back to the client as JSON. 
 
-This exporter returns data as [JSON encoding](https://developers.google.com/protocol-buffers/docs/proto3#json)
-using [Jaeger protocol](https://github.com/jaegertracing/jaeger-idl/tree/master/proto/api_v2).
+Spans are returned as [JSON encoding](https://developers.google.com/protocol-buffers/docs/proto3#json)
+using [Jaeger protocol](https://github.com/jaegertracing/jaeger-idl/tree/master/proto/api_v2). We plan to
+switch this to OTLP in future.
+
+Metrics are returned as JSON encoding using the [OTLP protocol](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto).
 
 Please note that there is no guarantee that exact field names will remain stable.
-This intended for primarily for testing observability pipelines without setting up backends.
+This is intended primarily for automatic and manual testing (and occasional debugging) observability pipelines without setting up backends.
 
-Supported pipeline types: traces.
+Supported pipeline types: traces, metrics.
 
 ## Getting Started
 
@@ -26,3 +31,9 @@ exporters:
   httpsink:
     endpoint: "0.0.0.0:8378"
 ```
+
+## Example usage:
+
+- Splunk Otel Python uses this to implement [end to end tests](https://github.com/signalfx/splunk-otel-python/tree/main/tests/integration).
+- Splunk Otel JS uses this to [implement tests](https://github.com/signalfx/splunk-otel-js/tree/666f4406e29a8dee2dadbfd1efc0cc1cb6154755/test/examples).
+- Used internally at Splunk for occasional debugging.

--- a/internal/exporter/httpsinkexporter/client.go
+++ b/internal/exporter/httpsinkexporter/client.go
@@ -16,104 +16,148 @@
 package httpsinkexporter
 
 import (
+	"context"
 	"fmt"
-	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/jaegertracing/jaeger/model"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-type options struct {
-	attrs   map[string]string
-	names   []string
-	count   int
-	timeout time.Duration
-}
-
-func parseOptions(r *http.Request) (options, error) {
-	opts := options{
-		count:   1,
-		timeout: time.Second * 10,
-		names:   []string{},
-		attrs:   map[string]string{},
-	}
-
-	q := r.URL.Query()
-
-	for _, attr := range q["attr"] {
-		parts := strings.SplitN(attr, "=", 2)
-		if len(parts) != 2 {
-			return opts, fmt.Errorf("attr query string parameter is not formatted correctly")
-		}
-		opts.attrs[parts[0]] = parts[1]
-	}
-
-	opts.names = q["name"]
-
-	if timeout, ok := q["timeout"]; ok {
-		timeoutNum, err := strconv.Atoi(timeout[0])
-		if err != nil {
-			return opts, err
-		}
-		opts.timeout = time.Second * time.Duration(timeoutNum)
-	}
-
-	if count, ok := q["count"]; ok {
-		countNum, err := strconv.Atoi(count[0])
-		if err != nil {
-			return opts, err
-		}
-		opts.count = countNum
-	}
-
-	return opts, nil
-}
-
 type client struct {
-	ch      chan *model.Batch
+	spans   chan *model.Batch
+	metrics chan pmetric.Metrics
 	opts    options
 	stopped bool
 }
 
 func newClient(opts options) *client {
 	return &client{
-		ch:   make(chan *model.Batch),
-		opts: opts,
+		spans:   make(chan *model.Batch),
+		metrics: make(chan pmetric.Metrics),
+		opts:    opts,
 	}
 }
 
-func (c *client) response() ([]byte, error) {
-	// TODO: add support to filter by attributes and names
+func (c *client) response(ctx context.Context) ([]byte, error) {
+	// TODO: add support to filter spans by attributes
 	defer func() {
 		c.stopped = true
 	}()
 
-	spans := []string{}
+	results := []string{}
 	received := 0
 
 	done := make(chan struct{})
 	for {
 		select {
-		case batch := <-c.ch:
+		case batch := <-c.spans:
+			batch = c.filterSpans(batch)
 			for _, span := range batch.Spans {
-				json, err := marshaler.MarshalToString(span)
+				json, err := spanMarshaler.MarshalToString(span)
 				if err != nil {
 					return nil, err
 				}
-				spans = append(spans, json)
+				results = append(results, json)
 				received++
 				if received == c.opts.count {
 					close(done)
 				}
 			}
+		case md := <-c.metrics:
+			md = c.filterMetrics(md)
+			count := md.MetricCount()
+			if count > 0 {
+				json, err := metricMarshaler.MarshalMetrics(md)
+				if err != nil {
+					return nil, err
+				}
+				results = append(results, string(json))
+				received += count
+			}
+			if received >= c.opts.count {
+				close(done)
+			}
+
 		case <-time.After(c.opts.timeout):
-			return nil, fmt.Errorf("timed out while waiting for spans")
+			return nil, fmt.Errorf("timed out while waiting for results")
+
+		case <-ctx.Done():
+			return nil, fmt.Errorf("context deadline exceeded")
 
 		case <-done:
-			result := "[" + strings.Join(spans, ",") + "]"
+			result := "[" + strings.Join(results, ",") + "]"
 			return []byte(result), nil
 		}
 	}
+}
+
+func (c *client) filterSpans(b *model.Batch) *model.Batch {
+	spans := []*model.Span{}
+
+	for _, span := range b.Spans {
+		match := c.filterByName(span.OperationName)
+		if match {
+			spans = append(spans, span)
+		}
+	}
+
+	return &model.Batch{
+		Process: b.Process,
+		Spans:   spans,
+	}
+}
+
+func (c *client) filterMetrics(md pmetric.Metrics) pmetric.Metrics {
+	m := pmetric.NewMetrics()
+	md.CopyTo(m)
+	for i := 0; i < m.ResourceMetrics().Len(); i++ {
+		rm := m.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			sm.Metrics().RemoveIf(func(metric pmetric.Metric) bool {
+				matched := c.filterByName(metric.Name()) || c.filterMetricByAttrs(metric)
+				return !matched
+			})
+		}
+	}
+	return m
+}
+
+func (c *client) filterByName(name string) bool {
+	if len(c.opts.names) == 0 {
+		return true
+	}
+
+	for _, n := range c.opts.names {
+		if name == n {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *client) filterMetricByAttrs(metric pmetric.Metric) bool {
+	if len(c.opts.attrs) == 0 {
+		return true
+	}
+
+	switch metric.Type() {
+	case pmetric.MetricTypeGauge:
+		return filterMetricByAttr[pmetric.NumberDataPoint, pmetric.NumberDataPointSlice](metric.Gauge(), c.opts.attrs)
+
+	case pmetric.MetricTypeSum:
+		return filterMetricByAttr[pmetric.NumberDataPoint, pmetric.NumberDataPointSlice](metric.Sum(), c.opts.attrs)
+
+	case pmetric.MetricTypeHistogram:
+		return filterMetricByAttr[pmetric.HistogramDataPoint, pmetric.HistogramDataPointSlice](metric.Histogram(), c.opts.attrs)
+
+	case pmetric.MetricTypeExponentialHistogram:
+		return filterMetricByAttr[pmetric.ExponentialHistogramDataPoint, pmetric.ExponentialHistogramDataPointSlice](metric.ExponentialHistogram(), c.opts.attrs)
+
+	case pmetric.MetricTypeSummary:
+		return filterMetricByAttr[pmetric.SummaryDataPoint, pmetric.SummaryDataPointSlice](metric.Summary(), c.opts.attrs)
+	}
+	return false
 }

--- a/internal/exporter/httpsinkexporter/httpsink_exporter_test.go
+++ b/internal/exporter/httpsinkexporter/httpsink_exporter_test.go
@@ -20,16 +20,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.uber.org/zap"
 )
 
 func Test_httpSinkExporter_Start(t *testing.T) {
-	sink := &httpSinkExporter{
-		endpoint: "localhost:0",
-		ch:       nil,
-		clients:  nil,
-	}
-	err := sink.Start(context.Background(), componenttest.NewNopHost())
+	exp := newExporter(zap.NewNop(), "localhost:0")
+	err := exp.Start(context.Background(), componenttest.NewNopHost())
 	assert.NoError(t, err)
-	err = sink.Shutdown(context.Background())
+	err = exp.Shutdown(context.Background())
 	assert.NoError(t, err)
 }

--- a/internal/exporter/httpsinkexporter/metrics.go
+++ b/internal/exporter/httpsinkexporter/metrics.go
@@ -1,0 +1,55 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpsinkexporter
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+type dataPoint interface {
+	pmetric.NumberDataPoint | pmetric.SummaryDataPoint | pmetric.HistogramDataPoint | pmetric.ExponentialHistogramDataPoint
+	Attributes() pcommon.Map
+}
+
+type dataPointSlice[D dataPoint] interface {
+	Len() int
+	At(int) D
+}
+
+type metric[D dataPoint, S dataPointSlice[D]] interface {
+	pmetric.Gauge | pmetric.Sum | pmetric.Histogram | pmetric.ExponentialHistogram | pmetric.Summary
+	DataPoints() S
+}
+
+func filterMetricByAttr[D dataPoint, S dataPointSlice[D], M metric[D, S]](m M, attrs map[string]string) bool {
+	if len(attrs) == 0 {
+		return true
+	}
+	dps := m.DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		dpAttrs := dp.Attributes()
+		for k, v := range attrs {
+			if val, found := dpAttrs.Get(k); found {
+				if val.AsString() == v {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/internal/exporter/httpsinkexporter/options.go
+++ b/internal/exporter/httpsinkexporter/options.go
@@ -1,0 +1,87 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpsinkexporter
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type dataType int
+
+const (
+	typeSpans dataType = iota
+	typeMetrics
+)
+
+type options struct {
+	attrs    map[string]string
+	names    []string
+	dataType dataType
+	count    int
+	timeout  time.Duration
+}
+
+func parseOptions(r *http.Request) (options, error) {
+	opts := options{
+		count:   1,
+		timeout: time.Second * 10,
+		names:   []string{},
+		attrs:   map[string]string{},
+	}
+
+	switch r.URL.Path {
+	case "/metrics":
+		opts.dataType = typeMetrics
+	case "/spans":
+		opts.dataType = typeSpans
+	default:
+		return opts, fmt.Errorf("unsupported data-type. only metrics and spans are supported")
+	}
+
+	q := r.URL.Query()
+
+	for _, attr := range q["attr"] {
+		parts := strings.SplitN(attr, "=", 2)
+		if len(parts) != 2 {
+			return opts, fmt.Errorf("attr query string parameter is not formatted correctly")
+		}
+		opts.attrs[parts[0]] = parts[1]
+	}
+
+	opts.names = q["name"]
+
+	if timeout, ok := q["timeout"]; ok {
+		timeoutNum, err := strconv.Atoi(timeout[0])
+		if err != nil {
+			return opts, err
+		}
+		opts.timeout = time.Second * time.Duration(timeoutNum)
+	}
+
+	if count, ok := q["count"]; ok {
+		countNum, err := strconv.Atoi(count[0])
+		if err != nil {
+			return opts, err
+		}
+		opts.count = countNum
+	}
+
+	return opts, nil
+}

--- a/internal/exporter/httpsinkexporter/sink.go
+++ b/internal/exporter/httpsinkexporter/sink.go
@@ -1,0 +1,139 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpsinkexporter
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+var sinkFactoryMu = sync.Mutex{}
+var sinks = map[string]*sink{}
+
+type sink struct {
+	server    *http.Server
+	logger    *zap.Logger
+	endpoint  string
+	_clients  []*client
+	startOnce sync.Once
+	mu        sync.Mutex
+}
+
+func newSink(logger *zap.Logger, endpoint string) *sink {
+	sinkFactoryMu.Lock()
+	defer sinkFactoryMu.Unlock()
+	s, ok := sinks[endpoint]
+	if !ok {
+		s = &sink{
+			logger:    logger,
+			endpoint:  endpoint,
+			startOnce: sync.Once{},
+		}
+		sinks[endpoint] = s
+	}
+	return s
+}
+
+func (s *sink) start(ctx context.Context) {
+	s.logger.Info("starting sink", zap.String("endpoint", s.endpoint))
+	s.startOnce.Do(func() {
+		mux := http.NewServeMux()
+		mux.Handle("/", http.HandlerFunc(s.handleDefault))
+		mux.Handle("/spans", http.HandlerFunc(s.handle))
+		mux.Handle("/metrics", http.HandlerFunc(s.handle))
+
+		s.server = &http.Server{
+			Addr:    s.endpoint,
+			Handler: mux,
+			BaseContext: func(listener net.Listener) context.Context {
+				return ctx
+			},
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		go s.server.ListenAndServe()
+	})
+}
+
+func (s *sink) shutdown(ctx context.Context) error {
+	if s.server != nil {
+		return s.server.Shutdown(ctx)
+	}
+	return nil
+}
+
+func (s *sink) clients(dType dataType) []*client {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var clients []*client
+	for _, c := range s._clients {
+		if c.opts.dataType == dType {
+			clients = append(clients, c)
+		}
+	}
+	return clients
+}
+
+func (s *sink) addClient(c *client) {
+	s.mu.Lock()
+	s._clients = append(s._clients, c)
+	s.mu.Unlock()
+}
+
+func (s *sink) removeClient(c *client) {
+	s.mu.Lock()
+	index := -1
+	for i, v := range s._clients {
+		if v == c {
+			index = i
+			break
+		}
+	}
+	if index != -1 {
+		s._clients = append(s._clients[:index], s._clients[index+1:]...)
+	}
+	s.mu.Unlock()
+}
+
+func (s *sink) handleDefault(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write([]byte("404 not found - use one of the following endpoints: \n\n \t- /spans\n \t- /metrics"))
+}
+
+func (s *sink) handle(w http.ResponseWriter, r *http.Request) {
+	opts, err := parseOptions(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	c := newClient(opts)
+	s.addClient(c)
+	defer s.removeClient(c)
+
+	result, err := c.response(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(result)
+}


### PR DESCRIPTION
- now supports metrics datatype.
- also supports filtering by name and attributes (metrics only)
- query URL has changed from `/` to `/spans` and `/metrics`
- fixed some other subtle bugs/issues