### PR TITLE
json encode statement maps and more informative bundler errors

### DIFF
--- a/internal/confmapprovider/discovery/bundle/cmd/discoverybundler/main.go
+++ b/internal/confmapprovider/discovery/bundle/cmd/discoverybundler/main.go
@@ -73,11 +73,15 @@ func main() {
 
 	var rendered map[string]any
 	// confirm rendered is valid yaml
-	panicOnError(yaml.Unmarshal(out.Bytes(), &rendered))
+	if err = yaml.Unmarshal(out.Bytes(), &rendered); err != nil {
+		panicOnError(fmt.Errorf("failed unmarshaling %s: %w", s.templateFile, err))
+	}
 
 	outFilename := strings.TrimSuffix(s.templateFile, ".tmpl")
 	if s.renderInParentDir {
-		panicOnError(os.WriteFile(outFilename, out.Bytes(), 0600))
+		if err = os.WriteFile(outFilename, out.Bytes(), 0600); err != nil {
+			panicOnError(fmt.Errorf("failed writing to %s: %w", outFilename, err))
+		}
 	} else {
 		fmt.Fprint(os.Stdout, out.String())
 	}

--- a/internal/receiver/discoveryreceiver/statement_evaluator.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator.go
@@ -15,6 +15,7 @@
 package discoveryreceiver
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -24,7 +25,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"gopkg.in/yaml.v3"
 
 	"github.com/signalfx/splunk-otel-collector/internal/common/discovery"
 	"github.com/signalfx/splunk-otel-collector/internal/receiver/discoveryreceiver/statussources"
@@ -79,7 +79,7 @@ func newStatementEvaluator(logger *zap.Logger, id component.ID, config *Config, 
 // exprEnv will unpack logged statement message and field content for expr program use
 func (se *statementEvaluator) exprEnv(pattern string) map[string]any {
 	patternMap := map[string]any{}
-	if err := yaml.Unmarshal([]byte(pattern), &patternMap); err != nil {
+	if err := json.Unmarshal([]byte(pattern), &patternMap); err != nil {
 		se.logger.Info(fmt.Sprintf("failed unmarshaling pattern map %q", pattern), zap.Error(err))
 		patternMap = map[string]any{"message": pattern}
 	}
@@ -168,10 +168,10 @@ func (se *statementEvaluator) evaluateStatement(statement *statussources.Stateme
 	}
 
 	var patternMapStr string
-	if pm, err := yaml.Marshal(patternMap); err != nil {
+	if pm, err := json.Marshal(patternMap); err != nil {
 		se.logger.Debug(fmt.Sprintf("failed marshaling pattern map for %q", statement.Message), zap.Error(err))
 		// best effort default in marshaling failure cases
-		patternMapStr = fmt.Sprintf("message: %q\n", statement.Message)
+		patternMapStr = fmt.Sprintf(`{"message":%q}`, statement.Message)
 	} else {
 		patternMapStr = string(pm)
 	}

--- a/internal/receiver/discoveryreceiver/statement_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator_test.go
@@ -38,7 +38,7 @@ func TestStatementEvaluation(t *testing.T) {
 		match Match
 	}{
 		{name: "strict", match: Match{Strict: "desired.statement"}},
-		{name: "regexp", match: Match{Regexp: "message: d[esired]{6}.statement"}},
+		{name: "regexp", match: Match{Regexp: `"message":"d[esired]{6}.statement"`}},
 		{name: "expr", match: Match{Expr: "message == 'desired.statement' && ExprEnv['field.one'] == 'field.one.value' && field_two contains 'two.value'"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tests/general/discoverymode/testdata/k8s-observer-config.d/receivers/smart-agent-redis.discovery.yaml
+++ b/tests/general/discoverymode/testdata/k8s-observer-config.d/receivers/smart-agent-redis.discovery.yaml
@@ -17,7 +17,7 @@ smartagent:
               body: Successfully scraped metrics from redis pod
     statements:
       failed:
-        - regexp: "message: redis_info plugin: Error connecting to .* - ConnectionRefusedError"
+        - regexp: '"message":"redis_info plugin: Error connecting to .* - ConnectionRefusedError"'
           first_only: true
           log_record:
             severity_text: debug

--- a/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
+++ b/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
@@ -32,7 +32,7 @@ receivers:
                 log_record:
                   severity_text: debug
                   body: (strict) Port appears to not be serving prometheus metrics
-              - regexp: 'message: Failed to scrape Prometheus endpoint'
+              - regexp: '"message":"Failed to scrape Prometheus endpoint"'
                 first_only: true
                 log_record:
                   severity_text: debug


### PR DESCRIPTION
These changes improve https://github.com/signalfx/splunk-otel-collector/pull/3004 by using json encoding instead of yaml as multiline and apostrophe containing strings were encoded in unintuitive ways that required odd escaping in discovery rules.

Also adding discovery bundler file paths in render errors for easier debugging.