### PR TITLE
ansible: Support RHEL9 and Amazon 2023

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -59,12 +59,14 @@ jobs:
       matrix:
         ansible:
           - ansible~=2.10.0
-          - ansible~=3.0
-          - ansible~=4.0
+          - ansible~=6.0
+          - ansible~=7.0
         distro:
           - amazonlinux2
+          - amazonlinux2023
           - centos7
           - centos8
+          - centos9
           - debian9
           - debian10
           - debian11
@@ -74,6 +76,10 @@ jobs:
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
+        exclude:
+          # ansible<6 unsupported on Amazon Linux 2023
+          - distro: amazonlinux2023
+            ansible: ansible~=2.10.0
 
     steps:
       - name: Check out the codebase.
@@ -88,6 +94,7 @@ jobs:
             molecule-docker==0.2.4
             docker==5.0.0
             ansible-lint==5.4.0
+            urllib3<2
 
       - name: Set up Python 3.
         uses: actions/setup-python@v4
@@ -119,8 +126,8 @@ jobs:
       matrix:
         ansible:
           - ansible~=2.10.0
-          - ansible~=3.0
-          - ansible~=4.0
+          - ansible~=6.0
+          - ansible~=7.0
         distro:
           - "2012"
           - "2016"

--- a/deployments/ansible/CHANGELOG.md
+++ b/deployments/ansible/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## ansible-v0.18.0
+
+### 💡 Enhancements 💡
+
+- Add support for RHEL 9 and Amazon Linux 2023
+
 ## ansible-v0.17.0
 
 ### 🧰 Bug fixes 🧰

--- a/deployments/ansible/README.md
+++ b/deployments/ansible/README.md
@@ -11,8 +11,8 @@ Observability Cloud](https://www.splunk.com/en_us/observability.html).
 ## Linux
 Currently, the following Linux distributions and versions are supported:
 
-- Amazon Linux: 2
-- CentOS / Red Hat / Oracle: 7, 8
+- Amazon Linux: 2, 2023 (**Note:** Log collection with Fluentd not currently supported for Amazon Linux 2023.)
+- CentOS / Red Hat / Oracle: 7, 8, 9
 - Debian: 9, 10, 11
 - SUSE: 12, 15 (**Note:** Only for collector versions v0.34.0 or higher. Log collection with Fluentd not currently supported.)
 - Ubuntu: 16.04, 18.04, 20.04, 22.04

--- a/deployments/ansible/contributing/requirements-dev-linux.txt
+++ b/deployments/ansible/contributing/requirements-dev-linux.txt
@@ -1,4 +1,6 @@
-ansible==3.4.0
+ansible~=7.0
+ansible-lint==5.4.0
 molecule==3.3.0
 molecule-docker==0.2.4
 docker==5.0.0
+urllib3<2

--- a/deployments/ansible/galaxy.yml
+++ b/deployments/ansible/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: signalfx
 name: splunk_otel_collector
 description: Ansible collection for Splunk OpenTelemetry Collector
-version: 0.17.0
+version: 0.18.0
 readme: README.md
 authors:
   - Splunk Inc.

--- a/deployments/ansible/molecule/config/docker.yml
+++ b/deployments/ansible/molecule/config/docker.yml
@@ -12,8 +12,9 @@ platforms:
     image: ${MOLECULE_DISTRO:-centos8}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
+    cgroupns: host
     pre_build_image: false
 
 provisioner:

--- a/deployments/ansible/molecule/custom_vars/verify.yml
+++ b/deployments/ansible/molecule/custom_vars/verify.yml
@@ -108,7 +108,7 @@
     - name: Assert custom_fluentd.conf is created
       assert:
         that: custom_fluentd_config.stat.exists
-      when: ansible_os_family != "Suse"
+      when: fluentd_supported
 
     - name: Assert custom_fluentd.conf is used
       ansible.builtin.lineinfile:
@@ -116,7 +116,7 @@
         dest: /etc/systemd/system/td-agent.service.d/splunk-otel-collector.conf
         state: present
       check_mode: yes
-      when: ansible_os_family != "Suse"
+      when: fluentd_supported
 
     - name: Send a test log message
       ansible.builtin.uri:
@@ -124,7 +124,7 @@
         method: POST
         url: http://localhost:9880/app.log
       changed_when: false
-      when: ansible_os_family != "Suse"
+      when: fluentd_supported
 
     - name: Look for the test log message in collector service output
       ansible.builtin.shell:
@@ -134,4 +134,4 @@
       until: result.stdout
       retries: 20
       delay: 1
-      when: ansible_os_family != "Suse"
+      when: fluentd_supported

--- a/deployments/ansible/molecule/default/Dockerfile.j2
+++ b/deployments/ansible/molecule/default/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% if item.image not in ["opensuse12", "opensuse15"] %}
+{% if item.image not in ["opensuse12", "opensuse15", "centos9"] %}
 FROM geerlingguy/docker-{{ item.image }}-ansible:latest
 {% if item.image == "centos8" %}
 RUN sed -i 's|#mirrorlist|mirrorlist|g' /etc/yum.repos.d/CentOS*.repo
@@ -8,6 +8,22 @@ RUN sed -i 's|\$releasever|8-stream|g' /etc/yum.repos.d/CentOS*.repo
 RUN sed -i 's|http://.*.debian.org|http://archive.debian.org|' /etc/apt/sources.list
 RUN sed -i '/stretch-updates/d' /etc/apt/sources.list
 {% endif %}
+{% elif item.image == "centos9" %}
+FROM quay.io/centos/centos:stream9
+ENV container docker
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+RUN dnf install -y initscripts sudo systemd
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
+    "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;\
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+# Disable requiretty.
+RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
+CMD ["/usr/sbin/init"]
 {% else %}
 {% if item.image == "opensuse12" %}
 FROM opensuse/leap:42

--- a/deployments/ansible/molecule/shared/verify_tasks.yml
+++ b/deployments/ansible/molecule/shared/verify_tasks.yml
@@ -4,6 +4,17 @@
 - name: Populate service facts
   ansible.builtin.service_facts:
 
+- name: Set fluentd_supported fact
+  ansible.builtin.set_fact:
+    fluentd_supported: |-
+      {%- if ansible_os_family == "Suse" -%}
+        false
+      {%- elif ansible_distribution == "Amazon" and ansible_distribution_version == "2023" -%}
+        false
+      {%- else -%}
+        true
+      {%- endif -%}
+
 - name: Assert splunk-otel-collector service is running
   assert:
     that: ansible_facts.services['splunk-otel-collector.service'].state == 'running'
@@ -11,4 +22,4 @@
 - name: Assert td-agent service is running
   assert:
     that: ansible_facts.services['td-agent.service'].state == 'running'
-  when: ansible_os_family != "Suse"
+  when: fluentd_supported

--- a/deployments/ansible/roles/collector/handlers/main.yml
+++ b/deployments/ansible/roles/collector/handlers/main.yml
@@ -13,7 +13,7 @@
     name: td-agent
     state: restarted
   when:
-    - install_fluentd and (start_service | default(true) | bool)
+    - install_fluentd and fluentd_supported and (start_service | default(true) | bool)
   listen: "restart td-agent"
 
 - name: Restart Splunk OpenTelemetry Collector

--- a/deployments/ansible/roles/collector/meta/main.yml
+++ b/deployments/ansible/roles/collector/meta/main.yml
@@ -12,6 +12,11 @@ galaxy_info:
   min_ansible_version: "2.10"
 
   platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+        - 9
     - name: Ubuntu
       versions:
         - bionic

--- a/deployments/ansible/roles/collector/tasks/linux_install.yml
+++ b/deployments/ansible/roles/collector/tasks/linux_install.yml
@@ -60,7 +60,7 @@
 
 - name: Install FluentD
   ansible.builtin.import_tasks: linux_install_fluentd.yml
-  when: install_fluentd and ansible_os_family != "Suse"
+  when: install_fluentd and fluentd_supported
 
 - name: Install Splunk OpenTelemetry Auto Instrumentation with apt package manager
   ansible.builtin.import_tasks: apt_install_auto_instrumentation.yml

--- a/deployments/ansible/roles/collector/tasks/linux_install_fluentd.yml
+++ b/deployments/ansible/roles/collector/tasks/linux_install_fluentd.yml
@@ -3,7 +3,7 @@
 
 - name: Set required td-agent version
   ansible.builtin.set_fact:
-    td_agent_version: |
+    td_agent_version: |-
       {%- if td_agent_version -%}
         {{ td_agent_version }}
       {%- elif ansible_distribution_release == "stretch" -%}

--- a/deployments/ansible/roles/collector/tasks/vars.yml
+++ b/deployments/ansible/roles/collector/tasks/vars.yml
@@ -25,6 +25,14 @@
       {%- else -%}
         /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
       {%- endif -%}
+    fluentd_supported: |-
+      {%- if ansible_os_family == "Suse" -%}
+        false
+      {%- elif ansible_distribution == "Amazon" and ansible_distribution_version == "2023" -%}
+        false
+      {%- else -%}
+        true
+      {%- endif -%}
   when: ansible_os_family != "Windows"
 
 - name: set default vars for Windows


### PR DESCRIPTION
- Skip fluentd installation on Amazon 2023 since the td-agent package currently unavailable
- Update molecule tests and dependencies
- Update test matrix for ansible 6 and 7 (drop 3 and 4)