### PR TITLE
Update qemu to 7.0.0 for github workflows

### DIFF
--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -29,6 +29,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
+          image: tonistiigi/binfmt:qemu-v7.0.0
 
       - name: Build libsplunk.so
         run: make -C instrumentation dist ARCH=${{ matrix.ARCH }}
@@ -104,6 +105,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
+          image: tonistiigi/binfmt:qemu-v7.0.0
 
       - name: Test
         run: docker run --platform linux/${{ matrix.ARCH }} --rm -v $(pwd):/repo -w /repo ${{ matrix.DISTRO }} /repo/instrumentation/packaging/fpm/test.sh deb ${{ matrix.ARCH }}
@@ -132,6 +134,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
+          image: tonistiigi/binfmt:qemu-v7.0.0
 
       - name: Test
         run: docker run --platform linux/${{ matrix.ARCH }} --rm -v $(pwd):/repo -w /repo ${{ matrix.DISTRO }} /repo/instrumentation/packaging/fpm/test.sh rpm ${{ matrix.ARCH }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -233,6 +233,7 @@ jobs:
         if: ${{ matrix.ARCH != 'amd64' }}
         with:
           platforms: ${{ matrix.ARCH }}
+          image: tonistiigi/binfmt:qemu-v7.0.0
 
       - run: make -C pkg/signalfx-agent/bundle agent-bundle-linux ARCH=${{ matrix.ARCH }}
 
@@ -357,6 +358,7 @@ jobs:
         if: ${{ matrix.ARCH != 'amd64' }}
         with:
           platforms: ${{ matrix.ARCH }}
+          image: tonistiigi/binfmt:qemu-v7.0.0
 
       - name: Setup python
         uses: actions/setup-python@v4
@@ -676,6 +678,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
         with:
           platforms: ${{ matrix.ARCH }}
+          image: tonistiigi/binfmt:qemu-v7.0.0
 
       - name: Downloading binaries-linux_${{ matrix.ARCH }}
         uses: actions/download-artifact@v3

--- a/.github/workflows/installer-script-test.yml
+++ b/.github/workflows/installer-script-test.yml
@@ -63,6 +63,7 @@ jobs:
         if: ${{ matrix.ARCH != 'amd64' }}
         with:
           platforms: ${{ matrix.ARCH }}
+          image: tonistiigi/binfmt:qemu-v7.0.0
 
       - name: Setup python
         uses: actions/setup-python@v4

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -50,6 +50,7 @@ jobs:
         if: ${{ matrix.ARCH != 'amd64' }}
         with:
           platforms: ${{ matrix.ARCH }}
+          image: tonistiigi/binfmt:qemu-v7.0.0
       - run: |
           make docker-otelcol ARCH=${{ matrix.ARCH }}
         env:
@@ -85,6 +86,7 @@ jobs:
         if: ${{ matrix.ARCH != 'amd64' }}
         with:
           platforms: ${{ matrix.ARCH }}
+          image: tonistiigi/binfmt:qemu-v7.0.0
       - run: docker load -i ./bin/image.tar
       - run: chmod a+x ./bin/*
       - run: make integration-vet
@@ -117,6 +119,7 @@ jobs:
         if: ${{ matrix.ARCH != 'amd64' }}
         with:
           platforms: ${{ matrix.ARCH }}
+          image: tonistiigi/binfmt:qemu-v7.0.0
       - run: docker load -i ./bin/image.tar
       - run: chmod a+x ./bin/*
       - run: make integration-test-split

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -66,6 +66,7 @@ jobs:
         if: ${{ matrix.ARCH != 'amd64' }}
         with:
           platforms: ${{ matrix.ARCH }}
+          image: tonistiigi/binfmt:qemu-v7.0.0
       - run: |
           make docker-otelcol ARCH=${{ matrix.ARCH }}
         env:
@@ -90,6 +91,7 @@ jobs:
         if: ${{ matrix.ARCH != 'amd64' }}
         with:
           platforms: ${{ matrix.ARCH }}
+          image: tonistiigi/binfmt:qemu-v7.0.0
       - uses: actions/download-artifact@v3
         with:
           name: otelcol-${{ matrix.ARCH }}
@@ -120,6 +122,7 @@ jobs:
         if: ${{ matrix.ARCH != 'amd64' }}
         with:
           platforms: ${{ matrix.ARCH }}
+          image: tonistiigi/binfmt:qemu-v7.0.0
       - uses: actions/download-artifact@v3
         with:
           name: otelcol-${{ matrix.ARCH }}


### PR DESCRIPTION
Updates the `tonistiigi/binfmt` image for `docker/setup-qemu-action` from the default (latest, 6.2.0) to 7.0.0 to help with stability and performance for arm64 builds and tests in github workflows.