### PR TITLE
Switch Windows IIS zero-config test to check for traces instead of metrics

### DIFF
--- a/tests/testutils/README.md
+++ b/tests/testutils/README.md
@@ -96,7 +96,7 @@ err = myContainerFromBuildContext.Start(context.Background())
 
 ### OTLP Metrics Receiver Sink
 
-The `OTLPReceiverSink` is a helper type that will easily stand up an inmemory OTLP Receiver with
+The `OTLPReceiverSink` is a helper type that will easily stand up an in memory OTLP Receiver with
 `consumertest.MetricsSink` functionality.  It will listen to the configured gRPC endpoint that running Collector
 processes can be configured to reach and provides an `AssertAllMetricsReceived()` test method to confirm that expected
 `ResourceMetrics` are received within the specified window.

--- a/tests/testutils/otlp_receiver_sink.go
+++ b/tests/testutils/otlp_receiver_sink.go
@@ -138,16 +138,7 @@ func (otlp *OTLPReceiverSink) Start() error {
 		return err
 	}
 
-	if err := (*otlp.metricsReceiver).Start(context.Background(), otlp.Host); err != nil {
-		return err
-	}
-
-	if err := (*otlp.tracesReceiver).Start(context.Background(), otlp.Host); err != nil {
-		_ = (*otlp.metricsReceiver).Shutdown(context.Background())
-		return err
-	}
-
-	return nil
+	return (*otlp.metricsReceiver).Start(context.Background(), otlp.Host)
 }
 
 func (otlp *OTLPReceiverSink) Shutdown() error {
@@ -155,15 +146,7 @@ func (otlp *OTLPReceiverSink) Shutdown() error {
 		return err
 	}
 
-	metricsShutdownErr := (*otlp.metricsReceiver).Shutdown(context.Background())
-	tracesShutdownErr := (*otlp.tracesReceiver).Shutdown(context.Background())
-	if metricsShutdownErr != nil {
-		return metricsShutdownErr
-	}
-	if tracesShutdownErr != nil {
-		return tracesShutdownErr
-	}
-	return nil
+	return (*otlp.metricsReceiver).Shutdown(context.Background())
 }
 
 func (otlp *OTLPReceiverSink) AllLogs() []plog.Logs {

--- a/tests/testutils/otlp_receiver_sink.go
+++ b/tests/testutils/otlp_receiver_sink.go
@@ -296,12 +296,12 @@ func (otlp *OTLPReceiverSink) AssertAllMetricsReceived(t testing.TB, expectedRes
 	return err
 }
 
-func (otlp *OTLPReceiverSink) AssertAllTracesReceived(t testing.TB, exptectedResourceTraces telemetry.ResourceTraces, waitTime time.Duration) error {
+func (otlp *OTLPReceiverSink) AssertAllTracesReceived(t testing.TB, expectedResourceTraces telemetry.ResourceTraces, waitTime time.Duration) error {
 	if err := otlp.assertBuilt("AssertAllTracesReceived"); err != nil {
 		return err
 	}
 
-	if len(exptectedResourceTraces.ResourceSpans) == 0 {
+	if len(expectedResourceTraces.ResourceSpans) == 0 {
 		return fmt.Errorf("empty ResourceTraces provided")
 	}
 
@@ -324,7 +324,7 @@ func (otlp *OTLPReceiverSink) AssertAllTracesReceived(t testing.TB, exptectedRes
 		receivedTraces = telemetry.FlattenResourceTraces(receivedResourceTraces)
 
 		var containsAll bool
-		containsAll, err = receivedTraces.ContainsAll(exptectedResourceTraces)
+		containsAll, err = receivedTraces.ContainsAll(expectedResourceTraces)
 		return containsAll
 	}, waitTime, 10*time.Millisecond, "Failed to receive expected traces")
 

--- a/tests/testutils/otlp_receiver_sink.go
+++ b/tests/testutils/otlp_receiver_sink.go
@@ -89,7 +89,7 @@ func (otlp OTLPReceiverSink) Build() (*OTLPReceiverSink, error) {
 
 	otlp.logsSink = new(consumertest.LogsSink)
 	otlp.metricsSink = new(consumertest.MetricsSink)
-	otlp.tracesSink = new (consumertest.TracesSink)
+	otlp.tracesSink = new(consumertest.TracesSink)
 
 	otlpFactory := otlpreceiver.NewFactory()
 	otlpConfig := otlpFactory.CreateDefaultConfig().(*otlpreceiver.Config)
@@ -126,9 +126,9 @@ func (otlp OTLPReceiverSink) Build() (*OTLPReceiverSink, error) {
 }
 
 func (otlp *OTLPReceiverSink) assertBuilt(operation string) error {
-	if otlp.logsReceiver == nil || otlp.logsSink == nil || 
-	otlp.metricsReceiver == nil || otlp.metricsSink == nil ||
-	otlp.tracesReceiver == nil || otlp.tracesSink == nil {
+	if otlp.logsReceiver == nil || otlp.logsSink == nil ||
+		otlp.metricsReceiver == nil || otlp.metricsSink == nil ||
+		otlp.tracesReceiver == nil || otlp.tracesSink == nil {
 		return fmt.Errorf("cannot invoke %s() on an OTLPReceiverSink that hasn't been built", operation)
 	}
 	return nil

--- a/tests/testutils/otlp_receiver_sink_test.go
+++ b/tests/testutils/otlp_receiver_sink_test.go
@@ -47,6 +47,8 @@ func TestNewOTLPReceiverSink(t *testing.T) {
 	require.Nil(t, otlp.logsSink)
 	require.Nil(t, otlp.metricsReceiver)
 	require.Nil(t, otlp.metricsSink)
+	require.Nil(t, otlp.tracesReceiver)
+	require.Nil(t, otlp.tracesSink)
 }
 
 func TestBuilderMethods(t *testing.T) {
@@ -82,6 +84,8 @@ func TestBuildDefaults(t *testing.T) {
 	assert.NotNil(t, otlp.logsSink)
 	assert.NotNil(t, otlp.metricsReceiver)
 	assert.NotNil(t, otlp.metricsSink)
+	assert.NotNil(t, otlp.tracesReceiver)
+	assert.NotNil(t, otlp.tracesSink)
 }
 
 func TestReceiverMethodsWithoutBuildingDisallowed(t *testing.T) {
@@ -98,8 +102,14 @@ func TestReceiverMethodsWithoutBuildingDisallowed(t *testing.T) {
 	metrics := otlp.AllMetrics()
 	require.Nil(t, metrics)
 
-	count := otlp.DataPointCount()
-	require.Zero(t, count)
+	dataPointCount := otlp.DataPointCount()
+	require.Zero(t, dataPointCount)
+
+	traces := otlp.AllTraces()
+	require.Nil(t, traces)
+
+	spanCount := otlp.SpanCount()
+	require.Zero(t, spanCount)
 
 	// doesn't panic
 	otlp.Reset()
@@ -107,18 +117,21 @@ func TestReceiverMethodsWithoutBuildingDisallowed(t *testing.T) {
 	err = otlp.AssertAllMetricsReceived(t, telemetry.ResourceMetrics{}, 0)
 	require.Error(t, err)
 	require.EqualError(t, err, "cannot invoke AssertAllMetricsReceived() on an OTLPReceiverSink that hasn't been built")
+
+	err = otlp.AssertAllTracesReceived(t, telemetry.ResourceTraces{}, 0)
+	require.Error(t, err)
+	require.EqualError(t, err, "cannot invoke AssertAllTracesReceived() on an OTLPReceiverSink that hasn't been built")
 }
 
-func otlpExporter(t *testing.T) otelcolexporter.Metrics {
+func createOTLPFactoryParameters() (otlpexporter.Config, otelcolexporter.CreateSettings) {
 	exporterCfg := otlpexporter.Config{
 		GRPCClientSettings: configgrpc.GRPCClientSettings{
 			Endpoint: "localhost:4317",
 			TLSSetting: configtls.TLSClientSetting{
 				Insecure: true,
 			},
-		}}
-	otlpExporterFactory := otlpexporter.NewFactory()
-	ctx := context.Background()
+		},
+	}
 	createParams := otelcolexporter.CreateSettings{
 		TelemetrySettings: component.TelemetrySettings{
 			Logger:         zap.NewNop(),
@@ -126,7 +139,17 @@ func otlpExporter(t *testing.T) otelcolexporter.Metrics {
 			MeterProvider:  metric.NewNoopMeterProvider(),
 		},
 	}
+
+	return exporterCfg, createParams
+}
+
+func otlpMetricsExporter(t *testing.T) otelcolexporter.Metrics {
+	exporterCfg, createParams := createOTLPFactoryParameters() 
+	otlpExporterFactory := otlpexporter.NewFactory()
+	ctx := context.Background()
+	
 	exporter, err := otlpExporterFactory.CreateMetricsExporter(ctx, createParams, &exporterCfg)
+	
 	require.NoError(t, err)
 	require.NotNil(t, exporter)
 	err = exporter.Start(ctx, componenttest.NewNopHost())
@@ -144,7 +167,7 @@ func TestOTLPReceiverMetricsAvailableToSink(t *testing.T) {
 	}()
 	require.NoError(t, err)
 
-	exporter := otlpExporter(t)
+	exporter := otlpMetricsExporter(t)
 	defer func() { require.NoError(t, exporter.Shutdown(context.Background())) }()
 
 	metrics := telemetry.PDataMetrics()
@@ -167,7 +190,7 @@ func TestAssertAllMetricsReceivedHappyPath(t *testing.T) {
 	}()
 	require.NoError(t, err)
 
-	exporter := otlpExporter(t)
+	exporter := otlpMetricsExporter(t)
 	defer func() { require.NoError(t, exporter.Shutdown(context.Background())) }()
 
 	metrics := telemetry.PDataMetrics()
@@ -178,4 +201,64 @@ func TestAssertAllMetricsReceivedHappyPath(t *testing.T) {
 	resourceMetrics = telemetry.FlattenResourceMetrics(resourceMetrics)
 	require.NoError(t, err)
 	require.NoError(t, otlp.AssertAllMetricsReceived(t, resourceMetrics, 100*time.Millisecond))
+}
+
+func otlpTracesExporter(t *testing.T) otelcolexporter.Traces {
+	exporterCfg, createParams := createOTLPFactoryParameters() 
+	otlpExporterFactory := otlpexporter.NewFactory()
+	ctx := context.Background()
+	
+	exporter, err := otlpExporterFactory.CreateTracesExporter(ctx, createParams, &exporterCfg)
+	
+	require.NoError(t, err)
+	require.NotNil(t, exporter)
+	err = exporter.Start(ctx, componenttest.NewNopHost())
+	require.NoError(t, err)
+	return exporter
+}
+
+func TestOTLPReceiverTracesAvailableToSink(t *testing.T) {
+	otlp, err := NewOTLPReceiverSink().WithEndpoint("localhost:4317").Build()
+	require.NoError(t, err)
+
+	err = otlp.Start()
+	defer func() {
+		require.NoError(t, otlp.Shutdown())
+	}()
+	require.NoError(t, err)
+
+	exporter := otlpTracesExporter(t)
+	defer func() { require.NoError(t, exporter.Shutdown(context.Background())) }()
+
+	traces := telemetry.PDataTraces()
+	expectedCount := traces.SpanCount()
+	err = exporter.ConsumeTraces(context.Background(), traces)
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		return otlp.SpanCount() == expectedCount
+	}, 5*time.Second, 1*time.Millisecond)
+}
+
+func TestAssertAllTracesReceivedHappyPath(t *testing.T) {
+	otlp, err := NewOTLPReceiverSink().WithEndpoint("localhost:4317").Build()
+	require.NoError(t, err)
+
+	err = otlp.Start()
+	defer func() {
+		require.NoError(t, otlp.Shutdown())
+	}()
+	require.NoError(t, err)
+
+	exporter := otlpTracesExporter(t)
+	defer func() { require.NoError(t, exporter.Shutdown(context.Background())) }()
+
+	traces := telemetry.PDataTraces()
+	err = exporter.ConsumeTraces(context.Background(), traces)
+	require.NoError(t, err)
+
+	resourceTraces, err := telemetry.PDataToResourceTraces(traces)
+	resourceTraces = telemetry.FlattenResourceTraces(resourceTraces)
+	require.NoError(t, err)
+	require.NoError(t, otlp.AssertAllTracesReceived(t, resourceTraces, 100*time.Millisecond))
 }

--- a/tests/testutils/otlp_receiver_sink_test.go
+++ b/tests/testutils/otlp_receiver_sink_test.go
@@ -144,12 +144,12 @@ func createOTLPFactoryParameters() (otlpexporter.Config, otelcolexporter.CreateS
 }
 
 func otlpMetricsExporter(t *testing.T) otelcolexporter.Metrics {
-	exporterCfg, createParams := createOTLPFactoryParameters() 
+	exporterCfg, createParams := createOTLPFactoryParameters()
 	otlpExporterFactory := otlpexporter.NewFactory()
 	ctx := context.Background()
-	
+
 	exporter, err := otlpExporterFactory.CreateMetricsExporter(ctx, createParams, &exporterCfg)
-	
+
 	require.NoError(t, err)
 	require.NotNil(t, exporter)
 	err = exporter.Start(ctx, componenttest.NewNopHost())
@@ -204,12 +204,12 @@ func TestAssertAllMetricsReceivedHappyPath(t *testing.T) {
 }
 
 func otlpTracesExporter(t *testing.T) otelcolexporter.Traces {
-	exporterCfg, createParams := createOTLPFactoryParameters() 
+	exporterCfg, createParams := createOTLPFactoryParameters()
 	otlpExporterFactory := otlpexporter.NewFactory()
 	ctx := context.Background()
-	
+
 	exporter, err := otlpExporterFactory.CreateTracesExporter(ctx, createParams, &exporterCfg)
-	
+
 	require.NoError(t, err)
 	require.NotNil(t, exporter)
 	err = exporter.Start(ctx, componenttest.NewNopHost())

--- a/tests/testutils/telemetry/helpers_test.go
+++ b/tests/testutils/telemetry/helpers_test.go
@@ -1,0 +1,28 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build testutils
+
+package telemetry
+
+import (
+	"runtime"
+)
+
+func invalidPathErrorMsg() string {
+	if runtime.GOOS == "windows" {
+		return "open notafile: The system cannot find the file specified."
+	}
+	return "no such file or directory"
+}

--- a/tests/testutils/telemetry/logs_test.go
+++ b/tests/testutils/telemetry/logs_test.go
@@ -109,7 +109,7 @@ func TestLoadLogsHappyPath(t *testing.T) {
 func TestLoadLogsNotAValidPath(t *testing.T) {
 	resourceLogs, err := LoadResourceLogs("notafile")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no such file or directory")
+	require.Contains(t, err.Error(), invalidPathErrorMsg())
 	require.Nil(t, resourceLogs)
 }
 

--- a/tests/testutils/telemetry/metrics_test.go
+++ b/tests/testutils/telemetry/metrics_test.go
@@ -107,7 +107,7 @@ func TestLoadMetricsHappyPath(t *testing.T) {
 func TestLoadMetricsNotAValidPath(t *testing.T) {
 	resourceMetrics, err := LoadResourceMetrics("notafile")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no such file or directory")
+	require.Contains(t, err.Error(), invalidPathErrorMsg())
 	require.Nil(t, resourceMetrics)
 }
 

--- a/tests/testutils/telemetry/pdata_traces.go
+++ b/tests/testutils/telemetry/pdata_traces.go
@@ -1,0 +1,100 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// PDataToResourceTraces returns a ResourceTraces item generated from ptrace.Traces content.
+func PDataToResourceTraces(pdataTraces ...ptrace.Traces) (ResourceTraces, error) {
+	resourceTraces := ResourceTraces{}
+	for _, pdataTrace := range pdataTraces {
+		pdataResourceSpans := pdataTrace.ResourceSpans()
+		for i := 0; i < pdataResourceSpans.Len(); i++ {
+			resourceSpans := ResourceSpans{}
+			pdataResourceSpan := pdataResourceSpans.At(i)
+			sanitizedAttrs := sanitizeAttributes(pdataResourceSpan.Resource().Attributes().AsRaw())
+			resourceSpans.Resource.Attributes = &sanitizedAttrs
+			pdataScopedSpans := pdataResourceSpan.ScopeSpans()
+			for j := 0; j < pdataScopedSpans.Len(); j++ {
+				scopedSpans := ScopeSpans{Spans: []Span{}}
+				pdataScopedSpan := pdataScopedSpans.At(j)
+				attrs := sanitizeAttributes(pdataScopedSpan.Scope().Attributes().AsRaw())
+				scopedSpans.Scope = InstrumentationScope{
+					Name:       pdataScopedSpan.Scope().Name(),
+					Version:    pdataScopedSpan.Scope().Version(),
+					Attributes: &attrs,
+				}
+				pdataSpans := pdataScopedSpan.Spans()
+				for k := 0; k < pdataSpans.Len(); k++ {
+					pdataSpan := pdataSpans.At(k)
+					spanAttrs := sanitizeAttributes(pdataSpan.Attributes().AsRaw())
+					span := Span{
+						Name:       pdataSpan.Name(),
+						Attributes: &spanAttrs,
+					}
+					scopedSpans.Spans = append(scopedSpans.Spans, span)
+				}
+				resourceSpans.ScopeSpans = append(resourceSpans.ScopeSpans, scopedSpans)
+			}
+			resourceTraces.ResourceSpans = append(resourceTraces.ResourceSpans, resourceSpans)
+		}
+	}
+	return resourceTraces, nil
+}
+
+func PDataTraces() ptrace.Traces {
+	traces := ptrace.NewTraces()
+
+	resourceTraces := traces.ResourceSpans().AppendEmpty()
+	resourceTracesAttrs := resourceTraces.Resource().Attributes()
+	resourceTracesAttrs.PutBool("bool", true)
+	resourceTracesAttrs.PutStr("string", "a_string")
+	resourceTracesAttrs.PutInt("int", 123)
+	resourceTracesAttrs.PutDouble("double", 123.45)
+	resourceTracesAttrs.PutEmpty("null")
+
+	scopeSpans := resourceTraces.ScopeSpans()
+	scopeOne := scopeSpans.AppendEmpty()
+	scopeOne.Scope().SetName("instrumentation_scope_one")
+	scopeOne.Scope().SetVersion("instrumentation_scope_one_version")
+
+	scopeOneSpans := scopeOne.Spans()
+	scopeOneSpanOne := scopeOneSpans.AppendEmpty()
+	scopeOneSpanOne.SetName("span_one")
+	scopeOneSpanOne.SetKind(ptrace.SpanKindClient)
+	scopeOneSpanOneAttrs := scopeOneSpanOne.Attributes()
+	scopeOneSpanOneAttrs.PutBool("bool", true)
+	scopeOneSpanOneAttrs.PutStr("string", "a_string")
+	scopeOneSpanOneAttrs.PutInt("int", 123)
+	scopeOneSpanOneAttrs.PutDouble("double", 123.45)
+	scopeOneSpanOneAttrs.PutEmpty("null")
+
+	scopeOneSpanTwo := scopeOneSpans.AppendEmpty()
+	scopeOneSpanTwo.SetName("span_two")
+	scopeOneSpanTwo.SetKind(ptrace.SpanKindServer)
+
+	scopeTwo := scopeSpans.AppendEmpty()
+	scopeTwo.Scope().SetName("instrumentation_scope_two")
+	scopeTwo.Scope().SetVersion("instrumentation_scope_two_version")
+
+	scopeTwoSpans := scopeTwo.Spans()
+	scopeTwoSpanOne := scopeTwoSpans.AppendEmpty()
+	scopeTwoSpanOne.SetName("span_one")
+	scopeTwoSpanOne.SetKind(ptrace.SpanKindClient)
+
+	return traces
+}

--- a/tests/testutils/telemetry/pdata_traces_test.go
+++ b/tests/testutils/telemetry/pdata_traces_test.go
@@ -1,0 +1,68 @@
+// Copyright  Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build testutils
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPDataToResourceTracesHappyPath(t *testing.T) {
+	resourceTraces, err := PDataToResourceTraces(PDataTraces())
+	assert.NoError(t, err)
+	require.NotNil(t, resourceTraces)
+
+	resourceSpans := resourceTraces.ResourceSpans
+	assert.Len(t, resourceSpans, 1)
+	fstResourceSpans := resourceSpans[0]
+	resourceAttributes := *fstResourceSpans.Resource.Attributes
+	assertExpectedAttributes(t, resourceAttributes)
+
+	scopeSpans := fstResourceSpans.ScopeSpans
+	assert.Len(t, scopeSpans, 2)
+
+	fstScopeSpans := fstResourceSpans.ScopeSpans[0]
+	assert.Equal(t, "instrumentation_scope_one", fstScopeSpans.Scope.Name)
+	assert.Equal(t, "instrumentation_scope_one_version", fstScopeSpans.Scope.Version)
+	assert.Len(t, fstScopeSpans.Spans, 2)
+
+	fstScopeFstSpan := fstScopeSpans.Spans[0]
+	assert.Equal(t, "span_one", fstScopeFstSpan.Name)
+	fstScopeFstSpanAttributes := *fstScopeFstSpan.Attributes
+	assertExpectedAttributes(t, fstScopeFstSpanAttributes)
+
+	fstScopeSndSpan := fstScopeSpans.Spans[1]
+	assert.Equal(t, "span_two", fstScopeSndSpan.Name)
+
+	sndScopeSpans := fstResourceSpans.ScopeSpans[1]
+	assert.Equal(t, "instrumentation_scope_two", sndScopeSpans.Scope.Name)
+	assert.Equal(t, "instrumentation_scope_two_version", sndScopeSpans.Scope.Version)
+	assert.Len(t, sndScopeSpans.Spans, 1)
+
+	sndScopeFstSpan := sndScopeSpans.Spans[0]
+	assert.Equal(t, "span_one", sndScopeFstSpan.Name)
+}
+
+func assertExpectedAttributes(t *testing.T, attrs map[string]any) {
+	assert.True(t, attrs["bool"].(bool))
+	assert.Equal(t, "a_string", attrs["string"])
+	assert.Equal(t, 123, attrs["int"])
+	assert.Equal(t, 123.45, attrs["double"])
+	assert.Nil(t, attrs["null"])
+}

--- a/tests/testutils/telemetry/testdata/traces/expected-traces.yaml
+++ b/tests/testutils/telemetry/testdata/traces/expected-traces.yaml
@@ -1,0 +1,28 @@
+resource_spans:
+- attributes:
+    one_attr: one_value
+    two_attr: two_value
+  scope_spans:
+  - instrumentation_scope:
+      attributes:
+        one_attr: one_value
+      name: scope_one
+      version: scope_one_version
+    spans:
+    - name: span_two
+      attributes: {}
+  - instrumentation_scope:
+      attributes: {}
+      name: instrumentation_scope_two
+      version: instrumentation_scope_two_version
+    spans:
+    - name: span_one
+      attributes: {}
+- attributes:
+    some_attr: some_value
+  scope_spans:
+  - instrumentation_scope:
+      name: scope_one
+      version: scope_one_version
+    spans:
+    - name: last_span

--- a/tests/testutils/telemetry/testdata/traces/invalid-resource-traces.yaml
+++ b/tests/testutils/telemetry/testdata/traces/invalid-resource-traces.yaml
@@ -1,0 +1,3 @@
+resource_spans:
+  - notAttributesOrScopeSpans:
+      - thing: value

--- a/tests/testutils/telemetry/testdata/traces/never-received-instrumentation-scope.yaml
+++ b/tests/testutils/telemetry/testdata/traces/never-received-instrumentation-scope.yaml
@@ -1,0 +1,10 @@
+resource_spans:
+- attributes:
+    some_attr: some_value
+  scope_spans:
+  - instrumentation_scope:
+      name: unmatched_instrumentation_scope
+      version: scope_one_version
+    spans:
+    - name: last_span
+

--- a/tests/testutils/telemetry/testdata/traces/never-received-resource.yaml
+++ b/tests/testutils/telemetry/testdata/traces/never-received-resource.yaml
@@ -1,0 +1,10 @@
+resource_spans:
+- attributes:
+    some_attr: different_value
+  scope_spans:
+  - instrumentation_scope:
+      name: scope_one
+      version: scope_one_version
+    spans:
+    - name: last_span
+

--- a/tests/testutils/telemetry/testdata/traces/never-received-spans.yaml
+++ b/tests/testutils/telemetry/testdata/traces/never-received-spans.yaml
@@ -1,0 +1,10 @@
+resource_spans:
+- attributes:
+    some_attr: some_value
+  scope_spans:
+  - instrumentation_scope:
+      name: scope_one
+      version: scope_one_version
+    spans:
+    - name: last_span
+    - name: missing_span

--- a/tests/testutils/telemetry/testdata/traces/resource-traces.yaml
+++ b/tests/testutils/telemetry/testdata/traces/resource-traces.yaml
@@ -1,0 +1,33 @@
+resource_spans:
+- attributes:
+    one_attr: one_value
+    two_attr: two_value
+  scope_spans:
+  - instrumentation_scope:
+      attributes:
+        one_attr: one_value
+      name: scope_one
+      version: scope_one_version
+    spans:
+    - name: span_one
+      attributes:
+        one_attr: one_value
+        two_attr: two_value
+    - name: span_two
+      attributes: {}
+  - instrumentation_scope:
+      attributes: {}
+      name: instrumentation_scope_two
+      version: instrumentation_scope_two_version
+    spans:
+    - name: span_one
+      attributes: {}
+- attributes:
+    some_attr: some_value
+  scope_spans:
+  - instrumentation_scope:
+      name: scope_one
+      version: scope_one_version
+    spans:
+    - name: last_span
+

--- a/tests/testutils/telemetry/traces.go
+++ b/tests/testutils/telemetry/traces.go
@@ -1,0 +1,257 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// ResourceTraces is a convenience type for test helpers and assertions.
+type ResourceTraces struct {
+	ResourceSpans []ResourceSpans `yaml:"resource_spans"`
+}
+
+// ResourceSpans is the top level grouping of trace data given a Resource (set of attributes) and associated ScopeSpans.
+type ResourceSpans struct {
+	Resource   Resource     `yaml:",inline,omitempty"`
+	ScopeSpans []ScopeSpans `yaml:"scope_spans"`
+}
+
+// ScopeSpans is the top level grouping of trace data given InstrumentationScope and associated collection of Span
+// instances.
+type ScopeSpans struct {
+	Scope InstrumentationScope `yaml:"instrumentation_scope,omitempty"`
+	Spans []Span               `yaml:"spans,omitempty"`
+}
+
+// Span is the trace content, here defined only with the fields required for tests.
+type Span struct {
+	Name       string          `yaml:"name,omitempty"`
+	Attributes *map[string]any `yaml:"attributes,omitempty"`
+}
+
+// SaveResourceTraces is a helper function that saves the ResourceTraces to an yaml file.
+func (rt *ResourceTraces) SaveResourceTraces(path string) error {
+	yamlData, err := yaml.Marshal(rt)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(path, yamlData, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LoadResourceTraces returns a ResourceTraces instance generated via parsing a valid yaml file at the provided path.
+func LoadResourceTraces(path string) (*ResourceTraces, error) {
+	traceFile, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer traceFile.Close()
+
+	buffer := new(bytes.Buffer)
+	if _, err = buffer.ReadFrom(traceFile); err != nil {
+		return nil, err
+	}
+	by := buffer.Bytes()
+
+	var loaded ResourceTraces
+	err = yaml.UnmarshalStrict(by, &loaded)
+	if err != nil {
+		return nil, err
+	}
+
+	// Not all spans have data in their instrumentation scope. If a test requires version validation it should include
+	// it on the expected data. That's why there is no FillDefaultValues() for ResourceTraces.
+	//
+	// There is no parsing that requires validation so there isn't a Validate() method either.
+
+	return &loaded, nil
+}
+
+func (span Span) String() string {
+	out, err := yaml.Marshal(span)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+func (span Span) RelaxedEquals(toCompare Span) bool {
+	return span.Name == toCompare.Name && attributesAreEqual(span.Attributes, toCompare.Attributes)
+}
+
+// FlattenResourceTraces takes multiple instances of ResourceTraces and flattens them to only unique entries by
+// Resource, InstrumentationScope, and Span contents.
+// It will preserve order by removing subsequent occurrences of repeated items from the returned flattened
+// ResourceTraces item
+func FlattenResourceTraces(resourceTracesSlice ...ResourceTraces) ResourceTraces {
+	flattened := ResourceTraces{}
+
+	var resourceHashes []string
+	// maps of resource hashes to objects
+	resources := map[string]Resource{}
+	resourceHashToScopeSpans := map[string][]ScopeSpans{}
+
+	// flatten by Resource
+	for _, resourceTraces := range resourceTracesSlice {
+		for _, resourceSpans := range resourceTraces.ResourceSpans {
+			resourceHash := resourceSpans.Resource.Hash()
+			if _, ok := resources[resourceHash]; !ok {
+				resources[resourceHash] = resourceSpans.Resource
+				resourceHashes = append(resourceHashes, resourceHash)
+			}
+			resourceHashToScopeSpans[resourceHash] = append(resourceHashToScopeSpans[resourceHash], resourceSpans.ScopeSpans...)
+		}
+	}
+
+	// flatten by InstrumentationScope
+	for _, resourceHash := range resourceHashes {
+		resource := resources[resourceHash]
+		resourceSpans := ResourceSpans{
+			Resource: resource,
+		}
+
+		var ilHashes []string
+		// maps of hashes to object
+		ils := map[string]InstrumentationScope{}
+		ilSpans := map[string][]Span{}
+		for _, ilss := range resourceHashToScopeSpans[resourceHash] {
+			ilHash := ilss.Scope.Hash()
+			if _, ok := ils[ilHash]; !ok {
+				ils[ilHash] = ilss.Scope
+				ilHashes = append(ilHashes, ilHash)
+			}
+			if ilss.Spans == nil {
+				ilss.Spans = []Span{}
+			}
+			ilSpans[ilHash] = append(ilSpans[ilHash], ilss.Spans...)
+		}
+
+		// flatten by Span
+		for _, ilHash := range ilHashes {
+			il := ils[ilHash]
+			allILSpans := ilSpans[ilHash]
+			if allILSpans == nil {
+				allILSpans = []Span{}
+			}
+			scopeSpans := ScopeSpans{
+				Scope: il,
+				Spans: allILSpans,
+			}
+			resourceSpans.ScopeSpans = append(resourceSpans.ScopeSpans, scopeSpans)
+		}
+
+		flattened.ResourceSpans = append(flattened.ResourceSpans, resourceSpans)
+	}
+
+	return flattened
+}
+
+// ContainsAll determines if everything in `expected` ResourceTraces is in the receiver ResourceTraces
+// item (i.e. expected ⊆ resourceTraces). Neither guarantees equivalence, nor that expected contains all of received
+// (i.e. is not an expected ≣ resourceTraces nor resourceTraces ⊆ expected check).
+// Span equivalence is based on RelaxedEquals() check: fields not in expected (e.g. unit, type, value, etc.)
+// are not compared to received, but all labels must match.
+// For better reliability, it's advised that both ResourceTraces items have been flattened by FlattenResourceTraces.
+func (resourceTraces ResourceTraces) ContainsAll(expected ResourceTraces) (bool, error) {
+	var missingResources []string
+	missingInstrumentationScopes := map[string]struct{}{}
+	var missingSpans []string
+
+	for _, expectedResourceSpans := range expected.ResourceSpans {
+		resourceMatched := false
+		for _, resourceSpans := range resourceTraces.ResourceSpans {
+			if expectedResourceSpans.Resource.Equals(resourceSpans.Resource) {
+				resourceMatched = true
+				innerMissingInstrumentationScopes := map[string]struct{}{}
+				for _, expectedILS := range expectedResourceSpans.ScopeSpans {
+					matchingInstrumentationScope := ""
+					for _, ils := range resourceSpans.ScopeSpans {
+						if expectedILS.Scope.Equals(ils.Scope) {
+							matchingInstrumentationScope = ils.Scope.String()
+							for _, expectedSpan := range expectedILS.Spans {
+								spanFound := false
+								for _, span := range ils.Spans {
+									if expectedSpan.RelaxedEquals(span) {
+										spanFound = true
+									}
+								}
+								if !spanFound {
+									missingSpans = append(missingSpans, expectedSpan.String())
+								}
+							}
+							if len(missingSpans) != 0 {
+								return false, fmt.Errorf(
+									"%v doesn't contain all of %v. Missing Spans: %s",
+									ils.Spans, expectedILS.Spans, missingSpans)
+							}
+						}
+					}
+					if matchingInstrumentationScope != "" {
+						// no longer globally missing
+						delete(missingInstrumentationScopes, matchingInstrumentationScope)
+					} else {
+						innerMissingInstrumentationScopes[expectedILS.Scope.String()] = struct{}{}
+					}
+				}
+				if len(innerMissingInstrumentationScopes) != 0 {
+					if expectedResourceSpans.Resource.Attributes == nil {
+						// since nil attributes will be equal with everything
+						// keep track of inner missing scopes globally to be
+						// removed above
+						for k, v := range innerMissingInstrumentationScopes {
+							missingInstrumentationScopes[k] = v
+						}
+						continue
+					}
+					var missingIS []string
+					for k := range innerMissingInstrumentationScopes {
+						missingIS = append(missingIS, k)
+					}
+					return false, fmt.Errorf(
+						"%v doesn't contain all of %v. Missing InstrumentationScopes: %s",
+						resourceSpans.ScopeSpans, expectedResourceSpans.ScopeSpans, missingIS,
+					)
+				}
+			}
+		}
+		if !resourceMatched {
+			missingResources = append(missingResources, expectedResourceSpans.Resource.String())
+		}
+	}
+	if len(missingInstrumentationScopes) != 0 {
+		var missingIS []string
+		for k := range missingInstrumentationScopes {
+			missingIS = append(missingIS, k)
+		}
+		return false, fmt.Errorf("Missing InstrumentationScopes: %s", missingIS)
+	}
+	if len(missingResources) != 0 {
+		return false, fmt.Errorf(
+			"%v doesn't contain all of %v. Missing resources: %s",
+			resourceTraces.ResourceSpans, expected.ResourceSpans, missingResources,
+		)
+	}
+	return true, nil
+}

--- a/tests/testutils/telemetry/traces.go
+++ b/tests/testutils/telemetry/traces.go
@@ -42,8 +42,8 @@ type ScopeSpans struct {
 
 // Span is the trace content, here defined only with the fields required for tests.
 type Span struct {
-	Name       string          `yaml:"name,omitempty"`
 	Attributes *map[string]any `yaml:"attributes,omitempty"`
+	Name       string          `yaml:"name,omitempty"`
 }
 
 // SaveResourceTraces is a helper function that saves the ResourceTraces to an yaml file.
@@ -53,7 +53,7 @@ func (rt *ResourceTraces) SaveResourceTraces(path string) error {
 		return err
 	}
 
-	err = os.WriteFile(path, yamlData, 0644)
+	err = os.WriteFile(path, yamlData, 0600)
 	if err != nil {
 		return err
 	}
@@ -174,14 +174,14 @@ func FlattenResourceTraces(resourceTracesSlice ...ResourceTraces) ResourceTraces
 // Span equivalence is based on RelaxedEquals() check: fields not in expected (e.g. unit, type, value, etc.)
 // are not compared to received, but all labels must match.
 // For better reliability, it's advised that both ResourceTraces items have been flattened by FlattenResourceTraces.
-func (resourceTraces ResourceTraces) ContainsAll(expected ResourceTraces) (bool, error) {
+func (rt ResourceTraces) ContainsAll(expected ResourceTraces) (bool, error) {
 	var missingResources []string
 	missingInstrumentationScopes := map[string]struct{}{}
 	var missingSpans []string
 
 	for _, expectedResourceSpans := range expected.ResourceSpans {
 		resourceMatched := false
-		for _, resourceSpans := range resourceTraces.ResourceSpans {
+		for _, resourceSpans := range rt.ResourceSpans {
 			if expectedResourceSpans.Resource.Equals(resourceSpans.Resource) {
 				resourceMatched = true
 				innerMissingInstrumentationScopes := map[string]struct{}{}
@@ -250,7 +250,7 @@ func (resourceTraces ResourceTraces) ContainsAll(expected ResourceTraces) (bool,
 	if len(missingResources) != 0 {
 		return false, fmt.Errorf(
 			"%v doesn't contain all of %v. Missing resources: %s",
-			resourceTraces.ResourceSpans, expected.ResourceSpans, missingResources,
+			rt.ResourceSpans, expected.ResourceSpans, missingResources,
 		)
 	}
 	return true, nil

--- a/tests/testutils/telemetry/traces_test.go
+++ b/tests/testutils/telemetry/traces_test.go
@@ -39,7 +39,7 @@ func TestSaveAndLoadCycle(t *testing.T) {
 	require.NotNil(t, loadedResourceTraces)
 
 	containsAll, err := loadedResourceTraces.ContainsAll(toSaveResourceTraces)
-	require.NoError(t, err) 
+	require.NoError(t, err)
 	require.True(t, containsAll)
 }
 
@@ -183,7 +183,7 @@ func TestFlattenResourceTracesBySpansIdentity(t *testing.T) {
 	spans := []Span{
 		{Name: "a span"},
 		{Name: "another span", Attributes: &map[string]any{}},
-		{Name: "yet another span", Attributes: &map[string]any{ "attr": "value"}},
+		{Name: "yet another span", Attributes: &map[string]any{"attr": "value"}},
 	}
 	ss := ScopeSpans{Spans: spans}
 	resourceTraces := ResourceTraces{

--- a/tests/testutils/telemetry/traces_test.go
+++ b/tests/testutils/telemetry/traces_test.go
@@ -19,7 +19,6 @@ package telemetry
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -224,13 +223,7 @@ func TestTraceContainsAllNoBijection(t *testing.T) {
 	containsAll, err = expected.ContainsAll(received)
 	require.False(t, containsAll)
 	require.Error(t, err)
-	// The function used to generate the string representation of the span doesn't guarantee the order of the fields
-	// test both possibilities to ensure the test passes in all platforms.
-	errMsg := err.Error()
-	containsExpectedMissingSpanMsg :=
-		strings.Contains(errMsg, "Missing Spans: [name: span_one\nattributes:\n  one_attr: one_value\n  two_attr: two_value\n]") ||
-			strings.Contains(errMsg, "Missing Spans: [attributes:\n  one_attr: one_value\n  two_attr: two_value\nname: span_one\n]")
-	require.True(t, containsExpectedMissingSpanMsg)
+	require.Contains(t, err.Error(), "Missing Spans: [attributes:\n  one_attr: one_value\n  two_attr: two_value\nname: span_one\n]")
 }
 
 func TestTraceContainsAllSpansNeverReceived(t *testing.T) {

--- a/tests/testutils/telemetry/traces_test.go
+++ b/tests/testutils/telemetry/traces_test.go
@@ -1,0 +1,266 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build testutils
+
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveAndLoadCycle(t *testing.T) {
+	yamlFile := filepath.Join(".", "testdata", "traces", "tmp-save-and-load-cycle.yaml")
+
+	toSaveResourceTraces, err := PDataToResourceTraces(PDataTraces())
+	require.NoError(t, err)
+	require.NotNil(t, toSaveResourceTraces)
+	require.NoError(t, toSaveResourceTraces.SaveResourceTraces(yamlFile))
+	defer os.Remove(yamlFile)
+
+	loadedResourceTraces, err := LoadResourceTraces(yamlFile)
+	require.NoError(t, err)
+	require.NotNil(t, loadedResourceTraces)
+
+	containsAll, err := loadedResourceTraces.ContainsAll(toSaveResourceTraces)
+	require.NoError(t, err) 
+	require.True(t, containsAll)
+}
+
+func loadedResourceTraces(t *testing.T) ResourceTraces {
+	yamlFile := filepath.Join(".", "testdata", "traces", "resource-traces.yaml")
+	resourceTraces, err := LoadResourceTraces(yamlFile)
+	require.NoError(t, err)
+	require.NotNil(t, resourceTraces)
+	return *resourceTraces
+}
+
+func TestLoadTracesHappyPath(t *testing.T) {
+	resourceTraces := loadedResourceTraces(t)
+
+	assert.Equal(t, 2, len(resourceTraces.ResourceSpans))
+
+	firstRSs := resourceTraces.ResourceSpans[0]
+	firstRSsAttrs := *firstRSs.Resource.Attributes
+	require.Equal(t, 2, len(firstRSsAttrs))
+	require.NotNil(t, firstRSsAttrs["one_attr"])
+	assert.Equal(t, "one_value", firstRSsAttrs["one_attr"])
+	require.NotNil(t, firstRSsAttrs["two_attr"])
+	assert.Equal(t, "two_value", firstRSsAttrs["two_attr"])
+
+	assert.Equal(t, 2, len(firstRSs.ScopeSpans))
+	firstRSsFirstSSs := firstRSs.ScopeSpans[0]
+	require.NotNil(t, firstRSsFirstSSs)
+	require.NotNil(t, firstRSsFirstSSs.Scope)
+	assert.Equal(t, "scope_one", firstRSsFirstSSs.Scope.Name)
+	assert.Equal(t, "scope_one_version", firstRSsFirstSSs.Scope.Version)
+	firstRSsFirstSSsScopeAttrs := *firstRSsFirstSSs.Scope.Attributes
+	require.Equal(t, 1, len(firstRSsFirstSSsScopeAttrs))
+	require.NotNil(t, firstRSsAttrs["one_attr"])
+	assert.Equal(t, "one_value", firstRSsAttrs["one_attr"])
+
+	spans := firstRSsFirstSSs.Spans
+	assert.Equal(t, 2, len(spans))
+	require.NotNil(t, spans[0])
+	assert.Equal(t, "span_one", spans[0].Name)
+	spanAttrs := *spans[0].Attributes
+	require.Equal(t, 2, len(spanAttrs))
+	require.NotNil(t, spanAttrs["one_attr"])
+	assert.Equal(t, "one_value", spanAttrs["one_attr"])
+	require.NotNil(t, spanAttrs["two_attr"])
+	assert.Equal(t, "two_value", spanAttrs["two_attr"])
+
+	require.NotNil(t, spans[1])
+	assert.Equal(t, "span_two", spans[1].Name)
+	spanAttrs = *spans[1].Attributes
+	assert.NotNil(t, spanAttrs)
+	assert.Equal(t, 0, len(spanAttrs))
+
+	firstRSsSecondSSs := firstRSs.ScopeSpans[1]
+	require.NotNil(t, firstRSsSecondSSs)
+	require.NotNil(t, firstRSsSecondSSs.Scope)
+	assert.Equal(t, "instrumentation_scope_two", firstRSsSecondSSs.Scope.Name)
+	assert.Equal(t, "instrumentation_scope_two_version", firstRSsSecondSSs.Scope.Version)
+	firstRSsSecondSSsScopeAttrs := *firstRSsSecondSSs.Scope.Attributes
+	assert.NotNil(t, firstRSsSecondSSsScopeAttrs)
+	assert.Equal(t, 0, len(firstRSsSecondSSsScopeAttrs))
+
+	spans = firstRSsSecondSSs.Spans
+	assert.Equal(t, 1, len(spans))
+	require.NotNil(t, spans[0])
+	assert.Equal(t, "span_one", spans[0].Name)
+	spanAttrs = *spans[0].Attributes
+	assert.NotNil(t, spanAttrs)
+	assert.Equal(t, 0, len(spanAttrs))
+
+	secondRSs := resourceTraces.ResourceSpans[1]
+	secondRSsAttrs := *secondRSs.Resource.Attributes
+	require.Equal(t, 1, len(secondRSsAttrs))
+	require.NotNil(t, secondRSsAttrs["some_attr"])
+	assert.Equal(t, "some_value", secondRSsAttrs["some_attr"])
+
+	assert.Equal(t, 1, len(secondRSs.ScopeSpans))
+	secondRSsFirstSSs := secondRSs.ScopeSpans[0]
+	require.NotNil(t, secondRSsFirstSSs)
+	require.NotNil(t, secondRSsFirstSSs.Scope)
+	assert.Equal(t, "scope_one", secondRSsFirstSSs.Scope.Name)
+	assert.Equal(t, "scope_one_version", secondRSsFirstSSs.Scope.Version)
+	assert.Nil(t, secondRSsFirstSSs.Scope.Attributes)
+
+	spans = secondRSsFirstSSs.Spans
+	assert.Equal(t, 1, len(spans))
+	require.NotNil(t, spans[0])
+	assert.Equal(t, "last_span", spans[0].Name)
+	assert.Nil(t, spans[0].Attributes)
+}
+
+func TestLoadResourcesNotAValidPath(t *testing.T) {
+	resourceTraces, err := LoadResourceTraces("notafile")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), invalidPathErrorMsg())
+	require.Nil(t, resourceTraces)
+}
+
+func TestLoadTracesInvalidItems(t *testing.T) {
+	resourceTraces, err := LoadResourceTraces(filepath.Join(".", "testdata", "traces", "invalid-resource-traces.yaml"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "field notAttributesOrScopeSpans not found in type telemetry.ResourceSpans")
+	require.Nil(t, resourceTraces)
+}
+
+func TestFlattenResourceTracesByResourceIdentity(t *testing.T) {
+	resource := Resource{Attributes: &map[string]any{"attribute_one": nil, "attribute_two": 123.456}}
+	resourceTraces := ResourceTraces{
+		ResourceSpans: []ResourceSpans{
+			{Resource: resource},
+			{Resource: resource},
+			{Resource: resource},
+		},
+	}
+	expectedResourceTraces := ResourceTraces{ResourceSpans: []ResourceSpans{{Resource: resource}}}
+	require.Equal(t, expectedResourceTraces, FlattenResourceTraces(resourceTraces))
+}
+
+func TestFlattenResourceTracesByScopeSpansIdentity(t *testing.T) {
+	resource := Resource{Attributes: &map[string]any{"attribute_three": true, "attribute_four": 23456}}
+	ss := ScopeSpans{Scope: InstrumentationScope{
+		Name: "an instrumentation library", Version: "an instrumentation library version",
+	}, Spans: []Span{}}
+	resourceTraces := ResourceTraces{
+		ResourceSpans: []ResourceSpans{
+			{Resource: resource, ScopeSpans: []ScopeSpans{}},
+			{Resource: resource, ScopeSpans: []ScopeSpans{ss}},
+			{Resource: resource, ScopeSpans: []ScopeSpans{ss, ss}},
+			{Resource: resource, ScopeSpans: []ScopeSpans{ss, ss, ss}},
+		},
+	}
+	expectedResourceTraces := ResourceTraces{
+		ResourceSpans: []ResourceSpans{
+			{Resource: resource, ScopeSpans: []ScopeSpans{ss}},
+		},
+	}
+	require.Equal(t, expectedResourceTraces, FlattenResourceTraces(resourceTraces))
+}
+
+func TestFlattenResourceTracesBySpansIdentity(t *testing.T) {
+	resource := Resource{}
+	spans := []Span{
+		{Name: "a span"},
+		{Name: "another span", Attributes: &map[string]any{}},
+		{Name: "yet another span", Attributes: &map[string]any{ "attr": "value"}},
+	}
+	ss := ScopeSpans{Spans: spans}
+	resourceTraces := ResourceTraces{
+		ResourceSpans: []ResourceSpans{
+			{Resource: resource, ScopeSpans: []ScopeSpans{}},
+			{Resource: resource, ScopeSpans: []ScopeSpans{{Spans: spans[0:1]}}},
+			{Resource: resource, ScopeSpans: []ScopeSpans{{Spans: spans[1:3]}}},
+		},
+	}
+	expectedResourceTraces := ResourceTraces{
+		ResourceSpans: []ResourceSpans{
+			{Resource: resource, ScopeSpans: []ScopeSpans{ss}},
+		},
+	}
+	require.Equal(t, expectedResourceTraces, FlattenResourceTraces(resourceTraces))
+}
+
+func TestTraceContainsAllSelfCheck(t *testing.T) {
+	resourceTraces := loadedResourceTraces(t)
+	containsAll, err := resourceTraces.ContainsAll(resourceTraces)
+	require.True(t, containsAll)
+	require.NoError(t, err)
+}
+
+func TestTraceContainsAllNoBijection(t *testing.T) {
+	received := loadedResourceTraces(t)
+
+	expected, err := LoadResourceTraces(filepath.Join(".", "testdata", "traces", "expected-traces.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, expected)
+
+	containsAll, err := received.ContainsAll(*expected)
+	require.True(t, containsAll, err)
+	require.NoError(t, err)
+
+	// Since expected-traces.yaml specify a single resource spans, they will never find resource spans from received.
+	containsAll, err = expected.ContainsAll(received)
+	require.False(t, containsAll)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Missing Spans: [name: span_one\nattributes:\n  one_attr: one_value\n  two_attr: two_value\n]")
+}
+
+func TestTraceContainsAllSpansNeverReceived(t *testing.T) {
+	received := loadedResourceTraces(t)
+	expected, err := LoadResourceTraces(filepath.Join(".", "testdata", "traces", "never-received-spans.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, expected)
+
+	// never-received-spans.yaml contains a span that isn't in resource-metrics.yaml
+	containsAll, err := received.ContainsAll(*expected)
+	require.False(t, containsAll)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Missing Spans: [name: missing_span\n]")
+}
+
+func TestTraceContainsAllInstrumentationScopeNeverReceived(t *testing.T) {
+	received := loadedResourceTraces(t)
+	expected, err := LoadResourceTraces(filepath.Join(".", "testdata", "traces", "never-received-instrumentation-scope.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, expected)
+
+	// never-received-instrumentation-scope.yaml details an InstrumentationScope that isn't in resource-traces.yaml
+	containsAll, err := received.ContainsAll(*expected)
+	require.False(t, containsAll)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Missing InstrumentationScopes: [name: unmatched_instrumentation_scope\nversion: scope_one_version\n]")
+}
+
+func TestTraceContainsAllResourceNeverReceived(t *testing.T) {
+	received := loadedResourceTraces(t)
+	expected, err := LoadResourceTraces(filepath.Join(".", "testdata", "traces", "never-received-resource.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, expected)
+
+	// never-received-resource.yaml details a Resource that isn't in resource-traces.yaml
+	containsAll, err := received.ContainsAll(*expected)
+	require.False(t, containsAll)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Missing resources: [some_attr: different_value\n]")
+}

--- a/tests/testutils/telemetry/traces_test.go
+++ b/tests/testutils/telemetry/traces_test.go
@@ -19,6 +19,7 @@ package telemetry
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -223,7 +224,13 @@ func TestTraceContainsAllNoBijection(t *testing.T) {
 	containsAll, err = expected.ContainsAll(received)
 	require.False(t, containsAll)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Missing Spans: [name: span_one\nattributes:\n  one_attr: one_value\n  two_attr: two_value\n]")
+	// The function used to generate the string representation of the span doesn't guarantee the order of the fields
+	// test both possibilities to ensure the test passes in all platforms.
+	errMsg := err.Error()
+	containsExpectedMissingSpanMsg :=
+		strings.Contains(errMsg, "Missing Spans: [name: span_one\nattributes:\n  one_attr: one_value\n  two_attr: two_value\n]") ||
+			strings.Contains(errMsg, "Missing Spans: [attributes:\n  one_attr: one_value\n  two_attr: two_value\nname: span_one\n]")
+	require.True(t, containsExpectedMissingSpanMsg)
 }
 
 func TestTraceContainsAllSpansNeverReceived(t *testing.T) {

--- a/tests/zeroconfig/windows/run-tests.ps1
+++ b/tests/zeroconfig/windows/run-tests.ps1
@@ -10,7 +10,7 @@ $testdata_path = Join-Path $repo_root tests/zeroconfig/windows/testdata/
 $docker_setup_path = Join-Path $testdata_path docker-setup/
 
 if (!(Test-Path $docker_setup_path)) {
-    New-Item $testdata_path -ItemType Directory -Value docker-setup
+    New-Item $testdata_path -Force -ItemType Directory -Name docker-setup
 }
 
 # Copy files required to build the docker images.

--- a/tests/zeroconfig/windows/testdata/Dockerfile.iis.server
+++ b/tests/zeroconfig/windows/testdata/Dockerfile.iis.server
@@ -17,7 +17,7 @@ ENV ACCESS_TOKEN_TMP=$access_token
 RUN `
     $token = $Env:ACCESS_TOKEN_TMP; `
     $collector_msi_path = (dir "c:\setup\splunk-otel-collector-*.msi").FullName; `
-    c:\setup\install.ps1 -access_token $token -msi_path $collector_msi_path -with_dotnet_instrumentation $true -deployment_env zc-iis-test -ingest_url "http://splunk-otel-collector:9943"
+    c:\setup\install.ps1 -access_token $token -msi_path $collector_msi_path -with_dotnet_instrumentation $true -deployment_env zc-iis-test -ingest_url "http://splunk-otel-collector:9943" -trace_url "http://splunk-otel-collector:7276/v2/trace"
 ENV ACCESS_TOKEN_TMP=
 
 COPY apps/bin/_PublishedWebsites/AspNet.WebApi.NetFramework/ /apps/aspnetfx

--- a/tests/zeroconfig/windows/testdata/Dockerfile.pipeline.collector
+++ b/tests/zeroconfig/windows/testdata/Dockerfile.pipeline.collector
@@ -18,7 +18,7 @@ ENV ACCESS_TOKEN_TMP=$access_token
 RUN `
     $token = $Env:ACCESS_TOKEN_TMP; `
     $collector_msi_path = (dir "c:\setup\splunk-otel-collector-*.msi").FullName; `
-    c:\setup\install.ps1 -access_token $token -msi_path $collector_msi_path -with_fluentd $false -ingest_url "http://192.0.2.1:12345"
+    c:\setup\install.ps1 -access_token $token -msi_path $collector_msi_path -with_fluentd $false -ingest_url "http://192.0.2.1:12345" -trace_url "http://192.0.2.1:12345"
 ENV ACCESS_TOKEN_TMP=
 RUN `
     Set-ItemProperty -force -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -name 'SPLUNK_CONFIG' -value 'C:\setup\pipeline-collector.yaml'

--- a/tests/zeroconfig/windows/testdata/expected_resource_metrics.yaml
+++ b/tests/zeroconfig/windows/testdata/expected_resource_metrics.yaml
@@ -1,6 +1,0 @@
-resource_metrics:
-  - attributes:
-    scope_metrics:
-      - metrics:
-          - name: otelcol_exporter_sent_spans
-            count: 2

--- a/tests/zeroconfig/windows/testdata/expected_resource_traces.yaml
+++ b/tests/zeroconfig/windows/testdata/expected_resource_traces.yaml
@@ -1,0 +1,31 @@
+resource_spans:
+- attributes:
+    deployment.environment: zc-iis-test
+    host.id: <ANY>
+    host.name: <ANY>
+    os.type: windows
+    service.name: Default Web Site/aspnetfxapp
+  scope_spans:
+  - instrumentation_scope:
+      attributes: {}
+    spans:
+    - name: GET /api/values/{id}
+      attributes:
+        http.host: localhost:8000
+        http.method: GET
+        http.status_code: "200"
+        http.url: http://localhost/aspnetfxapp/api/values
+        http.user_agent: Go-http-client/1.1
+        net.peer.ip: <ANY>
+        signalfx.tracing.library: dotnet-tracing
+        signalfx.tracing.version: <ANY>
+    - name: GET /api/values/{id}
+      attributes:
+        aspnet.controller: values
+        aspnet.route: api/{controller}/{id}
+        http.host: localhost:8000
+        http.method: GET
+        http.status_code: "200"
+        http.url: http://localhost/aspnetfxapp/api/values
+        http.user_agent: Go-http-client/1.1
+        net.peer.ip: <ANY>

--- a/tests/zeroconfig/windows/testdata/pipeline-collector.yaml
+++ b/tests/zeroconfig/windows/testdata/pipeline-collector.yaml
@@ -6,6 +6,11 @@ extensions:
 receivers:
   signalfx:
     endpoint: 0.0.0.0:9943
+  sapm:
+    endpoint: 0.0.0.0:7276
+
+processors:
+  batch:
 
 exporters:
   otlp:
@@ -18,4 +23,7 @@ service:
   pipelines:
     metrics:
       receivers: [signalfx]
+      exporters: [otlp]
+    traces:
+      receivers: [sapm]
       exporters: [otlp]

--- a/tests/zeroconfig/windows/windows_iis_test.go
+++ b/tests/zeroconfig/windows/windows_iis_test.go
@@ -96,9 +96,9 @@ func TestWindowsIISInstrumentation(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	t.Log("ASP.NET HTTP Request succeeded")
 
-	expectedResourceMetrics, err := telemetry.LoadResourceMetrics("expected_resource_metrics.yaml")
+	expectedResourceTraces, err := telemetry.LoadResourceTraces("expected_resource_traces.yaml")
 	require.NoError(t, err)
-	require.NoError(t, otlp.AssertAllMetricsReceived(t, *expectedResourceMetrics, 30*time.Second))
+	require.NoError(t, otlp.AssertAllTracesReceived(t, *expectedResourceTraces, 30*time.Second))
 }
 
 func requireNoErrorExecCommand(t *testing.T, name string, arg ...string) {


### PR DESCRIPTION
Stop using indirect metrics to validate the Windows IIS zero-config deployment for .NET Framework applications. Now the test checks for the expected spans instead, see [expected spans file](https://github.com/signalfx/splunk-otel-collector/pull/3051/files#diff-721729486953b4987e7865221feabbbcb1ba055349169c999929bc238bc4283b).

This PR adds a `ResourceTraces` to `testutils\telemetry`. This type has a few differences from the other o11y signals (`metrics` and `logs`):

- It doesn't have a "relaxed match" mode: the use of `<ANY>` on the attributes suffices. This can become an issue if spans expected by the tests change frequently; if that happens, adding a relaxed matching for the span attributes can be useful.
- Spans have IDs that should be ignored by integration tests; as such, they were not added to the respective types. Validating parent-children relations hasn't been used frequently for this type of test.

Due to these differences, the types and tests for `ResourceTraces` omitted a few functions and methods that are present on the types for metrics and logs:

Not implemented methods/functions:

1. `FillDefaultValues`: no need to add version build to the traces.
2. `Validate()`: no need to validate the traces. Metrics has metric types to parse; logs always return `nil`.
3. No need at this time to implement the relaxed equals for spans, so there is no need for `Hash`, `Equals`, etc.

Not implemented the related tests, e.g.: `Equivalence`, `Consistency`, and `AllWithMissingAndEmptyAttributes`.

1. TestLogEquivalence
2. TestLogRelaxedEquivalence
3. TestLogAttributeRelaxedEquivalence
4. TestLogHashFunctionConsistency
5. TestFlattenResourceLogsConsistency
6. TestLogContainsAllWithMissingAndEmptyAttributes


