### PR TITLE
Ansible fix Windows templating

### DIFF
--- a/deployments/ansible/roles/collector/tasks/otel_win_install.yml
+++ b/deployments/ansible/roles/collector/tasks/otel_win_install.yml
@@ -51,7 +51,7 @@
   notify: "restart windows splunk-otel-collector"
 
 - name: Push Custom Config file for splunk-otel-collector, If provided
-  ansible.windows.win_copy:
+  ansible.windows.win_template:
     src: "{{splunk_otel_collector_config_source}}"
     dest: "{{splunk_otel_collector_config}}"
   when: splunk_otel_collector_config_source != ""


### PR DESCRIPTION
This fixes the Ansible task needed to template the OTEL configuration for Windows.  

Like for the Linux part, this should be a `template` task.
https://github.com/signalfx/splunk-otel-collector/blob/00a9165ffaac9665e3d00b94bb8790e82a0164ad/deployments/ansible/roles/collector/tasks/linux_install.yml#L51-L59