### PR TITLE
[chore] [docs] Add missing upgrade guideline

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ manually before the backward compatibility is dropped. For every configuration u
 [the default agent config](https://github.com/signalfx/splunk-otel-collector/blob/main/cmd/otelcol/config/collector/agent_config.yaml)
 as a reference.
 
+### From 0.68.0 to 0.69.0
+
+- `gke` and `gce` resource detectors in `resourcedetection` processor are replaced with `gcp` resource detector. 
+  If you have `gke` and `gce` detectors configured in the `resourcedetection` processor, please update your 
+  configuration accordingly. More details: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/10347 
+
 ### From 0.41.0 to 0.42.0
 
 - The Splunk OpenTelemetry Collector used to [evaluate user configuration 


### PR DESCRIPTION
We show a warning with a link to upgrade guidelines, but the actual section in the guidelines is missing.

```
2023/05/04 00:49:20 normalize_gcp.go:67: [WARNING] `processors` -> `resourcedetection` -> `detectors` parameter contains a deprecated configuration. Please update the config according to the guideline: https://github.com/signalfx/splunk-otel-collector#from-0680-to-0690.
```