### PR TITLE
use hashicorp/vault docker repo for vault images

### DIFF
--- a/tests/general/configsources/vault_test.go
+++ b/tests/general/configsources/vault_test.go
@@ -34,7 +34,7 @@ func TestBasicSecretAccess(t *testing.T) {
 	defer tc.PrintLogsOnFailure()
 
 	vaultHostname := "vault"
-	vault := testutils.NewContainer().WithImage("vault:latest").WithNetworks("vault").WithName("vault").WithEnv(
+	vault := testutils.NewContainer().WithImage("hashicorp/vault:latest").WithNetworks("vault").WithName("vault").WithEnv(
 		map[string]string{
 			"VAULT_DEV_ROOT_TOKEN_ID": "token",
 			"VAULT_TOKEN":             "token",


### PR DESCRIPTION
Hashicorp has stopped publishing new images directly to dockerhub ([deprecation notice](https://hub.docker.com/_/vault)). This PR updates tests to use vault image from [Hashicorp publisher](https://hub.docker.com/r/hashicorp/vault).