### PR TITLE
Update integration tests to detect unexpected metrics

### DIFF
--- a/tests/general/discoverymode/testdata/docker-otlp-exporter-no-internal-prometheus.yaml
+++ b/tests/general/discoverymode/testdata/docker-otlp-exporter-no-internal-prometheus.yaml
@@ -1,0 +1,21 @@
+exporters:
+  otlp:
+    endpoint: "${OTLP_ENDPOINT}"
+    tls:
+      insecure: true
+processors:
+  filter:
+    metrics:
+      include:
+        match_type: strict
+        metric_names: [prometheus_tsdb_exemplar_exemplars_in_storage]
+service:
+  telemetry:
+    metrics:
+      level: none
+      address: ""
+  pipelines:
+    metrics:
+      exporters: [otlp]
+      processors: [filter]
+

--- a/tests/general/discoverymode/testdata/host-otlp-exporter-no-internal-prometheus.yaml
+++ b/tests/general/discoverymode/testdata/host-otlp-exporter-no-internal-prometheus.yaml
@@ -1,0 +1,21 @@
+exporters:
+  otlp:
+    endpoint: "${OTLP_ENDPOINT}"
+    tls:
+      insecure: true
+processors:
+  filter:
+    metrics:
+      include:
+        match_type: strict
+        metric_names: [otelcol_exporter_enqueue_failed_log_records]
+service:
+  telemetry:
+    metrics:
+      level: none
+      address: ""
+  pipelines:
+    metrics:
+      exporters: [otlp]
+      processors: [filter]
+

--- a/tests/general/discoverymode/testdata/k8s-otlp-exporter-no-internal-prometheus.yaml
+++ b/tests/general/discoverymode/testdata/k8s-otlp-exporter-no-internal-prometheus.yaml
@@ -3,6 +3,12 @@ exporters:
     endpoint: "${OTLP_ENDPOINT}"
     tls:
       insecure: true
+processors:
+  filter:
+    metrics:
+      include:
+        match_type: strict
+        metric_names: [gauge.connected_clients]
 service:
   telemetry:
     metrics:
@@ -11,4 +17,5 @@ service:
   pipelines:
     metrics:
       exporters: [otlp]
+      processors: [filter]
 

--- a/tests/general/testdata/activemq_config.yaml
+++ b/tests/general/testdata/activemq_config.yaml
@@ -8,6 +8,15 @@ receivers:
     extraMetrics: ["*"]
     intervalSeconds: 1
 
+processors:
+  filter:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - counter.amq.TotalConnectionsCount
+          - jmx_memory.committed
+
 exporters:
   otlp:
     endpoint: "${OTLP_ENDPOINT}"
@@ -17,6 +26,6 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers:
-        - smartagent/collectd_activemq
+      processors: [filter]
+      receivers: [smartagent/collectd_activemq]
       exporters: [otlp]

--- a/tests/general/testdata/solr_config.yaml
+++ b/tests/general/testdata/solr_config.yaml
@@ -6,6 +6,13 @@ receivers:
     extraMetrics: ["*"]
     intervalSeconds: 1
 
+processors:
+  filter:
+    metrics:
+      include:
+        match_type: strict
+        metric_names: [counter.solr.http_2xx_responses]
+
 exporters:
   otlp:
     endpoint: "${OTLP_ENDPOINT}"
@@ -15,6 +22,8 @@ exporters:
 service:
   pipelines:
     metrics:
+      processors:
+        - filter
       receivers:
         - smartagent/collectd_solr
       exporters:

--- a/tests/receivers/lightprometheus/testdata/resource_metrics/internal.yaml
+++ b/tests/receivers/lightprometheus/testdata/resource_metrics/internal.yaml
@@ -110,3 +110,21 @@ resource_metrics:
               service_instance_id: <ANY>
               service_name: otelcol
               service_version: <VERSION_FROM_BUILD>
+          - name: otelcol_scraper_scraped_metric_points
+            description: Number of metric points successfully scraped.
+            type: DoubleMonotonicCumulativeSum
+            attributes:
+              receiver: lightprometheus/myjob
+              scraper: lightprometheus
+              service_instance_id: <ANY>
+              service_name: otelcol
+              service_version: <VERSION_FROM_BUILD>
+          - name: otelcol_scraper_errored_metric_points
+            description: Number of metric points that were unable to be scraped.
+            type: DoubleMonotonicCumulativeSum
+            attributes:
+              receiver: lightprometheus/myjob
+              scraper: lightprometheus
+              service_instance_id: <ANY>
+              service_name: otelcol
+              service_version: <VERSION_FROM_BUILD>

--- a/tests/receivers/prometheus/testdata/resource_metrics/internal.yaml
+++ b/tests/receivers/prometheus/testdata/resource_metrics/internal.yaml
@@ -117,3 +117,27 @@ resource_metrics:
               service_name: otelcol
               service_version: <VERSION_FROM_BUILD>
               transport: http
+          - name: scrape_duration
+            description: Duration of the scrape
+            type: DoubleGauge
+            attributes: {}
+          - name: scrape_samples_post_metric_relabeling
+            description: The number of samples remaining after metric relabeling was applied
+            type: DoubleGauge
+            attributes: {}
+          - name: scrape_samples_scraped
+            description: The number of samples the target exposed
+            type: DoubleGauge
+            attributes: {}
+          - name: scrape_samples_post_metric_relabeling
+            description: The number of samples remaining after metric relabeling was applied
+            type: DoubleGauge
+            attributes: {}
+          - name: scrape_series_added
+            description: The approximate number of new series in this scrape
+            type: DoubleGauge
+            attributes: {}
+          - name: up
+            description: The scraping was successful
+            type: DoubleGauge
+            attributes: {}

--- a/tests/receivers/redis/redisreceiver_test.go
+++ b/tests/receivers/redis/redisreceiver_test.go
@@ -33,5 +33,5 @@ func TestRedisReceiverProvidesAllMetricsWithServer(t *testing.T) {
 	server := testutils.NewContainer().WithContext(path.Join(".", "testdata", "server")).WithExposedPorts("6379:6379").WithNetworks("redis_network").WithName("redis-server").WillWaitForLogs("Ready to accept connections")
 	client := testutils.NewContainer().WithContext(path.Join(".", "testdata", "client")).WithName("redis-client").WithNetworks("redis_network").WillWaitForLogs("redis client started")
 	containers := []testutils.Container{server, client}
-	testutils.AssertAllMetricsReceived(t, "all.yaml", "all_metrics_config.yaml", containers, nil)
+	testutils.AssertAllMetricsReceived(t, "all_server.yaml", "all_metrics_config.yaml", containers, nil)
 }

--- a/tests/receivers/redis/testdata/resource_metrics/all_server.yaml
+++ b/tests/receivers/redis/testdata/resource_metrics/all_server.yaml
@@ -1,0 +1,66 @@
+resource_metrics:
+  - attributes:
+      redis.version: <ANY>
+    scope_metrics:
+      - instrumentation_scope:
+          name: otelcol/redisreceiver
+          version: <ANY>
+        metrics:
+          - name: redis.uptime
+            type: IntMonotonicCumulativeSum
+          - name: redis.cpu.time
+            type: DoubleMonotonicCumulativeSum
+          - name: redis.clients.connected
+            type: IntNonmonotonicCumulativeSum
+          - name: redis.clients.max_input_buffer
+            type: IntGauge
+          - name: redis.clients.max_output_buffer
+            type: IntGauge
+          - name: redis.clients.blocked
+            type: IntNonmonotonicCumulativeSum
+          - name: redis.keys.expired
+            type: IntMonotonicCumulativeSum
+          - name: redis.keys.evicted
+            type: IntMonotonicCumulativeSum
+          - name: redis.connections.rejected
+            type: IntMonotonicCumulativeSum
+          - name: redis.memory.used
+            type: IntGauge
+          - name: redis.memory.rss
+            type: IntGauge
+          - name: redis.memory.peak
+            type: IntGauge
+          - name: redis.memory.lua
+            type: IntGauge
+          - name: redis.memory.fragmentation_ratio
+            type: DoubleGauge
+          - name: redis.rdb.changes_since_last_save
+            type: IntNonmonotonicCumulativeSum
+          - name: redis.commands
+            type: IntGauge
+          - name: redis.connections.received
+            type: IntMonotonicCumulativeSum
+          - name: redis.commands.processed
+            type: IntMonotonicCumulativeSum
+          - name: redis.net.input
+            type: IntMonotonicCumulativeSum
+          - name: redis.net.output
+            type: IntMonotonicCumulativeSum
+          - name: redis.keyspace.hits
+            type: IntMonotonicCumulativeSum
+          - name: redis.keyspace.misses
+            type: IntMonotonicCumulativeSum
+          - name: redis.latest_fork
+            type: IntGauge
+          - name: redis.slaves.connected
+            type: IntNonmonotonicCumulativeSum
+          - name: redis.replication.backlog_first_byte_offset
+            type: IntGauge
+          - name: redis.replication.offset
+            type: IntGauge
+          - name: redis.db.avg_ttl
+            type: IntGauge
+          - name: redis.db.expires
+            type: IntGauge
+          - name: redis.db.keys
+            type: IntGauge

--- a/tests/receivers/smartagent/collectd-kafka/testdata/resource_metrics/all_broker.yaml
+++ b/tests/receivers/smartagent/collectd-kafka/testdata/resource_metrics/all_broker.yaml
@@ -43,6 +43,12 @@ resource_metrics:
             type: IntGauge
           - name: gauge.kafka.produce.total-time.99th
             type: IntGauge
+          - name: counter.kafka.logs.flush-time.count
+            type: IntMonotonicCumulativeSum
+          - name: gauge.kafka.logs.flush-time.median
+            type: DoubleGauge
+          - name: gauge.kafka.logs.flush-time.99th
+            type: DoubleGauge
           - name: gauge.kafka.produce.total-time.median
           - name: gauge.loaded_classes
             type: IntGauge

--- a/tests/receivers/smartagent/collectd-postgresql/testdata/resource_metrics/all.yaml
+++ b/tests/receivers/smartagent/collectd-postgresql/testdata/resource_metrics/all.yaml
@@ -11,6 +11,8 @@ resource_metrics:
             type: IntMonotonicCumulativeSum
           - name: pg_blks.heap_read-test_schema-table_one
             type: IntMonotonicCumulativeSum
+          - name: pg_blks.heap_read-test_schema-table_two
+            type: IntMonotonicCumulativeSum
           - name: pg_blks.idx_hit
             type: IntMonotonicCumulativeSum
           - name: pg_blks.idx_hit-test_schema-table_one

--- a/tests/receivers/smartagent/collectd-tomcat/testdata/resource_metrics/default.yaml
+++ b/tests/receivers/smartagent/collectd-tomcat/testdata/resource_metrics/default.yaml
@@ -17,3 +17,19 @@ resource_metrics:
             type: IntGauge
           - name: gauge.tomcat.ThreadPool.maxThreads
             type: IntGauge
+          - name: gauge.loaded_classes
+            type: IntGauge
+          - name: jmx_memory.init
+            type: IntGauge
+          - name: jmx_memory.max
+            type: IntGauge
+          - name: jmx_memory.used
+            type: IntGauge
+          - name: gauge.jvm.threads.count
+            type: IntGauge
+          - name: invocations
+            type: IntMonotonicCumulativeSum
+          - name: jmx_memory.committed
+            type: IntGauge
+          - name: total_time_in_ms.collection_time
+            type: IntMonotonicCumulativeSum

--- a/tests/receivers/smartagent/telegraf-procstat/testdata/resource_metrics/all.yaml
+++ b/tests/receivers/smartagent/telegraf-procstat/testdata/resource_metrics/all.yaml
@@ -208,6 +208,42 @@ resource_metrics:
               telegraf_type: untyped
               user: splunk-otel-collector
             type: IntGauge
+          - name: procstat_lookup.pid_count
+            attributes:
+              exe: otelcol
+              pid_finder: native
+              plugin: telegraf-procstat
+              result: success
+              system.type: procstat
+              telegraf_type: untyped
+            type: IntGauge
+          - name: procstat.cpu_time_soft_irq
+            type: DoubleGauge
+            attributes:
+              exe: otelcol
+              plugin: telegraf-procstat
+              process_name: otelcol
+              system.type: procstat
+              telegraf_type: untyped
+              user: splunk-otel-collector
+          - name: procstat_lookup.running
+            type: IntGauge
+            attributes:
+              exe: otelcol
+              pid_finder: native
+              plugin: telegraf-procstat
+              result: success
+              system.type: procstat
+              telegraf_type: untyped
+          - name: procstat_lookup.result_code
+            type: IntGauge
+            attributes:
+              exe: otelcol
+              pid_finder: native
+              plugin: telegraf-procstat
+              result: success
+              system.type: procstat
+              telegraf_type: untyped
           - name: procstat.read_bytes
             attributes:
               system.type: procstat

--- a/tests/receivers/smartagent/telegraf-sqlserver/testdata/resource_metrics/all.yaml
+++ b/tests/receivers/smartagent/telegraf-sqlserver/testdata/resource_metrics/all.yaml
@@ -53,6 +53,8 @@ resource_metrics:
             type: DoubleGauge
           - name: sqlserver_performance.backup_restore_throughput_sec
             type: DoubleGauge
+          - name: sqlserver_performance.batch_requests_sec
+            type: DoubleGauge
           - name: sqlserver_performance.blocked_tasks
             type: DoubleGauge
           - name: sqlserver_performance.buffer_cache_hit_ratio

--- a/tests/testutils/otlp_receiver_sink.go
+++ b/tests/testutils/otlp_receiver_sink.go
@@ -266,9 +266,9 @@ func (otlp *OTLPReceiverSink) AssertAllMetricsReceived(t testing.TB, expectedRes
 		require.NotNil(t, receivedResourceMetrics)
 		receivedMetrics = telemetry.FlattenResourceMetrics(receivedMetrics, receivedResourceMetrics)
 
-		var containsAll bool
-		containsAll, err = receivedMetrics.ContainsAll(expectedResourceMetrics)
-		return containsAll
+		var containsOnly bool
+		containsOnly, err = receivedMetrics.ContainsOnly(expectedResourceMetrics)
+		return containsOnly
 	}, waitTime, 10*time.Millisecond, "Failed to receive expected metrics")
 
 	// testify won't render exceptionally long errors, so leaving this here for easy debugging


### PR DESCRIPTION
These changes make sure that all emitted metrics have an expected entry in the case's resource metrics in order for `AssertAllMetricsReceived()` to be successful.