### PR TITLE
[receiver/lightprometheus] OTL-2117: Limit resource attributes

### DIFF
--- a/internal/receiver/lightprometheusreceiver/config.go
+++ b/internal/receiver/lightprometheusreceiver/config.go
@@ -30,10 +30,33 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		ScraperControllerSettings: scs,
 		HTTPClientSettings:        confighttp.NewDefaultHTTPClientSettings(),
+		ResourceAttributes: ResourceAttributesConfig{
+			ServiceInstanceID: ResourceAttributeConfig{Enabled: true},
+			ServiceName:       ResourceAttributeConfig{Enabled: true},
+			NetHostName:       ResourceAttributeConfig{Enabled: false},
+			NetHostPort:       ResourceAttributeConfig{Enabled: false},
+			HTTPScheme:        ResourceAttributeConfig{Enabled: false},
+		},
 	}
+}
+
+// ResourceAttributeConfig provides configuration for a resource attribute.
+type ResourceAttributeConfig struct {
+	Enabled bool `mapstructure:"enabled"`
+}
+
+// ResourceAttributesConfig allows users to configure the resource attributes.
+type ResourceAttributesConfig struct {
+	ServiceName       ResourceAttributeConfig `mapstructure:"service.name"`
+	ServiceInstanceID ResourceAttributeConfig `mapstructure:"service.instance.id"`
+	NetHostName       ResourceAttributeConfig `mapstructure:"net.host.name"`
+	NetHostPort       ResourceAttributeConfig `mapstructure:"net.host.port"`
+	HTTPScheme        ResourceAttributeConfig `mapstructure:"http.scheme"`
 }
 
 type Config struct {
 	confighttp.HTTPClientSettings           `mapstructure:",squash"`
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
+	// ResourceAttributes that added to scraped metrics.
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }

--- a/internal/receiver/lightprometheusreceiver/scraper.go
+++ b/internal/receiver/lightprometheusreceiver/scraper.go
@@ -95,11 +95,21 @@ func (s *scraper) fetchPrometheusMetrics(fetch fetcher) (pmetric.Metrics, error)
 	}
 	rm := m.ResourceMetrics().AppendEmpty()
 	res := rm.Resource()
-	res.Attributes().PutStr(conventions.AttributeServiceName, s.name)
-	res.Attributes().PutStr(conventions.AttributeNetHostName, u.Host)
-	res.Attributes().PutStr(conventions.AttributeServiceInstanceID, u.Host)
-	res.Attributes().PutStr(conventions.AttributeNetHostPort, u.Port())
-	res.Attributes().PutStr(conventions.AttributeHTTPScheme, u.Scheme)
+	if s.cfg.ResourceAttributes.ServiceName.Enabled {
+		res.Attributes().PutStr(conventions.AttributeServiceName, s.name)
+	}
+	if s.cfg.ResourceAttributes.NetHostName.Enabled {
+		res.Attributes().PutStr(conventions.AttributeNetHostName, u.Host)
+	}
+	if s.cfg.ResourceAttributes.ServiceInstanceID.Enabled {
+		res.Attributes().PutStr(conventions.AttributeServiceInstanceID, u.Host)
+	}
+	if s.cfg.ResourceAttributes.NetHostPort.Enabled {
+		res.Attributes().PutStr(conventions.AttributeNetHostPort, u.Port())
+	}
+	if s.cfg.ResourceAttributes.HTTPScheme.Enabled {
+		res.Attributes().PutStr(conventions.AttributeHTTPScheme, u.Scheme)
+	}
 	s.convertMetricFamilies(metricFamilies, rm)
 	return m, nil
 }

--- a/internal/receiver/lightprometheusreceiver/scraper_test.go
+++ b/internal/receiver/lightprometheusreceiver/scraper_test.go
@@ -35,31 +35,76 @@ import (
 
 func TestScraper(t *testing.T) {
 	promMock := newPromMockServer(t)
-	cfg := createDefaultConfig().(*Config)
-	cfg.Endpoint = fmt.Sprintf("%s%s", promMock.URL, "/metrics")
-	require.NoError(t, component.ValidateConfig(cfg))
-
-	scraper := newScraper(receivertest.NewNopCreateSettings(), cfg)
-
-	err := scraper.start(context.Background(), componenttest.NewNopHost())
-	require.NoError(t, err)
-
-	actualMetrics, err := scraper.scrape(context.Background())
-	require.NoError(t, err)
-
-	expectedFile := filepath.Join("testdata", "scraper", "expected.json")
-	expectedMetrics, err := readMetrics(expectedFile)
-	require.NoError(t, err)
-	attrs := expectedMetrics.ResourceMetrics().At(0).Resource().Attributes()
 	u, err := url.Parse(promMock.URL)
 	require.NoError(t, err)
-	attrs.PutStr(conventions.AttributeNetHostPort, u.Port())
-	attrs.PutStr(conventions.AttributeNetHostName, u.Host)
-	attrs.PutStr(conventions.AttributeServiceInstanceID, u.Host)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
-		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(),
-		pmetrictest.IgnoreTimestamp(), pmetrictest.IgnoreMetricsOrder()))
+	tests := []struct {
+		cfg                        *Config
+		expectedResourceAttributes map[string]any
+		name                       string
+	}{
+		{
+			name: "default_config",
+			cfg:  createDefaultConfig().(*Config),
+			expectedResourceAttributes: map[string]any{
+				conventions.AttributeServiceName:       "",
+				conventions.AttributeServiceInstanceID: u.Host,
+			},
+		},
+		{
+			name: "all_resource_attributes",
+			cfg: func() *Config {
+				cfg := createDefaultConfig().(*Config)
+				cfg.ResourceAttributes.ServiceName.Enabled = true
+				cfg.ResourceAttributes.HTTPScheme.Enabled = true
+				cfg.ResourceAttributes.NetHostPort.Enabled = true
+				cfg.ResourceAttributes.NetHostName.Enabled = true
+				return cfg
+			}(),
+			expectedResourceAttributes: map[string]any{
+				conventions.AttributeServiceName:       "",
+				conventions.AttributeServiceInstanceID: u.Host,
+				conventions.AttributeNetHostName:       u.Host,
+				conventions.AttributeNetHostPort:       u.Port(),
+				conventions.AttributeHTTPScheme:        "http",
+			},
+		},
+		{
+			name: "no_resource_attributes",
+			cfg: func() *Config {
+				cfg := createDefaultConfig().(*Config)
+				cfg.ResourceAttributes.ServiceInstanceID.Enabled = false
+				cfg.ResourceAttributes.ServiceName.Enabled = false
+				return cfg
+			}(),
+			expectedResourceAttributes: map[string]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.cfg
+			cfg.Endpoint = fmt.Sprintf("%s%s", promMock.URL, "/metrics")
+			require.NoError(t, component.ValidateConfig(cfg))
+
+			scraper := newScraper(receivertest.NewNopCreateSettings(), cfg)
+
+			err := scraper.start(context.Background(), componenttest.NewNopHost())
+			require.NoError(t, err)
+
+			actualMetrics, err := scraper.scrape(context.Background())
+			require.NoError(t, err)
+
+			expectedFile := filepath.Join("testdata", "scraper", "expected.json")
+			expectedMetrics, err := readMetrics(expectedFile)
+			require.NoError(t, err)
+			require.NoError(t, expectedMetrics.ResourceMetrics().At(0).Resource().Attributes().FromRaw(tt.expectedResourceAttributes))
+
+			require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+				pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(),
+				pmetrictest.IgnoreTimestamp(), pmetrictest.IgnoreMetricsOrder()))
+		})
+	}
 }
 
 func readMetrics(filePath string) (pmetric.Metrics, error) {

--- a/internal/receiver/lightprometheusreceiver/testdata/scraper/expected.json
+++ b/internal/receiver/lightprometheusreceiver/testdata/scraper/expected.json
@@ -1,40 +1,6 @@
 {
   "resourceMetrics": [
     {
-      "resource": {
-          "attributes": [
-            {
-              "key": "http.scheme",
-              "value": {
-                "stringValue": "http"
-              }
-            },
-            {
-              "key": "net.host.name",
-              "value": {
-                "stringValue": "127.0.0.1:0"
-              }
-            },
-            {
-              "key": "net.host.port",
-              "value": {
-                "stringValue": "0"
-              }
-            },
-            {
-              "key": "service.instance.id",
-              "value": {
-                "stringValue": "127.0.0.1:0"
-              }
-            },
-            {
-              "key": "service.name",
-              "value": {
-                "stringValue": ""
-              }
-            }
-          ]
-      },
       "scopeMetrics": [
         {
           "scope": {},

--- a/tests/receivers/lightprometheus/testdata/resource_metrics/internal.yaml
+++ b/tests/receivers/lightprometheus/testdata/resource_metrics/internal.yaml
@@ -1,8 +1,5 @@
 resource_metrics:
   - attributes:
-      http.scheme: http
-      net.host.name: localhost:8889
-      net.host.port: "8889"
       service.instance.id: localhost:8889
       service.name: myjob
     scope_metrics:


### PR DESCRIPTION
Limit resource attributes added by the lightprometheus receiver by default and make them configurable. 

Make enabling/disabling particular attributes possible and disable the following attributes by default:
- net.host.name:
- net.host.port:
- http.scheme:

To enable them back the attributes add the following configuration:

```yaml
resource_attributes:
  net.host.name:
    enabled: true
  net.host.port:
    enabled: true
  http.scheme:
    enabled: true
```

The configuration interface is aligned with receivers created by the mdatagen tool