### PR TITLE
add defaultValue bundle.d helper

### DIFF
--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml
@@ -10,9 +10,9 @@ smartagent/postgresql:
       type: postgresql
       connectionString: 'sslmode=disable user={{.username}} password={{.password}}'
       params:
-        username: bundle.default
-        password: bundle.default
-      masterDBName: postgres
+        username: splunk.discovery
+        password: splunk.discovery
+      masterDBName: splunk.discovery
   status:
     metrics:
       successful:

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml.tmpl
@@ -7,9 +7,9 @@
       type: postgresql
       connectionString: 'sslmode=disable user={{ "{{.username}}" }} password={{ "{{.password}}" }}'
       params:
-        username: bundle.default
-        password: bundle.default
-      masterDBName: postgres
+        username: {{ defaultValue }}
+        password: {{ defaultValue }}
+      masterDBName: {{ defaultValue }}
   status:
     metrics:
       successful:

--- a/internal/confmapprovider/discovery/bundle/templatefunctions.go
+++ b/internal/confmapprovider/discovery/bundle/templatefunctions.go
@@ -26,6 +26,8 @@ import (
 	"github.com/signalfx/splunk-otel-collector/internal/confmapprovider/discovery/properties"
 )
 
+const defaultValue = "splunk.discovery"
+
 func FuncMap() template.FuncMap {
 	dc := newDiscoveryConfig()
 	return map[string]any{
@@ -33,6 +35,7 @@ func FuncMap() template.FuncMap {
 		"configPropertyEnvVar": dc.configPropertyEnvVar,
 		"extension":            dc.extension,
 		"receiver":             dc.receiver,
+		"defaultValue":         func() string { return defaultValue },
 	}
 }
 

--- a/internal/confmapprovider/discovery/bundle/templatefunctions_test.go
+++ b/internal/confmapprovider/discovery/bundle/templatefunctions_test.go
@@ -15,7 +15,9 @@
 package bundle
 
 import (
+	"bytes"
 	"testing"
+	"text/template"
 
 	"github.com/stretchr/testify/require"
 )
@@ -25,6 +27,7 @@ func TestFuncMap(t *testing.T) {
 	functions := []string{
 		"configProperty",
 		"configPropertyEnvVar",
+		"defaultValue",
 		"extension",
 		"receiver",
 	}
@@ -108,4 +111,12 @@ func TestExtensionConfigProperties(t *testing.T) {
 	prop, err = dc.configPropertyEnvVar("invalid")
 	require.EqualError(t, err, "configPropertyEnvVar takes key+ and value{1} arguments (minimum 2)")
 	require.Empty(t, prop)
+}
+
+func TestDefaultValue(t *testing.T) {
+	tmplt, err := template.New("").Funcs(FuncMap()).Parse("{{ defaultValue }}")
+	require.NoError(t, err)
+	out := &bytes.Buffer{}
+	require.NoError(t, tmplt.Execute(out, nil))
+	require.Equal(t, "splunk.discovery", out.String())
 }


### PR DESCRIPTION
The default auth and service field values for bundled discovery config should be transparent and uniform. These changes add a `{{ defaultValue }}` template function resolving to `"splunk.discovery"` so that the origin of requests is more clear than one-offs would allow.