### PR TITLE
increase statement evaluation log submission timeout

### DIFF
--- a/internal/receiver/discoveryreceiver/statement_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator_test.go
@@ -149,7 +149,7 @@ func TestStatementEvaluation(t *testing.T) {
 											require.Eventually(t, func() bool {
 												wg.Wait()
 												return true
-											}, 50*time.Millisecond, time.Millisecond)
+											}, 100*time.Millisecond, time.Millisecond)
 
 											for i := 0; i < numExpected; i++ {
 												rl := emitted.ResourceLogs().At(i)


### PR DESCRIPTION
Attempting to reduce flake in darwin and windows tests, though I've not been able to reproduce locally.