### PR TITLE
Apply config converters to `--dry-run` content.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🧰 Bug fixes 🧰
 
 - Evaluate `--set` properties as yaml values ([#3175](https://github.com/signalfx/splunk-otel-collector/pull/3175))
+- Evaluate config converter updates to `--dry-run` content ([#3176](https://github.com/signalfx/splunk-otel-collector/pull/3176))
 
 ## v0.77.0
 

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	confMapConverters := collectorSettings.ConfMapConverters()
 	configServer := configconverter.NewConfigServer()
-	dryRun := configconverter.NewDryRun(collectorSettings.IsDryRun())
+	dryRun := configconverter.NewDryRun(collectorSettings.IsDryRun(), confMapConverters)
 	confMapConverters = append(confMapConverters, dryRun, configServer)
 
 	discovery, err := discovery.New()

--- a/internal/configconverter/discovery.go
+++ b/internal/configconverter/discovery.go
@@ -77,7 +77,10 @@ func getServiceExtensions(out map[string]any) (map[string]any, []any, error) {
 	service := map[string]any{}
 	var serviceExtensions []any
 	if s, hasService := out["service"]; hasService && s != nil {
-		service = s.(map[string]any)
+		var ok bool
+		if service, ok = s.(map[string]any); !ok {
+			return nil, nil, fmt.Errorf("service is of unexpected form (%T): %v", s, s)
+		}
 		if ses, hasExtensions := service["extensions"]; hasExtensions && ses != nil {
 			var err error
 			if serviceExtensions, err = toAnySlice(ses); err != nil {

--- a/internal/configconverter/dry_run_test.go
+++ b/internal/configconverter/dry_run_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestDryRun(t *testing.T) {
 	cfgOne := confmap.NewFromStringMap(map[string]any{"key.one": "value.one"})
-	dr := NewDryRun(false)
+	dr := NewDryRun(false, []confmap.Converter{Discovery{}})
 	dr.OnNew()
 	defer func() { require.NotPanics(t, dr.OnShutdown) }()
 
@@ -54,7 +54,7 @@ func TestDryRun(t *testing.T) {
 		}
 	}())
 
-	dr = NewDryRun(true)
+	dr = NewDryRun(true, []confmap.Converter{Discovery{}})
 	cfgTwo := confmap.NewFromStringMap(map[string]any{"key.two": "value.two"})
 	dr.OnRetrieve("some.scheme", cfgOne.ToStringMap())
 	dr.OnRetrieve("another.scheme", cfgTwo.ToStringMap())

--- a/tests/general/discoverymode/configd_test.go
+++ b/tests/general/discoverymode/configd_test.go
@@ -47,7 +47,7 @@ func TestConfigDInitialAndEffectiveConfig(t *testing.T) {
 				"SPLUNK_CONFIG_DIR":             "/opt/config.d",
 				"CONFIG_FILE_PORT_FROM_ENV_VAR": "12345",
 				"CONFIGD_PORT_FROM_ENV_VAR":     "34567",
-			}).WithArgs("--configd")
+			}).WithArgs("--configd", "--set", "processors.batch/from-config-file.send_batch_size=123456789")
 		},
 	)
 
@@ -144,8 +144,10 @@ func TestConfigDInitialAndEffectiveConfig(t *testing.T) {
 			},
 		},
 		"processors": map[string]any{
-			"batch/from-config-file": nil,
-			"batch/from-configd":     map[string]any{},
+			"batch/from-config-file": map[string]any{
+				"send_batch_size": 123456789,
+			},
+			"batch/from-configd": map[string]any{},
 		},
 		"receivers": map[string]any{
 			"otlp/from-config-file": map[string]any{
@@ -185,7 +187,7 @@ func TestConfigDInitialAndEffectiveConfig(t *testing.T) {
 
 	sc, stdout, stderr := cc.Container.AssertExec(
 		tc, 15*time.Second, "bash", "-c",
-		"SPLUNK_DEBUG_CONFIG_SERVER=false /otelcol --config-dir /opt/config.d --configd --dry-run 2>/dev/null",
+		"SPLUNK_DEBUG_CONFIG_SERVER=false /otelcol --config-dir /opt/config.d --configd --set processors.batch/from-config-file.send_batch_size=123456789 --dry-run 2>/dev/null",
 	)
 	require.Equal(t, `exporters:
   otlp/from-config-file:
@@ -198,7 +200,8 @@ extensions:
   health_check/from-configd:
     endpoint: 0.0.0.0:45678
 processors:
-  batch/from-config-file: null
+  batch/from-config-file:
+    send_batch_size: 123456789
   batch/from-configd: {}
 receivers:
   otlp/from-config-file:


### PR DESCRIPTION
These changes fix a bug where config converter updates aren't propagated to* `--dry-run` content such that the reported config doesn't match that provided to the actual collector service.

~requires https://github.com/signalfx/splunk-otel-collector/pull/3175~