### PR TITLE
Prevent setting SA monitor configs with invalid endpoint fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Evaluate `--set` properties as yaml values ([#3175](https://github.com/signalfx/splunk-otel-collector/pull/3175))
 - Evaluate config converter updates to `--dry-run` content ([#3176](https://github.com/signalfx/splunk-otel-collector/pull/3176))
 - Support config provider uris in `--config` option values ([#3182](https://github.com/signalfx/splunk-otel-collector/pull/3182))
+- `smartagent`: Don't attempt to expand observer `endpoint` fields if host and port are unsupported ([#3187](https://github.com/signalfx/splunk-otel-collector/pull/3187))
 
 ## v0.77.0
 

--- a/pkg/receiver/smartagentreceiver/config_test.go
+++ b/pkg/receiver/smartagentreceiver/config_test.go
@@ -23,10 +23,12 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/core/common/kubelet"
 	"github.com/signalfx/signalfx-agent/pkg/core/common/kubernetes"
 	saconfig "github.com/signalfx/signalfx-agent/pkg/core/config"
+	"github.com/signalfx/signalfx-agent/pkg/monitors/cadvisor"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/collectd/consul"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/collectd/hadoop"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/collectd/python"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/collectd/redis"
+	"github.com/signalfx/signalfx-agent/pkg/monitors/elasticsearch/stats"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/filesystems"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/haproxy"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/kubernetes/volumes"
@@ -246,7 +248,7 @@ func TestLoadConfigWithEndpoints(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, 4, len(cfg.ToStringMap()))
+	assert.Equal(t, 6, len(cfg.ToStringMap()))
 
 	cm, err := cfg.Sub(component.NewIDWithName(typeStr, "haproxy").String())
 	require.NoError(t, err)
@@ -333,6 +335,57 @@ func TestLoadConfigWithEndpoints(t *testing.T) {
 		acceptsEndpoints: true,
 	}, etcdCfg)
 	require.NoError(t, etcdCfg.validate())
+
+	cm, err = cfg.Sub(component.NewIDWithName(typeStr, "elasticsearch").String())
+	require.NoError(t, err)
+	elasticCfg := CreateDefaultConfig().(*Config)
+	require.NoError(t, component.UnmarshalConfig(cm, elasticCfg))
+	tru := true
+	require.Equal(t, &Config{
+		Endpoint: "elastic:567",
+		monitorConfig: &stats.Config{
+			MonitorConfig: saconfig.MonitorConfig{
+				Type:                "elasticsearch",
+				IntervalSeconds:     567,
+				DatapointsToExclude: []saconfig.MetricFilter{},
+			},
+			HTTPConfig: httpclient.HTTPConfig{
+				HTTPTimeout: timeutil.Duration(10 * time.Second),
+			},
+			Host:                           "elastic",
+			Port:                           "567",
+			EnableIndexStats:               &tru,
+			IndexStatsIntervalSeconds:      60,
+			IndexStatsMasterOnly:           &tru,
+			EnableClusterHealth:            &tru,
+			ClusterHealthStatsMasterOnly:   &tru,
+			ThreadPools:                    []string{"search", "index"},
+			MetadataRefreshIntervalSeconds: 30,
+		},
+		acceptsEndpoints: true,
+	}, elasticCfg)
+	require.NoError(t, elasticCfg.validate())
+
+	cm, err = cfg.Sub(component.NewIDWithName(typeStr, "kubelet-stats").String())
+	require.NoError(t, err)
+	kubeletCfg := CreateDefaultConfig().(*Config)
+	require.NoError(t, component.UnmarshalConfig(cm, kubeletCfg))
+	require.Equal(t, &Config{
+		Endpoint: "disregarded:678",
+		monitorConfig: &cadvisor.KubeletStatsConfig{
+			MonitorConfig: saconfig.MonitorConfig{
+				Type:                "kubelet-stats",
+				IntervalSeconds:     789,
+				DatapointsToExclude: []saconfig.MetricFilter{},
+			},
+			KubeletAPI: kubelet.APIConfig{
+				AuthType:   "serviceAccount",
+				SkipVerify: &tru,
+			},
+		},
+		acceptsEndpoints: true,
+	}, kubeletCfg)
+	require.NoError(t, kubeletCfg.validate())
 }
 
 func TestLoadInvalidConfigWithInvalidEndpoint(t *testing.T) {

--- a/pkg/receiver/smartagentreceiver/testdata/endpoints_config.yaml
+++ b/pkg/receiver/smartagentreceiver/testdata/endpoints_config.yaml
@@ -20,3 +20,13 @@ smartagent/etcd:
   type: etcd
   host: localhost
   intervalSeconds: 456
+smartagent/elasticsearch:
+  type: elasticsearch
+  endpoint: elastic:567
+  intervalSeconds: 567
+smartagent/kubelet-stats:
+  type: kubelet-stats
+  endpoint: disregarded:678
+  intervalSeconds: 789
+  kubeletAPI:
+    authType: serviceAccount


### PR DESCRIPTION
Currently the `acceptsEndpoints` value is used to determine if `endpoint`-derived host and port values should be used in monitor configs. This logic is invalid where endpoints are accepted but `host` and `port` don't exist or are of unexpected string values. These changes ensure the field exists before attempting to set them, and also tries port strings since changing the config field type could be a breaking one.

Resolves https://github.com/signalfx/splunk-otel-collector/issues/2264.