### PR TITLE
ansible: Add support for dotnet auto instrumentation

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -163,6 +163,16 @@ jobs:
       - name: Install test dependencies.
         run: pip3 install --use-pep517 -r ${GITHUB_WORKSPACE}/requirements.txt
 
+      - name: Set IISRESET env var
+        run: |
+          # Currently only the 2022 vagrant box has IIS installed.
+          # The IISRESET env var will be used for the signalfx_dotnet_auto_instrumentation_iisreset test option.
+          if [[ "${{ matrix.distro }}" = "2022" ]]; then
+            echo "IISRESET=true" >> $GITHUB_ENV
+          else
+            echo "IISRESET=false" >> $GITHUB_ENV
+          fi
+
       - name: Run Molecule tests.
         run: molecule --debug -v --base-config ./molecule/config/windows.yml test -s ${{ matrix.scenario }} -p ${{ matrix.distro }}
         env:

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -137,6 +137,7 @@ jobs:
           - default
           - custom_vars
           - without_fluentd
+          - with_instrumentation
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v3

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -163,16 +163,6 @@ jobs:
       - name: Install test dependencies.
         run: pip3 install --use-pep517 -r ${GITHUB_WORKSPACE}/requirements.txt
 
-      - name: Set IISRESET env var
-        run: |
-          # Currently only the 2022 vagrant box has IIS installed.
-          # The IISRESET env var will be used for the signalfx_dotnet_auto_instrumentation_iisreset test option.
-          if [[ "${{ matrix.distro }}" = "2022" ]]; then
-            echo "IISRESET=true" >> $GITHUB_ENV
-          else
-            echo "IISRESET=false" >> $GITHUB_ENV
-          fi
-
       - name: Run Molecule tests.
         run: molecule --debug -v --base-config ./molecule/config/windows.yml test -s ${{ matrix.scenario }} -p ${{ matrix.distro }}
         env:

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -104,7 +104,11 @@ jobs:
           cache-dependency-path: "${{ github.workspace }}/requirements.txt"
 
       - name: Install test dependencies.
-        run: pip3 install --use-pep517 -r ${GITHUB_WORKSPACE}/requirements.txt
+        run: |
+          # workaround for https://github.com/yaml/pyyaml/issues/724
+          pip3 install 'wheel==0.40.0'
+          pip3 install 'Cython<3.0' 'PyYaml~=5.0' --no-build-isolation
+          pip3 install --use-pep517 -r ${GITHUB_WORKSPACE}/requirements.txt
 
       - name: Run Molecule tests.
         run: molecule --base-config ./molecule/config/docker.yml test --all

--- a/deployments/ansible/CHANGELOG.md
+++ b/deployments/ansible/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## ansible-v0.19.0
+
+### 💡 Enhancements 💡
+
+- Add support for Auto Instrumentation for .NET on Windows
+
 ## ansible-v0.18.0
 
 ### 💡 Enhancements 💡

--- a/deployments/ansible/galaxy.yml
+++ b/deployments/ansible/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: signalfx
 name: splunk_otel_collector
 description: Ansible collection for Splunk OpenTelemetry Collector
-version: 0.18.0
+version: 0.19.0
 readme: README.md
 authors:
   - Splunk Inc.

--- a/deployments/ansible/molecule/config/windows.yml
+++ b/deployments/ansible/molecule/config/windows.yml
@@ -36,8 +36,8 @@ platforms:
     memory: 4096
     instance_raw_config_args: *vagrant_args
   - name: "2022"
-    box: gusztavvargadr/windows-server-2022-standard
-    box_version: 2102.0.2305
+    box: gusztavvargadr/iis-windows-server
+    box_version: 10.2102.2306
     cpus: 2
     memory: 4096
     instance_raw_config_args: *vagrant_args

--- a/deployments/ansible/molecule/custom_vars/windows-converge.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-converge.yml
@@ -20,6 +20,7 @@
       MY_CUSTOM_VAR2: value2
     install_signalfx_dotnet_auto_instrumentation: true
     signalfx_dotnet_auto_instrumentation_version: 1.0.0
+    signalfx_dotnet_auto_instrumentation_system_wide: true
     signalfx_dotnet_auto_instrumentation_environment: test-environment
     signalfx_dotnet_auto_instrumentation_service_name: test-service-name
     signalfx_dotnet_auto_instrumentation_enable_profiler: true

--- a/deployments/ansible/molecule/custom_vars/windows-converge.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-converge.yml
@@ -18,6 +18,16 @@
     splunk_otel_collector_additional_env_vars:
       MY_CUSTOM_VAR1: value1
       MY_CUSTOM_VAR2: value2
+    install_signalfx_dotnet_auto_instrumentation: true
+    signalfx_dotnet_auto_instrumentation_version: 1.0.0
+    signalfx_dotnet_auto_instrumentation_github_token: ${GITHUB_TOKEN}
+    signalfx_dotnet_auto_instrumentation_environment: test-environment
+    signalfx_dotnet_auto_instrumentation_service_name: test-service-name
+    signalfx_dotnet_auto_instrumentation_enable_profiler: true
+    signalfx_dotnet_auto_instrumentation_enable_profiler_memory: true
+    signalfx_dotnet_auto_instrumentation_additional_options:
+      SIGNALFX_DOTNET_VAR1: value1
+      SIGNALFX_DOTNET_VAR2: value2
   tasks:
     - name: "Include signalfx.splunk_otel_collector.collector role"
       include_role:

--- a/deployments/ansible/molecule/custom_vars/windows-converge.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-converge.yml
@@ -25,7 +25,6 @@
     signalfx_dotnet_auto_instrumentation_service_name: test-service-name
     signalfx_dotnet_auto_instrumentation_enable_profiler: true
     signalfx_dotnet_auto_instrumentation_enable_profiler_memory: true
-    signalfx_dotnet_auto_instrumentation_iisreset: ${IISRESET}
     signalfx_dotnet_auto_instrumentation_additional_options:
       SIGNALFX_DOTNET_VAR1: value1
       SIGNALFX_DOTNET_VAR2: value2

--- a/deployments/ansible/molecule/custom_vars/windows-converge.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-converge.yml
@@ -20,11 +20,11 @@
       MY_CUSTOM_VAR2: value2
     install_signalfx_dotnet_auto_instrumentation: true
     signalfx_dotnet_auto_instrumentation_version: 1.0.0
-    signalfx_dotnet_auto_instrumentation_github_token: ${GITHUB_TOKEN}
     signalfx_dotnet_auto_instrumentation_environment: test-environment
     signalfx_dotnet_auto_instrumentation_service_name: test-service-name
     signalfx_dotnet_auto_instrumentation_enable_profiler: true
     signalfx_dotnet_auto_instrumentation_enable_profiler_memory: true
+    signalfx_dotnet_auto_instrumentation_iisreset: ${IISRESET}
     signalfx_dotnet_auto_instrumentation_additional_options:
       SIGNALFX_DOTNET_VAR1: value1
       SIGNALFX_DOTNET_VAR2: value2

--- a/deployments/ansible/molecule/custom_vars/windows-converge.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-converge.yml
@@ -26,8 +26,8 @@
     signalfx_dotnet_auto_instrumentation_enable_profiler: true
     signalfx_dotnet_auto_instrumentation_enable_profiler_memory: true
     signalfx_dotnet_auto_instrumentation_additional_options:
-      SIGNALFX_DOTNET_VAR1: value1
-      SIGNALFX_DOTNET_VAR2: value2
+      SIGNALFX_DOTNET_VAR1: dotnet-value1
+      SIGNALFX_DOTNET_VAR2: dotnet-value2
   tasks:
     - name: "Include signalfx.splunk_otel_collector.collector role"
       include_role:

--- a/deployments/ansible/molecule/custom_vars/windows-verify.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-verify.yml
@@ -3,6 +3,30 @@
   hosts: all
   gather_facts: true
   become: no
+  vars:
+    reg_values:
+      SPLUNK_CONFIG: '{{ ansible_env.ProgramData }}\Splunk\OpenTelemetry Collector\custom_config.yml'
+      SPLUNK_INGEST_URL: https://fake-splunk-ingest.com
+      SPLUNK_API_URL: https://fake-splunk-api.com
+      SPLUNK_TRACE_URL: https://fake-splunk-ingest.com/v2/trace
+      SPLUNK_HEC_URL: https://fake-splunk-hec.com
+      SPLUNK_HEC_TOKEN: fake-hec-token
+      SPLUNK_MEMORY_TOTAL_MIB: "256"
+      SPLUNK_BALLAST_SIZE_MIB: "100"
+      MY_CUSTOM_VAR1: value1
+      MY_CUSTOM_VAR2: value2
+      SIGNALFX_DOTNET_TRACER_HOME: '{{ ansible_env.ProgramFiles }}\SignalFx\.NET Tracing\'
+    dotnet_reg_values:
+      COR_ENABLE_PROFILING: "true"
+      COR_PROFILER: "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"
+      CORECLR_ENABLE_PROFILING: "true"
+      CORECLR_PROFILER: "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"
+      SIGNALFX_ENV: test-environment
+      SIGNALFX_SERVICE_NAME: test-service-name
+      SIGNALFX_PROFILER_ENABLED: "true"
+      SIGNALFX_PROFILER_MEMORY_ENABLED: "true"
+      SIGNALFX_DOTNET_VAR1: dotnet-value1
+      SIGNALFX_DOTNET_VAR2: dotnet-value2
   tasks:
     - name: Check splunk-otel-collector service
       ansible.windows.win_service:
@@ -52,146 +76,6 @@
       assert:
         that: custom_collector_config.stat.exists
 
-    - name: Check SPLUNK_CONFIG custom value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_CONFIG
-        data: '{{ansible_env.ProgramData}}\Splunk\OpenTelemetry Collector\custom_config.yml'
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert custom value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_INGEST_URL custom value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_INGEST_URL
-        data: https://fake-splunk-ingest.com
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert custom value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_API_URL custom value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_API_URL
-        data: https://fake-splunk-api.com
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert custom value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_TRACE_URL custom value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_TRACE_URL
-        data: https://fake-splunk-ingest.com/v2/trace
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert custom value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_HEC_URL custom value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_HEC_URL
-        data: https://fake-splunk-hec.com
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert custom value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_HEC_TOKEN custom value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_HEC_TOKEN
-        data: fake-hec-token
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert custom value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_MEMORY_TOTAL_MIB custom value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_MEMORY_TOTAL_MIB
-        data: 256
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert custom value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_BALLAST_SIZE_MIB custom value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_BALLAST_SIZE_MIB
-        data: 100
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert custom value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check MY_CUSTOM_VAR1 custom variable
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: MY_CUSTOM_VAR1
-        data: value1
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert custom value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check MY_CUSTOM_VAR2 custom variable
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: MY_CUSTOM_VAR2
-        data: value2
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert custom value exists
-      assert:
-        that: not reg_value.changed
-
     - name: Check fluentd custom_config.conf
       ansible.windows.win_stat:
         path: '{{ansible_env.ProgramFiles}}\Splunk\OpenTelemetry Collector\fluentd\custom_config.conf'
@@ -230,180 +114,21 @@
       assert:
         that: not msi_installed.changed
 
-    - name: Check IIS registry value
-      ansible.windows.win_regedit:
+    - name: Get IIS env vars
+      ansible.windows.win_reg_stat:
         path: HKLM:\SYSTEM\CurrentControlSet\Services\W3SVC
-        state: present
         name: Environment
-        data:
-          - COR_ENABLE_PROFILING=true
-          - COR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}
-          - CORECLR_ENABLE_PROFILING=true
-          - CORECLR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}
-          - SIGNALFX_DOTNET_VAR1=value1
-          - SIGNALFX_DOTNET_VAR2=value2
-          - SIGNALFX_ENV=test-environment
-          - SIGNALFX_PROFILER_ENABLED=true
-          - SIGNALFX_PROFILER_MEMORY_ENABLED=true
-          - SIGNALFX_SERVICE_NAME=test-service-name
-        type: multistring
-      check_mode: yes
-      register: reg_value
+      register: iis_env
 
-    - name: Assert registry value exists
+    - name: Verify IIS env vars
       assert:
-        that: not reg_value.changed
+        that: (item.key + '=' + item.value) in iis_env.value
+      loop: "{{ dotnet_reg_values | dict2items }}"
 
-    - name: Check SIGNALFX_DOTNET_TRACER_HOME registry value
-      ansible.windows.win_regedit:
+    - name: Verify env vars
+      include_tasks: ../shared/verify_registry_key.yml
+      vars:
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SIGNALFX_DOTNET_TRACER_HOME
-        data: C:\Program Files\SignalFx\.NET Tracing\
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check COR_ENABLE_PROFILING registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: COR_ENABLE_PROFILING
-        data: "true"
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check COR_PROFILER registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: COR_PROFILER
-        data: "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check CORECLR_ENABLE_PROFILING registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: CORECLR_ENABLE_PROFILING
-        data: "true"
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check CORECLR_PROFILER registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: CORECLR_PROFILER
-        data: "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SIGNALFX_ENV registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SIGNALFX_ENV
-        data: test-environment
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SIGNALFX_SERVICE_NAME registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SIGNALFX_SERVICE_NAME
-        data: test-service-name
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SIGNALFX_PROFILER_ENABLED registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SIGNALFX_PROFILER_ENABLED
-        data: "true"
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SIGNALFX_PROFILER_MEMORY_ENABLED registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SIGNALFX_PROFILER_MEMORY_ENABLED
-        data: "true"
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SIGNALFX_DOTNET_VAR1 registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SIGNALFX_DOTNET_VAR1
-        data: value1
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SIGNALFX_DOTNET_VAR2 registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SIGNALFX_DOTNET_VAR2
-        data: value2
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
+        name: "{{ item.key }}"
+        value: "{{ item.value }}"
+      loop: "{{ reg_values | combine(dotnet_reg_values) | dict2items }}"

--- a/deployments/ansible/molecule/custom_vars/windows-verify.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-verify.yml
@@ -211,3 +211,105 @@
     - name: Assert fluentd custom_config.conf is used
       assert:
         that: custom_fluentd_config.stat.checksum == td_agent_config.stat.checksum
+
+    - name: Download signalfx-dotnet-tracing-1.0.0-x64.msi
+      ansible.windows.win_get_url:
+        url: "https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/\
+              v1.0.0/signalfx-dotnet-tracing-1.0.0-x64.msi"
+        dest: "{{ansible_env.TEMP}}"
+      register: dotnet_msi_package
+
+    - name: Install signalfx-dotnet-tracing-1.0.0-x64.msi
+      ansible.windows.win_package:
+        path: "{{dotnet_msi_package.dest}}"
+        state: present
+      check_mode: yes
+      register: msi_installed
+
+    - name: Assert signalfx-dotnet-tracing-1.0.0-x64.msi is already installed
+      assert:
+        that: not msi_installed.changed
+
+    - name: Check SIGNALFX_ENV registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SIGNALFX_ENV
+        data: test-environment
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SIGNALFX_SERVICE_NAME registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SIGNALFX_SERVICE_NAME
+        data: test-service-name
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SIGNALFX_PROFILER_ENABLED registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SIGNALFX_PROFILER_ENABLED
+        data: "true"
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SIGNALFX_PROFILER_MEMORY_ENABLED registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SIGNALFX_PROFILER_MEMORY_ENABLED
+        data: "true"
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SIGNALFX_DOTNET_VAR1 registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SIGNALFX_DOTNET_VAR1
+        data: value1
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SIGNALFX_DOTNET_VAR2 registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SIGNALFX_DOTNET_VAR2
+        data: value2
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed

--- a/deployments/ansible/molecule/custom_vars/windows-verify.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-verify.yml
@@ -230,6 +230,100 @@
       assert:
         that: not msi_installed.changed
 
+    - name: Check IIS registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Services\W3SVC
+        state: present
+        name: Environment
+        data:
+          - COR_ENABLE_PROFILING=true
+          - COR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}
+          - CORECLR_ENABLE_PROFILING=true
+          - CORECLR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}
+          - SIGNALFX_DOTNET_VAR1=value1
+          - SIGNALFX_DOTNET_VAR2=value2
+          - SIGNALFX_ENV=test-environment
+          - SIGNALFX_PROFILER_ENABLED=true
+          - SIGNALFX_PROFILER_MEMORY_ENABLED=true
+          - SIGNALFX_SERVICE_NAME=test-service-name
+        type: multistring
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SIGNALFX_DOTNET_TRACER_HOME registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SIGNALFX_DOTNET_TRACER_HOME
+        data: C:\Program Files\SignalFx\.NET Tracing\
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check COR_ENABLE_PROFILING registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: COR_ENABLE_PROFILING
+        data: "true"
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check COR_PROFILER registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: COR_PROFILER
+        data: "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check CORECLR_ENABLE_PROFILING registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: CORECLR_ENABLE_PROFILING
+        data: "true"
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check CORECLR_PROFILER registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: CORECLR_PROFILER
+        data: "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
     - name: Check SIGNALFX_ENV registry value
       ansible.windows.win_regedit:
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment

--- a/deployments/ansible/molecule/default/windows-verify.yml
+++ b/deployments/ansible/molecule/default/windows-verify.yml
@@ -3,6 +3,16 @@
   hosts: all
   gather_facts: true
   become: no
+  vars:
+    reg_values:
+      SPLUNK_CONFIG: '{{ ansible_env.ProgramData }}\Splunk\OpenTelemetry Collector\agent_config.yaml'
+      SPLUNK_ACCESS_TOKEN: fake-token
+      SPLUNK_REALM: fake-realm
+      SPLUNK_API_URL: https://api.fake-realm.signalfx.com
+      SPLUNK_HEC_TOKEN: fake-token
+      SPLUNK_HEC_URL: https://ingest.fake-realm.signalfx.com/v1/log
+      SPLUNK_INGEST_URL: https://ingest.fake-realm.signalfx.com
+      SPLUNK_TRACE_URL: https://ingest.fake-realm.signalfx.com/v2/trace
   tasks:
     - name: Check splunk-otel-collector service
       ansible.windows.win_service:
@@ -26,100 +36,10 @@
       assert:
         that: not service_status.changed
 
-    - name: Check SPLUNK_ACCESS_TOKEN registry value
-      ansible.windows.win_regedit:
+    - name: Verify env vars
+      include_tasks: ../shared/verify_registry_key.yml
+      vars:
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_ACCESS_TOKEN
-        data: fake-token
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_REALM registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_REALM
-        data: fake-realm
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_API_URL registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_API_URL
-        data: https://api.fake-realm.signalfx.com
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_HEC_TOKEN registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_HEC_TOKEN
-        data: fake-token
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_HEC_URL registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_HEC_URL
-        data: https://ingest.fake-realm.signalfx.com/v1/log
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_INGEST_URL registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_INGEST_URL
-        data: https://ingest.fake-realm.signalfx.com
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_TRACE_URL registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_TRACE_URL
-        data: https://ingest.fake-realm.signalfx.com/v2/trace
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
+        name: "{{ item.key }}"
+        value: "{{ item.value }}"
+      loop: "{{ reg_values | dict2items }}"

--- a/deployments/ansible/molecule/shared/verify_registry_key.yml
+++ b/deployments/ansible/molecule/shared/verify_registry_key.yml
@@ -1,0 +1,16 @@
+---
+- name: Get registry entry
+  ansible.windows.win_reg_stat:
+    path: "{{ path }}"
+    name: "{{ name }}"
+  register: reg_entry
+
+- name: Verify registry entry value
+  assert:
+    that: reg_entry.value == value
+  when: exists | default(true)
+
+- name: Verify registry entry does not exist
+  assert:
+    that: not reg_entry.exists
+  when: not (exists | default(true))

--- a/deployments/ansible/molecule/with_instrumentation/windows-converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation/windows-converge.yml
@@ -8,7 +8,6 @@
     install_fluentd: false
     install_signalfx_dotnet_auto_instrumentation: true
     signalfx_dotnet_auto_instrumentation_github_token: ${GITHUB_TOKEN}
-    signalfx_dotnet_auto_instrumentation_iisreset: ${IISRESET}
   tasks:
     - name: "Include signalfx.splunk_otel_collector.collector role"
       include_role:

--- a/deployments/ansible/molecule/with_instrumentation/windows-converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation/windows-converge.yml
@@ -7,6 +7,7 @@
     splunk_realm: fake-realm
     install_signalfx_dotnet_auto_instrumentation: true
     signalfx_dotnet_auto_instrumentation_github_token: ${GITHUB_TOKEN}
+    signalfx_dotnet_auto_instrumentation_iisreset: ${IISRESET}
   tasks:
     - name: "Include signalfx.splunk_otel_collector.collector role"
       include_role:

--- a/deployments/ansible/molecule/with_instrumentation/windows-converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation/windows-converge.yml
@@ -5,6 +5,7 @@
   vars:
     splunk_access_token: fake-token
     splunk_realm: fake-realm
+    install_fluentd: false
     install_signalfx_dotnet_auto_instrumentation: true
     signalfx_dotnet_auto_instrumentation_github_token: ${GITHUB_TOKEN}
     signalfx_dotnet_auto_instrumentation_iisreset: ${IISRESET}

--- a/deployments/ansible/molecule/with_instrumentation/windows-converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation/windows-converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge scenario with dotnet instrumentation on Windows
+  hosts: all
+  become: no
+  vars:
+    splunk_access_token: fake-token
+    splunk_realm: fake-realm
+    install_signalfx_dotnet_auto_instrumentation: true
+    signalfx_dotnet_auto_instrumentation_github_token: ${GITHUB_TOKEN}
+  tasks:
+    - name: "Include signalfx.splunk_otel_collector.collector role"
+      include_role:
+        name: "collector"

--- a/deployments/ansible/molecule/with_instrumentation/windows-verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation/windows-verify.yml
@@ -15,16 +15,19 @@
       assert:
         that: not service_status.changed
 
-    - name: Check fluentdwinsvc service
-      ansible.windows.win_service:
-        name: fluentdwinsvc
-        state: started
+    - name: Check SPLUNK_CONFIG registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_CONFIG
+        data: '{{ansible_env.ProgramData}}\Splunk\OpenTelemetry Collector\agent_config.yaml'
+        type: string
       check_mode: yes
-      register: service_status
+      register: reg_value
 
-    - name: Assert fluentdwinsvc service status
+    - name: Assert registry value exists
       assert:
-        that: not service_status.changed
+        that: not reg_value.changed
 
     - name: Check SPLUNK_ACCESS_TOKEN registry value
       ansible.windows.win_regedit:
@@ -124,6 +127,90 @@
       assert:
         that: not reg_value.changed
 
+    - name: Check IIS registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Services\W3SVC
+        state: present
+        name: Environment
+        data:
+          - COR_ENABLE_PROFILING=true
+          - COR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}
+          - CORECLR_ENABLE_PROFILING=true
+          - CORECLR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}
+          - SIGNALFX_ENV=
+          - SIGNALFX_PROFILER_ENABLED=false
+          - SIGNALFX_PROFILER_MEMORY_ENABLED=false
+          - SIGNALFX_SERVICE_NAME=
+        type: multistring
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SIGNALFX_DOTNET_TRACER_HOME registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SIGNALFX_DOTNET_TRACER_HOME
+        data: C:\Program Files\SignalFx\.NET Tracing\
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check COR_ENABLE_PROFILING registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: absent
+        name: COR_ENABLE_PROFILING
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value does not exist
+      assert:
+        that: not reg_value.changed
+
+    - name: Check COR_PROFILER registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: absent
+        name: COR_PROFILER
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value does not exist
+      assert:
+        that: not reg_value.changed
+
+    - name: Check CORECLR_ENABLE_PROFILING registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: absent
+        name: CORECLR_ENABLE_PROFILING
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value does not exist
+      assert:
+        that: not reg_value.changed
+
+    - name: Check CORECLR_PROFILER registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: absent
+        name: CORECLR_PROFILER
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value does not exist
+      assert:
+        that: not reg_value.changed
+
     - name: Check SIGNALFX_ENV registry value
       ansible.windows.win_regedit:
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
@@ -132,7 +219,7 @@
       check_mode: yes
       register: reg_value
 
-    - name: Assert registry value exists
+    - name: Assert registry value does not exist
       assert:
         that: not reg_value.changed
 
@@ -144,34 +231,30 @@
       check_mode: yes
       register: reg_value
 
-    - name: Assert registry value exists
+    - name: Assert registry value does not exist
       assert:
         that: not reg_value.changed
 
     - name: Check SIGNALFX_PROFILER_ENABLED registry value
       ansible.windows.win_regedit:
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
+        state: absent
         name: SIGNALFX_PROFILER_ENABLED
-        data: "false"
-        type: string
       check_mode: yes
       register: reg_value
 
-    - name: Assert registry value exists
+    - name: Assert registry value does not exist
       assert:
         that: not reg_value.changed
 
     - name: Check SIGNALFX_PROFILER_MEMORY_ENABLED registry value
       ansible.windows.win_regedit:
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
+        state: absent
         name: SIGNALFX_PROFILER_MEMORY_ENABLED
-        data: "false"
-        type: string
       check_mode: yes
       register: reg_value
 
-    - name: Assert registry value exists
+    - name: Assert registry value does not exist
       assert:
         that: not reg_value.changed

--- a/deployments/ansible/molecule/with_instrumentation/windows-verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation/windows-verify.yml
@@ -3,6 +3,26 @@
   hosts: all
   gather_facts: true
   become: no
+  vars:
+    reg_values:
+      SPLUNK_CONFIG: '{{ ansible_env.ProgramData }}\Splunk\OpenTelemetry Collector\agent_config.yaml'
+      SPLUNK_ACCESS_TOKEN: fake-token
+      SPLUNK_REALM: fake-realm
+      SPLUNK_API_URL: https://api.fake-realm.signalfx.com
+      SPLUNK_HEC_TOKEN: fake-token
+      SPLUNK_HEC_URL: https://ingest.fake-realm.signalfx.com/v1/log
+      SPLUNK_INGEST_URL: https://ingest.fake-realm.signalfx.com
+      SPLUNK_TRACE_URL: https://ingest.fake-realm.signalfx.com/v2/trace
+      SIGNALFX_DOTNET_TRACER_HOME: '{{ ansible_env.ProgramFiles }}\SignalFx\.NET Tracing\'
+    dotnet_reg_values:
+      COR_ENABLE_PROFILING: "true"
+      COR_PROFILER: "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"
+      CORECLR_ENABLE_PROFILING: "true"
+      CORECLR_PROFILER: "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"
+      SIGNALFX_ENV: ""
+      SIGNALFX_SERVICE_NAME: ""
+      SIGNALFX_PROFILER_ENABLED: "false"
+      SIGNALFX_PROFILER_MEMORY_ENABLED: "false"
   tasks:
     - name: Check splunk-otel-collector service
       ansible.windows.win_service:
@@ -15,246 +35,29 @@
       assert:
         that: not service_status.changed
 
-    - name: Check SPLUNK_CONFIG registry value
-      ansible.windows.win_regedit:
+    - name: Verify collector env vars
+      include_tasks: ../shared/verify_registry_key.yml
+      vars:
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_CONFIG
-        data: '{{ansible_env.ProgramData}}\Splunk\OpenTelemetry Collector\agent_config.yaml'
-        type: string
-      check_mode: yes
-      register: reg_value
+        name: "{{ item.key }}"
+        value: "{{ item.value }}"
+      loop: "{{ reg_values | dict2items }}"
 
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_ACCESS_TOKEN registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_ACCESS_TOKEN
-        data: fake-token
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_REALM registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_REALM
-        data: fake-realm
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_API_URL registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_API_URL
-        data: https://api.fake-realm.signalfx.com
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_HEC_TOKEN registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_HEC_TOKEN
-        data: fake-token
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_HEC_URL registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_HEC_URL
-        data: https://ingest.fake-realm.signalfx.com/v1/log
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_INGEST_URL registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_INGEST_URL
-        data: https://ingest.fake-realm.signalfx.com
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SPLUNK_TRACE_URL registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SPLUNK_TRACE_URL
-        data: https://ingest.fake-realm.signalfx.com/v2/trace
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check IIS registry value
-      ansible.windows.win_regedit:
+    - name: Get IIS env vars
+      ansible.windows.win_reg_stat:
         path: HKLM:\SYSTEM\CurrentControlSet\Services\W3SVC
-        state: present
         name: Environment
-        data:
-          - COR_ENABLE_PROFILING=true
-          - COR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}
-          - CORECLR_ENABLE_PROFILING=true
-          - CORECLR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}
-          - SIGNALFX_ENV=
-          - SIGNALFX_PROFILER_ENABLED=false
-          - SIGNALFX_PROFILER_MEMORY_ENABLED=false
-          - SIGNALFX_SERVICE_NAME=
-        type: multistring
-      check_mode: yes
-      register: reg_value
+      register: iis_env
 
-    - name: Assert registry value exists
+    - name: Verify IIS env vars
       assert:
-        that: not reg_value.changed
+        that: (item.key + '=' + item.value) in iis_env.value
+      loop: "{{ dotnet_reg_values | dict2items }}"
 
-    - name: Check SIGNALFX_DOTNET_TRACER_HOME registry value
-      ansible.windows.win_regedit:
+    - name: Verify .NET tracing env vars were not added to the system
+      include_tasks: ../shared/verify_registry_key.yml
+      vars:
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: present
-        name: SIGNALFX_DOTNET_TRACER_HOME
-        data: C:\Program Files\SignalFx\.NET Tracing\
-        type: string
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value exists
-      assert:
-        that: not reg_value.changed
-
-    - name: Check COR_ENABLE_PROFILING registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: absent
-        name: COR_ENABLE_PROFILING
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value does not exist
-      assert:
-        that: not reg_value.changed
-
-    - name: Check COR_PROFILER registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: absent
-        name: COR_PROFILER
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value does not exist
-      assert:
-        that: not reg_value.changed
-
-    - name: Check CORECLR_ENABLE_PROFILING registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: absent
-        name: CORECLR_ENABLE_PROFILING
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value does not exist
-      assert:
-        that: not reg_value.changed
-
-    - name: Check CORECLR_PROFILER registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: absent
-        name: CORECLR_PROFILER
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value does not exist
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SIGNALFX_ENV registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: absent
-        name: SIGNALFX_ENV
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value does not exist
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SIGNALFX_SERVICE_NAME registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: absent
-        name: SIGNALFX_SERVICE_NAME
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value does not exist
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SIGNALFX_PROFILER_ENABLED registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: absent
-        name: SIGNALFX_PROFILER_ENABLED
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value does not exist
-      assert:
-        that: not reg_value.changed
-
-    - name: Check SIGNALFX_PROFILER_MEMORY_ENABLED registry value
-      ansible.windows.win_regedit:
-        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
-        state: absent
-        name: SIGNALFX_PROFILER_MEMORY_ENABLED
-      check_mode: yes
-      register: reg_value
-
-    - name: Assert registry value does not exist
-      assert:
-        that: not reg_value.changed
+        name: "{{ item.key }}"
+        exists: false
+      loop: "{{ dotnet_reg_values | dict2items }}"

--- a/deployments/ansible/molecule/with_instrumentation/windows-verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation/windows-verify.yml
@@ -1,0 +1,195 @@
+---
+- name: Verify scenario with the default configuration
+  hosts: all
+  gather_facts: true
+  become: no
+  tasks:
+    - name: Check splunk-otel-collector service
+      ansible.windows.win_service:
+        name: splunk-otel-collector
+        state: started
+      check_mode: yes
+      register: service_status
+
+    - name: Assert splunk-otel-collector service status
+      assert:
+        that: not service_status.changed
+
+    - name: Check fluentdwinsvc service
+      ansible.windows.win_service:
+        name: fluentdwinsvc
+        state: started
+      check_mode: yes
+      register: service_status
+
+    - name: Assert fluentdwinsvc service status
+      assert:
+        that: not service_status.changed
+
+    - name: Check SPLUNK_ACCESS_TOKEN registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_ACCESS_TOKEN
+        data: fake-token
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_REALM registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_REALM
+        data: fake-realm
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_API_URL registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_API_URL
+        data: https://api.fake-realm.signalfx.com
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_HEC_TOKEN registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_HEC_TOKEN
+        data: fake-token
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_HEC_URL registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_HEC_URL
+        data: https://ingest.fake-realm.signalfx.com/v1/log
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_INGEST_URL registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_INGEST_URL
+        data: https://ingest.fake-realm.signalfx.com
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SPLUNK_TRACE_URL registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SPLUNK_TRACE_URL
+        data: https://ingest.fake-realm.signalfx.com/v2/trace
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Download signalfx-dotnet-tracing-1.1.0-x64.msi
+      ansible.windows.win_get_url:
+        url: "https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/\
+              v1.1.0/signalfx-dotnet-tracing-1.1.0-x64.msi"
+        dest: "{{ansible_env.TEMP}}"
+      register: dotnet_msi_package
+
+    - name: Install signalfx-dotnet-tracing-1.1.0-x64.msi
+      ansible.windows.win_package:
+        path: "{{dotnet_msi_package.dest}}"
+        state: present
+      check_mode: yes
+      register: msi_installed
+
+    - name: Assert signalfx-dotnet-tracing-1.1.0-x64.msi is already installed
+      assert:
+        that: not msi_installed.changed
+
+    - name: Check SIGNALFX_ENV registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: absent
+        name: SIGNALFX_ENV
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SIGNALFX_SERVICE_NAME registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: absent
+        name: SIGNALFX_SERVICE_NAME
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SIGNALFX_PROFILER_ENABLED registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SIGNALFX_PROFILER_ENABLED
+        data: "false"
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed
+
+    - name: Check SIGNALFX_PROFILER_MEMORY_ENABLED registry value
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
+        state: present
+        name: SIGNALFX_PROFILER_MEMORY_ENABLED
+        data: "false"
+        type: string
+      check_mode: yes
+      register: reg_value
+
+    - name: Assert registry value exists
+      assert:
+        that: not reg_value.changed

--- a/deployments/ansible/molecule/with_instrumentation/windows-verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation/windows-verify.yml
@@ -124,24 +124,6 @@
       assert:
         that: not reg_value.changed
 
-    - name: Download signalfx-dotnet-tracing-1.1.0-x64.msi
-      ansible.windows.win_get_url:
-        url: "https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/\
-              v1.1.0/signalfx-dotnet-tracing-1.1.0-x64.msi"
-        dest: "{{ansible_env.TEMP}}"
-      register: dotnet_msi_package
-
-    - name: Install signalfx-dotnet-tracing-1.1.0-x64.msi
-      ansible.windows.win_package:
-        path: "{{dotnet_msi_package.dest}}"
-        state: present
-      check_mode: yes
-      register: msi_installed
-
-    - name: Assert signalfx-dotnet-tracing-1.1.0-x64.msi is already installed
-      assert:
-        that: not msi_installed.changed
-
     - name: Check SIGNALFX_ENV registry value
       ansible.windows.win_regedit:
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment

--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -256,10 +256,17 @@ after installation/configuration in order for any change to take effect.
 
 ### Auto Instrumentation for .NET on Windows
 
-**Note:** By default, only IIS applications will be instrumented after
-installation/configuration. Applications not running within IIS will need to
-restarted separately after installation/configuration in order for any change
-to take effect.
+***Warning:*** The `Environment` property in the
+`HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W3SVC` registry key will
+be overwritten by the options specified below to enable/configure auto
+instrumentation for IIS. Use the
+`signalfx_dotnet_auto_instrumentation_additional_options` option (see below for
+details) to include any other environment variables required for IIS.
+
+**Note:** By default, only IIS will be restarted with the `iisreset` command
+(if it exists) after installation/configuration. Applications/services not
+running within IIS need to be restarted separately in order for any changes to
+take effect.
 
 For proxy options, see the [Windows Proxy](#windows-proxy) section.
 
@@ -267,22 +274,21 @@ For proxy options, see the [Windows Proxy](#windows-proxy) section.
   install/manage [SignalFx Auto Instrumentation for .NET](
   https://docs.splunk.com/Observability/gdi/get-data-in/application/dotnet/get-started.html).
   When set to `true`, the `signalfx-dotnet-tracing` MSI package will be
-  downloaded and installed from [GitHub Releases](
-  https://github.com/signalfx/signalfx-dotnet-tracing/releases). (**default:**
-  `false`)
+  downloaded and installed. (**default:** `false`)
 
 - `signalfx_dotnet_auto_instrumentation_version` (Windows only): Version of the
   `signalfx-dotnet-tracing` MSI package to download and install from
   [GitHub Releases](https://github.com/signalfx/signalfx-dotnet-tracing/releases).
   By default, a request will be made to
-  `https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases` to
-  determine the latest release. If a version is specified, e.g. `1.0.0`, the
-  API request will be skipped and the MSI package will be downloaded from
+  `https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/latest`
+  to determine the latest release. If a version is specified, e.g. `1.0.0`,
+  the API request will be skipped and the MSI package will be downloaded from
   `https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v{{ signalfx_dotnet_auto_instrumentation_version }}/signalfx-dotnet-tracing-{{ signalfx_dotnet_auto_instrumentation_version }}-x64.msi`.
   (**default:** `latest`)
 
 - `signalfx_dotnet_auto_instrumentation_msi_url` (Windows only): Specify the
-  download URL to skip the GitHub API request, e.g.
+  download URL to the `signalfx-dotnet-tracing` MSI to skip the GitHub API
+  request, e.g.
   `https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v1.0.0/signalfx-dotnet-tracing-1.0.0-x64.msi`,
   or to download the MSI from a custom host, e.g.
   `https://my.host/signalfx-dotnet-tracing-1.0.0-x64.msi`. If specified, the
@@ -297,11 +303,40 @@ For proxy options, see the [Windows Proxy](#windows-proxy) section.
   are [rate-limited](https://docs.github.com/en/rest/rate-limit) by GitHub.
   (**default:** ``)
 
+- `signalfx_dotnet_auto_instrumentation_iisreset` (Windows only): By default,
+  the `iisreset.exe` Powershell command (if it exists) will be executed after
+  installation/configuration in order for any changes to take effect for IIS
+  applications. Set this option to `false` to skip this step if IIS is managed
+  separately or is not applicable. (**default:** `true`)
+
+- `signalfx_dotnet_auto_instrumentation_system_wide` (Windows only): By
+  default, the `Environment` property in the
+  `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W3SVC` registry key to
+  will be configured for the following environment variables and any from the
+  `signalfx_dotnet_auto_instrumentation_additional_options` option to enable auto
+  instrumentation for ***only*** IIS applications:
+  ```yaml
+  COR_ENABLE_PROFILING: true  # Required
+  COR_PROFILER: "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"  # Required
+  CORECLR_ENABLE_PROFILING: true  # Required
+  CORECLR_PROFILER: "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"  # Required
+  SIGNALFX_ENV: "{{ signalfx_dotnet_auto_instrumentation_environment }}"
+  SIGNALFX_PROFILER_ENABLED: "{{ signalfx_dotnet_auto_instrumentation_enable_profiler }}"
+  SIGNALFX_PROFILER_MEMORY_ENABLED: "{{ signalfx_dotnet_auto_instrumentation_enable_profiler_memory }}"
+  SIGNALFX_SERVICE_NAME: "{{ signalfx_dotnet_auto_instrumentation_service_name }}"
+  ```
+  Set this option to `true` to also add these environment variables and any
+  from the `signalfx_dotnet_auto_instrumentation_additional_options` option to
+  the
+  `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment`
+  registry key to enable auto instrumentation for ***all*** .NET
+  services/applications on the node. (**default:** `false`)
+
 - `signalfx_dotnet_auto_instrumentation_environment` (Windows only): Configure
-  this option to set the system-wide "Environment" value to be reported to
-  Splunk APM, e.g. `prod`. The value is assigned to the `SIGNALFX_ENV`
-  environment variable in the Windows registry. (**default:** ``, i.e. the
-  "Environment" will appear as `unknown` in Splunk APM for the instrumented
+  this option to set the "Environment" value to be reported to Splunk APM, e.g.
+  `production`. The value is assigned to the `SIGNALFX_ENV` environment
+  variable in the Windows registry (**default:** ``, i.e. the "Environment"
+  will appear as `unknown` in Splunk APM for the instrumented
   service/application)
 
 - `signalfx_dotnet_auto_instrumentation_service_name` (Windows only): Configure
@@ -321,21 +356,20 @@ For proxy options, see the [Windows Proxy](#windows-proxy) section.
   be assigned to the `SIGNALFX_PROFILER_MEMORY_ENABLED` environment variable in
   the Windows registry. (**default:** `false`)
 
-- `signalfx_dotnet_auto_instrumentation_iisreset` (Windows only): By default,
-  the `iisreset.exe` Powershell command will be executed after
-  installation/configuration in order for auto instrumentation to take effect
-  for IIS applications. Set this option to `false` to skip this step if IIS is
-  managed separately or not applicable. (**default:** `true`)
-
 - `signalfx_dotnet_auto_instrumentation_additional_options` (Windows only):
-  Dictionary of additional [supported options and values](
-  https://docs.splunk.com/Observability/gdi/get-data-in/application/dotnet/configuration/advanced-dotnet-configuration.html)
-  to be added to the Windows registry as environment variables. For example:
+  Dictionary of environment variables to be added to the Windows registry
+  ***in addition*** to the options above. (**default:** `{}`)
+
+  For example:
   ```yaml
   signalfx_dotnet_auto_instrumentation_additional_options:
-    SIGNALFX_VERSION: 1.2.3
+    SIGNALFX_VERSION: "1.2.3"
     SIGNALFX_FILE_LOG_ENABLED: false
+    # Hint: If signalfx_dotnet_auto_instrumentation_system_wide is set to true, use
+    # the following options to include/exclude processes from auto instrumentation.
+    SIGNALFX_PROFILER_PROCESSES: MyApp.exe;dotnet.exe
+    SIGNALFX_PROFILER_EXCLUDE_PROCESSES: ReservedProcess.exe;powershell.exe
   ```
-  These options/values will be added to the
-  `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment`
-  registry key, in addition to the other options above. (**default:** `{}`)
+  Check the [Advanced Configuration Guide](
+  https://docs.splunk.com/Observability/gdi/get-data-in/application/dotnet/configuration/advanced-dotnet-configuration.html)
+  for details about supported options.

--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -263,10 +263,10 @@ instrumentation for IIS. Use the
 `signalfx_dotnet_auto_instrumentation_additional_options` option (see below for
 details) to include any other environment variables required for IIS.
 
-**Note:** By default, only IIS will be restarted with the `iisreset` command
-(if it exists) after installation/configuration. Applications/services not
-running within IIS need to be restarted separately in order for any changes to
-take effect.
+**Note:** By default, IIS will be restarted with the `iisreset` command (if it
+exists) after installation/configuration. Applications ***not*** running within
+IIS need to be restarted/managed separately in order for any changes to take
+effect.
 
 For proxy options, see the [Windows Proxy](#windows-proxy) section.
 
@@ -274,7 +274,8 @@ For proxy options, see the [Windows Proxy](#windows-proxy) section.
   install/manage [SignalFx Auto Instrumentation for .NET](
   https://docs.splunk.com/Observability/gdi/get-data-in/application/dotnet/get-started.html).
   When set to `true`, the `signalfx-dotnet-tracing` MSI package will be
-  downloaded and installed. (**default:** `false`)
+  downloaded and installed, and the Windows registry will be updated based on
+  the options below. (**default:** `false`)
 
 - `signalfx_dotnet_auto_instrumentation_version` (Windows only): Version of the
   `signalfx-dotnet-tracing` MSI package to download and install from
@@ -304,17 +305,17 @@ For proxy options, see the [Windows Proxy](#windows-proxy) section.
   (**default:** ``)
 
 - `signalfx_dotnet_auto_instrumentation_iisreset` (Windows only): By default,
-  the `iisreset.exe` Powershell command (if it exists) will be executed after
+  the `iisreset.exe` command (if it exists) will be executed after
   installation/configuration in order for any changes to take effect for IIS
   applications. Set this option to `false` to skip this step if IIS is managed
   separately or is not applicable. (**default:** `true`)
 
 - `signalfx_dotnet_auto_instrumentation_system_wide` (Windows only): By
   default, the `Environment` property in the
-  `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W3SVC` registry key to
+  `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W3SVC` registry key
   will be configured for the following environment variables and any from the
-  `signalfx_dotnet_auto_instrumentation_additional_options` option to enable auto
-  instrumentation for ***only*** IIS applications:
+  `signalfx_dotnet_auto_instrumentation_additional_options` option to
+  enable/configure auto instrumentation for ***only*** IIS applications:
   ```yaml
   COR_ENABLE_PROFILING: true  # Required
   COR_PROFILER: "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"  # Required
@@ -329,8 +330,8 @@ For proxy options, see the [Windows Proxy](#windows-proxy) section.
   from the `signalfx_dotnet_auto_instrumentation_additional_options` option to
   the
   `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment`
-  registry key to enable auto instrumentation for ***all*** .NET
-  services/applications on the node. (**default:** `false`)
+  registry key to enable/configure auto instrumentation for ***all*** .NET
+  applications on the node. (**default:** `false`)
 
 - `signalfx_dotnet_auto_instrumentation_environment` (Windows only): Configure
   this option to set the "Environment" value to be reported to Splunk APM, e.g.
@@ -347,7 +348,7 @@ For proxy options, see the [Windows Proxy](#windows-proxy) section.
   Windows registry. (**default:** ``)
 
 - `signalfx_dotnet_auto_instrumentation_enable_profiler` (Windows only): Set
-  this option to `true` to enable AlwaysOn CPU Profiling. The value will be
+  this option to `true` to enable AlwaysOn Profiling. The value will be
   assigned to the `SIGNALFX_PROFILER_ENABLED` environment variable in the
   Windows registry. (**default:** `false`)
 
@@ -365,11 +366,13 @@ For proxy options, see the [Windows Proxy](#windows-proxy) section.
   signalfx_dotnet_auto_instrumentation_additional_options:
     SIGNALFX_VERSION: "1.2.3"
     SIGNALFX_FILE_LOG_ENABLED: false
-    # Hint: If signalfx_dotnet_auto_instrumentation_system_wide is set to true, use
-    # the following options to include/exclude processes from auto instrumentation.
+    # Hint: If the signalfx_dotnet_auto_instrumentation_system_wide option is
+    # set to true, all .NET applications on the node will be instrumented. Use
+    # the following options to include/exclude processes from auto
+    # instrumentation.
     SIGNALFX_PROFILER_PROCESSES: MyApp.exe;dotnet.exe
     SIGNALFX_PROFILER_EXCLUDE_PROCESSES: ReservedProcess.exe;powershell.exe
   ```
   Check the [Advanced Configuration Guide](
   https://docs.splunk.com/Observability/gdi/get-data-in/application/dotnet/configuration/advanced-dotnet-configuration.html)
-  for details about supported options.
+  for more details about the options above and other supported options.

--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -282,16 +282,17 @@ For proxy options, see the [Windows Proxy](#windows-proxy) section.
   [GitHub Releases](https://github.com/signalfx/signalfx-dotnet-tracing/releases).
   By default, a request will be made to
   `https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/latest`
-  to determine the latest release. If a version is specified, e.g. `1.0.0`,
-  the API request will be skipped and the MSI package will be downloaded from
+  to determine the latest release. If a version is specified, for example
+  `1.0.0`, the API request will be skipped and the MSI package will be
+  downloaded from
   `https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v{{ signalfx_dotnet_auto_instrumentation_version }}/signalfx-dotnet-tracing-{{ signalfx_dotnet_auto_instrumentation_version }}-x64.msi`.
   (**default:** `latest`)
 
 - `signalfx_dotnet_auto_instrumentation_msi_url` (Windows only): Specify the
-  download URL to the `signalfx-dotnet-tracing` MSI to skip the GitHub API
-  request, e.g.
+  URL to download the `signalfx-dotnet-tracing` MSI to skip the GitHub API
+  request, for example
   `https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v1.0.0/signalfx-dotnet-tracing-1.0.0-x64.msi`,
-  or to download the MSI from a custom host, e.g.
+  or to download the MSI from a custom host, for example
   `https://my.host/signalfx-dotnet-tracing-1.0.0-x64.msi`. If specified, the
   `signalfx_dotnet_auto_instrumentation_version` option is ignored.
   (**default:** ``)
@@ -334,8 +335,8 @@ For proxy options, see the [Windows Proxy](#windows-proxy) section.
   applications on the node. (**default:** `false`)
 
 - `signalfx_dotnet_auto_instrumentation_environment` (Windows only): Configure
-  this option to set the "Environment" value to be reported to Splunk APM, e.g.
-  `production`. The value is assigned to the `SIGNALFX_ENV` environment
+  this option to set the "Environment" value to be reported to Splunk APM, for
+  example `production`. The value is assigned to the `SIGNALFX_ENV` environment
   variable in the Windows registry (**default:** ``, i.e. the "Environment"
   will appear as `unknown` in Splunk APM for the instrumented
   service/application)
@@ -343,8 +344,8 @@ For proxy options, see the [Windows Proxy](#windows-proxy) section.
 - `signalfx_dotnet_auto_instrumentation_service_name` (Windows only): Configure
   this variable to override the [auto-generated service name](
   https://docs.splunk.com/Observability/gdi/get-data-in/application/dotnet/configuration/advanced-dotnet-configuration.html#changing-the-default-service-name)
-  for the instrumented service/application, e.g. `my-service-name`. The value
-  is assigned to the `SIGNALFX_SERVICE_NAME` environment variable in the
+  for the instrumented service/application, for example `my-service-name`. The
+  value is assigned to the `SIGNALFX_SERVICE_NAME` environment variable in the
   Windows registry. (**default:** ``)
 
 - `signalfx_dotnet_auto_instrumentation_enable_profiler` (Windows only): Set

--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -256,6 +256,13 @@ after installation/configuration in order for any change to take effect.
 
 ### Auto Instrumentation for .NET on Windows
 
+**Note:** By default, only IIS applications will be instrumented after
+installation/configuration. Applications not running within IIS will need to
+restarted separately after installation/configuration in order for any change
+to take effect.
+
+For proxy options, see the [Windows Proxy](#windows-proxy) section.
+
 - `install_signalfx_dotnet_auto_instrumentation` (Windows only): Whether to
   install/manage [SignalFx Auto Instrumentation for .NET](
   https://docs.splunk.com/Observability/gdi/get-data-in/application/dotnet/get-started.html).
@@ -266,26 +273,29 @@ after installation/configuration in order for any change to take effect.
 
 - `signalfx_dotnet_auto_instrumentation_version` (Windows only): Version of the
   `signalfx-dotnet-tracing` MSI package to download and install from
-  [GitHub Releases](https://github.com/signalfx/signalfx-dotnet-tracing/releases),
-  e.g. `1.0.0`. (**default:** `latest`)
-
-- `signalfx_dotnet_auto_instrumentation_msi_url` (Windows only): By default,
-  a request will be made to
+  [GitHub Releases](https://github.com/signalfx/signalfx-dotnet-tracing/releases).
+  By default, a request will be made to
   `https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases` to
-  get the download URL for the `signalfx-dotnet-tracing` MSI package. Specify
-  the download URL to skip the API request, e.g.
-  `https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v1.1.0/signalfx-dotnet-tracing-1.1.0-x64.msi`,
-  or to download the MSI from a custom source, e.g.
-  `https://my.server/signalfx-dotnet-tracing-1.2.3-x64.msi`. If specified, the
+  determine the latest release. If a version is specified, e.g. `1.0.0`, the
+  API request will be skipped and the MSI package will be downloaded from
+  `https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v{{ signalfx_dotnet_auto_instrumentation_version }}/signalfx-dotnet-tracing-{{ signalfx_dotnet_auto_instrumentation_version }}-x64.msi`.
+  (**default:** `latest`)
+
+- `signalfx_dotnet_auto_instrumentation_msi_url` (Windows only): Specify the
+  download URL to skip the GitHub API request, e.g.
+  `https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v1.0.0/signalfx-dotnet-tracing-1.0.0-x64.msi`,
+  or to download the MSI from a custom host, e.g.
+  `https://my.host/signalfx-dotnet-tracing-1.0.0-x64.msi`. If specified, the
   `signalfx_dotnet_auto_instrumentation_version` option is ignored.
   (**default:** ``)
 
 - `signalfx_dotnet_auto_instrumentation_github_token` (Windows only): Specify
   a token to authenticate with the GitHub API when making requests to get the
-  download URL for the `signalfx-dotnet-tracing` MSI package. This is
-  recommended when not using `signalfx_dotnet_auto_instrumentation_msi_url`
-  since unauthenticated requests are [rate-limited](
-  https://docs.github.com/en/rest/rate-limit) by GitHub. (**default:** ``)
+  latest `signalfx-dotnet-tracing` release. A token is recommended when
+  `signalfx_dotnet_auto_instrumentation_version` is `latest` or when not using
+  `signalfx_dotnet_auto_instrumentation_msi_url` since unauthenticated requests
+  are [rate-limited](https://docs.github.com/en/rest/rate-limit) by GitHub.
+  (**default:** ``)
 
 - `signalfx_dotnet_auto_instrumentation_environment` (Windows only): Configure
   this option to set the system-wide "Environment" value to be reported to
@@ -310,6 +320,12 @@ after installation/configuration in order for any change to take effect.
   Set this option to `true` to enable AlwaysOn Memory Profiling. The value will
   be assigned to the `SIGNALFX_PROFILER_MEMORY_ENABLED` environment variable in
   the Windows registry. (**default:** `false`)
+
+- `signalfx_dotnet_auto_instrumentation_iisreset` (Windows only): By default,
+  the `iisreset.exe` Powershell command will be executed after
+  installation/configuration in order for auto instrumentation to take effect
+  for IIS applications. Set this option to `false` to skip this step if IIS is
+  managed separately or not applicable. (**default:** `true`)
 
 - `signalfx_dotnet_auto_instrumentation_additional_options` (Windows only):
   Dictionary of additional [supported options and values](

--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -187,7 +187,7 @@ which allows setting up a proxy to download the collector binaries.
   e.g. `./custom_fluentd_config.conf`. (**default:** `""` meaning 
   that nothing will be copied and existing `splunk_fluentd_config` will be used)
 
-### Auto Instrumentation
+### Auto Instrumentation for Java on Linux
 
 **Note:** The Java application(s) on the node need to be restarted separately
 after installation/configuration in order for any change to take effect.
@@ -253,3 +253,73 @@ after installation/configuration in order for any change to take effect.
 
 - `splunk_otel_auto_instrumentation_enable_metrics` (Linux only): Enable or
   disable exporting Micrometer metrics. (**default**: `false`)
+
+### Auto Instrumentation for .NET on Windows
+
+- `install_signalfx_dotnet_auto_instrumentation` (Windows only): Whether to
+  install/manage [SignalFx Auto Instrumentation for .NET](
+  https://docs.splunk.com/Observability/gdi/get-data-in/application/dotnet/get-started.html).
+  When set to `true`, the `signalfx-dotnet-tracing` MSI package will be
+  downloaded and installed from [GitHub Releases](
+  https://github.com/signalfx/signalfx-dotnet-tracing/releases). (**default:**
+  `false`)
+
+- `signalfx_dotnet_auto_instrumentation_version` (Windows only): Version of the
+  `signalfx-dotnet-tracing` MSI package to download and install from
+  [GitHub Releases](https://github.com/signalfx/signalfx-dotnet-tracing/releases),
+  e.g. `1.0.0`. (**default:** `latest`)
+
+- `signalfx_dotnet_auto_instrumentation_msi_url` (Windows only): By default,
+  a request will be made to
+  `https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases` to
+  get the download URL for the `signalfx-dotnet-tracing` MSI package. Specify
+  the download URL to skip the API request, e.g.
+  `https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v1.1.0/signalfx-dotnet-tracing-1.1.0-x64.msi`,
+  or to download the MSI from a custom source, e.g.
+  `https://my.server/signalfx-dotnet-tracing-1.2.3-x64.msi`. If specified, the
+  `signalfx_dotnet_auto_instrumentation_version` option is ignored.
+  (**default:** ``)
+
+- `signalfx_dotnet_auto_instrumentation_github_token` (Windows only): Specify
+  a token to authenticate with the GitHub API when making requests to get the
+  download URL for the `signalfx-dotnet-tracing` MSI package. This is
+  recommended when not using `signalfx_dotnet_auto_instrumentation_msi_url`
+  since unauthenticated requests are [rate-limited](
+  https://docs.github.com/en/rest/rate-limit) by GitHub. (**default:** ``)
+
+- `signalfx_dotnet_auto_instrumentation_environment` (Windows only): Configure
+  this option to set the system-wide "Environment" value to be reported to
+  Splunk APM, e.g. `prod`. The value is assigned to the `SIGNALFX_ENV`
+  environment variable in the Windows registry. (**default:** ``, i.e. the
+  "Environment" will appear as `unknown` in Splunk APM for the instrumented
+  service/application)
+
+- `signalfx_dotnet_auto_instrumentation_service_name` (Windows only): Configure
+  this variable to override the [auto-generated service name](
+  https://docs.splunk.com/Observability/gdi/get-data-in/application/dotnet/configuration/advanced-dotnet-configuration.html#changing-the-default-service-name)
+  for the instrumented service/application, e.g. `my-service-name`. The value
+  is assigned to the `SIGNALFX_SERVICE_NAME` environment variable in the
+  Windows registry. (**default:** ``)
+
+- `signalfx_dotnet_auto_instrumentation_enable_profiler` (Windows only): Set
+  this option to `true` to enable AlwaysOn CPU Profiling. The value will be
+  assigned to the `SIGNALFX_PROFILER_ENABLED` environment variable in the
+  Windows registry. (**default:** `false`)
+
+- `signalfx_dotnet_auto_instrumentation_enable_profiler_memory` (Windows only):
+  Set this option to `true` to enable AlwaysOn Memory Profiling. The value will
+  be assigned to the `SIGNALFX_PROFILER_MEMORY_ENABLED` environment variable in
+  the Windows registry. (**default:** `false`)
+
+- `signalfx_dotnet_auto_instrumentation_additional_options` (Windows only):
+  Dictionary of additional [supported options and values](
+  https://docs.splunk.com/Observability/gdi/get-data-in/application/dotnet/configuration/advanced-dotnet-configuration.html)
+  to be added to the Windows registry as environment variables. For example:
+  ```yaml
+  signalfx_dotnet_auto_instrumentation_additional_options:
+    SIGNALFX_VERSION: 1.2.3
+    SIGNALFX_FILE_LOG_ENABLED: false
+  ```
+  These options/values will be added to the
+  `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment`
+  registry key, in addition to the other options above. (**default:** `{}`)

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -80,6 +80,7 @@ install_signalfx_dotnet_auto_instrumentation: false
 signalfx_dotnet_auto_instrumentation_version: latest
 signalfx_dotnet_auto_instrumentation_msi_url: ""
 signalfx_dotnet_auto_instrumentation_github_token: ""
+signalfx_dotnet_auto_instrumentation_system_wide: false
 signalfx_dotnet_auto_instrumentation_environment: ""
 signalfx_dotnet_auto_instrumentation_service_name: ""
 signalfx_dotnet_auto_instrumentation_enable_profiler: false

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -84,4 +84,5 @@ signalfx_dotnet_auto_instrumentation_environment: ""
 signalfx_dotnet_auto_instrumentation_service_name: ""
 signalfx_dotnet_auto_instrumentation_enable_profiler: false
 signalfx_dotnet_auto_instrumentation_enable_profiler_memory: false
+signalfx_dotnet_auto_instrumentation_iisreset: true
 signalfx_dotnet_auto_instrumentation_additional_options: {}

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -74,3 +74,14 @@ splunk_otel_auto_instrumentation_enable_metrics: false
 
 # Custom environment variables for the collector service
 splunk_otel_collector_additional_env_vars: {}
+
+# Configure Auto Instrumentation for .NET
+install_signalfx_dotnet_auto_instrumentation: false
+signalfx_dotnet_auto_instrumentation_version: latest
+signalfx_dotnet_auto_instrumentation_msi_url: ""
+signalfx_dotnet_auto_instrumentation_github_token: ""
+signalfx_dotnet_auto_instrumentation_environment: ""
+signalfx_dotnet_auto_instrumentation_service_name: ""
+signalfx_dotnet_auto_instrumentation_enable_profiler: false
+signalfx_dotnet_auto_instrumentation_enable_profiler_memory: false
+signalfx_dotnet_auto_instrumentation_additional_options: {}

--- a/deployments/ansible/roles/collector/handlers/main.yml
+++ b/deployments/ansible/roles/collector/handlers/main.yml
@@ -39,9 +39,3 @@
   listen: "restart windows fluentdwinsvc"
   when:
     - (start_service | default(true) | bool)
-
-- name: Reset IIS
-  ansible.windows.win_shell: "& { iisreset.exe }"
-  listen: "reset iis"
-  when:
-    - install_signalfx_dotnet_auto_instrumentation and signalfx_dotnet_auto_instrumentation_iisreset

--- a/deployments/ansible/roles/collector/handlers/main.yml
+++ b/deployments/ansible/roles/collector/handlers/main.yml
@@ -39,3 +39,9 @@
   listen: "restart windows fluentdwinsvc"
   when:
     - (start_service | default(true) | bool)
+
+- name: Reset IIS
+  ansible.windows.win_shell: "& { iisreset.exe }"
+  listen: "reset iis"
+  when:
+    - install_signalfx_dotnet_auto_instrumentation and signalfx_dotnet_auto_instrumentation_iisreset

--- a/deployments/ansible/roles/collector/handlers/main.yml
+++ b/deployments/ansible/roles/collector/handlers/main.yml
@@ -39,3 +39,15 @@
   listen: "restart windows fluentdwinsvc"
   when:
     - (start_service | default(true) | bool)
+
+- name: Reset IIS
+  ansible.windows.win_shell: |
+    try {
+      Get-Command iisreset.exe
+    } Catch {
+      Exit
+    }
+    & { iisreset.exe }
+  listen: "reset iis"
+  when:
+    - install_signalfx_dotnet_auto_instrumentation and signalfx_dotnet_auto_instrumentation_iisreset

--- a/deployments/ansible/roles/collector/tasks/vars.yml
+++ b/deployments/ansible/roles/collector/tasks/vars.yml
@@ -71,4 +71,14 @@
     package_stage: release
     win_base_url: https://dl.signalfx.com
     win_use_proxy: "no"
+    dotnet_options:
+      COR_ENABLE_PROFILING: true
+      COR_PROFILER: "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"
+      CORECLR_ENABLE_PROFILING: true
+      CORECLR_PROFILER: "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"
+      SIGNALFX_ENV: "{{ signalfx_dotnet_auto_instrumentation_environment }}"
+      SIGNALFX_SERVICE_NAME: "{{ signalfx_dotnet_auto_instrumentation_service_name }}"
+      SIGNALFX_PROFILER_ENABLED: "{{ signalfx_dotnet_auto_instrumentation_enable_profiler }}"
+      SIGNALFX_PROFILER_MEMORY_ENABLED: "{{ signalfx_dotnet_auto_instrumentation_enable_profiler_memory }}"
+    iis_registry_key: HKLM:\SYSTEM\CurrentControlSet\Services\W3SVC
   when: ansible_os_family == "Windows"

--- a/deployments/ansible/roles/collector/tasks/win_install.yml
+++ b/deployments/ansible/roles/collector/tasks/win_install.yml
@@ -11,3 +11,7 @@
 - name: Install Fluentd with msi package manager
   ansible.builtin.import_tasks: win_fluentd_install.yml
   when: install_fluentd
+
+- name: Install Auto Instrumentation for .NET
+  ansible.builtin.import_tasks: win_install_dotnet_auto_instrumentation.yml
+  when: install_signalfx_dotnet_auto_instrumentation

--- a/deployments/ansible/roles/collector/tasks/win_install_dotnet_auto_instrumentation.yml
+++ b/deployments/ansible/roles/collector/tasks/win_install_dotnet_auto_instrumentation.yml
@@ -1,12 +1,7 @@
 ---
-- name: Get signalfx-dotnet-tracing release json
+- name: Get latest signalfx-dotnet-tracing release json
   ansible.windows.win_uri:
-    url: |-
-      {%- if signalfx_dotnet_auto_instrumentation_version == "latest" -%}
-        {{ base_url }}/latest
-      {%- else -%}
-        {{ base_url }}/tags/v{{ signalfx_dotnet_auto_instrumentation_version }}
-      {%- endif -%}
+    url: "https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/latest"
     return_content: yes
     headers:
       Authorization: "{{ signalfx_dotnet_auto_instrumentation_github_token }}"
@@ -14,41 +9,47 @@
     proxy_url: "{{ win_proxy_url | default(omit) }}"
     proxy_username: "{{ win_proxy_username | default(omit) }}"
     use_proxy: "{{ win_use_proxy }}"
-  register: dotnet_tracing_release
-  vars:
-    base_url: https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases
-  when: signalfx_dotnet_auto_instrumentation_msi_url == ""
+  register: latest_dotnet_release
+  when: signalfx_dotnet_auto_instrumentation_version == "latest" and not signalfx_dotnet_auto_instrumentation_msi_url
 
-- name: Set dotnet_tracing_download_url fact
+- name: Set dotnet_download_url fact
   set_fact:
-    dotnet_tracing_download_url: "{{ item.browser_download_url }}"
-  loop: "{{ dotnet_tracing_release.json.assets | default([]) }}"
-  when: item.name.startswith("signalfx-dotnet-tracing") and item.name.endswith("x64.msi")
+    dotnet_download_url: |-
+      {%- if signalfx_dotnet_auto_instrumentation_msi_url -%}
+        {{ signalfx_dotnet_auto_instrumentation_msi_url }}
+      {%- else -%}
+        {%- if signalfx_dotnet_auto_instrumentation_version != "latest" -%}
+          {%- set version = signalfx_dotnet_auto_instrumentation_version.lstrip("v") -%}
+          {{ base_url }}/v{{ version }}/signalfx-dotnet-tracing-{{ version }}-x64.msi
+        {%- elif signalfx_dotnet_auto_instrumentation_version == "latest" and latest_dotnet_release is defined -%}
+          {%- set version = latest_dotnet_release.json.tag_name.lstrip("v") -%}
+          {{ base_url }}/v{{ version }}/signalfx-dotnet-tracing-{{ version }}-x64.msi
+        {%- endif -%}
+      {%- endif -%}
+  vars:
+    base_url: https://github.com/signalfx/signalfx-dotnet-tracing/releases/download
 
 - name: Download signalfx-dotnet-tracing MSI
   ansible.windows.win_get_url:
-    url: |-
-      {%- if signalfx_dotnet_auto_instrumentation_msi_url == "" -%}
-        {{ dotnet_tracing_download_url }}
-      {%- else -%}
-        {{ signalfx_dotnet_auto_instrumentation_msi_url }}
-      {%- endif -%}
+    url: "{{ dotnet_download_url }}"
     dest: "%TEMP%"
     proxy_password: "{{ win_proxy_password | default(omit) }}"
     proxy_url: "{{ win_proxy_url | default(omit) }}"
     proxy_username: "{{ win_proxy_username | default(omit) }}"
     use_proxy: "{{ win_use_proxy }}"
-  register: dotnet_tracing_msi
+  register: dotnet_msi
 
 - name: Install signalfx-dotnet-tracing MSI
   ansible.windows.win_package:
-    path: "{{ dotnet_tracing_msi.dest }}"
+    path: "{{ dotnet_msi.dest }}"
     state: present
+  notify: "reset iis"
 
 - name: Create registry path
   ansible.windows.win_regedit:
     path: "{{ registry_key }}"
     state: present
+  notify: "reset iis"
 
 - name: Set registry value
   ansible.windows.win_regedit:
@@ -58,6 +59,7 @@
     data: "{{ signalfx_dotnet_auto_instrumentation_environment }}"
     type: string
   when: signalfx_dotnet_auto_instrumentation_environment != ""
+  notify: "reset iis"
 
 - name: Set registry value
   ansible.windows.win_regedit:
@@ -67,6 +69,7 @@
     data: "{{ signalfx_dotnet_auto_instrumentation_service_name }}"
     type: string
   when: signalfx_dotnet_auto_instrumentation_service_name != ""
+  notify: "reset iis"
 
 - name: Set registry value
   ansible.windows.win_regedit:
@@ -75,6 +78,7 @@
     name: SIGNALFX_PROFILER_ENABLED
     data: "{{ signalfx_dotnet_auto_instrumentation_enable_profiler | string | lower }}"
     type: string
+  notify: "reset iis"
 
 - name: Set registry value
   ansible.windows.win_regedit:
@@ -83,6 +87,7 @@
     name: SIGNALFX_PROFILER_MEMORY_ENABLED
     data: "{{ signalfx_dotnet_auto_instrumentation_enable_profiler_memory | string | lower }}"
     type: string
+  notify: "reset iis"
 
 - name: Set additional registry values
   ansible.windows.win_regedit:
@@ -92,3 +97,4 @@
     data: "{{ item.value }}"
     type: string
   loop: "{{ signalfx_dotnet_auto_instrumentation_additional_options | default({}) | dict2items }}"
+  notify: "reset iis"

--- a/deployments/ansible/roles/collector/tasks/win_install_dotnet_auto_instrumentation.yml
+++ b/deployments/ansible/roles/collector/tasks/win_install_dotnet_auto_instrumentation.yml
@@ -3,8 +3,9 @@
   ansible.windows.win_uri:
     url: "https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/latest"
     return_content: yes
+    content_type: "application/json"
     headers:
-      Authorization: "{{ signalfx_dotnet_auto_instrumentation_github_token }}"
+      Authorization: "{{ signalfx_dotnet_auto_instrumentation_github_token | default(omit) }}"
     proxy_password: "{{ win_proxy_password | default(omit) }}"
     proxy_url: "{{ win_proxy_url | default(omit) }}"
     proxy_username: "{{ win_proxy_username | default(omit) }}"

--- a/deployments/ansible/roles/collector/tasks/win_install_dotnet_auto_instrumentation.yml
+++ b/deployments/ansible/roles/collector/tasks/win_install_dotnet_auto_instrumentation.yml
@@ -47,54 +47,46 @@
 
 - name: Create registry path
   ansible.windows.win_regedit:
-    path: "{{ registry_key }}"
+    path: "{{ iis_registry_key }}"
     state: present
+
+- name: Get IIS options list
+  set_fact:
+    options_list: |-
+      {%- set value = item.value -%}
+      {%- if (item.value | type_debug) == "bool" -%}
+        {%- set value = item.value | string | lower -%}
+      {%- endif -%}
+      {{ (options_list | default([])) + [item.key + '=' + (value | string)] }}
+  loop: "{{ dotnet_options | combine(signalfx_dotnet_auto_instrumentation_additional_options) | dict2items }}"
+
+- name: Set IIS registry value
+  ansible.windows.win_regedit:
+    path: "{{ iis_registry_key }}"
+    state: present
+    name: Environment
+    data: "{{ options_list | sort }}"
+    type: multistring
   notify: "reset iis"
 
-- name: Set registry value
+- name: Create registry path
   ansible.windows.win_regedit:
     path: "{{ registry_key }}"
     state: present
-    name: SIGNALFX_ENV
-    data: "{{ signalfx_dotnet_auto_instrumentation_environment }}"
-    type: string
-  when: signalfx_dotnet_auto_instrumentation_environment != ""
-  notify: "reset iis"
+  when: signalfx_dotnet_auto_instrumentation_system_wide
 
-- name: Set registry value
-  ansible.windows.win_regedit:
-    path: "{{ registry_key }}"
-    state: present
-    name: SIGNALFX_SERVICE_NAME
-    data: "{{ signalfx_dotnet_auto_instrumentation_service_name }}"
-    type: string
-  when: signalfx_dotnet_auto_instrumentation_service_name != ""
-  notify: "reset iis"
-
-- name: Set registry value
-  ansible.windows.win_regedit:
-    path: "{{ registry_key }}"
-    state: present
-    name: SIGNALFX_PROFILER_ENABLED
-    data: "{{ signalfx_dotnet_auto_instrumentation_enable_profiler | string | lower }}"
-    type: string
-  notify: "reset iis"
-
-- name: Set registry value
-  ansible.windows.win_regedit:
-    path: "{{ registry_key }}"
-    state: present
-    name: SIGNALFX_PROFILER_MEMORY_ENABLED
-    data: "{{ signalfx_dotnet_auto_instrumentation_enable_profiler_memory | string | lower }}"
-    type: string
-  notify: "reset iis"
-
-- name: Set additional registry values
+- name: Set system-wide registry value
   ansible.windows.win_regedit:
     path: "{{ registry_key }}"
     state: present
     name: "{{ item.key }}"
-    data: "{{ item.value }}"
+    data: |-
+      {%- set value = item.value -%}
+      {%- if (item.value | type_debug) == "bool" -%}
+        {%- set value = item.value | string | lower -%}
+      {%- endif -%}
+      {{ value | string }}
     type: string
-  loop: "{{ signalfx_dotnet_auto_instrumentation_additional_options | default({}) | dict2items }}"
+  loop: "{{ dotnet_options | combine(signalfx_dotnet_auto_instrumentation_additional_options) | dict2items }}"
+  when: signalfx_dotnet_auto_instrumentation_system_wide
   notify: "reset iis"

--- a/deployments/ansible/roles/collector/tasks/win_install_dotnet_auto_instrumentation.yml
+++ b/deployments/ansible/roles/collector/tasks/win_install_dotnet_auto_instrumentation.yml
@@ -1,0 +1,94 @@
+---
+- name: Get signalfx-dotnet-tracing release json
+  ansible.windows.win_uri:
+    url: |-
+      {%- if signalfx_dotnet_auto_instrumentation_version == "latest" -%}
+        {{ base_url }}/latest
+      {%- else -%}
+        {{ base_url }}/tags/v{{ signalfx_dotnet_auto_instrumentation_version }}
+      {%- endif -%}
+    return_content: yes
+    headers:
+      Authorization: "{{ signalfx_dotnet_auto_instrumentation_github_token }}"
+    proxy_password: "{{ win_proxy_password | default(omit) }}"
+    proxy_url: "{{ win_proxy_url | default(omit) }}"
+    proxy_username: "{{ win_proxy_username | default(omit) }}"
+    use_proxy: "{{ win_use_proxy }}"
+  register: dotnet_tracing_release
+  vars:
+    base_url: https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases
+  when: signalfx_dotnet_auto_instrumentation_msi_url == ""
+
+- name: Set dotnet_tracing_download_url fact
+  set_fact:
+    dotnet_tracing_download_url: "{{ item.browser_download_url }}"
+  loop: "{{ dotnet_tracing_release.json.assets | default([]) }}"
+  when: item.name.startswith("signalfx-dotnet-tracing") and item.name.endswith("x64.msi")
+
+- name: Download signalfx-dotnet-tracing MSI
+  ansible.windows.win_get_url:
+    url: |-
+      {%- if signalfx_dotnet_auto_instrumentation_msi_url == "" -%}
+        {{ dotnet_tracing_download_url }}
+      {%- else -%}
+        {{ signalfx_dotnet_auto_instrumentation_msi_url }}
+      {%- endif -%}
+    dest: "%TEMP%"
+    proxy_password: "{{ win_proxy_password | default(omit) }}"
+    proxy_url: "{{ win_proxy_url | default(omit) }}"
+    proxy_username: "{{ win_proxy_username | default(omit) }}"
+    use_proxy: "{{ win_use_proxy }}"
+  register: dotnet_tracing_msi
+
+- name: Install signalfx-dotnet-tracing MSI
+  ansible.windows.win_package:
+    path: "{{ dotnet_tracing_msi.dest }}"
+    state: present
+
+- name: Create registry path
+  ansible.windows.win_regedit:
+    path: "{{ registry_key }}"
+    state: present
+
+- name: Set registry value
+  ansible.windows.win_regedit:
+    path: "{{ registry_key }}"
+    state: present
+    name: SIGNALFX_ENV
+    data: "{{ signalfx_dotnet_auto_instrumentation_environment }}"
+    type: string
+  when: signalfx_dotnet_auto_instrumentation_environment != ""
+
+- name: Set registry value
+  ansible.windows.win_regedit:
+    path: "{{ registry_key }}"
+    state: present
+    name: SIGNALFX_SERVICE_NAME
+    data: "{{ signalfx_dotnet_auto_instrumentation_service_name }}"
+    type: string
+  when: signalfx_dotnet_auto_instrumentation_service_name != ""
+
+- name: Set registry value
+  ansible.windows.win_regedit:
+    path: "{{ registry_key }}"
+    state: present
+    name: SIGNALFX_PROFILER_ENABLED
+    data: "{{ signalfx_dotnet_auto_instrumentation_enable_profiler | string | lower }}"
+    type: string
+
+- name: Set registry value
+  ansible.windows.win_regedit:
+    path: "{{ registry_key }}"
+    state: present
+    name: SIGNALFX_PROFILER_MEMORY_ENABLED
+    data: "{{ signalfx_dotnet_auto_instrumentation_enable_profiler_memory | string | lower }}"
+    type: string
+
+- name: Set additional registry values
+  ansible.windows.win_regedit:
+    path: "{{ registry_key }}"
+    state: present
+    name: "{{ item.key }}"
+    data: "{{ item.value }}"
+    type: string
+  loop: "{{ signalfx_dotnet_auto_instrumentation_additional_options | default({}) | dict2items }}"


### PR DESCRIPTION
- Download and install the `signalfx-dotnet-tracing` MSI from https://github.com/signalfx/signalfx-dotnet-tracing/releases, and configure the environment variables in the windows registry. 
- Update tests to verify installation and configuration of env vars
- See the changes in `README.md` for details about the new options.