### PR TITLE
Align databricks metric's metadata.yaml to upstream

### DIFF
--- a/internal/receiver/databricksreceiver/metadata.yaml
+++ b/internal/receiver/databricksreceiver/metadata.yaml
@@ -1,4 +1,4 @@
-type: databricksreceiver
+name: databricksreceiver
 resource_attributes:
   databricks.instance.name:
     description: The name of the Databricks instance as defined by the value of the "instance_name" field in the config


### PR DESCRIPTION
test of `make generate-metrics` failing as a result of this