### PR TITLE
support custom --discovery-properties file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - (Splunk) Package default discovery configuration in reference form in `/etc/otel/collector/config.d` ([#3311](https://github.com/signalfx/splunk-otel-collector/pull/3311))
 - (Splunk) Add bundled collectd/nginx Smart Agent receiver discovery rules ([#3321](https://github.com/signalfx/splunk-otel-collector/pull/3321))
+- (Splunk) Support custom `--discovery-properties` file ([#3334](https://github.com/signalfx/splunk-otel-collector/pull/3334))
 
 ## v0.80.0
 

--- a/internal/confmapprovider/discovery/README.md
+++ b/internal/confmapprovider/discovery/README.md
@@ -88,7 +88,7 @@ service:
 
 ## Discovery Mode
 
-This component also provides a `--discovery [--dry-run]` option compatible with `config.d` that attempts to instantiate
+This component also provides a `--discovery [--dry-run] [--discovery-properties=<properties.yaml>]` option compatible with `config.d` that attempts to instantiate
 any `.discovery.yaml` receivers using corresponding `.discovery.yaml` observers in a "preflight" Collector service.
 Discovery mode will:
 
@@ -165,6 +165,8 @@ splunk.discovery.extensions.k8s_observer.enabled: false
 ```
 
 These properties can be in `config.d/properties.discovery.yaml` or specified at run time with `--set` command line options.
+
+You can also specify a `--discovery-properties=<filepath.yaml>` argument to disregard `config.d/properties.discovery.yaml` properties and load properties not to be shared with another Collector service, while still benefiting from existing discovery component definitions.
 
 The `config.d/properties.discovery.yaml` file supports specifying the property values directly as well within a mapped form:
 

--- a/internal/confmapprovider/discovery/discoverer.go
+++ b/internal/confmapprovider/discovery/discoverer.go
@@ -61,22 +61,23 @@ const (
 // of the underlying receivers were successfully discovered by the
 // discovery receiver from its emitted log records.
 type discoverer struct {
-	factories           otelcol.Factories
-	expandConverter     confmap.Converter
-	configs             map[string]*Config
-	extensions          map[component.ID]otelcolextension.Extension
-	logger              *zap.Logger
-	discoveredReceivers map[component.ID]discovery.StatusType
+	factories       otelcol.Factories
+	expandConverter confmap.Converter
 	// receiverID -> observerID -> config
 	unexpandedReceiverEntries map[component.ID]map[component.ID]map[string]any
+	extensions                map[component.ID]otelcolextension.Extension
+	logger                    *zap.Logger
+	discoveredReceivers       map[component.ID]discovery.StatusType
+	configs                   map[string]*Config
 	discoveredConfig          map[component.ID]map[string]any
 	discoveredObservers       map[component.ID]discovery.StatusType
 	// propertiesConf is a store of all properties from cmdline args and env vars
 	// that's merged with receiver/observer configs before creation
-	propertiesConf *confmap.Conf
-	info           component.BuildInfo
-	duration       time.Duration
-	mu             sync.Mutex
+	propertiesConf          *confmap.Conf
+	info                    component.BuildInfo
+	duration                time.Duration
+	mu                      sync.Mutex
+	propertiesFileSpecified bool
 }
 
 func newDiscoverer(logger *zap.Logger) (*discoverer, error) {
@@ -97,7 +98,7 @@ func newDiscoverer(logger *zap.Logger) (*discoverer, error) {
 	if err != nil {
 		return (*discoverer)(nil), err
 	}
-	m := &discoverer{
+	d := &discoverer{
 		logger:                    logger,
 		info:                      info,
 		factories:                 factories,
@@ -111,8 +112,8 @@ func newDiscoverer(logger *zap.Logger) (*discoverer, error) {
 		discoveredConfig:          map[component.ID]map[string]any{},
 		discoveredObservers:       map[component.ID]discovery.StatusType{},
 	}
-	m.propertiesConf = m.propertiesConfFromEnv()
-	return m, nil
+	d.propertiesConf = d.propertiesConfFromEnv()
+	return d, nil
 }
 
 func (d *discoverer) propertiesConfFromEnv() *confmap.Conf {
@@ -139,8 +140,10 @@ func (d *discoverer) propertiesConfFromEnv() *confmap.Conf {
 // discover will create all .discovery.yaml components, start them, wait the configured
 // duration, and tear them down before returning the discovery config.
 func (d *discoverer) discover(cfg *Config) (map[string]any, error) {
-	if err := d.mergeDiscoveryPropertiesEntry(cfg); err != nil {
-		return nil, fmt.Errorf("failed reconciling properties.discovery: %w", err)
+	if !d.propertiesFileSpecified {
+		if err := d.mergeDiscoveryPropertiesEntry(cfg); err != nil {
+			return nil, fmt.Errorf("failed reconciling properties.discovery: %w", err)
+		}
 	}
 	discoveryReceivers, discoveryObservers, err := d.createDiscoveryReceiversAndObservers(cfg)
 	if err != nil {

--- a/tests/general/discoverymode/testdata/docker-observer-config.d/properties.discovery.yaml
+++ b/tests/general/discoverymode/testdata/docker-observer-config.d/properties.discovery.yaml
@@ -1,12 +1,16 @@
-splunk.discovery.receivers.prometheus_simple.config.labels::label_three: overwritten by --set property
-splunk.discovery.receivers.prometheus_simple.config.labels::label_four: overwritten by env var property
-splunk.discovery.receivers.prometheus_simple.config.labels::label_five: actual.label.five.value
+splunk.discovery.receivers.prometheus_simple.config.labels::label_three: file contents should be disregarded
+splunk.discovery.receivers.prometheus_simple.config.labels::label_four: file contents should be disregarded
+splunk.discovery.receivers.prometheus_simple.config.labels::label_five: file contents should be disregarded
 splunk.discovery:
   extensions:
+    k8s_observer:
+      enabled: true
+    host_observer:
+      enabled: true
     docker_observer:
-      enabled: false # overwritten by --set and env var properties
+      enabled: false
   receivers:
     prometheus_simple:
       config:
         labels:
-          label_five: overwritten by above --set form
+          label_five: file contents should be disregarded

--- a/tests/general/discoverymode/testdata/docker-observer-properties.yaml
+++ b/tests/general/discoverymode/testdata/docker-observer-properties.yaml
@@ -1,0 +1,12 @@
+splunk.discovery.receivers.prometheus_simple.config.labels::label_three: overwritten by --set property
+splunk.discovery.receivers.prometheus_simple.config.labels::label_four: overwritten by env var property
+splunk.discovery.receivers.prometheus_simple.config.labels::label_five: actual.label.five.value
+splunk.discovery:
+  extensions:
+    docker_observer:
+      enabled: false # overwritten by --set and env var properties
+  receivers:
+    prometheus_simple:
+      config:
+        labels:
+          label_five: overwritten by above --set form

--- a/tests/general/discoverymode/testdata/resource_metrics/docker-observer-internal-prometheus.yaml
+++ b/tests/general/discoverymode/testdata/resource_metrics/docker-observer-internal-prometheus.yaml
@@ -13,5 +13,11 @@ resource_metrics:
           version: <VERSION_FROM_BUILD>
         metrics:
           - name: prometheus_tsdb_exemplar_exemplars_in_storage
+            attributes:
+              label_one: actual.label.one.value
+              label_two: actual.label.two.value
+              label_three: actual.label.three.value
+              label_four: actual.label.four.value
+              label_five: actual.label.five.value
             description: Number of exemplars currently in circular storage.
             type: DoubleGauge


### PR DESCRIPTION
These changes add a new startup option to take priority over the `<config-dir>/properties.discovery.yaml` file so that multiple collector services can use the same discovery configurations but with different property values.