### PR TITLE
add a .ready status

### DIFF
--- a/internal/receiver/signalfxgatewayprometheusremotewritereceiver/receiver_test.go
+++ b/internal/receiver/signalfxgatewayprometheusremotewritereceiver/receiver_test.go
@@ -60,6 +60,7 @@ func TestEmptySend(t *testing.T) {
 	require.NotEmpty(t, remoteWriteReceiver.settings)
 	require.NotNil(t, remoteWriteReceiver.reporter)
 	require.Equal(t, expectedEndpoint, remoteWriteReceiver.server.Addr)
+	require.Eventually(t, func() bool { remoteWriteReceiver.server.ready(); return true }, time.Second*10, 50*time.Millisecond)
 
 	client, err := NewMockPrwClient(
 		cfg.Endpoint,
@@ -110,6 +111,7 @@ func TestSuccessfulSend(t *testing.T) {
 	require.NotEmpty(t, remoteWriteReceiver.settings)
 	require.NotNil(t, remoteWriteReceiver.reporter)
 	require.Equal(t, expectedEndpoint, remoteWriteReceiver.server.Addr)
+	require.Eventually(t, func() bool { remoteWriteReceiver.server.ready(); return true }, time.Second*10, 50*time.Millisecond)
 
 	client, err := NewMockPrwClient(
 		cfg.Endpoint,
@@ -163,6 +165,7 @@ func TestRealReporter(t *testing.T) {
 	require.NotEmpty(t, remoteWriteReceiver.settings.TelemetrySettings)
 	require.NotEmpty(t, remoteWriteReceiver.settings.Logger)
 	require.NotEmpty(t, remoteWriteReceiver.settings.BuildInfo)
+	require.Eventually(t, func() bool { remoteWriteReceiver.server.ready(); return true }, time.Second*10, 50*time.Millisecond)
 
 	client, err := NewMockPrwClient(
 		cfg.Endpoint,


### PR DESCRIPTION
After we create the .listener, but before the http server is "up" and ready to respond to requests, we now signal that the socket is ready for data to be sent (even if the http server might need a few seconds to start dequeing/processing from said buffer) 