### PR TITLE
Discovery receiver and smartagent/postgres rule improvements

### DIFF
--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml
@@ -11,9 +11,9 @@ smartagent/postgresql:
       type: postgresql
       connectionString: 'sslmode=disable user={{.username}} password={{.password}}'
       params:
-        username: splunk.discovery
-        password: splunk.discovery
-      masterDBName: splunk.discovery
+        username: splunk.discovery.default
+        password: splunk.discovery.default
+      masterDBName: splunk.discovery.default
   status:
     metrics:
       successful:
@@ -24,26 +24,35 @@ smartagent/postgresql:
             body: PostgreSQL receiver is working!
     statements:
       failed:
+        - regexp: 'connect: network is unreachable'
+          first_only: true
+          log_record:
+            severity_text: info
+            append_pattern: true
+            body: The container cannot be reached by the collector. Is it in a shared network?
         - regexp: 'connect: connection refused'
           first_only: true
           log_record:
             severity_text: info
+            append_pattern: true
             body: The container is refusing PostgreSQL connections.
       partial:
         - regexp: 'pq: password authentication failed for user'
           first_only: true
           log_record:
             severity_text: info
+            append_pattern: true
             body: >-
               Please ensure your user credentials are correctly specified with
               `--set splunk.discovery.receivers.smartagent/postgresql.config.params::username="<username>"` and
               `--set splunk.discovery.receivers.smartagent/postgresql.config.params::password="<password>"` or
               `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_username="<username>"` and
               `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_password="<password>"` environment variables.
-        - regexp: 'pq: database ".*" does not exist'
+        - regexp: 'pq: database .* does not exist'
           first_only: true
           log_record:
             severity_text: info
+            append_pattern: true
             body: >-
               Make sure the target database is correctly specified using the
               `--set splunk.discovery.receivers.smartagent/postgresql.config.masterDBName="<db>"` command or the
@@ -52,17 +61,12 @@ smartagent/postgresql:
           first_only: true
           log_record:
             severity_text: info
+            append_pattern: true
             body: >-
               Make sure your PostgreSQL database has
               `shared_preload_libraries = 'pg_stat_statements'`
               in the postgresql.conf file and that
               `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
               has been run for each database you would like to monitor.
-        - regexp: 'could not monitor postgresql server: failed to determine total_time column name'
-          first_only: true
-          log_record:
-            severity_text: info
-            body: >-
-              Make sure that `pg_stat_statements` is available for each database you
-              would like to monitor. For example:
+              For example:
               `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml
@@ -29,7 +29,7 @@ smartagent/postgresql:
           log_record:
             severity_text: info
             append_pattern: true
-            body: The container cannot be reached by the collector. Is it in a shared network?
+            body: The container cannot be reached by the Collector. Make sure they're in the same network.
         - regexp: 'connect: connection refused'
           first_only: true
           log_record:

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml.tmpl
@@ -26,7 +26,7 @@
           log_record:
             severity_text: info
             append_pattern: true
-            body: The container cannot be reached by the collector. Is it in a shared network?
+            body: The container cannot be reached by the Collector. Make sure they're in the same network.
         - regexp: 'connect: connection refused'
           first_only: true
           log_record:

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml.tmpl
@@ -21,26 +21,35 @@
             body: PostgreSQL receiver is working!
     statements:
       failed:
+        - regexp: 'connect: network is unreachable'
+          first_only: true
+          log_record:
+            severity_text: info
+            append_pattern: true
+            body: The container cannot be reached by the collector. Is it in a shared network?
         - regexp: 'connect: connection refused'
           first_only: true
           log_record:
             severity_text: info
+            append_pattern: true
             body: The container is refusing PostgreSQL connections.
       partial:
         - regexp: 'pq: password authentication failed for user'
           first_only: true
           log_record:
             severity_text: info
+            append_pattern: true
             body: >-
               Please ensure your user credentials are correctly specified with
               `--set {{ configProperty "params" "username" "<username>" }}` and
               `--set {{ configProperty "params" "password" "<password>" }}` or
               `{{ configPropertyEnvVar "params" "username" "<username>" }}` and
               `{{ configPropertyEnvVar "params" "password" "<password>" }}` environment variables.
-        - regexp: 'pq: database ".*" does not exist'
+        - regexp: 'pq: database .* does not exist'
           first_only: true
           log_record:
             severity_text: info
+            append_pattern: true
             body: >-
               Make sure the target database is correctly specified using the
               `--set {{ configProperty "masterDBName" "<db>" }}` command or the
@@ -49,17 +58,12 @@
           first_only: true
           log_record:
             severity_text: info
+            append_pattern: true
             body: >-
               Make sure your PostgreSQL database has
               `shared_preload_libraries = 'pg_stat_statements'`
               in the postgresql.conf file and that
               `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
               has been run for each database you would like to monitor.
-        - regexp: 'could not monitor postgresql server: failed to determine total_time column name'
-          first_only: true
-          log_record:
-            severity_text: info
-            body: >-
-              Make sure that `pg_stat_statements` is available for each database you
-              would like to monitor. For example:
+              For example:
               `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`

--- a/internal/confmapprovider/discovery/bundle/templatefunctions.go
+++ b/internal/confmapprovider/discovery/bundle/templatefunctions.go
@@ -26,7 +26,7 @@ import (
 	"github.com/signalfx/splunk-otel-collector/internal/confmapprovider/discovery/properties"
 )
 
-const defaultValue = "splunk.discovery"
+const defaultValue = "splunk.discovery.default"
 
 func FuncMap() template.FuncMap {
 	dc := newDiscoveryConfig()

--- a/internal/confmapprovider/discovery/bundle/templatefunctions_test.go
+++ b/internal/confmapprovider/discovery/bundle/templatefunctions_test.go
@@ -118,5 +118,5 @@ func TestDefaultValue(t *testing.T) {
 	require.NoError(t, err)
 	out := &bytes.Buffer{}
 	require.NoError(t, tmplt.Execute(out, nil))
-	require.Equal(t, "splunk.discovery", out.String())
+	require.Equal(t, "splunk.discovery.default", out.String())
 }

--- a/internal/receiver/discoveryreceiver/README.md
+++ b/internal/receiver/discoveryreceiver/README.md
@@ -349,11 +349,12 @@ expr: 'ExprEnv["some.field.with.periods"] contains "value"'
 
 ### LogRecord
 
-| Name            | Type              | Default                                                 | Docs                                   |
-|-----------------|-------------------|---------------------------------------------------------|----------------------------------------|
-| `severity_text` | string            | Emitted log statement severity level, if any, or "info" | The emitted log record's severity text |
-| `body`          | string            | Emitted log statement message                           | The emitted log record's body          |
-| `attributes`    | map[string]string | Emitted log statements fields                           | The emitted log record's attributes    |
+| Name             | Type              | Default                                                 | Docs                                                                        |
+|------------------|-------------------|---------------------------------------------------------|-----------------------------------------------------------------------------|
+| `severity_text`  | string            | Emitted log statement severity level, if any, or "info" | The emitted log record's severity text                                      |
+| `body`           | string            | Emitted log statement message                           | The emitted log record's body                                               |
+| `attributes`     | map[string]string | Emitted log statements fields                           | The emitted log record's attributes                                         |
+| `append_pattern` | bool              | false                                                   | Whether to append the evaluated statement to the configured log record body |
 
 ## Status log record content
 

--- a/internal/receiver/discoveryreceiver/config.go
+++ b/internal/receiver/discoveryreceiver/config.go
@@ -88,9 +88,10 @@ type Match struct {
 
 // LogRecord is a definition of the desired plog.LogRecord content to emit for a match.
 type LogRecord struct {
-	Attributes   map[string]string `mapstructure:"attributes"`
-	SeverityText string            `mapstructure:"severity_text"`
-	Body         string            `mapstructure:"body"`
+	Attributes    map[string]string `mapstructure:"attributes"`
+	SeverityText  string            `mapstructure:"severity_text"`
+	Body          string            `mapstructure:"body"`
+	AppendPattern bool              `mapstructure:"append_pattern"`
 }
 
 func (cfg *Config) Validate() error {

--- a/internal/receiver/discoveryreceiver/statement_evaluator.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator.go
@@ -161,7 +161,7 @@ func (se *statementEvaluator) evaluateStatement(statement *statussources.Stateme
 	patternMap := map[string]string{"message": statement.Message}
 	for k, v := range statement.Fields {
 		switch k {
-		case "caller", "name", "stacktrace":
+		case "caller", "monitorID", "name", "stacktrace":
 		default:
 			patternMap[k] = fmt.Sprintf("%v", v)
 		}
@@ -198,7 +198,11 @@ func (se *statementEvaluator) evaluateStatement(statement *statussources.Stateme
 			}
 			statementLogRecord.CopyTo(logRecord)
 			if desiredRecord.Body != "" {
-				logRecord.Body().SetStr(desiredRecord.Body)
+				body := desiredRecord.Body
+				if desiredRecord.AppendPattern {
+					body = fmt.Sprintf("%s (evaluated %q)", body, p)
+				}
+				logRecord.Body().SetStr(body)
 			}
 			if len(desiredRecord.Attributes) > 0 {
 				for k, v := range desiredRecord.Attributes {

--- a/internal/receiver/discoveryreceiver/statement_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator_test.go
@@ -42,159 +42,172 @@ func TestStatementEvaluation(t *testing.T) {
 		{name: "expr", match: Match{Expr: "message == 'desired.statement' && ExprEnv['field.one'] == 'field.one.value' && field_two contains 'two.value'"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			match := tc.match
-			match.Record = &LogRecord{
-				Body: "desired body content",
-				Attributes: map[string]string{
-					"attr.one": "attr.one.value", "attr.two": "attr.two.value",
-				},
-			}
-			for _, status := range discovery.StatusTypes {
-				t.Run(string(status), func(t *testing.T) {
-					for _, level := range []string{"debug", "info", "warn", "error", "fatal", "dpanic", "panic"} {
-						t.Run(level, func(t *testing.T) {
-							for _, firstOnly := range []bool{true, false} {
-								match.FirstOnly = firstOnly
-								t.Run(fmt.Sprintf("FirstOnly:%v", firstOnly), func(t *testing.T) {
-									observerID := component.NewIDWithName("an.observer", "observer.name")
-									cfg := &Config{
-										Receivers: map[component.ID]ReceiverEntry{
-											component.NewIDWithName("a.receiver", "receiver.name"): {
-												Rule:   "a.rule",
-												Status: &Status{Statements: map[discovery.StatusType][]Match{status: {match}}},
-											},
-										},
-										WatchObservers: []component.ID{observerID},
-									}
-									require.NoError(t, cfg.Validate())
-
-									plogs := make(chan plog.Logs)
-
-									// If debugging tests, replace the Nop Logger with a test instance to see
-									// all statements. Not in regular use to avoid spamming output.
-									// logger := zaptest.NewLogger(t)
-									logger := zap.NewNop()
-									cStore := newCorrelationStore(logger, time.Hour)
-									cStore.UpdateEndpoint(
-										observer.Endpoint{ID: "endpoint.id"},
-										addedState, observerID,
-									)
-
-									se, err := newStatementEvaluator(logger, component.NewID("some.type"), cfg, plogs, cStore)
-									require.NoError(t, err)
-
-									evaluatedLogger := se.evaluatedLogger.With(
-										zap.String("name", `a.receiver/receiver.name/receiver_creator/rc.name/{endpoint=""}/endpoint.id`),
-									)
-
-									numExpected := 1
-									if !firstOnly {
-										numExpected = 3
-									}
-
-									emitted := plog.NewLogs()
-									wg := sync.WaitGroup{}
-									wg.Add(numExpected)
-
-									go func() {
-										timer := time.NewTimer(50 * time.Millisecond)
-										for i := 0; i < numExpected; i++ {
-											select {
-											case logs := <-plogs:
-												if emitted.LogRecordCount() == 0 {
-													emitted = logs
-												} else {
-													logs.ResourceLogs().MoveAndAppendTo(emitted.ResourceLogs())
-												}
-												wg.Done()
-											case <-timer.C:
-												return
+			for _, appendPattern := range []bool{true, false} {
+				t.Run(fmt.Sprintf("append_%v", appendPattern), func(t *testing.T) {
+					match := tc.match
+					match.Record = &LogRecord{
+						Body:          "desired body content",
+						AppendPattern: appendPattern,
+						Attributes: map[string]string{
+							"attr.one": "attr.one.value", "attr.two": "attr.two.value",
+						},
+					}
+					for _, status := range discovery.StatusTypes {
+						t.Run(string(status), func(t *testing.T) {
+							for _, level := range []string{"debug", "info", "warn", "error", "fatal", "dpanic", "panic"} {
+								t.Run(level, func(t *testing.T) {
+									for _, firstOnly := range []bool{true, false} {
+										match.FirstOnly = firstOnly
+										t.Run(fmt.Sprintf("FirstOnly:%v", firstOnly), func(t *testing.T) {
+											observerID := component.NewIDWithName("an.observer", "observer.name")
+											cfg := &Config{
+												Receivers: map[component.ID]ReceiverEntry{
+													component.NewIDWithName("a.receiver", "receiver.name"): {
+														Rule:   "a.rule",
+														Status: &Status{Statements: map[discovery.StatusType][]Match{status: {match}}},
+													},
+												},
+												WatchObservers: []component.ID{observerID},
 											}
-										}
-									}()
+											require.NoError(t, cfg.Validate())
 
-									logMethod := map[string]func(string, ...zap.Field){
-										"debug":  evaluatedLogger.Debug,
-										"info":   evaluatedLogger.Info,
-										"warn":   evaluatedLogger.Warn,
-										"error":  evaluatedLogger.Error,
-										"fatal":  evaluatedLogger.Fatal,
-										"dpanic": evaluatedLogger.DPanic,
-										"panic":  evaluatedLogger.Panic,
-									}[level]
+											plogs := make(chan plog.Logs)
 
-									for _, statement := range []string{
-										"undesired.statement",
-										"another.undesired.statement",
-										"desired.statement",
-										"desired.statement",
-										"desired.statement",
-									} {
-										panicCheck := require.NotPanics
-										if level == "panic" {
-											panicCheck = require.Panics
-										}
-										panicCheck(t, func() {
-											logMethod(
-												statement,
-												zap.String("field.one", "field.one.value"),
-												zap.String("field_two", "field.two.value"),
+											// If debugging tests, replace the Nop Logger with a test instance to see
+											// all statements. Not in regular use to avoid spamming output.
+											// logger := zaptest.NewLogger(t)
+											logger := zap.NewNop()
+											cStore := newCorrelationStore(logger, time.Hour)
+											cStore.UpdateEndpoint(
+												observer.Endpoint{ID: "endpoint.id"},
+												addedState, observerID,
 											)
+
+											se, err := newStatementEvaluator(logger, component.NewID("some.type"), cfg, plogs, cStore)
+											require.NoError(t, err)
+
+											evaluatedLogger := se.evaluatedLogger.With(
+												zap.String("name", `a.receiver/receiver.name/receiver_creator/rc.name/{endpoint=""}/endpoint.id`),
+											)
+
+											numExpected := 1
+											if !firstOnly {
+												numExpected = 3
+											}
+
+											emitted := plog.NewLogs()
+											wg := sync.WaitGroup{}
+											wg.Add(numExpected)
+
+											go func() {
+												timer := time.NewTimer(50 * time.Millisecond)
+												for i := 0; i < numExpected; i++ {
+													select {
+													case logs := <-plogs:
+														if emitted.LogRecordCount() == 0 {
+															emitted = logs
+														} else {
+															logs.ResourceLogs().MoveAndAppendTo(emitted.ResourceLogs())
+														}
+														wg.Done()
+													case <-timer.C:
+														return
+													}
+												}
+											}()
+
+											logMethod := map[string]func(string, ...zap.Field){
+												"debug":  evaluatedLogger.Debug,
+												"info":   evaluatedLogger.Info,
+												"warn":   evaluatedLogger.Warn,
+												"error":  evaluatedLogger.Error,
+												"fatal":  evaluatedLogger.Fatal,
+												"dpanic": evaluatedLogger.DPanic,
+												"panic":  evaluatedLogger.Panic,
+											}[level]
+
+											for _, statement := range []string{
+												"undesired.statement",
+												"another.undesired.statement",
+												"desired.statement",
+												"desired.statement",
+												"desired.statement",
+											} {
+												panicCheck := require.NotPanics
+												if level == "panic" {
+													panicCheck = require.Panics
+												}
+												panicCheck(t, func() {
+													logMethod(
+														statement,
+														zap.String("field.one", "field.one.value"),
+														zap.String("field_two", "field.two.value"),
+													)
+												})
+											}
+
+											require.Eventually(t, func() bool {
+												wg.Wait()
+												return true
+											}, 50*time.Millisecond, time.Millisecond)
+
+											for i := 0; i < numExpected; i++ {
+												rl := emitted.ResourceLogs().At(i)
+												rAttrs := rl.Resource().Attributes()
+												require.Equal(t, map[string]any{
+													"discovery.endpoint.id":   "endpoint.id",
+													"discovery.event.type":    "statement.match",
+													"discovery.observer.id":   "an.observer/observer.name",
+													"discovery.receiver.name": "receiver.name",
+													"discovery.receiver.rule": "a.rule",
+													"discovery.receiver.type": "a.receiver",
+												}, rAttrs.AsRaw())
+
+												sLogs := rl.ScopeLogs()
+												require.Equal(t, 1, sLogs.Len())
+												sl := sLogs.At(0)
+												lrs := sl.LogRecords()
+												require.Equal(t, 1, lrs.Len())
+												lr := sl.LogRecords().At(0)
+
+												lrAttrs := lr.Attributes().AsRaw()
+
+												require.Contains(t, lrAttrs, "caller")
+												_, expectedFile, _, _ := runtime.Caller(0)
+												// runtime doesn't use os.PathSeparator
+												splitPath := strings.Split(expectedFile, "/")
+												expectedCaller := splitPath[len(splitPath)-1]
+												require.Contains(t, lrAttrs["caller"], expectedCaller)
+												delete(lrAttrs, "caller")
+
+												// argOrder doesn't like this for some reason
+												// nolint:gocritic
+												if strings.Contains("error fatal dpanic panic", level) {
+													require.Contains(t, lrAttrs, "stacktrace")
+													delete(lrAttrs, "stacktrace")
+												}
+
+												require.Equal(t, map[string]any{
+													"discovery.status": string(status),
+													"name":             `a.receiver/receiver.name/receiver_creator/rc.name/{endpoint=""}/endpoint.id`,
+													"attr.one":         "attr.one.value",
+													"attr.two":         "attr.two.value",
+													"field.one":        "field.one.value",
+													"field_two":        "field.two.value",
+												}, lrAttrs)
+
+												expected := "desired body content"
+												if match.Record.AppendPattern {
+													if match.Strict != "" {
+														expected = fmt.Sprintf("%s (evaluated \"desired.statement\")", expected)
+													} else {
+														expected = fmt.Sprintf("%s (evaluated \"{\\\"field.one\\\":\\\"field.one.value\\\",\\\"field_two\\\":\\\"field.two.value\\\",\\\"message\\\":\\\"desired.statement\\\"}\")", expected)
+													}
+												}
+												require.Equal(t, expected, lr.Body().AsString())
+												require.Equal(t, level, lr.SeverityText())
+											}
 										})
-									}
-
-									require.Eventually(t, func() bool {
-										wg.Wait()
-										return true
-									}, 50*time.Millisecond, time.Millisecond)
-
-									for i := 0; i < numExpected; i++ {
-										rl := emitted.ResourceLogs().At(i)
-										rAttrs := rl.Resource().Attributes()
-										require.Equal(t, map[string]any{
-											"discovery.endpoint.id":   "endpoint.id",
-											"discovery.event.type":    "statement.match",
-											"discovery.observer.id":   "an.observer/observer.name",
-											"discovery.receiver.name": "receiver.name",
-											"discovery.receiver.rule": "a.rule",
-											"discovery.receiver.type": "a.receiver",
-										}, rAttrs.AsRaw())
-
-										sLogs := rl.ScopeLogs()
-										require.Equal(t, 1, sLogs.Len())
-										sl := sLogs.At(0)
-										lrs := sl.LogRecords()
-										require.Equal(t, 1, lrs.Len())
-										lr := sl.LogRecords().At(0)
-
-										lrAttrs := lr.Attributes().AsRaw()
-
-										require.Contains(t, lrAttrs, "caller")
-										_, expectedFile, _, _ := runtime.Caller(0)
-										// runtime doesn't use os.PathSeparator
-										splitPath := strings.Split(expectedFile, "/")
-										expectedCaller := splitPath[len(splitPath)-1]
-										require.Contains(t, lrAttrs["caller"], expectedCaller)
-										delete(lrAttrs, "caller")
-
-										// argOrder doesn't like this for some reason
-										// nolint:gocritic
-										if strings.Contains("error fatal dpanic panic", level) {
-											require.Contains(t, lrAttrs, "stacktrace")
-											delete(lrAttrs, "stacktrace")
-										}
-
-										require.Equal(t, map[string]any{
-											"discovery.status": string(status),
-											"name":             `a.receiver/receiver.name/receiver_creator/rc.name/{endpoint=""}/endpoint.id`,
-											"attr.one":         "attr.one.value",
-											"attr.two":         "attr.two.value",
-											"field.one":        "field.one.value",
-											"field_two":        "field.two.value",
-										}, lrAttrs)
-
-										require.Equal(t, "desired body content", lr.Body().AsString())
-										require.Equal(t, level, lr.SeverityText())
 									}
 								})
 							}

--- a/tests/receivers/smartagent/postgresql/bundled_test.go
+++ b/tests/receivers/smartagent/postgresql/bundled_test.go
@@ -398,12 +398,14 @@ func (cluster testCluster) daemonSetManifest(namespace, serviceAccount, configMa
 				Image: testutils.GetCollectorImageOrSkipTest(cluster.Testcase),
 				Command: []string{
 					"/otelcol", "--config=/config/config.yaml", "--discovery",
-					"--set", "splunk.discovery.receivers.smartagent/postgresql.config.params::username=test_user",
-					"--set", "splunk.discovery.receivers.smartagent/postgresql.config.params::password=test_password",
+					"--set", "splunk.discovery.receivers.smartagent/postgresql.config.params::username='${PG_USERNAME}'",
+					"--set", "splunk.discovery.receivers.smartagent/postgresql.config.params::password='${PG_PASSWORD}'",
 					"--set", "splunk.discovery.receivers.smartagent/postgresql.config.masterDBName=test_db",
 					"--set", `splunk.discovery.receivers.smartagent/postgresql.config.extraMetrics=["*"]`,
 				},
 				Env: []corev1.EnvVar{
+					{Name: "PG_USERNAME", Value: "test_user"},
+					{Name: "PG_PASSWORD", Value: "test_password"},
 					{Name: "OTLP_ENDPOINT", Value: otlpEndpoint},
 					// Helpful for debugging
 					// {Name: "SPLUNK_DISCOVERY_DURATION", Value: "20s"},


### PR DESCRIPTION
These changes provide a new `append_pattern` option for discovery receiver statement evaluation to not require debug logging to see the originating statements and source them in the smartagent/postgres rules, with a couple of corrections that the feature led to.

They also update the default placeholder value to "splunk.discovery.default" to provide a bit more clarity.