### PR TITLE
Add binaries-darwin_arm64 make target

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -193,7 +193,7 @@ jobs:
     needs: [setup-environment]
     strategy:
       matrix:
-        SYS_BINARIES: [ "binaries-darwin_amd64", "binaries-linux_amd64", "binaries-linux_arm64", "binaries-windows_amd64", "binaries-linux_ppc64le" ]
+        SYS_BINARIES: [ "binaries-darwin_amd64", "binaries-darwin_arm64", "binaries-linux_amd64", "binaries-linux_arm64", "binaries-windows_amd64", "binaries-linux_ppc64le" ]
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v3

--- a/.github/workflows/darwin-test.yml
+++ b/.github/workflows/darwin-test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
-        OS: [ "macos-11", "macos-12" ]
+        OS: [ "macos-11", "macos-12", "macos-11-arm64" ]
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -162,7 +162,7 @@ compile:
   stage: build
   parallel:
     matrix:
-      - TARGET: [binaries-darwin_amd64, binaries-linux_amd64, binaries-linux_arm64, binaries-windows_amd64, binaries-linux_ppc64le]
+      - TARGET: [binaries-darwin_amd64, binaries-darwin_arm64, binaries-linux_amd64, binaries-linux_arm64, binaries-windows_amd64, binaries-linux_ppc64le]
   script: make $TARGET
   after_script:
     - if [ -e bin/otelcol ]; then rm -f bin/otelcol; fi  # remove the symlink
@@ -286,6 +286,9 @@ sign-osx:
   stage: sign-binaries
   needs:
     - compile
+  parallel:
+    matrix:
+      - ARCH: [amd64, arm64]
   variables:
     ARTIFACT: bin/packages.tar.gz
     SIGN_TYPE: OSX
@@ -293,14 +296,14 @@ sign-osx:
     DOWNLOAD_DIR: dist/signed
   before_script:
     - mkdir -p dist
-    - pushd bin && tar -czvf packages.tar.gz otelcol_darwin_amd64 translatesfx_darwin_amd64 && popd
+    - pushd bin && tar -czvf packages.tar.gz otelcol_darwin_${ARCH} translatesfx_darwin_${ARCH} && popd
   after_script:
     - tar -xzvf dist/signed/packages.tar.gz -C dist/signed/
     - rm dist/signed/packages.tar.gz
   artifacts:
     paths:
-      - dist/signed/otelcol_darwin_amd64
-      - dist/signed/translatesfx_darwin_amd64
+      - dist/signed/otelcol_darwin_${ARCH}
+      - dist/signed/translatesfx_darwin_${ARCH}
 
 build-linux-image:
   extends: .trigger-filter

--- a/Makefile
+++ b/Makefile
@@ -172,13 +172,19 @@ endif
 	rm -rf ./cmd/otelcol/dist
 
 .PHONY: binaries-all-sys
-binaries-all-sys: binaries-darwin_amd64 binaries-linux_amd64 binaries-linux_arm64 binaries-windows_amd64 binaries-linux_ppc64le
+binaries-all-sys: binaries-darwin_amd64 binaries-darwin_arm64 binaries-linux_amd64 binaries-linux_arm64 binaries-windows_amd64 binaries-linux_ppc64le
 
 .PHONY: binaries-darwin_amd64
 binaries-darwin_amd64:
 	GOOS=darwin  GOARCH=amd64 $(MAKE) otelcol
 	GOOS=darwin  GOARCH=amd64 $(MAKE) translatesfx
 	GOOS=darwin  GOARCH=amd64 $(MAKE) migratecheckpoint
+
+.PHONY: binaries-darwin_arm64
+binaries-darwin_arm64:
+	GOOS=darwin  GOARCH=arm64 $(MAKE) otelcol
+	GOOS=darwin  GOARCH=arm64 $(MAKE) translatesfx
+	GOOS=darwin  GOARCH=arm64 $(MAKE) migratecheckpoint
 
 .PHONY: binaries-linux_amd64
 binaries-linux_amd64:


### PR DESCRIPTION
- Build, sign, and include the `otelcol_darwin_arm64` and `translatesfx_darwin_arm64` standalone binaries in github releases from the gitlab pipeline
- Add the `macos-11-arm64` self-hosted runner to the `darwin-test` workflow