### PR TITLE
Enable fastestmirror for centos test images

### DIFF
--- a/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.centos-7
+++ b/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.centos-7
@@ -4,6 +4,7 @@ FROM centos:7
 
 ENV container docker
 
+RUN echo 'fastestmirror=1' >> /etc/yum.conf
 RUN yum install -y curl procps initscripts systemd wget
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \

--- a/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.centos-8
+++ b/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.centos-8
@@ -4,6 +4,7 @@ FROM quay.io/centos/centos:stream8
 
 ENV container docker
 
+RUN echo 'fastestmirror=1' >> /etc/yum.conf
 RUN dnf install -y procps initscripts systemd wget
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \

--- a/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.centos-9
+++ b/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.centos-9
@@ -5,6 +5,7 @@ FROM quay.io/centos/centos:stream9
 ENV container docker
 
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+RUN echo 'fastestmirror=1' >> /etc/yum.conf
 RUN dnf install -y procps initscripts systemd wget
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \


### PR DESCRIPTION
Try to reduce test timeouts due to slow mirrors.