### PR TITLE
tests: fix CollectorProcess failures

### DIFF
--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -105,7 +105,6 @@ github.com/bkielbasa/cyclop v1.2.1 h1:AeF71HZDob1P2/pRm1so9cd1alZnrpyc4q2uP2l0gJ
 github.com/bkielbasa/cyclop v1.2.1/go.mod h1:K/dT/M0FPAiYjBgQGau7tz+3TMh4FWAEqlMhzFWCrgM=
 github.com/blizzy78/varnamelen v0.8.0 h1:oqSblyuQvFsW1hbBHh1zfwrKe3kcSj0rnXkKzsQ089M=
 github.com/blizzy78/varnamelen v0.8.0/go.mod h1:V9TzQZ4fLJ1DSrjVDfl89H7aMnTvKkApdHeyESmyR7k=
-github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
 github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
 github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,8 +14,9 @@ is:
 ...but if you are interested in something else enhancements and contributions are a great way to ensure this library
 is more useful overall.
 
-At this time only limited metric content is supported.  If you need additional metric functionality or trace/log
-helpers, please don't hesitate to contribute!
+**NOTE** At this time, integration tests generally target collector containers (`SPLUNK_OTEL_COLLECTOR_IMAGE` env var),
+and test coverage for the subprocess is best effort only, unless the test cases explicitly maintain one.
+The collector process targets are generally for test development without requiring frequent rebuilds of a local docker image.
 
 ```go
 package example_test

--- a/tests/general/container_test.go
+++ b/tests/general/container_test.go
@@ -162,6 +162,7 @@ service:
 
 // This test also exercises collectd binary usage and managed config writing
 func TestNonDefaultGIDCanAccessJavaInAgentBundle(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
 	testutils.AssertAllMetricsReceived(t, "activemq.yaml", "activemq_config.yaml",
 		[]testutils.Container{testutils.NewContainer().WithContext(
 			filepath.Join("..", "receivers", "smartagent", "collectd-activemq", "testdata", "server"),
@@ -177,6 +178,7 @@ func TestNonDefaultGIDCanAccessJavaInAgentBundle(t *testing.T) {
 }
 
 func TestNonDefaultGIDCanAccessPythonInAgentBundle(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
 	testutils.AssertAllMetricsReceived(t, "solr.yaml", "solr_config.yaml",
 		[]testutils.Container{
 			testutils.NewContainer().WithContext(

--- a/tests/general/discoverymode/configd_test.go
+++ b/tests/general/discoverymode/configd_test.go
@@ -241,17 +241,13 @@ func TestStandaloneConfigD(t *testing.T) {
 		t, "memory.yaml", "empty-config.yaml",
 		nil, []testutils.CollectorBuilder{
 			func(c testutils.Collector) testutils.Collector {
-				cc := c.(*testutils.CollectorContainer)
 				configd, err := filepath.Abs(filepath.Join(".", "testdata", "standalone-config.d"))
 				require.NoError(t, err)
-				cc.Container = cc.Container.WithMount(testcontainers.BindMount(configd, "/opt/config.d"))
-
-				return cc
-			},
-			func(c testutils.Collector) testutils.Collector {
-				return c.WithEnv(map[string]string{
-					"SPLUNK_CONFIG_DIR": "/opt/config.d",
-				}).WithArgs("--configd")
+				if cc, ok := c.(*testutils.CollectorContainer); ok {
+					cc.Container = cc.Container.WithMount(testcontainers.BindMount(configd, "/opt/config.d"))
+					configd = "/opt/config.d"
+				}
+				return c.WithEnv(map[string]string{"SPLUNK_CONFIG_DIR": configd}).WithArgs("--configd")
 			},
 		},
 	)

--- a/tests/general/discoverymode/docker_observer_discovery_test.go
+++ b/tests/general/discoverymode/docker_observer_discovery_test.go
@@ -35,6 +35,7 @@ import (
 // starting a collector with the daemon domain socket mounted and the container running with its group id
 // before starting a prometheus container with a label the receiver creator rule matches against.
 func TestDockerObserver(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
 	if runtime.GOOS == "darwin" {
 		t.Skip("unable to share sockets between mac and d4m vm: https://github.com/docker/for-mac/issues/483#issuecomment-758836836")
 	}

--- a/tests/general/discoverymode/host_observer_discovery_test.go
+++ b/tests/general/discoverymode/host_observer_discovery_test.go
@@ -44,6 +44,7 @@ import (
 // one and that the first collector process's initial and effective configs from the config server
 // are as expected.
 func TestHostObserver(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
 	if testutils.CollectorImageIsForArm(t) {
 		t.Skip("host_observer missing process info on arm")
 	}

--- a/tests/general/discoverymode/k8s_observer_discovery_test.go
+++ b/tests/general/discoverymode/k8s_observer_discovery_test.go
@@ -39,6 +39,7 @@ import (
 )
 
 func TestK8sObserver(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
 	tc := testutils.NewTestcase(t, testutils.OTLPReceiverSinkAllInterfaces)
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()

--- a/tests/receivers/discovery/host_observer_test.go
+++ b/tests/receivers/discovery/host_observer_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestDiscoveryReceiverWithHostObserverProvidesEndpointLogs(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
 	if testutils.CollectorImageIsForArm(t) {
 		t.Skip("host_observer missing process info on arm")
 	}
@@ -33,6 +34,7 @@ func TestDiscoveryReceiverWithHostObserverProvidesEndpointLogs(t *testing.T) {
 }
 
 func TestDiscoveryReceiverWithHostObserverAndSimplePrometheusReceiverProvideStatusLogs(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
 	if testutils.CollectorImageIsForArm(t) {
 		t.Skip("host_observer missing process info on arm")
 	}

--- a/tests/receivers/discovery/k8s_observer_test.go
+++ b/tests/receivers/discovery/k8s_observer_test.go
@@ -39,6 +39,7 @@ import (
 )
 
 func TestDiscoveryReceiverWithK8sObserverProvidesEndpointLogs(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
 	tc := testutils.NewTestcase(t, testutils.OTLPReceiverSinkAllInterfaces)
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()
@@ -112,6 +113,7 @@ func TestDiscoveryReceiverWithK8sObserverProvidesEndpointLogs(t *testing.T) {
 }
 
 func TestDiscoveryReceiverWithK8sObserverAndSmartAgentRedisReceiverProvideStatusLogs(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
 	tc := testutils.NewTestcase(t, testutils.OTLPReceiverSinkAllInterfaces)
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()

--- a/tests/receivers/filelog/filelog_test.go
+++ b/tests/receivers/filelog/filelog_test.go
@@ -30,11 +30,13 @@ func TestFilelogReceiverSyslogFormat(t *testing.T) {
 	testutils.AssertAllLogsReceived(t, "syslog.yaml", "syslog_config.yaml",
 		nil, []testutils.CollectorBuilder{
 			func(c testutils.Collector) testutils.Collector {
-				cc := c.(*testutils.CollectorContainer)
 				syslog, err := filepath.Abs(filepath.Join(".", "testdata", "syslog"))
 				require.NoError(t, err)
-				cc.Container = cc.Container.WithMount(testcontainers.BindMount(syslog, "/opt/syslog"))
-				return cc
+				if cc, ok := c.(*testutils.CollectorContainer); ok {
+					cc.Container = cc.Container.WithMount(testcontainers.BindMount(syslog, "/opt/syslog"))
+					syslog = "/opt/syslog"
+				}
+				return c.WithEnv(map[string]string{"LOGFILE_PATH": syslog})
 			},
 		},
 	)

--- a/tests/receivers/filelog/testdata/syslog_config.yaml
+++ b/tests/receivers/filelog/testdata/syslog_config.yaml
@@ -1,6 +1,6 @@
 receivers:
   filelog:
-    include: [/opt/syslog]
+    include: ["${env:LOGFILE_PATH}"]
     start_at: beginning
     operators:
       type: syslog_parser

--- a/tests/receivers/lightprometheus/internal_prometheus_test.go
+++ b/tests/receivers/lightprometheus/internal_prometheus_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestInternalPrometheusMetrics(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t) // TODO: enhance internal metric settings detection for process config
 	testutils.AssertAllMetricsReceived(
 		t, "internal.yaml", "internal_metrics_config.yaml", nil, nil,
 	)

--- a/tests/receivers/prometheus/internal_prometheus_test.go
+++ b/tests/receivers/prometheus/internal_prometheus_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestInternalPrometheusMetrics(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t) // TODO: enhance internal metric settings detection for process config
 	testutils.AssertAllMetricsReceived(
 		t, "internal.yaml", "internal_metrics_config.yaml", nil, nil,
 	)

--- a/tests/receivers/smartagent/collectd-mysql/bundled_test.go
+++ b/tests/receivers/smartagent/collectd-mysql/bundled_test.go
@@ -38,6 +38,7 @@ import (
 )
 
 func TestK8sObserver(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
 	tc := testutils.NewTestcase(t, testutils.OTLPReceiverSinkAllInterfaces)
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()

--- a/tests/receivers/smartagent/jmx/jmx_test.go
+++ b/tests/receivers/smartagent/jmx/jmx_test.go
@@ -33,6 +33,7 @@ var cassandra = []testutils.Container{
 }
 
 func TestJmxReceiverProvidesAllMetrics(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
 	testutils.AssertAllMetricsReceived(
 		t, "all.yaml", "all_metrics_config.yaml", cassandra,
 		[]testutils.CollectorBuilder{

--- a/tests/receivers/smartagent/postgresql/bundled_test.go
+++ b/tests/receivers/smartagent/postgresql/bundled_test.go
@@ -39,6 +39,7 @@ import (
 )
 
 func TestK8sObserver(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
 	tc := testutils.NewTestcase(t, testutils.OTLPReceiverSinkAllInterfaces)
 	defer tc.PrintLogsOnFailure()
 	defer tc.ShutdownOTLPReceiverSink()

--- a/tests/receivers/smartagent/prometheus-exporter/prometheus_exporter_test.go
+++ b/tests/receivers/smartagent/prometheus-exporter/prometheus_exporter_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestPrometheusExporterProvidesInternalMetrics(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
 	testutils.AssertAllMetricsReceived(
 		t, "internal.yaml", "internal_metrics_config.yaml", nil, nil,
 	)

--- a/tests/receivers/smartagent/telegraf-procstat/telegraf_procstat_test.go
+++ b/tests/receivers/smartagent/telegraf-procstat/telegraf_procstat_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestTelegrafProcstatReceiverProvidesAllMetrics(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
 	expectedMetrics := "all.yaml"
 	// telegraf/procstat is missing cpu metrics on arm64 as an apparently unsupported platform.
 	if testutils.CollectorImageIsForArm(t) {

--- a/tests/testutils/collector.go
+++ b/tests/testutils/collector.go
@@ -15,6 +15,7 @@
 package testutils
 
 import (
+	"regexp"
 	"testing"
 
 	"go.uber.org/zap"
@@ -33,4 +34,15 @@ type Collector interface {
 	Shutdown() error
 	InitialConfig(t testing.TB, port uint16) map[string]any
 	EffectiveConfig(t testing.TB, port uint16) map[string]any
+}
+
+var configFromArgsPattern = regexp.MustCompile("--config($|[^d-]+)")
+
+func configIsSetByArgs(args []string) bool {
+	for _, c := range args {
+		if configFromArgsPattern.Match([]byte(c)) {
+			return true
+		}
+	}
+	return false
 }

--- a/tests/testutils/collector_container.go
+++ b/tests/testutils/collector_container.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -36,8 +35,6 @@ import (
 )
 
 const collectorImageEnvVar = "SPLUNK_OTEL_COLLECTOR_IMAGE"
-
-var configFromArgsPattern = regexp.MustCompile("--config($|[^d-]+)")
 
 var _ Collector = (*CollectorContainer)(nil)
 var _ testcontainers.LogConsumer = (*collectorLogConsumer)(nil)
@@ -214,12 +211,7 @@ func (collector *CollectorContainer) buildContextArchive() (io.Reader, error) {
 
 		// We need to tell the Collector to use the provided config
 		// but only if not already done so in the test
-		var configSetByArgs bool
-		for _, c := range collector.Args {
-			if configFromArgsPattern.Match([]byte(c)) {
-				configSetByArgs = true
-			}
-		}
+		configSetByArgs := configIsSetByArgs(collector.Args)
 		_, configSetByEnvVar := collector.Container.Env["SPLUNK_CONFIG"]
 		if !configSetByArgs && !configSetByEnvVar {
 			// only specify w/ args if none are used in the test

--- a/tests/testutils/collector_container.go
+++ b/tests/testutils/collector_container.go
@@ -303,6 +303,10 @@ func CollectorImageIsSet() bool {
 	return GetCollectorImage() != ""
 }
 
+func SkipIfNotContainerTest(t testing.TB) {
+	_ = GetCollectorImageOrSkipTest(t)
+}
+
 func GetCollectorImageOrSkipTest(t testing.TB) string {
 	image := GetCollectorImage()
 	if image == "" {

--- a/tests/testutils/collector_process.go
+++ b/tests/testutils/collector_process.go
@@ -103,9 +103,6 @@ func (collector CollectorProcess) WillFail(fail bool) Collector {
 }
 
 func (collector CollectorProcess) Build() (Collector, error) {
-	if collector.ConfigPath == "" && collector.Args == nil {
-		return nil, fmt.Errorf("you must specify a ConfigPath for your CollectorProcess before building")
-	}
 	if collector.Path == "" {
 		collectorPath, err := findCollectorPath()
 		if err != nil {
@@ -119,9 +116,18 @@ func (collector CollectorProcess) Build() (Collector, error) {
 	if collector.LogLevel == "" {
 		collector.LogLevel = "info"
 	}
-	if collector.Args == nil {
-		collector.Args = []string{
-			fmt.Sprintf("--set=service.telemetry.logs.level=%s", collector.LogLevel), "--config", collector.ConfigPath, "--set=service.telemetry.metrics.level=none",
+
+	configSetByArgs := configIsSetByArgs(collector.Args)
+	_, configSetByEnvVar := collector.Env["SPLUNK_CONFIG"]
+	if collector.ConfigPath != "" && !configSetByArgs && !configSetByEnvVar {
+		// only specify w/ args if none are used in the test
+		if collector.Args == nil {
+			collector.Args = []string{
+				fmt.Sprintf("--set=service.telemetry.logs.level=%s", collector.LogLevel), "--config", collector.ConfigPath, "--set=service.telemetry.metrics.level=none",
+			}
+		} else {
+			// fallback to env var
+			collector.Env["SPLUNK_CONFIG"] = collector.ConfigPath
 		}
 	}
 

--- a/tests/testutils/collector_process_test.go
+++ b/tests/testutils/collector_process_test.go
@@ -62,14 +62,6 @@ func TestCollectorProcessBuilders(t *testing.T) {
 	assert.Empty(t, builder.LogLevel)
 }
 
-func TestConfigPathNotRequiredUponBuildWithoutArgs(t *testing.T) {
-	builder := NewCollectorProcess()
-
-	collector, err := builder.Build()
-	require.NoError(t, err)
-	assert.NotNil(t, collector)
-}
-
 func TestCollectorProcessBuildDefaults(t *testing.T) {
 	// specifying Path to avoid built otelcol requirement
 	builder := NewCollectorProcess().WithPath("somepath").WithConfigPath("someconfigpath")
@@ -86,6 +78,17 @@ func TestCollectorProcessBuildDefaults(t *testing.T) {
 	assert.NotNil(t, collector.Logger)
 	assert.Equal(t, "info", collector.LogLevel)
 	assert.Equal(t, []string{"--set=service.telemetry.logs.level=info", "--config", "someconfigpath", "--set=service.telemetry.metrics.level=none"}, collector.Args)
+}
+
+func TestConfigPathNotRequiredUponBuildWithoutArgs(t *testing.T) {
+	builder := NewCollectorProcess().WithPath("somepath")
+	c, err := builder.Build()
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	collector, ok := c.(*CollectorProcess)
+	require.True(t, ok)
+	require.Nil(t, collector.Args)
 }
 
 func TestStartAndShutdownInvalidWithoutBuilding(t *testing.T) {

--- a/tests/testutils/collector_process_test.go
+++ b/tests/testutils/collector_process_test.go
@@ -62,13 +62,12 @@ func TestCollectorProcessBuilders(t *testing.T) {
 	assert.Empty(t, builder.LogLevel)
 }
 
-func TestConfigPathRequiredUponBuildWithoutArgs(t *testing.T) {
+func TestConfigPathNotRequiredUponBuildWithoutArgs(t *testing.T) {
 	builder := NewCollectorProcess()
 
 	collector, err := builder.Build()
-	assert.Nil(t, collector)
-	require.Error(t, err)
-	assert.EqualError(t, err, "you must specify a ConfigPath for your CollectorProcess before building")
+	require.NoError(t, err)
+	assert.NotNil(t, collector)
 }
 
 func TestCollectorProcessBuildDefaults(t *testing.T) {


### PR DESCRIPTION
The subprocess target runs have drifted as ci only adopts the container target. These changes align the auto-config loading to match the container builder logic and update tests to be more intuitively skipped or work w/ the subprocess.