### PR TITLE
evaluate --set property values as yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🧰 Bug fixes 🧰
+
+- Evaluate `--set` properties as yaml values ([#3175](https://github.com/signalfx/splunk-otel-collector/pull/3175))
+
 ## v0.77.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.77.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.77.0) and the [opentelemetry-collector-contrib v0.77.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.77.0) releases where appropriate.

--- a/internal/configconverter/overwrite_properties_test.go
+++ b/internal/configconverter/overwrite_properties_test.go
@@ -36,23 +36,33 @@ func TestOverwritePropertiesConverter(t *testing.T) {
 	props := []string{
 		"processors.batch.timeout=2s",
 		"processors.batch/foo.timeout=3s",
+		"processors.batch/bar.send_batch_size=200000",
 		"receivers.otlp.protocols.grpc.endpoint=localhost:1818",
 		"exporters.kafka.brokers=foo:9200,foo2:9200",
+		"exporters.otlp.protocols={grpc: {endpoint: localhost:1819}}",
+		"processors.filter.metrics.include.metric_names=[metric.one, metric.two]",
 	}
 
 	pmp := NewOverwritePropertiesConverter(props)
 	conf := confmap.New()
 	require.NoError(t, pmp.Convert(context.Background(), conf))
 	keys := conf.AllKeys()
-	assert.Len(t, keys, 4)
+	assert.Len(t, keys, 7)
 	assert.Equal(t, "2s", conf.Get("processors::batch::timeout"))
 	assert.Equal(t, "3s", conf.Get("processors::batch/foo::timeout"))
+	assert.Equal(t, 200000, conf.Get("processors::batch/bar::send_batch_size"))
 	assert.Equal(t, "foo:9200,foo2:9200", conf.Get("exporters::kafka::brokers"))
 	assert.Equal(t, "localhost:1818", conf.Get("receivers::otlp::protocols::grpc::endpoint"))
+	assert.Equal(t, "localhost:1819", conf.Get("exporters::otlp::protocols::grpc::endpoint"))
+	assert.Equal(t, []any{"metric.one", "metric.two"}, conf.Get("processors::filter::metrics::include::metric_names"))
 }
 
 func TestOverwritePropertiesConverter_InvalidProperty(t *testing.T) {
 	pmp := NewOverwritePropertiesConverter([]string{"=2s"})
 	conf := confmap.New()
 	assert.Error(t, pmp.Convert(context.Background(), conf))
+
+	pmp = NewOverwritePropertiesConverter([]string{"key={:false"})
+	conf = confmap.New()
+	assert.EqualError(t, pmp.Convert(context.Background(), conf), "error unmarshalling \"key\" value: yaml: did not find expected node content")
 }

--- a/tests/general/set_properties_test.go
+++ b/tests/general/set_properties_test.go
@@ -103,7 +103,7 @@ func TestSetProperties(t *testing.T) {
 			"otlp": map[string]any{
 				"protocols": map[string]any{
 					"grpc": map[string]any{
-						"max_recv_msg_size_mib": "1",
+						"max_recv_msg_size_mib": 1,
 					},
 					"http": map[string]any{
 						"endpoint": "localhost:0",
@@ -116,7 +116,7 @@ func TestSetProperties(t *testing.T) {
 				"metrics": map[string]any{
 					"include": map[string]any{
 						"match_type":   "regexp",
-						"metric_names": "[a.name]",
+						"metric_names": []any{"a.name"},
 					},
 				},
 			},
@@ -124,7 +124,7 @@ func TestSetProperties(t *testing.T) {
 				"metrics": map[string]any{
 					"include": map[string]any{
 						"match_type":   "strict",
-						"metric_names": "[another.name]",
+						"metric_names": []any{"another.name"},
 					},
 				},
 			},


### PR DESCRIPTION
These changes will unmarshal `--set` property values as yaml. This is to match the existing core service functionality of converting `--set` flags to yaml, though without the yaml confmap provider directives we don't currently include.