### PR TITLE
Add yaml representation to testutils/telemetry

### DIFF
--- a/tests/testutils/telemetry/common.go
+++ b/tests/testutils/telemetry/common.go
@@ -15,11 +15,12 @@
 package telemetry
 
 import (
+	"bytes"
 	"crypto/md5" // #nosec this is not for cryptographic purposes
 	"fmt"
 	"reflect"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/signalfx/splunk-otel-collector/tests/internal/version"
 )
@@ -29,16 +30,22 @@ const (
 	buildVersionPlaceholder = "<VERSION_FROM_BUILD>"
 )
 
+func marshal(y any) string {
+	b := &bytes.Buffer{}
+	enc := yaml.NewEncoder(b)
+	enc.SetIndent(2)
+	if err := enc.Encode(y); err != nil {
+		panic(err)
+	}
+	return b.String()
+}
+
 type Resource struct {
 	Attributes *map[string]any `yaml:"attributes,omitempty"`
 }
 
 func (resource Resource) String() string {
-	out, err := yaml.Marshal(resource.Attributes)
-	if err != nil {
-		panic(err)
-	}
-	return string(out)
+	return marshal(resource)
 }
 
 // Hash provides an md5 hash determined by Resource content.
@@ -68,11 +75,7 @@ type InstrumentationScope struct {
 }
 
 func (is InstrumentationScope) String() string {
-	out, err := yaml.Marshal(is)
-	if err != nil {
-		panic(err)
-	}
-	return string(out)
+	return marshal(is)
 }
 
 // Hash provides an md5 hash determined by InstrumentationScope fields.

--- a/tests/testutils/telemetry/common_test.go
+++ b/tests/testutils/telemetry/common_test.go
@@ -28,7 +28,7 @@ func TestResourceHashFunctionConsistency(t *testing.T) {
 		"one": "1", "two": 2, "three": 3.000, "four": false, "five": nil,
 	}}
 	for i := 0; i < 100; i++ {
-		require.Equal(t, "d3b92e5ff5847c43f397d5856f14c607", resource.Hash())
+		require.Equal(t, "8c2edf4b5b71836ef95c2d64c200f30c", resource.Hash())
 	}
 
 	il := InstrumentationScope{Name: "some instrumentation library", Version: "some instrumentation version"}

--- a/tests/testutils/telemetry/logs.go
+++ b/tests/testutils/telemetry/logs.go
@@ -116,12 +116,20 @@ func (resourceLogs ResourceLogs) Validate() error {
 	return nil
 }
 
+func (resourceLogs ResourceLogs) String() string {
+	return marshal(resourceLogs)
+}
+
+func (resourceLog ResourceLog) String() string {
+	return marshal(resourceLog)
+}
+
+func (scopeLogs ScopeLogs) String() string {
+	return marshal(scopeLogs)
+}
+
 func (log Log) String() string {
-	out, err := yaml.Marshal(log)
-	if err != nil {
-		panic(err)
-	}
-	return string(out)
+	return marshal(log)
 }
 
 // Hash provides an md5 hash determined by Log content.

--- a/tests/testutils/telemetry/logs_test.go
+++ b/tests/testutils/telemetry/logs_test.go
@@ -17,6 +17,8 @@
 package telemetry
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,6 +32,13 @@ func loadedResourceLogs(t *testing.T) ResourceLogs {
 	require.NoError(t, err)
 	require.NotNil(t, resourceLogs)
 	return *resourceLogs
+}
+
+func TestResourceLogsYamlStringRep(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join(".", "testdata", "logs", "resource-logs.yaml"))
+	require.NoError(t, err)
+	resourceLogs := loadedResourceLogs(t)
+	require.Equal(t, string(b), fmt.Sprintf("%v", resourceLogs))
 }
 
 func TestLoadLogsHappyPath(t *testing.T) {
@@ -389,7 +398,7 @@ func TestLogContainsAllResourceNeverReceived(t *testing.T) {
 	containsAll, err := received.ContainsAll(*expected)
 	require.False(t, containsAll)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Missing resources: [not: matched\n]")
+	require.Contains(t, err.Error(), "Missing resources: [attributes:\n  not: matched\n]")
 }
 
 func TestLogContainsAllWithMissingAndEmptyAttributes(t *testing.T) {

--- a/tests/testutils/telemetry/metrics_test.go
+++ b/tests/testutils/telemetry/metrics_test.go
@@ -18,6 +18,7 @@ package telemetry
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,6 +31,13 @@ func loadedResourceMetrics(t *testing.T) ResourceMetrics {
 	require.NoError(t, err)
 	require.NotNil(t, resourceMetrics)
 	return *resourceMetrics
+}
+
+func TestResourceMetricsYamlStringRep(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join(".", "testdata", "metrics", "resource-metrics.yaml"))
+	require.NoError(t, err)
+	resourceMetrics := loadedResourceMetrics(t)
+	require.Equal(t, string(b), fmt.Sprintf("%v", resourceMetrics))
 }
 
 func TestLoadMetricsHappyPath(t *testing.T) {
@@ -442,7 +450,7 @@ func TestMetricContainsAllResourceNeverReceived(t *testing.T) {
 	containsAll, err := received.ContainsAll(*expected)
 	require.False(t, containsAll)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Missing resources: [not: matched\n]")
+	require.Contains(t, err.Error(), "Missing resources: [attributes:\n  not: matched\n]")
 }
 
 func TestMetricContainsAllWithMissingAndEmptyAttributes(t *testing.T) {
@@ -465,7 +473,7 @@ func TestMetricContainsAllWithMissingAndEmptyAttributes(t *testing.T) {
 	containsAll, err = received.ContainsAll(*empty)
 	require.False(t, containsAll)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Missing Metrics: [attributes: {}\nname: another_int_gauge\ntype: IntGauge\nvalue: 111\n]")
+	require.Contains(t, err.Error(), "Missing Metrics: [name: another_int_gauge\ntype: IntGauge\nvalue: 111\n]")
 }
 
 func TestMetricContainsOnlyDetectsUnexpectedMetric(t *testing.T) {
@@ -474,5 +482,5 @@ func TestMetricContainsOnlyDetectsUnexpectedMetric(t *testing.T) {
 	sm[0].Metrics = append(sm[0].Metrics, Metric{Name: "unexpected_metric"})
 	containsAll, err := resourceMetrics.ContainsOnly(loadedResourceMetrics(t))
 	require.False(t, containsAll, err)
-	require.EqualError(t, err, fmt.Sprintf("%v contains unexpected metrics unexpected_metric", resourceMetrics.ResourceMetrics))
+	require.EqualError(t, err, fmt.Sprintf("%v contains unexpected metrics unexpected_metric", resourceMetrics))
 }

--- a/tests/testutils/telemetry/testdata/logs/resource-logs.yaml
+++ b/tests/testutils/telemetry/testdata/logs/resource-logs.yaml
@@ -8,11 +8,11 @@ resource_logs:
           version: some_version
       - logs:
           - body: a string body
-            severity_text: info
-            severity: 1
             attributes:
               one_lr_attr: one_lr_value
               two_lr_attr: two_lr_value
+            severity: 1
+            severity_text: info
           - body: 0
   - scope_logs:
       - instrumentation_scope:
@@ -20,7 +20,7 @@ resource_logs:
           version: another_version
         logs:
           - body: true
-            severity_text: arbitrary
             severity: 24
+            severity_text: arbitrary
           - body: 0.123
             severity: 9

--- a/tests/testutils/telemetry/testdata/metrics/resource-metrics.yaml
+++ b/tests/testutils/telemetry/testdata/metrics/resource-metrics.yaml
@@ -7,9 +7,9 @@ resource_metrics:
           name: without_metrics
           version: some_version
       - metrics:
-          - name: an_int_gauge
+          - description: an_int_gauge_description
+            name: an_int_gauge
             type: IntGauge
-            description: an_int_gauge_description
             unit: an_int_gauge_unit
             value: 123
           - name: a_double_gauge

--- a/tests/testutils/telemetry/testdata/traces/resource-traces.yaml
+++ b/tests/testutils/telemetry/testdata/traces/resource-traces.yaml
@@ -1,33 +1,32 @@
 resource_spans:
-- attributes:
-    one_attr: one_value
-    two_attr: two_value
-  scope_spans:
-  - instrumentation_scope:
-      attributes:
-        one_attr: one_value
-      name: scope_one
-      version: scope_one_version
-    spans:
-    - name: span_one
-      attributes:
-        one_attr: one_value
-        two_attr: two_value
-    - name: span_two
-      attributes: {}
-  - instrumentation_scope:
-      attributes: {}
-      name: instrumentation_scope_two
-      version: instrumentation_scope_two_version
-    spans:
-    - name: span_one
-      attributes: {}
-- attributes:
-    some_attr: some_value
-  scope_spans:
-  - instrumentation_scope:
-      name: scope_one
-      version: scope_one_version
-    spans:
-    - name: last_span
-
+  - attributes:
+      one_attr: one_value
+      two_attr: two_value
+    scope_spans:
+      - instrumentation_scope:
+          attributes:
+            one_attr: one_value
+          name: scope_one
+          version: scope_one_version
+        spans:
+          - attributes:
+              one_attr: one_value
+              two_attr: two_value
+            name: span_one
+          - attributes: {}
+            name: span_two
+      - instrumentation_scope:
+          attributes: {}
+          name: instrumentation_scope_two
+          version: instrumentation_scope_two_version
+        spans:
+          - attributes: {}
+            name: span_one
+  - attributes:
+      some_attr: some_value
+    scope_spans:
+      - instrumentation_scope:
+          name: scope_one
+          version: scope_one_version
+        spans:
+          - name: last_span

--- a/tests/testutils/telemetry/traces.go
+++ b/tests/testutils/telemetry/traces.go
@@ -61,6 +61,10 @@ func (rt *ResourceTraces) SaveResourceTraces(path string) error {
 	return nil
 }
 
+func (rt ResourceTraces) String() string {
+	return marshal(rt)
+}
+
 // LoadResourceTraces returns a ResourceTraces instance generated via parsing a valid yaml file at the provided path.
 func LoadResourceTraces(path string) (*ResourceTraces, error) {
 	traceFile, err := os.Open(path)
@@ -89,12 +93,16 @@ func LoadResourceTraces(path string) (*ResourceTraces, error) {
 	return &loaded, nil
 }
 
+func (resourceSpans ResourceSpans) String() string {
+	return marshal(resourceSpans)
+}
+
+func (scopeSpans ScopeSpans) String() string {
+	return marshal(scopeSpans)
+}
+
 func (span Span) String() string {
-	out, err := yaml.Marshal(span)
-	if err != nil {
-		panic(err)
-	}
-	return string(out)
+	return marshal(span)
 }
 
 func (span Span) RelaxedEquals(toCompare Span) bool {

--- a/tests/testutils/telemetry/traces_test.go
+++ b/tests/testutils/telemetry/traces_test.go
@@ -17,6 +17,7 @@
 package telemetry
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -49,6 +50,13 @@ func loadedResourceTraces(t *testing.T) ResourceTraces {
 	require.NoError(t, err)
 	require.NotNil(t, resourceTraces)
 	return *resourceTraces
+}
+
+func TestResourceTracesYamlStringRep(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join(".", "testdata", "traces", "resource-traces.yaml"))
+	require.NoError(t, err)
+	resourceTraces := loadedResourceTraces(t)
+	require.Equal(t, string(b), fmt.Sprintf("%v", resourceTraces))
 }
 
 func TestLoadTracesHappyPath(t *testing.T) {
@@ -262,5 +270,5 @@ func TestTraceContainsAllResourceNeverReceived(t *testing.T) {
 	containsAll, err := received.ContainsAll(*expected)
 	require.False(t, containsAll)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Missing resources: [some_attr: different_value\n]")
+	require.Contains(t, err.Error(), "Missing resources: [attributes:\n  some_attr: different_value\n]")
 }


### PR DESCRIPTION
The failure output for integration tests is suboptimal, to say the least. These changes adopt yaml representation to the telemetry helpers to help make* debugging and updating resource telemetry content easier.