### PR TITLE
use parent `config` field in discovery observer configuration and properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- (Splunk) Embed observer configuration in `observer.discovery.yaml` `config` mapping. This is only a breaking change if you have written your own custom discovery mode observer configuration ([#3277](https://github.com/signalfx/splunk-otel-collector/pull/3277)).
+
 ## v0.79.1
 
 ### 🛑 Breaking changes 🛑

--- a/cmd/otelcol/config/collector/config.d.linux/extensions/k8s-observer.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/extensions/k8s-observer.discovery.yaml
@@ -3,4 +3,5 @@
 #####################################################################################
 # k8s_observer:
 #   enabled: true
-#   auth_type: serviceAccount
+#   config:
+#     auth_type: serviceAccount

--- a/internal/confmapprovider/discovery/README.md
+++ b/internal/confmapprovider/discovery/README.md
@@ -100,9 +100,37 @@ successfully started observers.
 1. Log any receiver resulting in a `discovery.status` of `partial` with the configured guidance for setting any relevant discovery properties.
 1. Stop all temporary components before continuing on to the actual Collector service (or exiting early with `--dry-run`).
 
-
 By default, the Discovery mode is provided with pre-made discovery config components in [`bundle.d`](./bundle/README.md).
 
+Unlike `config.d` component files, which are direct configuration entries for the desired component, Discovery component
+configs have an `enabled` boolean and `config` parent mapping field to determine use and configure the functionality of
+the components:
+
+```yaml
+# <some-observer-type-with-optional-name.discovery.yaml>
+<observer_type>(/<observer_name>):
+  enabled: <true | false> # true by default
+  config:
+    <embedded observer config>
+```
+
+```yaml
+# <some-receiver-type-with-optional-name.discovery.yaml>
+<receiver_type>(/<receiver_name>):
+  enabled: <true | false> # true by default
+  rule:
+    <observer_type>(/<observer_name>): <receiver creator rule for this observer>
+  config:
+    default:
+      <default embedded receiver config>
+    <observer_type>(/<observer_name>):
+      <observer-specific config items, merged with `default`>
+  status:
+    metrics:
+      <discovery receiver metric status entries>
+    statements:
+      <discovery receiver statement status entries>
+```
 
 ### Discovery properties
 

--- a/internal/confmapprovider/discovery/bundle/README.md
+++ b/internal/confmapprovider/discovery/bundle/README.md
@@ -20,8 +20,8 @@ Example `redis.discovery.yaml.tmpl`:
 
 ```yaml
 {{ receiver "redis" }}:
+  enabled: true
   rule:
-    enabled: true
     docker_observer: type == "container" and port == 6379
     <...>
   status:

--- a/internal/confmapprovider/discovery/bundle/bundle.d/extensions/k8s-observer.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/extensions/k8s-observer.discovery.yaml
@@ -3,4 +3,5 @@
 #####################################################################################
 k8s_observer:
   enabled: true
-  auth_type: serviceAccount
+  config:
+    auth_type: serviceAccount

--- a/internal/confmapprovider/discovery/bundle/bundle.d/extensions/k8s-observer.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/extensions/k8s-observer.discovery.yaml.tmpl
@@ -1,3 +1,4 @@
 {{ extension "k8s_observer" }}:
   enabled: true
-  auth_type: serviceAccount
+  config:
+    auth_type: serviceAccount

--- a/internal/confmapprovider/discovery/config.go
+++ b/internal/confmapprovider/discovery/config.go
@@ -171,6 +171,7 @@ var _ entryType = (*ObserverEntry)(nil)
 
 type ObserverEntry struct {
 	Enabled *bool
+	Config  Entry
 	Entry   `yaml:",inline"`
 }
 
@@ -554,12 +555,12 @@ func mergeConfigWithBundle(userCfg *Config, bundleCfg *Config) error {
 		if userObs.Enabled != nil {
 			enabled = userObs.Enabled
 		}
-		bundledConfMap := confmap.NewFromStringMap(bundledObs.ToStringMap())
-		userConfMap := confmap.NewFromStringMap(userObs.ToStringMap())
+		bundledConfMap := confmap.NewFromStringMap(bundledObs.Config.ToStringMap())
+		userConfMap := confmap.NewFromStringMap(userObs.Config.ToStringMap())
 		if err := bundledConfMap.Merge(userConfMap); err != nil {
 			return fmt.Errorf("failed merged user and bundled observer %q discovery configs: %w", obs, err)
 		}
-		userCfg.DiscoveryObservers[obs] = ObserverEntry{Enabled: enabled, Entry: bundledConfMap.ToStringMap()}
+		userCfg.DiscoveryObservers[obs] = ObserverEntry{Enabled: enabled, Config: bundledConfMap.ToStringMap()}
 	}
 	for rec, bundledRec := range bundleCfg.ReceiversToDiscover {
 		userRec, ok := userCfg.ReceiversToDiscover[rec]

--- a/internal/confmapprovider/discovery/config_test.go
+++ b/internal/confmapprovider/discovery/config_test.go
@@ -186,7 +186,7 @@ var expectedConfig = Config{
 	DiscoveryObservers: map[component.ID]ObserverEntry{
 		component.NewID("docker_observer"): {
 			Enabled: &tru,
-			Entry: Entry{
+			Config: Entry{
 				"endpoint": "tcp://debian:54321",
 				"timeout":  "2s",
 			},

--- a/internal/confmapprovider/discovery/properties/conf_test.go
+++ b/internal/confmapprovider/discovery/properties/conf_test.go
@@ -40,7 +40,9 @@ func TestConf(t *testing.T) {
 						"enabled": "false",
 					},
 					"host_observer/with_a_name": map[string]any{
-						"refresh_interval": "1h",
+						"config": map[string]any{
+							"refresh_interval": "1h",
+						},
 					},
 				},
 				"receivers": map[string]any{

--- a/internal/confmapprovider/discovery/properties/env_var_test.go
+++ b/internal/confmapprovider/discovery/properties/env_var_test.go
@@ -56,8 +56,10 @@ func TestValidEnvVarProperties(t *testing.T) {
 				stringMap: map[string]any{
 					"extensions": map[string]any{
 						"extension.type/extension____name": map[string]any{
-							"one": map[string]any{
-								"two": "a.val",
+							"config": map[string]any{
+								"one": map[string]any{
+									"two": "a.val",
+								},
 							},
 						},
 					},

--- a/internal/confmapprovider/discovery/properties/property.go
+++ b/internal/confmapprovider/discovery/properties/property.go
@@ -93,10 +93,7 @@ func NewProperty(property, val string) (*Property, error) {
 		if err = yaml.Unmarshal(cfgItem, &dst); err != nil {
 			return nil, fmt.Errorf("failed unmarshaling property %q: %w", p.Key, err)
 		}
-		subStringMap = confmap.NewFromStringMap(dst).ToStringMap()
-		if p.ComponentType == "receivers" {
-			subStringMap = map[string]any{"config": subStringMap}
-		}
+		subStringMap = map[string]any{"config": confmap.NewFromStringMap(dst).ToStringMap()}
 	}
 	p.stringMap = map[string]any{
 		p.ComponentType: map[string]any{

--- a/internal/confmapprovider/discovery/properties/property_test.go
+++ b/internal/confmapprovider/discovery/properties/property_test.go
@@ -95,7 +95,9 @@ func TestValidProperties(t *testing.T) {
 				stringMap: map[string]any{
 					"extensions": map[string]any{
 						"extension-type/extensionname": map[string]any{
-							"key": "val",
+							"config": map[string]any{
+								"key": "val",
+							},
 						},
 					},
 				},
@@ -168,7 +170,9 @@ func TestValidProperties(t *testing.T) {
 				stringMap: map[string]any{
 					"extensions": map[string]any{
 						"extension--0-1-with-config-in-type-_x64__x86_🙈🙉🙊4:000x0;;0;;0;;-___-----type/e/x/t/e%ns<i>o<=n=>nam/e-with-config": map[string]any{
-							"o": map[string]any{"n": map[string]any{"e.config": "val"}}},
+							"config": map[string]any{
+								"o": map[string]any{"n": map[string]any{"e.config": "val"}}},
+						},
 					},
 				},
 				Input: "splunk.discovery.extensions.extension--0-1-with-config-in-type-_x64__x86_🙈🙉🙊4:000x0;;0;;0;;-___-----type/e/x/t/e%ns<i>o<=n=>nam/e-with-config.config.o::n::e.config",

--- a/internal/confmapprovider/discovery/testdata/config.d/extensions/docker-observer.discovery.yaml
+++ b/internal/confmapprovider/discovery/testdata/config.d/extensions/docker-observer.discovery.yaml
@@ -1,4 +1,5 @@
 docker_observer:
   enabled: true
-  endpoint: tcp://debian:54321
-  timeout: 2s
+  config:
+    endpoint: tcp://debian:54321
+    timeout: 2s

--- a/tests/general/discoverymode/testdata/docker-observer-config.d/extensions/docker-observer.discovery.yaml
+++ b/tests/general/discoverymode/testdata/docker-observer-config.d/extensions/docker-observer.discovery.yaml
@@ -1,3 +1,4 @@
 docker_observer:
   enabled: false # overwritten by --set and env var properties
-  endpoint: overwritten.by.cmdline.property.that.references.env.var
+  config:
+    endpoint: overwritten.by.cmdline.property.that.references.env.var

--- a/tests/general/discoverymode/testdata/host-observer-config.d/extensions/host-observer.discovery.yaml
+++ b/tests/general/discoverymode/testdata/host-observer-config.d/extensions/host-observer.discovery.yaml
@@ -1,2 +1,3 @@
 host_observer:
-  refresh_interval: overrwritten by property
+  config:
+    refresh_interval: overrwritten by property

--- a/tests/general/discoverymode/testdata/k8s-observer-config.d/extensions/k8s-observer.discovery.yaml
+++ b/tests/general/discoverymode/testdata/k8s-observer-config.d/extensions/k8s-observer.discovery.yaml
@@ -1,2 +1,3 @@
 k8s_observer:
-  auth_type: serviceAccount
+  config:
+    auth_type: serviceAccount


### PR DESCRIPTION
These changes embed observer configuration in a `config` mapping like is done with receivers. This will allow the addition of future discovery mode fields (though none planned atm) without interfering with the underlying component config.