### PR TITLE
add discovery config converter to respect existing service config

### DIFF
--- a/internal/common/discovery/discovery.go
+++ b/internal/common/discovery/discovery.go
@@ -27,6 +27,9 @@ const (
 	ReceiverNameAttr   = "discovery.receiver.name"
 	ReceiverTypeAttr   = "discovery.receiver.type"
 	StatusAttr         = "discovery.status"
+
+	DiscoExtensionsKey = "extensions/splunk.discovery"
+	DiscoReceiversKey  = "receivers/splunk.discovery"
 )
 
 var NoType = component.NewID("")

--- a/internal/configconverter/discovery.go
+++ b/internal/configconverter/discovery.go
@@ -1,0 +1,168 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configconverter
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/collector/confmap"
+
+	"github.com/signalfx/splunk-otel-collector/internal/common/discovery"
+)
+
+type Discovery struct{}
+
+// Convert will find `service::<extensions|receivers>/splunk.discovery` entries
+// provided by the discovery confmap.Provider and relocate them to
+// `service::extensions` and `service::pipelines::metrics::receivers`,
+// by appending them to existing sequences, if any.
+func (Discovery) Convert(_ context.Context, in *confmap.Conf) error {
+	if in == nil {
+		return nil
+	}
+
+	out := in.ToStringMap()
+	service, serviceExtensions, err := getServiceExtensions(out)
+	if err != nil {
+		return err
+	}
+	out["service"] = service
+
+	discoExtensionsIsSet, discoExtensions, err := getDiscoExtensions(service)
+	if err != nil {
+		return err
+	}
+
+	discoReceiversIsSet, discoReceivers, err := getDiscoReceivers(service)
+	if err != nil {
+		return err
+	}
+
+	// do nothing if discovery provider didn't modify config
+	if !discoExtensionsIsSet && !discoReceiversIsSet {
+		return nil
+	}
+
+	if len(discoExtensions) > 0 {
+		service["extensions"] = appendUnique(serviceExtensions, discoExtensions)
+	}
+
+	metricsPipeline, metricsReceivers, err := getMetricsPipelineAndReceivers(service)
+	if err != nil {
+		return err
+	}
+
+	if len(discoReceivers) > 0 {
+		metricsPipeline["receivers"] = appendUnique(metricsReceivers, discoReceivers)
+	}
+
+	*in = *confmap.NewFromStringMap(out)
+	return nil
+}
+
+func getServiceExtensions(out map[string]any) (map[string]any, []any, error) {
+	service := map[string]any{}
+	var serviceExtensions []any
+	if s, hasService := out["service"]; hasService && s != nil {
+		service = s.(map[string]any)
+		if ses, hasExtensions := service["extensions"]; hasExtensions && ses != nil {
+			var err error
+			if serviceExtensions, err = toAnySlice(ses); err != nil {
+				return nil, nil, fmt.Errorf("cannot determine service extensions: %w", err)
+			}
+		}
+	}
+	return service, serviceExtensions, nil
+}
+
+func getDiscoExtensions(service map[string]any) (bool, []any, error) {
+	var isSet bool
+	var extensions []any
+	if des, hasDiscoExtensions := service[discovery.DiscoExtensionsKey]; hasDiscoExtensions {
+		isSet = true
+		delete(service, discovery.DiscoExtensionsKey)
+		var err error
+		if extensions, err = toAnySlice(des); err != nil {
+			return false, nil, fmt.Errorf("cannot determine discovery extensions: %w", err)
+		}
+	}
+	return isSet, extensions, nil
+}
+
+func getDiscoReceivers(service map[string]any) (bool, []any, error) {
+	var isSet bool
+	var receivers []any
+	if des, hasDiscoReceivers := service[discovery.DiscoReceiversKey]; hasDiscoReceivers {
+		isSet = true
+		delete(service, discovery.DiscoReceiversKey)
+		var err error
+		if receivers, err = toAnySlice(des); err != nil {
+			return false, nil, fmt.Errorf("cannot determine discovery receivers: %w", err)
+		}
+	}
+	return isSet, receivers, nil
+}
+
+func getMetricsPipelineAndReceivers(service map[string]any) (map[string]any, []any, error) {
+	pipelines := map[string]any{}
+	if pl, ok := service["pipelines"]; ok && pl != nil {
+		pipelines = pl.(map[string]any)
+	}
+	service["pipelines"] = pipelines
+
+	metricsPipeline := map[string]any{}
+	if mp, ok := pipelines["metrics"]; ok && mp != nil {
+		metricsPipeline = mp.(map[string]any)
+	}
+	pipelines["metrics"] = metricsPipeline
+
+	var metricsReceivers []any
+	if mr, ok := metricsPipeline["receivers"]; ok && mr != nil {
+		var err error
+		if metricsReceivers, err = toAnySlice(mr); err != nil {
+			return nil, nil, fmt.Errorf("cannot determine metrics pipeline receivers: %w", err)
+		}
+	}
+	return metricsPipeline, metricsReceivers, nil
+}
+
+func appendUnique(serviceComponents []any, discoComponents []any) []any {
+	existing := map[any]struct{}{}
+	for _, e := range serviceComponents {
+		existing[e] = struct{}{}
+	}
+	for _, e := range discoComponents {
+		if _, exists := existing[e]; !exists {
+			serviceComponents = append(serviceComponents, e)
+		}
+	}
+	return serviceComponents
+}
+
+func toAnySlice(s any) ([]any, error) {
+	var out []any
+	switch v := s.(type) {
+	case []any:
+		out = v
+	case []string:
+		for _, i := range v {
+			out = append(out, i)
+		}
+	default:
+		return nil, fmt.Errorf("unexpected form %T", s)
+	}
+	return out, nil
+}

--- a/internal/configconverter/discovery_test.go
+++ b/internal/configconverter/discovery_test.go
@@ -1,0 +1,216 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configconverter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+	"gopkg.in/yaml.v3"
+)
+
+func TestDiscovery(t *testing.T) {
+	in := confFromYaml(t, `service:
+  extensions: [ext/one, ext/two, ext/three, ext/four]
+  extensions/splunk.discovery: [ext/four, ext/five]
+  pipelines:
+    metrics:
+      receivers: [recv/one, recv/two, recv/three, recv/four]
+      processors: [proc/one, proc/two, proc/three]
+      exporters: [exp/one, exp/two, exp/three]
+    metrics/untouched:
+      receivers: [recv/six, recv/seven, recv/eight]
+      processors: [proc/six, proc/seven, proc/eight]
+      exporters: [exp/six, exp/seven, exp/eight]
+  receivers/splunk.discovery: [recv/four, recv/five]
+`)
+
+	expected := confFromYaml(t, `service:
+  extensions: [ext/one, ext/two, ext/three, ext/four, ext/five]
+  pipelines:
+    metrics:
+      receivers: [recv/one, recv/two, recv/three, recv/four, recv/five]
+      processors: [proc/one, proc/two, proc/three]
+      exporters: [exp/one, exp/two, exp/three]
+    metrics/untouched:
+      receivers: [recv/six, recv/seven, recv/eight]
+      processors: [proc/six, proc/seven, proc/eight]
+      exporters: [exp/six, exp/seven, exp/eight]
+`)
+
+	require.NoError(t, Discovery{}.Convert(context.Background(), in))
+	require.Equal(t, expected.ToStringMap(), in.ToStringMap())
+}
+
+func TestDiscoveryNotDetected(t *testing.T) {
+	in := confFromYaml(t, `service:
+  extensions: [ext/one, ext/two, ext/three]
+  pipelines:
+    metrics:
+      receivers: [recv/one, recv/two, recv/three]
+      processors: [proc/one, proc/two, proc/three]
+      exporters: [exp/one, exp/two, exp/three]
+    metrics/untouched:
+      receivers: [recv/six, recv/seven, recv/eight]
+      processors: [proc/six, proc/seven, proc/eight]
+      exporters: [exp/six, exp/seven, exp/eight]
+`)
+
+	expected := confFromYaml(t, `service:
+  extensions: [ext/one, ext/two, ext/three]
+  pipelines:
+    metrics:
+      receivers: [recv/one, recv/two, recv/three]
+      processors: [proc/one, proc/two, proc/three]
+      exporters: [exp/one, exp/two, exp/three]
+    metrics/untouched:
+      receivers: [recv/six, recv/seven, recv/eight]
+      processors: [proc/six, proc/seven, proc/eight]
+      exporters: [exp/six, exp/seven, exp/eight]
+`)
+
+	require.NoError(t, Discovery{}.Convert(context.Background(), in))
+	require.Equal(t, expected.ToStringMap(), in.ToStringMap())
+}
+
+func TestDiscoveryExtensionsOnly(t *testing.T) {
+	in := confFromYaml(t, `service:
+  extensions/splunk.discovery: [ext/one, ext/two]
+  pipelines:
+    metrics:
+      receivers: [recv/one, recv/two, recv/three]
+      processors: [proc/one, proc/two, proc/three]
+      exporters: [exp/one, exp/two, exp/three]
+    metrics/untouched:
+      receivers: [recv/six, recv/seven, recv/eight]
+      processors: [proc/six, proc/seven, proc/eight]
+      exporters: [exp/six, exp/seven, exp/eight]
+`)
+
+	expected := confFromYaml(t, `service:
+  extensions: [ext/one, ext/two]
+  pipelines:
+    metrics:
+      receivers: [recv/one, recv/two, recv/three]
+      processors: [proc/one, proc/two, proc/three]
+      exporters: [exp/one, exp/two, exp/three]
+    metrics/untouched:
+      receivers: [recv/six, recv/seven, recv/eight]
+      processors: [proc/six, proc/seven, proc/eight]
+      exporters: [exp/six, exp/seven, exp/eight]
+`)
+
+	require.NoError(t, Discovery{}.Convert(context.Background(), in))
+	require.Equal(t, expected.ToStringMap(), in.ToStringMap())
+}
+
+func TestDiscoveryEmptyExtensions(t *testing.T) {
+	in := confFromYaml(t, `service:
+  extensions/splunk.discovery: []
+  pipelines:
+    metrics:
+      receivers: [recv/one, recv/two, recv/three]
+      processors: [proc/one, proc/two, proc/three]
+      exporters: [exp/one, exp/two, exp/three]
+    metrics/untouched:
+      receivers: [recv/six, recv/seven, recv/eight]
+      processors: [proc/six, proc/seven, proc/eight]
+      exporters: [exp/six, exp/seven, exp/eight]
+  receivers/splunk.discovery: [recv/four, recv/five]
+`)
+
+	expected := confFromYaml(t, `service:
+  pipelines:
+    metrics:
+      receivers: [recv/one, recv/two, recv/three, recv/four, recv/five]
+      processors: [proc/one, proc/two, proc/three]
+      exporters: [exp/one, exp/two, exp/three]
+    metrics/untouched:
+      receivers: [recv/six, recv/seven, recv/eight]
+      processors: [proc/six, proc/seven, proc/eight]
+      exporters: [exp/six, exp/seven, exp/eight]
+`)
+
+	require.NoError(t, Discovery{}.Convert(context.Background(), in))
+	require.Equal(t, expected.ToStringMap(), in.ToStringMap())
+}
+
+func TestDiscoveryReceiversOnly(t *testing.T) {
+	in := confFromYaml(t, `service:
+  pipelines:
+    metrics:
+      receivers: []
+      processors: [proc/one, proc/two, proc/three]
+      exporters: [exp/one, exp/two, exp/three]
+    metrics/untouched:
+      receivers: [recv/six, recv/seven, recv/eight]
+      processors: [proc/six, proc/seven, proc/eight]
+      exporters: [exp/six, exp/seven, exp/eight]
+  receivers/splunk.discovery: [recv/one, recv/two]
+`)
+
+	expected := confFromYaml(t, `service:
+  pipelines:
+    metrics:
+      receivers: [recv/one, recv/two]
+      processors: [proc/one, proc/two, proc/three]
+      exporters: [exp/one, exp/two, exp/three]
+    metrics/untouched:
+      receivers: [recv/six, recv/seven, recv/eight]
+      processors: [proc/six, proc/seven, proc/eight]
+      exporters: [exp/six, exp/seven, exp/eight]
+`)
+
+	require.NoError(t, Discovery{}.Convert(context.Background(), in))
+	require.Equal(t, expected.ToStringMap(), in.ToStringMap())
+}
+
+func TestDiscoveryEmptyReceivers(t *testing.T) {
+	in := confFromYaml(t, `service:
+  pipelines:
+    metrics:
+      processors: [proc/one, proc/two, proc/three]
+      exporters: [exp/one, exp/two, exp/three]
+    metrics/untouched:
+      receivers: [recv/six, recv/seven, recv/eight]
+      processors: [proc/six, proc/seven, proc/eight]
+      exporters: [exp/six, exp/seven, exp/eight]
+  receivers/splunk.discovery: []
+`)
+
+	expected := confFromYaml(t, `service:
+  pipelines:
+    metrics:
+      processors: [proc/one, proc/two, proc/three]
+      exporters: [exp/one, exp/two, exp/three]
+    metrics/untouched:
+      receivers: [recv/six, recv/seven, recv/eight]
+      processors: [proc/six, proc/seven, proc/eight]
+      exporters: [exp/six, exp/seven, exp/eight]
+`)
+
+	require.NoError(t, Discovery{}.Convert(context.Background(), in))
+	require.Equal(t, expected.ToStringMap(), in.ToStringMap())
+}
+
+func confFromYaml(t testing.TB, content string) *confmap.Conf {
+	var conf map[string]any
+	if err := yaml.Unmarshal([]byte(content), &conf); err != nil {
+		t.Errorf("failed loading conf from yaml: %v", err)
+	}
+	return confmap.NewFromStringMap(conf)
+}

--- a/internal/confmapprovider/discovery/README.md
+++ b/internal/confmapprovider/discovery/README.md
@@ -96,7 +96,7 @@ Discovery mode will:
 [Discovery Receiver](../../receiver/discoveryreceiver/README.md) instance to receive discovery events from all
 successfully started observers.
 1. Wait 10s or the configured `SPLUNK_DISCOVERY_DURATION` environment variable [`time.Duration`](https://pkg.go.dev/time#ParseDuration).
-1. Embed any receiver instances' configs resulting in a `discovery.status` of `successful` inside a `receiver_creator/discovery` receiver's configuration to be passed to the final Collector service config (or outputted w/ `--dry-run`).
+1. Embed any receiver instances' configs resulting in a `discovery.status` of `successful` inside a `receiver_creator/discovery` receiver's configuration to be passed to the final Collector service config in a new or existing `service::pipelines::metrics::receivers` sequence (or outputted w/ `--dry-run`). Any required observers will be added to `service::extensions`.
 1. Log any receiver resulting in a `discovery.status` of `partial` with the configured guidance for setting any relevant discovery properties.
 1. Stop all temporary components before continuing on to the actual Collector service (or exiting early with `--dry-run`).
 

--- a/internal/confmapprovider/discovery/discoverer.go
+++ b/internal/confmapprovider/discovery/discoverer.go
@@ -428,17 +428,14 @@ func (d *discoverer) discoveryConfig(cfg *Config) (map[string]any, error) {
 			receiverAdded = true
 		}
 	}
+
 	if receiverAdded {
-		if err := dCfg.Merge(confmap.NewFromStringMap(map[string]any{
-			"service": map[string]any{
-				"pipelines": map[string]any{
-					"metrics": map[string]any{
-						"receivers": []string{"receiver_creator/discovery"},
-					},
-				},
-			},
-		})); err != nil {
-			return nil, fmt.Errorf("failed adding receiver_creator/discovery to metrics pipeline: %w", err)
+		if err := dCfg.Merge(
+			confmap.NewFromStringMap(
+				map[string]any{"service": map[string]any{discovery.DiscoReceiversKey: []string{"receiver_creator/discovery"}}},
+			),
+		); err != nil {
+			return nil, fmt.Errorf("failed forming suggested discovery receivers array: %w", err)
 		}
 	}
 
@@ -464,7 +461,7 @@ func (d *discoverer) discoveryConfig(cfg *Config) (map[string]any, error) {
 	if len(observers) > 0 {
 		if err := dCfg.Merge(
 			confmap.NewFromStringMap(
-				map[string]any{"service": map[string]any{"extensions": observers}},
+				map[string]any{"service": map[string]any{discovery.DiscoExtensionsKey: observers}},
 			),
 		); err != nil {
 			return nil, fmt.Errorf("failed forming suggested discovery observer extensions array: %w", err)

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -146,6 +146,7 @@ func getConfigDir(f *Settings) string {
 func (s *Settings) ConfMapConverters() []confmap.Converter {
 	confMapConverters := []confmap.Converter{
 		configconverter.NewOverwritePropertiesConverter(s.setProperties),
+		configconverter.Discovery{},
 	}
 	if !s.noConvertConfig {
 		confMapConverters = append(

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -113,6 +113,7 @@ func TestNewSettingsNoConvertConfig(t *testing.T) {
 	}, settings.ResolverURIs())
 	require.Equal(t, []confmap.Converter{
 		configconverter.NewOverwritePropertiesConverter(settings.setProperties),
+		configconverter.Discovery{},
 	}, settings.ConfMapConverters())
 	require.Equal(t, []string{"--feature-gates", "foo", "--feature-gates", "-bar"}, settings.ColCoreArgs())
 }
@@ -140,6 +141,7 @@ func TestNewSettingsConvertConfig(t *testing.T) {
 	require.Equal(t, []string{configPath, anotherConfigPath}, settings.ResolverURIs())
 	require.Equal(t, []confmap.Converter{
 		configconverter.NewOverwritePropertiesConverter(settings.setProperties),
+		configconverter.Discovery{},
 		configconverter.RemoveBallastKey{},
 		configconverter.MoveOTLPInsecureKey{},
 		configconverter.MoveHecTLS{},

--- a/tests/general/discoverymode/docker_observer_discovery_test.go
+++ b/tests/general/discoverymode/docker_observer_discovery_test.go
@@ -146,12 +146,8 @@ func TestDockerObserver(t *testing.T) {
 				},
 			},
 			"service": map[string]any{
-				"extensions": []any{"docker_observer"},
-				"pipelines": map[string]any{
-					"metrics": map[string]any{
-						"receivers": []any{"receiver_creator/discovery"},
-					},
-				},
+				"extensions/splunk.discovery": []any{"docker_observer"},
+				"receivers/splunk.discovery":  []any{"receiver_creator/discovery"},
 			},
 		},
 		"splunk.property": map[string]any{},

--- a/tests/general/discoverymode/host_observer_discovery_test.go
+++ b/tests/general/discoverymode/host_observer_discovery_test.go
@@ -169,12 +169,8 @@ func TestHostObserver(t *testing.T) {
 				},
 			},
 			"service": map[string]any{
-				"extensions": []any{"host_observer"},
-				"pipelines": map[string]any{
-					"metrics": map[string]any{
-						"receivers": []any{"receiver_creator/discovery"},
-					},
-				},
+				"extensions/splunk.discovery": []any{"host_observer"},
+				"receivers/splunk.discovery":  []any{"receiver_creator/discovery"},
 			},
 		},
 		"splunk.property": map[string]any{},


### PR DESCRIPTION
The initial behavior of discovery mode for receiver and extension suggestions was destructive to existing service config* components. These changes add a new discovery config converter to append the components by way of temporary `service::extensions/splunk.discovery` and `service::receivers/splunk.discovery` intermediaries.