### PR TITLE
Replace deprecated logging exporter parameter

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -150,7 +150,7 @@ exporters:
       insecure: true
   # Debug
   logging:
-    loglevel: debug
+    verbosity: detailed
 
 service:
   extensions: [health_check, http_forwarder, zpages, memory_ballast, smartagent]

--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -471,7 +471,7 @@ exporters:
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter
   # NOTE: This exporter is very helpful in troubleshooting issues
   logging:
-    loglevel: debug
+    verbosity: detailed
 
 ###############################################################################
 # Extensions

--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -109,7 +109,7 @@ exporters:
     sync_host_metadata: true
   # Debug
   #logging:
-    #loglevel: debug
+    #verbosity: detailed
 
 service:
   extensions: [health_check, http_forwarder, zpages, memory_ballast]

--- a/cmd/otelcol/config/collector/otlp_config_linux.yaml
+++ b/cmd/otelcol/config/collector/otlp_config_linux.yaml
@@ -86,7 +86,7 @@ exporters:
     realm: "${SPLUNK_REALM}"
   # Debug
   #logging:
-    #loglevel: debug
+    #verbosity: detailed
 
 extensions:
   health_check:

--- a/cmd/otelcol/config/collector/upstream_agent_config.yaml
+++ b/cmd/otelcol/config/collector/upstream_agent_config.yaml
@@ -140,7 +140,7 @@ exporters:
       insecure: true
   # Debug
   logging:
-    loglevel: debug
+    verbosity: detailed
 
 service:
   extensions: [health_check, http_forwarder, zpages, memory_ballast]

--- a/deployments/ansible/molecule/custom_vars/custom_collector_config.yml
+++ b/deployments/ansible/molecule/custom_vars/custom_collector_config.yml
@@ -24,7 +24,7 @@ processors:
 
 exporters:
   logging/debug:
-    verbosity: detailed
+    loglevel: debug
   logging/info:
     loglevel: info
 

--- a/deployments/nomad/README.md
+++ b/deployments/nomad/README.md
@@ -71,7 +71,7 @@ exporters:
     ingest_url: https://ingest.${SPLUNK_REALM}.signalfx.com
     sync_host_metadata: true
   logging:
-    loglevel: debug
+    verbosity: detailed
 service:
   extensions:
   - health_check

--- a/deployments/nomad/otel-agent.nomad
+++ b/deployments/nomad/otel-agent.nomad
@@ -214,7 +214,7 @@ exporters:
     ingest_url: https://ingest.${SPLUNK_REALM}.signalfx.com
     sync_host_metadata: true
   logging:
-    loglevel: debug
+    verbosity: detailed
 service:
   extensions:
   - health_check

--- a/deployments/nomad/otel-gateway.nomad
+++ b/deployments/nomad/otel-gateway.nomad
@@ -193,7 +193,7 @@ exporters:
     api_url: https://api.${SPLUNK_REALM}.signalfx.com
     ingest_url: https://ingest.${SPLUNK_REALM}.signalfx.com
   logging:
-    loglevel: debug
+    verbosity: detailed
 service:
   extensions:
   - health_check

--- a/deployments/salt/templates/agent_config.yaml
+++ b/deployments/salt/templates/agent_config.yaml
@@ -26,7 +26,7 @@ processors:
 
 exporters:
   logging/debug:
-    loglevel: debug
+    verbosity: detailed
   logging/info:
     loglevel: info
 

--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -542,7 +542,7 @@ receivers:
          cpu:
 exporters:
    logging:
-      loglevel: debug
+      verbosity: detailed
 service:
    pipelines:
       metrics:

--- a/examples/nomad/otel-demo.nomad
+++ b/examples/nomad/otel-demo.nomad
@@ -175,7 +175,7 @@ processors:
         key: deployment.environment
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   signalfx:
     access_token: ${SPLUNK_ACCESS_TOKEN}
     api_url: https://api.${SPLUNK_REALM}.signalfx.com
@@ -369,7 +369,7 @@ exporters:
     tls:
       insecure: true
   logging:
-    loglevel: debug
+    verbosity: detailed
 service:
   extensions:
   - health_check

--- a/examples/redis/otel-collector-config.yaml
+++ b/examples/redis/otel-collector-config.yaml
@@ -21,7 +21,7 @@ exporters:
     access_token: ${SPLUNK_ACCESS_TOKEN}
     realm: "${SPLUNK_REALM}"
   logging:
-    loglevel: debug
+    verbosity: detailed
 service:
   telemetry:
     metrics:

--- a/examples/splunk-hec-traces/otel-collector-config.yml
+++ b/examples/splunk-hec-traces/otel-collector-config.yml
@@ -27,7 +27,7 @@ exporters:
         # For this demo, we use a self-signed certificate on the Splunk docker instance, so this flag is set to true.
         insecure_skip_verify: true
     logging:
-      loglevel: debug
+      verbosity: detailed
       sampling_initial: 5
       sampling_thereafter: 200
 

--- a/internal/receiver/discoveryreceiver/README.md
+++ b/internal/receiver/discoveryreceiver/README.md
@@ -31,7 +31,7 @@ receivers:
     log_endpoints: true
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
 service:
   extensions: [docker_observer]
   pipelines:
@@ -172,7 +172,7 @@ receivers:
                    body: Container appears to not be accepting redis connections.
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
     sampling_initial: 1
     sampling_thereafter: 1
 service:

--- a/internal/receiver/signalfxgatewayprometheusremotewritereceiver/internal/testdata/otel-collector-config.yaml
+++ b/internal/receiver/signalfxgatewayprometheusremotewritereceiver/internal/testdata/otel-collector-config.yaml
@@ -11,7 +11,7 @@ exporters:
     access_token: "${SPLUNK_ACCESS_TOKEN}"
     realm: "${SPLUNK_REALM}"
   logging:
-    loglevel: debug
+    verbosity: detailed
 service:
   telemetry:
     metrics:

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -326,7 +326,7 @@ func TestConfigPrecedence(t *testing.T) {
       cpu:
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
 service:
   pipelines:
     metrics:

--- a/tests/general/default_config_test.go
+++ b/tests/general/default_config_test.go
@@ -191,7 +191,7 @@ func TestDefaultAgentConfig(t *testing.T) {
 	require.Equal(t, map[string]any{
 		"exporters": map[string]any{
 			"logging": map[string]any{
-				"loglevel": "debug",
+				"verbosity": "detailed",
 			},
 			"otlp": map[string]any{
 				"endpoint": ":4317",

--- a/tests/general/discoverymode/testdata/logging-exporter-internal-prometheus-config.d/exporters/logging.yaml
+++ b/tests/general/discoverymode/testdata/logging-exporter-internal-prometheus-config.d/exporters/logging.yaml
@@ -1,2 +1,2 @@
 logging:
-  loglevel: debug
+  verbosity: detailed

--- a/tests/receivers/discovery/testdata/k8s_observer_smart_agent_redis_config.yaml
+++ b/tests/receivers/discovery/testdata/k8s_observer_smart_agent_redis_config.yaml
@@ -47,7 +47,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
   otlp:
     endpoint: "${OTLP_ENDPOINT}"
     tls:


### PR DESCRIPTION
The config files in the repo are still using the deprecated `loglevel: debug` for the `logging` exporter. This setting should now be `verbosity: detailed` as per https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/loggingexporter/README.md