### PR TITLE
Use ubuntu-22.04 runner for amazonlinux 2023 tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -328,7 +328,7 @@ jobs:
 
   test-package:
     # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJSON('["ubuntu-20.04", "ubuntu-22.04"]')[matrix.DISTRO == 'amazonlinux-2023'] }}
     timeout-minutes: 20
     needs: [build-package, test-package-matrix]
     strategy:

--- a/.github/workflows/installer-script-test.yml
+++ b/.github/workflows/installer-script-test.yml
@@ -45,7 +45,7 @@ jobs:
 
   linux-installer-script-test:
     # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJSON('["ubuntu-20.04", "ubuntu-22.04"]')[matrix.DISTRO == 'amazonlinux-2023'] }}
     needs: installer-test-matrix
     strategy:
       matrix: ${{ fromJSON(needs.installer-test-matrix.outputs.matrix) }}


### PR DESCRIPTION
The installer and package tests for amazonlinux 2023 have been flaky due to timeouts because systemd has been hanging in the test containers.  Updating the runner image to `ubuntu-22.04` seems to help.