### PR TITLE
Add generate-metrics job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,9 +68,32 @@ jobs:
       - name: gofmt
         run: |
           make install-tools
-          gofmt -s -w .
+          make fmt
           if ! git diff --exit-code; then
-            echo "One or more Go files are not formatted correctly. Run 'gofmt -s -w .' and push the changes."
+            echo "One or more Go files are not formatted correctly. Run 'make fmt' and push the changes."
+            exit 1
+          fi
+
+  generate-metrics:
+    name: generate-metrics
+    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
+    runs-on: ubuntu-20.04
+    needs: [setup-environment]
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
+
+      - name: generate-metrics
+        run: |
+          make generate-metrics
+          if ! git diff --exit-code; then
+            echo "Generated code is out of date. Run 'make generate-metrics' and push the changes."
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ install-tools:
 .PHONY: generate-metrics
 generate-metrics: install-tools
 	go generate -tags mdatagen ./...
+	$(MAKE) fmt
 
 .PHONY: otelcol
 otelcol:


### PR DESCRIPTION
For #3005:
- Add job to run `make generate-metrics` and fail if there are changes
- Update Makefile to run `make fmt` after mdatagen to ensure changes are formatted
- Change the `gofmt` job to run `make fmt` instead of only `gofmt -s -w .`