### PR TITLE
fix flaky test by retrying and waiting if server does not respond in time

### DIFF
--- a/internal/receiver/prometheusremotewritereceiver/client_test.go
+++ b/internal/receiver/prometheusremotewritereceiver/client_test.go
@@ -74,7 +74,7 @@ func (prwc *MockPrwClient) SendWriteRequest(wr *prompb.WriteRequest) error {
 			break
 		}
 		if errors.Is(err, syscall.ECONNREFUSED) {
-			retry -= 1
+			retry--
 			time.Sleep(2 * time.Second)
 		}
 	}


### PR DESCRIPTION
Could consider moving this to an end-to-end test or similar as well