### PR TITLE
collectd/spark test: use working image

### DIFF
--- a/internal/buildscripts/packaging/tests/deployments/puppet/images/deb/Dockerfile.debian-stretch
+++ b/internal/buildscripts/packaging/tests/deployments/puppet/images/deb/Dockerfile.debian-stretch
@@ -1,5 +1,8 @@
 FROM debian:stretch
 
+RUN sed -i 's|http://.*.debian.org|http://archive.debian.org|' /etc/apt/sources.list
+RUN sed -i '/stretch-updates/d' /etc/apt/sources.list
+
 RUN apt-get update &&\
     apt-get install -yq ca-certificates procps systemd wget apt-transport-https libcap2-bin curl gnupg lsb-release
 

--- a/internal/buildscripts/packaging/tests/deployments/puppet/images/rpm/Dockerfile.centos-7
+++ b/internal/buildscripts/packaging/tests/deployments/puppet/images/rpm/Dockerfile.centos-7
@@ -2,7 +2,7 @@ FROM centos:7
 
 ENV container docker
 
-RUN yum install -y systemd procps initscripts
+RUN yum install -y systemd procps initscripts deltarpm
 
 ARG PUPPET_RELEASE="6"
 RUN rpm -Uvh https://yum.puppet.com/puppet${PUPPET_RELEASE}-release-el-7.noarch.rpm && \

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.debian-stretch
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.debian-stretch
@@ -2,6 +2,9 @@ FROM debian:stretch
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN sed -i 's|http://.*.debian.org|http://archive.debian.org|' /etc/apt/sources.list
+RUN sed -i '/stretch-updates/d' /etc/apt/sources.list
+
 RUN apt-get update && apt-get upgrade -y -o DPkg::Options::=--force-confold
 RUN apt-get install -y software-properties-common ca-certificates wget curl apt-transport-https python3-pip vim procps
 

--- a/internal/buildscripts/packaging/tests/images/deb/Dockerfile.debian-stretch
+++ b/internal/buildscripts/packaging/tests/images/deb/Dockerfile.debian-stretch
@@ -4,6 +4,9 @@ FROM debian:stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN sed -i 's|http://.*.debian.org|http://archive.debian.org|' /etc/apt/sources.list
+RUN sed -i '/stretch-updates/d' /etc/apt/sources.list
+
 RUN apt-get update &&\
     apt-get install -yq ca-certificates curl procps systemd wget
 

--- a/tests/receivers/smartagent/collectd-spark/testdata/server/Dockerfile
+++ b/tests/receivers/smartagent/collectd-spark/testdata/server/Dockerfile
@@ -1,7 +1,4 @@
-FROM gettyimages/spark:2.4.1-hadoop-3.0
-
-RUN apt-get update && \
-    apt-get install -y netcat procps
+FROM bitnami/spark:3.1.3
 
 EXPOSE 8080
 


### PR DESCRIPTION
Updating spark image since stretch packages appear to have been pulled from http://deb.debian.org/debian/dists