### PR TITLE
Remove use of File.exists?, prefer File.exist? instead

### DIFF
--- a/deployments/puppet/lib/facter/local_groups.rb
+++ b/deployments/puppet/lib/facter/local_groups.rb
@@ -5,7 +5,7 @@ Facter.add(:local_groups) do
   confine :kernel => 'Linux'
   setcode do
     groups = Array.new
-    if File.exists?("/etc/group")
+    if File.exist?("/etc/group")
       File.open("/etc/group").each do |line|
         next if line.match(/^\s|^#|^$/)
         groups << line.split(':').first

--- a/deployments/puppet/lib/facter/local_users.rb
+++ b/deployments/puppet/lib/facter/local_users.rb
@@ -5,7 +5,7 @@ Facter.add(:local_users) do
   confine :kernel => 'Linux'
   setcode do
     users = Array.new
-    if File.exists?("/etc/passwd")
+    if File.exist?("/etc/passwd")
       File.open("/etc/passwd").each do |line|
         next if line.match(/^\s|^#|^$/)
         users << line.split(':').first

--- a/deployments/puppet/lib/facter/win_collector_path.rb
+++ b/deployments/puppet/lib/facter/win_collector_path.rb
@@ -9,7 +9,7 @@ Facter.add(:win_collector_path) do
       Win32::Registry::HKEY_LOCAL_MACHINE.open('SYSTEM\CurrentControlSet\Services\splunk-otel-collector') do |regkey|
         value = regkey['ExePath']
       end
-      if value and !File.exists?(value)
+      if value and !File.exist?(value)
         value = ''
       end
       value


### PR DESCRIPTION
See #3147 - this should help support new versions of Puppet which use versions of Ruby where this deprecated method was removed.