### PR TITLE
Add workflow to lint examples

### DIFF
--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -1,0 +1,42 @@
+name: lint-examples
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/lint-examples.yml'
+      - 'examples/**/*.go'
+      - 'examples/**/go.mod'
+      - 'examples/**/go.sum'
+
+concurrency:
+  group: lint-examples-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: 1.19.6
+
+jobs:
+  lint:
+    name: lint
+    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
+
+      - name: Lint
+        run: |
+          make install-tools
+          for gomod in $(find examples -name "go.mod"); do
+            dir=$(dirname $gomod)
+            pushd $dir >/dev/null
+            echo "Running 'make lint' in $dir ..."
+            make lint
+            popd >/dev/null
+          done


### PR DESCRIPTION
Run `make lint` for PRs with go-related changes in `examples`.