### PR TITLE
set sql monitor logger type from config

### DIFF
--- a/pkg/signalfx-agent/pkg/monitors/sql/monitor.go
+++ b/pkg/signalfx-agent/pkg/monitors/sql/monitor.go
@@ -25,8 +25,6 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/utils"
 )
 
-var logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType})
-
 func init() {
 	monitors.Register(&monitorMetadata, func() interface{} { return &Monitor{} }, &Config{})
 }
@@ -152,7 +150,7 @@ type Monitor struct {
 
 // Configure the monitor and kick off metric gathering
 func (m *Monitor) Configure(conf *Config) error {
-	m.logger = logger.WithField("monitorID", conf.MonitorID)
+	m.logger = logrus.WithField("monitorType", conf.Type).WithField("monitorID", conf.MonitorID)
 	m.ctx, m.cancel = context.WithCancel(context.Background())
 
 	// This will "open" a database by verifying that the config is sane but


### PR DESCRIPTION
The sql monitor is wrapped by a number of other monitors, and their type isn't used in underlying query statements (causing issues w/ logrus->zap agent receiver shim). These changes take the type value from the user config instead of hardcoded "sql".