### PR TITLE
Add smartagent/telegraf-exec integration test

### DIFF
--- a/tests/receivers/smartagent/telegraf-exec/telegraf_exec_test.go
+++ b/tests/receivers/smartagent/telegraf-exec/telegraf_exec_test.go
@@ -1,0 +1,40 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package tests
+
+import (
+	"path"
+	"testing"
+
+	"github.com/signalfx/splunk-otel-collector/tests/testutils"
+)
+
+func TestTelegrafExecWithGoScript(t *testing.T) {
+	collectorImage := testutils.GetCollectorImageOrSkipTest(t)
+	testutils.AssertAllMetricsReceived(
+		t, "all.yaml", "", nil,
+		[]testutils.CollectorBuilder{func(collector testutils.Collector) testutils.Collector {
+			cc := collector.(*testutils.CollectorContainer)
+			cc.Container = cc.Container.WithContext(
+				path.Join(".", "testdata", "exec"),
+			).WithBuildArgs(map[string]*string{
+				"SPLUNK_OTEL_COLLECTOR_IMAGE": &collectorImage,
+			})
+			return cc.WithArgs("--config", "/etc/config.yaml")
+		}},
+	)
+}

--- a/tests/receivers/smartagent/telegraf-exec/telegraf_exec_test.go
+++ b/tests/receivers/smartagent/telegraf-exec/telegraf_exec_test.go
@@ -25,6 +25,10 @@ import (
 
 func TestTelegrafExecWithGoScript(t *testing.T) {
 	collectorImage := testutils.GetCollectorImageOrSkipTest(t)
+	platform := "amd64"
+	if testutils.CollectorImageIsForArm(t) {
+		platform = "arm64"
+	}
 	testutils.AssertAllMetricsReceived(
 		t, "all.yaml", "", nil,
 		[]testutils.CollectorBuilder{func(collector testutils.Collector) testutils.Collector {
@@ -32,6 +36,7 @@ func TestTelegrafExecWithGoScript(t *testing.T) {
 			cc.Container = cc.Container.WithContext(
 				path.Join(".", "testdata", "exec"),
 			).WithBuildArgs(map[string]*string{
+				"IMAGE_PLATFORM":              &platform,
 				"SPLUNK_OTEL_COLLECTOR_IMAGE": &collectorImage,
 			})
 			return cc.WithArgs("--config", "/etc/config.yaml")

--- a/tests/receivers/smartagent/telegraf-exec/testdata/exec/Dockerfile
+++ b/tests/receivers/smartagent/telegraf-exec/testdata/exec/Dockerfile
@@ -1,5 +1,6 @@
 ARG SPLUNK_OTEL_COLLECTOR_IMAGE
-FROM golang:1.19 as golang
+ARG IMAGE_PLATFORM
+FROM --platform=${IMAGE_PLATFORM} golang:1.19 as golang
 
 RUN mkdir -p /some/path
 

--- a/tests/receivers/smartagent/telegraf-exec/testdata/exec/Dockerfile
+++ b/tests/receivers/smartagent/telegraf-exec/testdata/exec/Dockerfile
@@ -1,0 +1,16 @@
+ARG SPLUNK_OTEL_COLLECTOR_IMAGE
+FROM golang:1.19 as golang
+
+RUN mkdir -p /some/path
+
+FROM ${SPLUNK_OTEL_COLLECTOR_IMAGE}
+
+ENV PATH=/some/path/go/bin:$PATH
+ENV GOROOT=/some/path/go
+ENV GOCACHE=/tmp/.cache/go-build
+
+COPY telegraf-exec.go /opt/telegraf-exec.go
+COPY config.yaml /etc/config.yaml
+COPY --from=golang --chown=999 /tmp /tmp
+COPY --from=golang --chown=999 /some/path /some/path
+COPY --from=golang --chown=999 /usr/local/go /some/path/go

--- a/tests/receivers/smartagent/telegraf-exec/testdata/exec/config.yaml
+++ b/tests/receivers/smartagent/telegraf-exec/testdata/exec/config.yaml
@@ -1,0 +1,24 @@
+receivers:
+  smartagent/exec:
+    type: telegraf/exec
+    command: 'go run /opt/telegraf-exec.go'
+    intervalSeconds: 1
+    telegrafParser:
+      metricName: some.metric
+      defaultTags:
+        tag.one: one
+        tag.two: two
+      dataFormat: value
+      dataType: integer
+
+exporters:
+  otlp:
+    endpoint: "${OTLP_ENDPOINT}"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [smartagent/exec]
+      exporters: [otlp]

--- a/tests/receivers/smartagent/telegraf-exec/testdata/exec/telegraf-exec.go
+++ b/tests/receivers/smartagent/telegraf-exec/testdata/exec/telegraf-exec.go
@@ -1,0 +1,24 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+func main() {
+	fmt.Printf("%d\n", rand.Int())
+}

--- a/tests/receivers/smartagent/telegraf-exec/testdata/resource_metrics/all.yaml
+++ b/tests/receivers/smartagent/telegraf-exec/testdata/resource_metrics/all.yaml
@@ -1,0 +1,9 @@
+resource_metrics:
+  - scope_metrics:
+      - metrics:
+          - name: some.metric
+            attributes:
+              tag.one: one
+              tag.two: two
+              system.type: exec
+            type: IntGauge

--- a/tests/testutils/container.go
+++ b/tests/testutils/container.go
@@ -86,6 +86,11 @@ func (container Container) WithContext(path string) Container {
 	return container
 }
 
+func (container Container) WithBuildArgs(args map[string]*string) Container {
+	container.Dockerfile.BuildArgs = args
+	return container
+}
+
 func (container Container) WithContextArchive(contextArchive io.Reader) Container {
 	container.Dockerfile.ContextArchive = contextArchive
 	return container

--- a/tests/testutils/container_test.go
+++ b/tests/testutils/container_test.go
@@ -57,6 +57,12 @@ func TestDockerBuilderMethods(t *testing.T) {
 	assert.NotSame(t, builder, withContext)
 	assert.Empty(t, builder.Dockerfile.Context)
 
+	val := "value"
+	withBuildArgs := builder.WithBuildArgs(map[string]*string{"BUILD_ARG": &val})
+	assert.Equal(t, &val, withBuildArgs.Dockerfile.BuildArgs["BUILD_ARG"])
+	assert.NotSame(t, builder, withBuildArgs)
+	assert.Empty(t, builder.Dockerfile.BuildArgs)
+
 	contextArchive := noopReader{}
 	withContextArchive := builder.WithContextArchive(contextArchive)
 	assert.Equal(t, contextArchive, withContextArchive.Dockerfile.ContextArchive)


### PR DESCRIPTION
Also allows setting the build context (and build args) for the target collector to make embedding go into the collector image possible.