### PR TITLE
Remove generate call from agent lint target

### DIFF
--- a/pkg/signalfx-agent/Makefile
+++ b/pkg/signalfx-agent/Makefile
@@ -23,7 +23,6 @@ vetall:
 
 .PHONY: lint
 lint:
-	go generate ./...
 	@echo 'Linting LINUX code'
 	CGO_ENABLED=0 GOGC=40 golangci-lint run --allow-parallel-runners --timeout 10m
 	@echo 'Linting WINDOWS code'


### PR DESCRIPTION
Our lint action routinely times out, so removing a redundant generate call to help reduce build requirements.