### PR TITLE
discovery: allow out of order shutdown

### DIFF
--- a/internal/receiver/discoveryreceiver/receiver_test.go
+++ b/internal/receiver/discoveryreceiver/receiver_test.go
@@ -41,6 +41,9 @@ func TestNewDiscoveryReceiver(t *testing.T) {
 	receiver, err := newDiscoveryReceiver(rcs, cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, receiver)
+
+	// out of order shutdown
+	require.NoError(t, receiver.Shutdown(context.Background()))
 }
 
 func TestObservablesFromHost(t *testing.T) {


### PR DESCRIPTION
Fixes a bug where invalid receiver creator rules lead to partial setup and panic on shutdown.