### PR TITLE
expand collectd/mysql discovery rules

### DIFF
--- a/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-collectd-mysql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-collectd-mysql.discovery.yaml
@@ -9,9 +9,9 @@
 # smartagent/collectd/mysql:
 #   enabled: true
 #   rule:
-#     docker_observer: type == "container" and port == 3306
-#     host_observer: type == "hostport" and command contains "mysqld" and port == 3306
-#     k8s_observer: type == "port" and pod.name contains "mysql" and port == 3306
+#     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)mysql"}) and not (command matches "splunk.discovery")
+#     host_observer: type == "hostport" and command matches "(?i)mysqld"
+#     k8s_observer: type == "port" and pod.name matches "(?i)mysql"
 #   config:
 #     default:
 #       type: collectd/mysql

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml
@@ -5,9 +5,9 @@
 smartagent/collectd/mysql:
   enabled: true
   rule:
-    docker_observer: type == "container" and port == 3306
-    host_observer: type == "hostport" and command contains "mysqld" and port == 3306
-    k8s_observer: type == "port" and pod.name contains "mysql" and port == 3306
+    docker_observer: type == "container" and any([name, image, command], {# matches "(?i)mysql"}) and not (command matches "splunk.discovery")
+    host_observer: type == "hostport" and command matches "(?i)mysqld"
+    k8s_observer: type == "port" and pod.name matches "(?i)mysql"
   config:
     default:
       type: collectd/mysql

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml.tmpl
@@ -1,9 +1,9 @@
 {{ receiver "smartagent/collectd/mysql" }}:
   enabled: true
   rule:
-    docker_observer: type == "container" and port == 3306
-    host_observer: type == "hostport" and command contains "mysqld" and port == 3306
-    k8s_observer: type == "port" and pod.name contains "mysql" and port == 3306
+    docker_observer: type == "container" and any([name, image, command], {# matches "(?i)mysql"}) and not (command matches "splunk.discovery")
+    host_observer: type == "hostport" and command matches "(?i)mysqld"
+    k8s_observer: type == "port" and pod.name matches "(?i)mysql"
   config:
     default:
       type: collectd/mysql


### PR DESCRIPTION
Similar to https://github.com/signalfx/splunk-otel-collector/pull/3329 these changes don't rely on mysql's default port and expand discovery rules to support more options.