### PR TITLE
discovery receiver: provide zap fields to regexp and expr

### DIFF
--- a/internal/receiver/discoveryreceiver/evaluator.go
+++ b/internal/receiver/discoveryreceiver/evaluator.go
@@ -99,6 +99,7 @@ func (e *evaluator) evaluateMatch(match Match, pattern string, status discovery.
 		}
 	}
 
+	e.logger.Debug(fmt.Sprintf("evaluated match %v against %q (should log: %v)", matchPattern, pattern, shouldLog))
 	return shouldLog, nil
 }
 

--- a/internal/receiver/discoveryreceiver/evaluator.go
+++ b/internal/receiver/discoveryreceiver/evaluator.go
@@ -31,6 +31,9 @@ import (
 	"github.com/signalfx/splunk-otel-collector/internal/common/discovery"
 )
 
+// exprEnvFunc is to create an expr.Env function from pattern content.
+type exprEnvFunc func(pattern string) map[string]any
+
 // evaluator is the base status matcher that determines if telemetry warrants emitting a matching log record.
 // It also provides embedded config correlation that its embedding structs will utilize.
 type evaluator struct {
@@ -40,8 +43,17 @@ type evaluator struct {
 	// if match.FirstOnly this ~sync.Map(map[string]struct{}) keeps track of
 	// whether we've already emitted a record for the statement and can skip processing.
 	alreadyLogged *sync.Map
-	exprEnv       func(pattern string) map[string]any
-	id            component.ID
+	exprEnv       exprEnvFunc
+}
+
+func newEvaluator(logger *zap.Logger, config *Config, correlations correlationStore, envFunc exprEnvFunc) *evaluator {
+	return &evaluator{
+		logger:        logger,
+		config:        config,
+		correlations:  correlations,
+		alreadyLogged: &sync.Map{},
+		exprEnv:       envFunc,
+	}
 }
 
 // evaluateMatch parses the provided Match and returns whether it warrants a status log record
@@ -67,12 +79,15 @@ func (e *evaluator) evaluateMatch(match Match, pattern string, status discovery.
 	case match.Expr != "":
 		matchPattern = match.Expr
 		var program *vm.Program
+		// we need a way to look up fields that aren't valid identifiers https://github.com/antonmedv/expr/issues/106
+		env := e.exprEnv(pattern)
+		env["ExprEnv"] = env
 		// TODO: cache compiled programs for performance benefit
-		if program, err = expr.Compile(match.Expr, expr.Env(e.exprEnv(pattern))); err != nil {
+		if program, err = expr.Compile(match.Expr, expr.Env(env)); err != nil {
 			err = fmt.Errorf("invalid match expr statement: %w", err)
 		} else {
 			matchFunc = func(p string) (bool, error) {
-				ret, runErr := vm.Run(program, e.exprEnv(p))
+				ret, runErr := vm.Run(program, env)
 				if runErr != nil {
 					return false, runErr
 				}

--- a/internal/receiver/discoveryreceiver/evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/evaluator_test.go
@@ -25,13 +25,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap"
 
 	"github.com/signalfx/splunk-otel-collector/internal/common/discovery"
 )
 
-func setup(t testing.TB) (*evaluator, component.ID, observer.EndpointID) {
-	logger := zaptest.NewLogger(t)
+func setup() (*evaluator, component.ID, observer.EndpointID) {
+	// If debugging tests, replace the Nop Logger with a test instance to see
+	// all statements. Not in regular use to avoid spamming output.
+	// logger := zaptest.NewLogger(t)
+	logger := zap.NewNop()
 	alreadyLogged := &sync.Map{}
 	eval := &evaluator{
 		logger:        logger,
@@ -49,7 +52,7 @@ func setup(t testing.TB) (*evaluator, component.ID, observer.EndpointID) {
 }
 
 func TestEvaluateMatch(t *testing.T) {
-	eval, receiverID, endpointID := setup(t)
+	eval, receiverID, endpointID := setup()
 	anotherReceiverID := component.NewIDWithName("type", "another.name")
 
 	for _, tc := range []struct {
@@ -87,7 +90,7 @@ func TestEvaluateMatch(t *testing.T) {
 }
 
 func TestEvaluateInvalidMatch(t *testing.T) {
-	eval, receiverID, endpointID := setup(t)
+	eval, receiverID, endpointID := setup()
 
 	for _, tc := range []struct {
 		typ           string
@@ -109,7 +112,7 @@ func TestEvaluateInvalidMatch(t *testing.T) {
 func TestCorrelateResourceAttrs(t *testing.T) {
 	for _, embed := range []bool{false, true} {
 		t.Run(fmt.Sprintf("embed-%v", embed), func(t *testing.T) {
-			eval, _, endpointID := setup(t)
+			eval, _, endpointID := setup()
 			eval.config.EmbedReceiverConfig = embed
 
 			endpoint := observer.Endpoint{ID: endpointID}
@@ -158,7 +161,7 @@ func TestCorrelateResourceAttrs(t *testing.T) {
 func TestCorrelateResourceAttrsWithExistingConfig(t *testing.T) {
 	for _, embed := range []bool{false, true} {
 		t.Run(fmt.Sprintf("embed-%v", embed), func(t *testing.T) {
-			eval, _, endpointID := setup(t)
+			eval, _, endpointID := setup()
 			eval.config.EmbedReceiverConfig = embed
 
 			endpoint := observer.Endpoint{ID: endpointID}

--- a/internal/receiver/discoveryreceiver/metric_evaluator.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator.go
@@ -17,10 +17,8 @@ package discoveryreceiver
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -50,20 +48,15 @@ type metricEvaluator struct {
 	pLogs chan plog.Logs
 }
 
-func newMetricEvaluator(logger *zap.Logger, id component.ID, cfg *Config, pLogs chan plog.Logs, correlations correlationStore) *metricEvaluator {
+func newMetricEvaluator(logger *zap.Logger, cfg *Config, pLogs chan plog.Logs, correlations correlationStore) *metricEvaluator {
 	return &metricEvaluator{
 		pLogs: pLogs,
-		evaluator: &evaluator{
-			logger:        logger,
-			config:        cfg,
-			correlations:  correlations,
-			alreadyLogged: &sync.Map{},
+		evaluator: newEvaluator(logger, cfg, correlations,
 			// TODO: provide more capable env w/ resource and metric attributes
-			exprEnv: func(pattern string) map[string]any {
+			func(pattern string) map[string]any {
 				return map[string]any{"name": pattern}
 			},
-			id: id,
-		},
+		),
 	}
 }
 

--- a/internal/receiver/discoveryreceiver/receiver.go
+++ b/internal/receiver/discoveryreceiver/receiver.go
@@ -99,7 +99,7 @@ func (d *discoveryReceiver) Start(ctx context.Context, host component.Host) (err
 	d.endpointTracker = newEndpointTracker(d.observables, d.config, d.logger, d.pLogs, correlations)
 	d.endpointTracker.start()
 
-	d.metricEvaluator = newMetricEvaluator(d.logger, d.settings.ID, d.config, d.pLogs, correlations)
+	d.metricEvaluator = newMetricEvaluator(d.logger, d.config, d.pLogs, correlations)
 
 	if d.statementEvaluator, err = newStatementEvaluator(d.logger, d.settings.ID, d.config, d.pLogs, correlations); err != nil {
 		return fmt.Errorf("failed creating statement evaluator: %w", err)

--- a/internal/receiver/discoveryreceiver/statement_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator_test.go
@@ -27,7 +27,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest"
 
 	"github.com/signalfx/splunk-otel-collector/internal/common/discovery"
 	"github.com/signalfx/splunk-otel-collector/internal/receiver/discoveryreceiver/statussources"
@@ -222,7 +221,7 @@ func TestLogRecordDefaultAndArbitrarySeverityText(t *testing.T) {
 
 	plogs := make(chan plog.Logs)
 
-	logger := zaptest.NewLogger(t)
+	logger := zap.NewNop()
 	cStore := newCorrelationStore(logger, time.Hour)
 	cStore.UpdateEndpoint(
 		observer.Endpoint{ID: "endpoint.id"},

--- a/tests/general/discoverymode/testdata/k8s-observer-config.d/receivers/smart-agent-redis.discovery.yaml
+++ b/tests/general/discoverymode/testdata/k8s-observer-config.d/receivers/smart-agent-redis.discovery.yaml
@@ -17,7 +17,7 @@ smartagent:
               body: Successfully scraped metrics from redis pod
     statements:
       failed:
-        - regexp: "^redis_info plugin: Error connecting to .* - ConnectionRefusedError.*$"
+        - regexp: "message: redis_info plugin: Error connecting to .* - ConnectionRefusedError"
           first_only: true
           log_record:
             severity_text: debug

--- a/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
+++ b/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
@@ -31,7 +31,17 @@ receivers:
                 first_only: true
                 log_record:
                   severity_text: debug
-                  body: Port appears to not be serving prometheus metrics
+                  body: (strict) Port appears to not be serving prometheus metrics
+              - regexp: 'message: Failed to scrape Prometheus endpoint'
+                first_only: true
+                log_record:
+                  severity_text: debug
+                  body: (regexp) Port appears to not be serving prometheus metrics
+              - expr: message == 'Failed to scrape Prometheus endpoint' && target_labels contains 'up'
+                first_only: true
+                log_record:
+                  severity_text: debug
+                  body: (expr) Port appears to not be serving prometheus metrics
 
     watch_observers:
       - host_observer

--- a/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
+++ b/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
@@ -21,25 +21,6 @@ resource_logs:
             severity: 0
             severity_text: info
   - attributes:
-      discovery.endpoint.id: (host_observer)[::]-4318-TCP-1
-      discovery.event.type: statement.match
-      discovery.observer.id: host_observer
-      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyCg==
-      discovery.receiver.name: ""
-      discovery.receiver.rule: type == "hostport"
-      discovery.receiver.type: prometheus_simple
-    scope_logs:
-      - logs:
-          - body: Port appears to not be serving prometheus metrics
-            attributes:
-              caller: <ANY>
-              discovery.status: failed
-              kind: receiver
-              name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer)[::]-4318-TCP-1
-              target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
-            severity: 0
-            severity_text: debug
-  - attributes:
       discovery.endpoint.id: (host_observer/with_name)[::]-8888-TCP-1
       discovery.event.type: metric.match
       discovery.observer.id: host_observer/with_name
@@ -60,25 +41,6 @@ resource_logs:
               metric.name: otelcol_receiver_accepted_metric_points
             severity: 0
             severity_text: info
-  - attributes:
-      discovery.endpoint.id: (host_observer/with_name)[::]-4318-TCP-1
-      discovery.event.type: statement.match
-      discovery.observer.id: host_observer/with_name
-      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyL3dpdGhfbmFtZQo=
-      discovery.receiver.name: ""
-      discovery.receiver.rule: type == "hostport"
-      discovery.receiver.type: prometheus_simple
-    scope_logs:
-      - logs:
-          - body: Port appears to not be serving prometheus metrics
-            attributes:
-              caller: <ANY>
-              discovery.status: failed
-              kind: receiver
-              name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer/with_name)[::]-4318-TCP-1
-              target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
-            severity: 0
-            severity_text: debug
   - attributes:
       discovery.endpoint.id: (host_observer/with/another/name)[::]-8888-TCP-1
       discovery.event.type: metric.match
@@ -101,6 +63,44 @@ resource_logs:
             severity: 0
             severity_text: info
   - attributes:
+      discovery.endpoint.id: (host_observer)[::]-4318-TCP-1
+      discovery.event.type: statement.match
+      discovery.observer.id: host_observer
+      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyCg==
+      discovery.receiver.name: ""
+      discovery.receiver.rule: type == "hostport"
+      discovery.receiver.type: prometheus_simple
+    scope_logs:
+      - logs:
+          - body: (strict) Port appears to not be serving prometheus metrics
+            attributes:
+              caller: <ANY>
+              discovery.status: failed
+              kind: receiver
+              name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer)[::]-4318-TCP-1
+              target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
+            severity: 0
+            severity_text: debug
+  - attributes:
+      discovery.endpoint.id: (host_observer/with_name)[::]-4318-TCP-1
+      discovery.event.type: statement.match
+      discovery.observer.id: host_observer/with_name
+      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyL3dpdGhfbmFtZQo=
+      discovery.receiver.name: ""
+      discovery.receiver.rule: type == "hostport"
+      discovery.receiver.type: prometheus_simple
+    scope_logs:
+      - logs:
+          - body: (strict) Port appears to not be serving prometheus metrics
+            attributes:
+              caller: <ANY>
+              discovery.status: failed
+              kind: receiver
+              name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer/with_name)[::]-4318-TCP-1
+              target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
+            severity: 0
+            severity_text: debug
+  - attributes:
       discovery.endpoint.id: (host_observer/with/another/name)[::]-4318-TCP-1
       discovery.event.type: statement.match
       discovery.observer.id: host_observer/with/another/name
@@ -110,7 +110,121 @@ resource_logs:
       discovery.receiver.type: prometheus_simple
     scope_logs:
       - logs:
-          - body: Port appears to not be serving prometheus metrics
+          - body: (strict) Port appears to not be serving prometheus metrics
+            attributes:
+              caller: <ANY>
+              discovery.status: failed
+              kind: receiver
+              name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer/with/another/name)[::]-4318-TCP-1
+              target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
+            severity: 0
+            severity_text: debug
+  - attributes:
+      discovery.endpoint.id: (host_observer)[::]-4318-TCP-1
+      discovery.event.type: statement.match
+      discovery.observer.id: host_observer
+      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyCg==
+      discovery.receiver.name: ""
+      discovery.receiver.rule: type == "hostport"
+      discovery.receiver.type: prometheus_simple
+    scope_logs:
+      - logs:
+          - body: (regexp) Port appears to not be serving prometheus metrics
+            attributes:
+              caller: <ANY>
+              discovery.status: failed
+              kind: receiver
+              name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer)[::]-4318-TCP-1
+              target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
+            severity: 0
+            severity_text: debug
+  - attributes:
+      discovery.endpoint.id: (host_observer/with_name)[::]-4318-TCP-1
+      discovery.event.type: statement.match
+      discovery.observer.id: host_observer/with_name
+      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyL3dpdGhfbmFtZQo=
+      discovery.receiver.name: ""
+      discovery.receiver.rule: type == "hostport"
+      discovery.receiver.type: prometheus_simple
+    scope_logs:
+      - logs:
+          - body: (regexp) Port appears to not be serving prometheus metrics
+            attributes:
+              caller: <ANY>
+              discovery.status: failed
+              kind: receiver
+              name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer/with_name)[::]-4318-TCP-1
+              target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
+            severity: 0
+            severity_text: debug
+  - attributes:
+      discovery.endpoint.id: (host_observer/with/another/name)[::]-4318-TCP-1
+      discovery.event.type: statement.match
+      discovery.observer.id: host_observer/with/another/name
+      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyL3dpdGgvYW5vdGhlci9uYW1lCg==
+      discovery.receiver.name: ""
+      discovery.receiver.rule: type == "hostport"
+      discovery.receiver.type: prometheus_simple
+    scope_logs:
+      - logs:
+          - body: (regexp) Port appears to not be serving prometheus metrics
+            attributes:
+              caller: <ANY>
+              discovery.status: failed
+              kind: receiver
+              name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer/with/another/name)[::]-4318-TCP-1
+              target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
+            severity: 0
+            severity_text: debug
+  - attributes:
+      discovery.endpoint.id: (host_observer)[::]-4318-TCP-1
+      discovery.event.type: statement.match
+      discovery.observer.id: host_observer
+      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyCg==
+      discovery.receiver.name: ""
+      discovery.receiver.rule: type == "hostport"
+      discovery.receiver.type: prometheus_simple
+    scope_logs:
+      - logs:
+          - body: (expr) Port appears to not be serving prometheus metrics
+            attributes:
+              caller: <ANY>
+              discovery.status: failed
+              kind: receiver
+              name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer)[::]-4318-TCP-1
+              target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
+            severity: 0
+            severity_text: debug
+  - attributes:
+      discovery.endpoint.id: (host_observer/with_name)[::]-4318-TCP-1
+      discovery.event.type: statement.match
+      discovery.observer.id: host_observer/with_name
+      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyL3dpdGhfbmFtZQo=
+      discovery.receiver.name: ""
+      discovery.receiver.rule: type == "hostport"
+      discovery.receiver.type: prometheus_simple
+    scope_logs:
+      - logs:
+          - body: (expr) Port appears to not be serving prometheus metrics
+            attributes:
+              caller: <ANY>
+              discovery.status: failed
+              kind: receiver
+              name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer/with_name)[::]-4318-TCP-1
+              target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
+            severity: 0
+            severity_text: debug
+  - attributes:
+      discovery.endpoint.id: (host_observer/with/another/name)[::]-4318-TCP-1
+      discovery.event.type: statement.match
+      discovery.observer.id: host_observer/with/another/name
+      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiCndhdGNoX29ic2VydmVyczoKLSBob3N0X29ic2VydmVyL3dpdGgvYW5vdGhlci9uYW1lCg==
+      discovery.receiver.name: ""
+      discovery.receiver.rule: type == "hostport"
+      discovery.receiver.type: prometheus_simple
+    scope_logs:
+      - logs:
+          - body: (expr) Port appears to not be serving prometheus metrics
             attributes:
               caller: <ANY>
               discovery.status: failed


### PR DESCRIPTION
In some cases the most helpful information from a logged statement is in its zap fields, which are currently unavailable to the statement evaluator. These changes add all fields not including `name`, `caller`, and `stacktrace` to the matched pattern for regexp and expr match types. Also includes adding an `ExprEnv` object for accessing fields that make invalid identifiers.

These changes are breaking for both regexp and expr. It's my opinion that these are ok to land without transitional guidance as the component is still in development.

regexp: Since the pattern is no longer just the message, `^$` start and end identifiers will likely no longer lead to matches. `message: ` prefixes can reasonably* replace `^`, and `$` will persist where no fields are logged.

expr: The env has been updated to use `message` instead of `msg`. 