### PR TITLE
Update lint target and job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -89,11 +89,18 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
 
+      - run: echo "GOLANGCI_LINT_CACHE=${HOME}/.cache/golangci-lint" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.GOLANGCI_LINT_CACHE }}
+          key: golangci-lint-${{ hashFiles('**/.golangci.yml', '**/*.go', '**/go.sum') }}
+
       - name: Lint
         run: |
           make install-tools
-          make -j4 for-all CMD="make checklicense impi lint misspell"
-  
+          make for-all CMD="make lint"
+
   test:
     name: test
     # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ run:
   concurrency: 4
 
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 10m
+  timeout: 15m
 
   # exit code when at least one issue was found, default is 1
   issues-exit-code: 1

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,6 @@ TO_MOD_DIR=dirname {} \; | sort | egrep  '^./'
 # NONROOT_MODS includes ./* dirs (excludes . dir)
 NONROOT_MODS := $(shell find . $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
 
-# CircleCI runtime.NumCPU() is for host machine despite container instance only granting 2.
-# If we are in a CI job, limit to 2 (and scale as we increase executor size).
-NUM_CORES := $(shell if [ -z ${CIRCLE_JOB} ]; then echo `getconf _NPROCESSORS_ONLN` ; else echo 2; fi )
 GOTEST=go test -p $(NUM_CORES)
 
 # Currently integration tests are flakey when run in parallel due to internal metric and config server conflicts

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -19,6 +19,7 @@ LINT=golangci-lint
 IMPI=impi
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release
+NUM_CORES := $(shell getconf _NPROCESSORS_ONLN)
 
 ALL_PKG_DIRS := $(shell $(GOCMD) list -f '{{ .Dir }}' ./... | sort)
 
@@ -90,8 +91,8 @@ fmt: addlicense misspell-correction
 	fieldalignment -fix ./... || true
 
 .PHONY: lint
-lint: checklicense misspell
-	$(LINT) run --allow-parallel-runners --timeout 10m
+lint: checklicense misspell impi
+	$(LINT) run --allow-parallel-runners -j$(NUM_CORES)
 
 .PHONY: tidy
 tidy:

--- a/pkg/signalfx-agent/Makefile
+++ b/pkg/signalfx-agent/Makefile
@@ -24,9 +24,9 @@ vetall:
 .PHONY: lint
 lint:
 	@echo 'Linting LINUX code'
-	CGO_ENABLED=0 GOGC=40 golangci-lint run --allow-parallel-runners --timeout 10m
+	CGO_ENABLED=0 GOGC=40 golangci-lint run --allow-parallel-runners --timeout 10m -j$(NUM_CORES)
 	@echo 'Linting WINDOWS code'
-	GOOS=windows CGO_ENABLED=0 GOGC=40 golangci-lint run --allow-parallel-runners --timeout 10m
+	GOOS=windows CGO_ENABLED=0 GOGC=40 golangci-lint run --allow-parallel-runners --timeout 10m -j$(NUM_CORES)
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
The `lint` github job usually takes over 20m and frequently fails due to `golangci-lint` timeouts
- Increase `golangci-lint` timeout to 15m
- Use `-j$(NUM_CORES)` for concurrency
- Add `impi` to `lint` make target
- Remove redundant calls to `checklicense`, `impi`, and `misspell` targets in the job
- Cache `${HOME}/.cache/golangci-lint` in the job to help reduce run time (~25% faster)