### PR TITLE
Add JMX receiver support

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -22,6 +22,7 @@ The distribution offers support for the following components.
 | [fluentforward](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/fluentforwardreceiver)             | [beta]           |
 | [hostmetrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver)                 | [beta]           |
 | [jaeger](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jaegerreceiver)                           | [beta]           |
+| [jmx](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jmxreceiver)                                 | [alpha]          |
 | [journald](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver)                       | [alpha]          |
 | [k8s_cluster](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sclusterreceiver)                  | [beta]           |
 | [k8s_events](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver)                    | [alpha]          |

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.76.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.76.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.76.3
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.76.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.76.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.76.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.76.3

--- a/go.sum
+++ b/go.sum
@@ -1577,6 +1577,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsre
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.76.3/go.mod h1:Nwd3Ac8nHETTMsGjs4BZrUXWVdxxSN0yqT4y1DXKTkw=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.76.3 h1:yJ1+m8Fr45GU1pe08XPqjle0+ki8Cy8TzbzkS/RyZxs=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.76.3/go.mod h1:+OtY82Rv9hloUibz6t8PtG/v+po6Pw5DCHF2jflHXAY=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.76.3 h1:bRrBV6r8qgvFT3FRiJZUeTXtSMIYZaP5Yfv30Oz3B30=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.76.3/go.mod h1:a6hfLDD/zF3U8El+6LFSo/8jV4mV9T3i7yMcpoRpXvk=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.76.3 h1:EUyaQ3ZGh+W9b1prasvX0OGy/Nv8gzCcAdOa8ZxRSiA=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.76.3/go.mod h1:7L5U+211R1h7p6MIR0TWBX3xCTt2uA4YMHOWtuEVylo=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.76.3 h1:tb+Qf78p/x48ujMj8JMLDUjmxDRs+sfDPUXDfeGkI38=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -52,6 +52,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver"
@@ -135,6 +136,7 @@ func Get() (otelcol.Factories, error) {
 		filelogreceiver.NewFactory(),
 		hostmetricsreceiver.NewFactory(),
 		jaegerreceiver.NewFactory(),
+		jmxreceiver.NewFactory(),
 		journaldreceiver.NewFactory(),
 		k8sclusterreceiver.NewFactory(),
 		k8seventsreceiver.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -50,6 +50,7 @@ func TestDefaultComponents(t *testing.T) {
 		"fluentforward",
 		"hostmetrics",
 		"jaeger",
+		"jmx",
 		"journald",
 		"k8s_cluster",
 		"k8s_events",


### PR DESCRIPTION
This change adds support for the JMX receiver, which is implemented in the contrib repo.

Note: This receiver is not currently tested in a containerized environment.