### PR TITLE
support uris as --config args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Evaluate `--set` properties as yaml values ([#3175](https://github.com/signalfx/splunk-otel-collector/pull/3175))
 - Evaluate config converter updates to `--dry-run` content ([#3176](https://github.com/signalfx/splunk-otel-collector/pull/3176))
+- Support config provider uris in `--config` option values ([#3182](https://github.com/signalfx/splunk-otel-collector/pull/3182))
 
 ## v0.77.0
 


### PR DESCRIPTION
These changes add support for* using resolver* uri's for `--config` option values as documented generally by https://github.com/open-telemetry/opentelemetry-collector/tree/main/service#single-config-source