### PR TITLE
Pin requests<2.30.0 for tests

### DIFF
--- a/internal/buildscripts/packaging/tests/requirements.txt
+++ b/internal/buildscripts/packaging/tests/requirements.txt
@@ -6,3 +6,4 @@ pytest-xdist==3.2.1
 py>=1.8.2
 requests<2.30.0
 six==1.16.0
+urllib3<2

--- a/internal/buildscripts/packaging/tests/requirements.txt
+++ b/internal/buildscripts/packaging/tests/requirements.txt
@@ -4,4 +4,5 @@ pytest==7.3.1
 pytest-html==3.1.1
 pytest-xdist==3.2.1
 py>=1.8.2
+requests<2.30.0
 six==1.16.0


### PR DESCRIPTION
Latest [requests release](https://github.com/psf/requests/releases/tag/v2.30.0) breaks compatibility with the `docker` module.