### PR TITLE
check for nil before coercing to string

### DIFF
--- a/cmd/translatesfx/translatesfx/translate.go
+++ b/cmd/translatesfx/translatesfx/translate.go
@@ -51,6 +51,10 @@ func toString(saExpanded map[any]any, name string) string {
 	if !ok {
 		return ""
 	}
+	if v == nil {
+		// this can happen if an included file is empty
+		return ""
+	}
 	return v.(string)
 }
 

--- a/cmd/translatesfx/translatesfx/translate_test.go
+++ b/cmd/translatesfx/translatesfx/translate_test.go
@@ -50,6 +50,12 @@ func TestSAExpandedToCfgInfo_ZK(t *testing.T) {
 	assert.Equal(t, "${zookeeper:/redis/port}", zkPwd)
 }
 
+func TestToString(t *testing.T) {
+	assert.Equal(t, "bar", toString(map[any]any{"foo": "bar"}, "foo"))
+	assert.Equal(t, "", toString(map[any]any{"foo": "bar"}, "baz"))
+	assert.Equal(t, "", toString(map[any]any{"foo": nil}, "foo"))
+}
+
 func yamlToCfgInfo(t *testing.T, filename string) saCfgInfo {
 	v := fromYAML(t, filename)
 	expanded, _, err := expandSA(v, "")


### PR DESCRIPTION
A customer referenced an empty file in their SA config and translatesfx panicked because that resulted in a nil being coerced to string.  This change tests the unmarshaled variable for nil before attempting to coerce it to a string.