### PR TITLE
Update matrix for test-package job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -299,27 +299,55 @@ jobs:
           name: ${{ matrix.SYS_PACKAGE }}-${{ matrix.ARCH }}-package
           path: ./dist/splunk-otel-collector*
 
+  test-package-matrix:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Get matrix
+        id: get-matrix
+        run: |
+          # create test matrix for distro and arch
+          dockerfiles=$(find internal/buildscripts/packaging/tests/images/ -name "Dockerfile.*" | cut -d '.' -f2- | sort -u)
+          if [ -z "$dockerfiles" ]; then
+            echo "Failed to get dockerfiles from internal/buildscripts/packaging/tests/images!" >&2
+            exit 1
+          fi
+          distro=$(for d in $dockerfiles; do echo -n "\"$d\","; done)
+          arch="\"amd64\", \"arm64\""
+          matrix="{\"DISTRO\": [${distro%,}], \"ARCH\": [${arch}]}"
+          echo "$matrix" | jq
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+    outputs:
+      matrix: ${{ steps.get-matrix.outputs.matrix }}
+
   test-package:
     # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
     runs-on: ubuntu-20.04
-    timeout-minutes: 60
-    needs: [build-package]
+    timeout-minutes: 20
+    needs: [build-package, test-package-matrix]
     strategy:
-      matrix:
-        SYS_PACKAGE: [ "deb", "rpm", "tar" ]
-        ARCH: [ "amd64", "arm64" ]
-        TEST_CASE: [ "install", "upgrade" ]
-        exclude:
-          - SYS_PACKAGE: "tar"
-            TEST_CASE: "upgrade"
+      matrix: ${{ fromJSON(needs.test-package-matrix.outputs.matrix) }}
       fail-fast: false
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v3
 
+      - name: Get package type for ${{ matrix.DISTRO }}
+        run: |
+          for pkg in "deb" "rpm" "tar"; do
+            if [[ -f "internal/buildscripts/packaging/tests/images/${pkg}/Dockerfile.${{ matrix.DISTRO }}" ]]; then
+              echo "SYS_PACKAGE=${pkg}" >> $GITHUB_ENV
+              exit 0
+            fi
+          done
+          echo "Unknown distro '${{ matrix.DISTRO }}'!"
+          exit 1
+
       - uses: actions/download-artifact@v3
         with:
-          name: ${{ matrix.SYS_PACKAGE }}-${{ matrix.ARCH }}-package
+          name: ${{ env.SYS_PACKAGE }}-${{ matrix.ARCH }}-package
           path: ./dist
 
       - uses: docker/setup-qemu-action@v2
@@ -344,21 +372,16 @@ jobs:
           fi
           pip install -r "${{ env.REQUIREMENTS_PATH }}"
 
-      - name: Test ${{ matrix.SYS_PACKAGE }} ${{ matrix.ARCH }} package ${{ matrix.TEST_CASE }}
+      - name: Test ${{ env.SYS_PACKAGE }} on ${{ matrix.DISTRO }} ${{ matrix.ARCH }}
         run: |
-          mkdir -p ${{ env.RESULT_PATH }}
-          pytest -n2 --verbose -m ${{ matrix.SYS_PACKAGE }} \
-            -k "${{ matrix.ARCH }} and ${{ matrix.TEST_CASE }}" \
-            --junitxml=${{ env.RESULT_PATH }}/results.xml \
-            --html=${{ env.RESULT_PATH }}/results.html \
-            --self-contained-html \
+          distro="${{ matrix.DISTRO }}"
+          if [[ "$distro" = "amazonlinux-2" ]]; then
+            # workaround for pytest substring matching
+            distro="amazonlinux-2 and not amazonlinux-2023"
+          fi
+          pytest -s --verbose -m "${{ env.SYS_PACKAGE }}" \
+            -k "$distro and ${{ matrix.ARCH }}" \
             internal/buildscripts/packaging/tests/package_test.py
-
-      - name: Uploading test result artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.SYS_PACKAGE }}-${{ matrix.ARCH }}-${{ matrix.TEST_CASE }}-test-result
-          path: ${{ env.RESULT_PATH }}
 
   windows-msi:
     name: windows-msi


### PR DESCRIPTION
- Dynamically create the matrix for the `test-package` job for supported distros and archs
- Reduce workflow run times and failures due to job timeouts