### PR TITLE
use ipv4 explicitly to fix flakiness 

### DIFF
--- a/internal/receiver/signalfxgatewayprometheusremotewritereceiver/client_test.go
+++ b/internal/receiver/signalfxgatewayprometheusremotewritereceiver/client_test.go
@@ -83,7 +83,7 @@ func (prwc *MockPrwClient) SendWriteRequest(wr *prompb.WriteRequest) error {
 }
 
 func GetFreePort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
~~while we investigate why we get issues with ipv6~~

Well [there's the problem](https://github.com/actions/runner-images/issues/668) lol