### PR TITLE
kubernetes-cluster: sync node labels as properties on node name dimension

### DIFF
--- a/internal/signalfx-agent/pkg/monitors/kubernetes/cluster/metrics/dimensions.go
+++ b/internal/signalfx-agent/pkg/monitors/kubernetes/cluster/metrics/dimensions.go
@@ -23,23 +23,25 @@ type DimensionHandler struct {
 	uidKindCache      map[types.UID]string
 	sendDimensionFunc func(*atypes.Dimension)
 
-	podCache        *k8sutil.PodCache
-	serviceCache    *k8sutil.ServiceCache
-	replicaSetCache *k8sutil.ReplicaSetCache
-	jobCache        *k8sutil.JobCache
-	logger          log.FieldLogger
+	podCache              *k8sutil.PodCache
+	serviceCache          *k8sutil.ServiceCache
+	replicaSetCache       *k8sutil.ReplicaSetCache
+	jobCache              *k8sutil.JobCache
+	addPropertiesNodeName bool
+	logger                log.FieldLogger
 }
 
 // NewDimensionHandler creates a handler for dimension updates
-func NewDimensionHandler(sendDimensionFunc func(*atypes.Dimension), logger log.FieldLogger) *DimensionHandler {
+func NewDimensionHandler(sendDimensionFunc func(*atypes.Dimension), addPropertiesNodeName bool, logger log.FieldLogger) *DimensionHandler {
 	return &DimensionHandler{
-		uidKindCache:      make(map[types.UID]string),
-		sendDimensionFunc: sendDimensionFunc,
-		podCache:          k8sutil.NewPodCache(),
-		serviceCache:      k8sutil.NewServiceCache(),
-		replicaSetCache:   k8sutil.NewReplicaSetCache(),
-		jobCache:          k8sutil.NewJobCache(),
-		logger:            logger,
+		uidKindCache:          make(map[types.UID]string),
+		sendDimensionFunc:     sendDimensionFunc,
+		podCache:              k8sutil.NewPodCache(),
+		serviceCache:          k8sutil.NewServiceCache(),
+		replicaSetCache:       k8sutil.NewReplicaSetCache(),
+		jobCache:              k8sutil.NewJobCache(),
+		addPropertiesNodeName: addPropertiesNodeName,
+		logger:                logger,
 	}
 }
 
@@ -68,7 +70,9 @@ func (dh *DimensionHandler) HandleAdd(newObj runtime.Object) interface{} {
 		dh.sendDimensionFunc(dimensionForReplicationController(o))
 		kind = "ReplicationController"
 	case *v1.Node:
-		dh.sendDimensionFunc(dimensionForNode(o))
+		for _, dim := range dimensionsForNode(o, dh.addPropertiesNodeName) {
+			dh.sendDimensionFunc(dim)
+		}
 		kind = "Node"
 	case *v1.Service:
 		dh.handleAddService(o)

--- a/internal/signalfx-agent/pkg/monitors/kubernetes/cluster/metrics/dimensions.go
+++ b/internal/signalfx-agent/pkg/monitors/kubernetes/cluster/metrics/dimensions.go
@@ -23,25 +23,25 @@ type DimensionHandler struct {
 	uidKindCache      map[types.UID]string
 	sendDimensionFunc func(*atypes.Dimension)
 
-	podCache              *k8sutil.PodCache
-	serviceCache          *k8sutil.ServiceCache
-	replicaSetCache       *k8sutil.ReplicaSetCache
-	jobCache              *k8sutil.JobCache
-	addPropertiesNodeName bool
-	logger                log.FieldLogger
+	podCache                *k8sutil.PodCache
+	serviceCache            *k8sutil.ServiceCache
+	replicaSetCache         *k8sutil.ReplicaSetCache
+	jobCache                *k8sutil.JobCache
+	updatesForNodeDimension bool
+	logger                  log.FieldLogger
 }
 
 // NewDimensionHandler creates a handler for dimension updates
-func NewDimensionHandler(sendDimensionFunc func(*atypes.Dimension), addPropertiesNodeName bool, logger log.FieldLogger) *DimensionHandler {
+func NewDimensionHandler(sendDimensionFunc func(*atypes.Dimension), updatesForNodeDimension bool, logger log.FieldLogger) *DimensionHandler {
 	return &DimensionHandler{
-		uidKindCache:          make(map[types.UID]string),
-		sendDimensionFunc:     sendDimensionFunc,
-		podCache:              k8sutil.NewPodCache(),
-		serviceCache:          k8sutil.NewServiceCache(),
-		replicaSetCache:       k8sutil.NewReplicaSetCache(),
-		jobCache:              k8sutil.NewJobCache(),
-		addPropertiesNodeName: addPropertiesNodeName,
-		logger:                logger,
+		uidKindCache:            make(map[types.UID]string),
+		sendDimensionFunc:       sendDimensionFunc,
+		podCache:                k8sutil.NewPodCache(),
+		serviceCache:            k8sutil.NewServiceCache(),
+		replicaSetCache:         k8sutil.NewReplicaSetCache(),
+		jobCache:                k8sutil.NewJobCache(),
+		updatesForNodeDimension: updatesForNodeDimension,
+		logger:                  logger,
 	}
 }
 
@@ -70,7 +70,7 @@ func (dh *DimensionHandler) HandleAdd(newObj runtime.Object) interface{} {
 		dh.sendDimensionFunc(dimensionForReplicationController(o))
 		kind = "ReplicationController"
 	case *v1.Node:
-		for _, dim := range dimensionsForNode(o, dh.addPropertiesNodeName) {
+		for _, dim := range dimensionsForNode(o, dh.updatesForNodeDimension) {
 			dh.sendDimensionFunc(dim)
 		}
 		kind = "Node"

--- a/internal/signalfx-agent/pkg/monitors/kubernetes/cluster/metrics/node.go
+++ b/internal/signalfx-agent/pkg/monitors/kubernetes/cluster/metrics/node.go
@@ -57,14 +57,14 @@ func datapointsForNode(
 	return datapoints
 }
 
-func dimensionsForNode(node *v1.Node, addPropertiesNodeName bool) []*atypes.Dimension {
+func dimensionsForNode(node *v1.Node, updatesForNodeDimension bool) []*atypes.Dimension {
 	var out []*atypes.Dimension
 	props, tags := k8sutil.PropsAndTagsFromLabels(node.Labels)
 	_ = getPropsFromTaints(node.Spec.Taints)
 
 	props["node_creation_timestamp"] = node.GetCreationTimestamp().Format(time.RFC3339)
 
-	if addPropertiesNodeName {
+	if updatesForNodeDimension {
 		propsCopy := make(map[string]string)
 		for k, v := range props {
 			propsCopy[k] = v
@@ -75,7 +75,7 @@ func dimensionsForNode(node *v1.Node, addPropertiesNodeName bool) []*atypes.Dime
 		}
 		out = append(out, &atypes.Dimension{
 			Name:       "kubernetes_node",
-			Value:      string(node.Name),
+			Value:      node.Name,
 			Properties: propsCopy,
 			Tags:       tagsCopy,
 		})

--- a/internal/signalfx-agent/pkg/monitors/kubernetes/cluster/monitor.go
+++ b/internal/signalfx-agent/pkg/monitors/kubernetes/cluster/monitor.go
@@ -60,6 +60,9 @@ type Config struct {
 	// with a value of `0` corresponding to "False", `1` to "True", and `-1`
 	// to "Unknown".
 	NodeConditionTypesToReport []string `yaml:"nodeConditionTypesToReport" default:"[\"Ready\"]"`
+	// If set to true, the kubernetes_node dimension, in addition to the kubernetes_node_uid dimension, will get
+	// properties about each respective node synced to it. Do not enable this, if node names in the cluster are reused.
+	AddPropertiesNodeName bool `yaml:"addPropertiesNodeName" default:"false"`
 }
 
 // Validate the k8s-specific config
@@ -106,7 +109,7 @@ func (m *Monitor) Configure(config *Config) error {
 	}
 
 	m.datapointCache = metrics.NewDatapointCache(m.config.NodeConditionTypesToReport, m.logger)
-	m.dimHandler = metrics.NewDimensionHandler(m.Output.SendDimensionUpdate, m.logger)
+	m.dimHandler = metrics.NewDimensionHandler(m.Output.SendDimensionUpdate, m.config.AddPropertiesNodeName, m.logger)
 	m.stop = make(chan struct{})
 
 	return m.Start()

--- a/internal/signalfx-agent/pkg/monitors/kubernetes/cluster/monitor.go
+++ b/internal/signalfx-agent/pkg/monitors/kubernetes/cluster/monitor.go
@@ -60,9 +60,10 @@ type Config struct {
 	// with a value of `0` corresponding to "False", `1` to "True", and `-1`
 	// to "Unknown".
 	NodeConditionTypesToReport []string `yaml:"nodeConditionTypesToReport" default:"[\"Ready\"]"`
-	// If set to true, the kubernetes_node dimension, in addition to the kubernetes_node_uid dimension, will get
-	// properties about each respective node synced to it. Do not enable this, if node names in the cluster are reused.
-	AddPropertiesNodeName bool `yaml:"addPropertiesNodeName" default:"false"`
+	// If set to true, the `kubernetes_node` dimension, in addition to the `kubernetes_node_uid` dimension, will get
+	// properties about each respective node synced to it. Do not enable this, if node names in the cluster are
+	// reused (can lead to colliding or stale properties).
+	UpdatesForNodeDimension bool `yaml:"updatesForNodeDimension" default:"false"`
 }
 
 // Validate the k8s-specific config
@@ -109,7 +110,7 @@ func (m *Monitor) Configure(config *Config) error {
 	}
 
 	m.datapointCache = metrics.NewDatapointCache(m.config.NodeConditionTypesToReport, m.logger)
-	m.dimHandler = metrics.NewDimensionHandler(m.Output.SendDimensionUpdate, m.config.AddPropertiesNodeName, m.logger)
+	m.dimHandler = metrics.NewDimensionHandler(m.Output.SendDimensionUpdate, m.config.UpdatesForNodeDimension, m.logger)
 	m.stop = make(chan struct{})
 
 	return m.Start()


### PR DESCRIPTION
Adds a configuration to the smartagent/kubernetes-cluster receiver to optional sync node labels as properties on the kubernetes_node dimension.