### PR TITLE
Update github.com/containerd/containerd to v1.5.18

### DIFF
--- a/pkg/signalfx-agent/go.mod
+++ b/pkg/signalfx-agent/go.mod
@@ -15,7 +15,7 @@ replace (
 // security updates
 replace (
 	github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.9.18
-	github.com/containerd/containerd => github.com/containerd/containerd v1.5.13
+	github.com/containerd/containerd => github.com/containerd/containerd v1.5.18
 	github.com/go-kit/kit => github.com/go-kit/kit v0.12.0
 	github.com/nats-io/jwt/v2 => github.com/nats-io/jwt/v2 v2.2.0
 	github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.2


### PR DESCRIPTION
For GHSA-2qjp-425j-52j9, GHSA-259w-8hf6-59c2, and GHSA-hmfx-3pcx-653p