### PR TITLE
Unexport more from signalfxprometheusremotewritereceiver

### DIFF
--- a/internal/receiver/signalfxgatewayprometheusremotewritereceiver/client_test.go
+++ b/internal/receiver/signalfxgatewayprometheusremotewritereceiver/client_test.go
@@ -30,12 +30,12 @@ import (
 	"github.com/prometheus/prometheus/storage/remote"
 )
 
-type MockPrwClient struct {
+type mockPrwClient struct {
 	Client  remote.WriteClient
 	Timeout time.Duration
 }
 
-func NewMockPrwClient(addr string, path string, timeout time.Duration) (MockPrwClient, error) {
+func newMockPrwClient(addr string, path string, timeout time.Duration) (mockPrwClient, error) {
 	URL := &config.URL{
 		URL: &url.URL{
 			Scheme: "http",
@@ -49,13 +49,13 @@ func NewMockPrwClient(addr string, path string, timeout time.Duration) (MockPrwC
 		HTTPClientConfig: config.HTTPClientConfig{},
 	}
 	client, err := remote.NewWriteClient("mock_prw_client", cfg)
-	return MockPrwClient{
+	return mockPrwClient{
 		Client:  client,
 		Timeout: timeout,
 	}, err
 }
 
-func (prwc *MockPrwClient) SendWriteRequest(wr *prompb.WriteRequest) error {
+func (prwc *mockPrwClient) sendWriteRequest(wr *prompb.WriteRequest) error {
 
 	data, err := proto.Marshal(wr)
 	if err != nil {
@@ -82,7 +82,7 @@ func (prwc *MockPrwClient) SendWriteRequest(wr *prompb.WriteRequest) error {
 	return errors.New("failed to send prometheus remote write requests to server")
 }
 
-func GetFreePort() (int, error) {
+func getFreePort() (int, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
 	if err != nil {
 		return 0, err

--- a/internal/receiver/signalfxgatewayprometheusremotewritereceiver/factory.go
+++ b/internal/receiver/signalfxgatewayprometheusremotewritereceiver/factory.go
@@ -40,7 +40,7 @@ func createMetricsReceiver(
 	consumer consumer.Metrics,
 ) (receiver.Metrics, error) {
 	c := cfg.(*Config)
-	return New(params, c, consumer)
+	return newReceiver(params, c, consumer)
 }
 
 func createDefaultConfig() component.Config {

--- a/internal/receiver/signalfxgatewayprometheusremotewritereceiver/factory_test.go
+++ b/internal/receiver/signalfxgatewayprometheusremotewritereceiver/factory_test.go
@@ -37,7 +37,7 @@ func TestFactory(t *testing.T) {
 	defer cancel()
 
 	cfg := createDefaultConfig().(*Config)
-	freePort, err := GetFreePort()
+	freePort, err := getFreePort()
 	require.NoError(t, err)
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
 	cfg.Endpoint = fmt.Sprintf("localhost:%d", freePort)
@@ -46,7 +46,7 @@ func TestFactory(t *testing.T) {
 	nopHost := componenttest.NewNopHost()
 	mockSettings := receivertest.NewNopCreateSettings()
 	mockConsumer := consumertest.NewNop()
-	receiver, err := New(mockSettings, cfg, mockConsumer)
+	receiver, err := newReceiver(mockSettings, cfg, mockConsumer)
 
 	assert.NoError(t, err)
 	require.NotNil(t, receiver)

--- a/internal/receiver/signalfxgatewayprometheusremotewritereceiver/prometheus_remote_write_requests_test.go
+++ b/internal/receiver/signalfxgatewayprometheusremotewritereceiver/prometheus_remote_write_requests_test.go
@@ -29,7 +29,7 @@ var (
 	Jan20 = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 )
 
-func SampleCounterTs() []prompb.TimeSeries {
+func sampleCounterTs() []prompb.TimeSeries {
 	return []prompb.TimeSeries{
 		{
 			Labels: []prompb.Label{
@@ -43,11 +43,11 @@ func SampleCounterTs() []prompb.TimeSeries {
 		},
 	}
 }
-func SampleCounterWq() *prompb.WriteRequest {
-	return &prompb.WriteRequest{Timeseries: SampleCounterTs()}
+func sampleCounterWq() *prompb.WriteRequest {
+	return &prompb.WriteRequest{Timeseries: sampleCounterTs()}
 }
 
-func SampleGaugeTs() []prompb.TimeSeries {
+func sampleGaugeTs() []prompb.TimeSeries {
 	return []prompb.TimeSeries{
 		{
 			Labels: []prompb.Label{
@@ -60,9 +60,9 @@ func SampleGaugeTs() []prompb.TimeSeries {
 	}
 }
 
-func SampleGaugeWq() *prompb.WriteRequest { return &prompb.WriteRequest{Timeseries: SampleGaugeTs()} }
+func sampleGaugeWq() *prompb.WriteRequest { return &prompb.WriteRequest{Timeseries: sampleGaugeTs()} }
 
-func SampleHistogramTs() []prompb.TimeSeries {
+func sampleHistogramTs() []prompb.TimeSeries {
 	return []prompb.TimeSeries{
 		{
 			Labels: []prompb.Label{
@@ -101,13 +101,13 @@ func SampleHistogramTs() []prompb.TimeSeries {
 	}
 }
 
-func SampleHistogramWq() *prompb.WriteRequest {
+func sampleHistogramWq() *prompb.WriteRequest {
 	return &prompb.WriteRequest{
-		Timeseries: SampleHistogramTs(),
+		Timeseries: sampleHistogramTs(),
 	}
 }
 
-func SampleSummaryTs() []prompb.TimeSeries {
+func sampleSummaryTs() []prompb.TimeSeries {
 	return []prompb.TimeSeries{
 		{
 			Labels: []prompb.Label{
@@ -146,13 +146,13 @@ func SampleSummaryTs() []prompb.TimeSeries {
 	}
 }
 
-func SampleSummaryWq() *prompb.WriteRequest {
+func sampleSummaryWq() *prompb.WriteRequest {
 	return &prompb.WriteRequest{
-		Timeseries: SampleSummaryTs(),
+		Timeseries: sampleSummaryTs(),
 	}
 }
 
-func ExpectedCounter() pmetric.Metrics {
+func expectedCounter() pmetric.Metrics {
 	result := pmetric.NewMetrics()
 	resourceMetrics := result.ResourceMetrics().AppendEmpty()
 	scopeMetrics := resourceMetrics.ScopeMetrics().AppendEmpty()
@@ -173,7 +173,7 @@ func ExpectedCounter() pmetric.Metrics {
 	return result
 }
 
-func ExpectedGauge() pmetric.Metrics {
+func expectedGauge() pmetric.Metrics {
 	result := pmetric.NewMetrics()
 	resourceMetrics := result.ResourceMetrics().AppendEmpty()
 	scopeMetrics := resourceMetrics.ScopeMetrics().AppendEmpty()
@@ -190,7 +190,7 @@ func ExpectedGauge() pmetric.Metrics {
 	return result
 }
 
-func ExpectedSfxCompatibleHistogram() pmetric.Metrics {
+func expectedSfxCompatibleHistogram() pmetric.Metrics {
 	result := pmetric.NewMetrics()
 	resourceMetrics := result.ResourceMetrics().AppendEmpty()
 	scopeMetrics := resourceMetrics.ScopeMetrics().AppendEmpty()
@@ -249,7 +249,7 @@ func ExpectedSfxCompatibleHistogram() pmetric.Metrics {
 	return result
 }
 
-func ExpectedSfxCompatibleQuantile() pmetric.Metrics {
+func expectedSfxCompatibleQuantile() pmetric.Metrics {
 	result := pmetric.NewMetrics()
 	resourceMetrics := result.ResourceMetrics().AppendEmpty()
 	scopeMetrics := resourceMetrics.ScopeMetrics().AppendEmpty()
@@ -306,21 +306,21 @@ func ExpectedSfxCompatibleQuantile() pmetric.Metrics {
 	return result
 }
 
-func GetWriteRequestsOfAllTypesWithoutMetadata() []*prompb.WriteRequest {
+func getWriteRequestsOfAllTypesWithoutMetadata() []*prompb.WriteRequest {
 	var sampleWriteRequestsNoMetadata = []*prompb.WriteRequest{
 		// Counter
-		SampleCounterWq(),
+		sampleCounterWq(),
 		// Gauge
-		SampleGaugeWq(),
+		sampleGaugeWq(),
 		// Histogram
-		SampleHistogramWq(),
+		sampleHistogramWq(),
 		// Summary
-		SampleSummaryWq(),
+		sampleSummaryWq(),
 	}
 	return sampleWriteRequestsNoMetadata
 }
 
-func AddSfxCompatibilityMetrics(metrics pmetric.Metrics, expectedNans int64, expectedMissing int64, expectedInvalid int64) pmetric.Metrics {
+func addSfxCompatibilityMetrics(metrics pmetric.Metrics, expectedNans int64, expectedMissing int64, expectedInvalid int64) pmetric.Metrics {
 	if metrics == pmetric.NewMetrics() {
 		metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
 	}
@@ -376,7 +376,7 @@ func addSfxCompatibilityNanMetrics(scopeMetrics pmetric.ScopeMetrics, value int6
 	return metric
 }
 
-func FlattenWriteRequests(request []*prompb.WriteRequest) *prompb.WriteRequest {
+func flattenWriteRequests(request []*prompb.WriteRequest) *prompb.WriteRequest {
 	var ts []prompb.TimeSeries
 	for _, req := range request {
 		ts = append(ts, req.Timeseries...)
@@ -387,7 +387,7 @@ func FlattenWriteRequests(request []*prompb.WriteRequest) *prompb.WriteRequest {
 }
 
 func TestBasicNoMd(t *testing.T) {
-	wqs := GetWriteRequestsOfAllTypesWithoutMetadata()
+	wqs := getWriteRequestsOfAllTypesWithoutMetadata()
 	require.NotNil(t, wqs)
 	for _, wq := range wqs {
 		for _, ts := range wq.Timeseries {

--- a/internal/receiver/signalfxgatewayprometheusremotewritereceiver/prometheus_to_otel_test.go
+++ b/internal/receiver/signalfxgatewayprometheusremotewritereceiver/prometheus_to_otel_test.go
@@ -30,7 +30,7 @@ func TestParseAndPartitionPrometheusRemoteWriteRequest(t *testing.T) {
 	require.NotNil(t, reporter)
 	parser := newPrometheusRemoteOtelParser()
 
-	sampleWriteRequests := FlattenWriteRequests(GetWriteRequestsOfAllTypesWithoutMetadata())
+	sampleWriteRequests := flattenWriteRequests(getWriteRequestsOfAllTypesWithoutMetadata())
 	noMdPartitions, err := parser.partitionWriteRequest(sampleWriteRequests)
 	require.NoError(t, err)
 	require.Empty(t, sampleWriteRequests.Metadata, "NoMetadata (heuristical) portion of test contains metadata")
@@ -80,23 +80,23 @@ func TestAddMetricsHappyPath(t *testing.T) {
 	}{
 		{
 			Name:     "test counters",
-			Sample:   SampleCounterWq(),
-			Expected: AddSfxCompatibilityMetrics(ExpectedCounter(), 0, 0, 0),
+			Sample:   sampleCounterWq(),
+			Expected: addSfxCompatibilityMetrics(expectedCounter(), 0, 0, 0),
 		},
 		{
 			Name:     "test gauges",
-			Sample:   SampleGaugeWq(),
-			Expected: AddSfxCompatibilityMetrics(ExpectedGauge(), 0, 0, 0),
+			Sample:   sampleGaugeWq(),
+			Expected: addSfxCompatibilityMetrics(expectedGauge(), 0, 0, 0),
 		},
 		{
 			Name:     "test histograms",
-			Sample:   SampleHistogramWq(),
-			Expected: AddSfxCompatibilityMetrics(ExpectedSfxCompatibleHistogram(), 0, 0, 0),
+			Sample:   sampleHistogramWq(),
+			Expected: addSfxCompatibilityMetrics(expectedSfxCompatibleHistogram(), 0, 0, 0),
 		},
 		{
 			Name:     "test quantiles",
-			Sample:   SampleSummaryWq(),
-			Expected: AddSfxCompatibilityMetrics(ExpectedSfxCompatibleQuantile(), 0, 0, 0),
+			Sample:   sampleSummaryWq(),
+			Expected: addSfxCompatibilityMetrics(expectedSfxCompatibleQuantile(), 0, 0, 0),
 		},
 	}
 

--- a/internal/receiver/signalfxgatewayprometheusremotewritereceiver/receiver.go
+++ b/internal/receiver/signalfxgatewayprometheusremotewritereceiver/receiver.go
@@ -74,16 +74,19 @@ func (receiver *prometheusRemoteWriteReceiver) Start(ctx context.Context, host c
 		Host:               host,
 		Parser:             newPrometheusRemoteOtelParser(),
 	}
-	ctx, receiver.cancel = context.WithCancel(ctx)
-	server, err := newPrometheusRemoteWriteServer(cfg)
-	if err != nil {
-		return err
-	}
-	if nil != receiver.server {
+	if receiver.server != nil {
 		err := receiver.server.close()
 		if err != nil {
 			return err
 		}
+	}
+	if receiver.cancel != nil {
+		receiver.cancel()
+	}
+	ctx, receiver.cancel = context.WithCancel(ctx)
+	server, err := newPrometheusRemoteWriteServer(cfg)
+	if err != nil {
+		return err
 	}
 	receiver.server = server
 

--- a/internal/receiver/signalfxgatewayprometheusremotewritereceiver/receiver.go
+++ b/internal/receiver/signalfxgatewayprometheusremotewritereceiver/receiver.go
@@ -38,8 +38,7 @@ type prometheusRemoteWriteReceiver struct {
 	settings     receiver.CreateSettings
 }
 
-// New creates the PrometheusRemoteWrite receiver with the given parameters.
-func New(
+func newReceiver(
 	settings receiver.CreateSettings,
 	config *Config,
 	nextConsumer consumer.Metrics,

--- a/internal/receiver/signalfxgatewayprometheusremotewritereceiver/server_test.go
+++ b/internal/receiver/signalfxgatewayprometheusremotewritereceiver/server_test.go
@@ -31,7 +31,7 @@ import (
 func TestWriteEmpty(t *testing.T) {
 	mc := make(chan<- pmetric.Metrics)
 	mockReporter := newMockReporter()
-	freePort, err := GetFreePort()
+	freePort, err := getFreePort()
 	require.NoError(t, err)
 	expectedEndpoint := fmt.Sprintf("localhost:%d", freePort)
 	parser := newPrometheusRemoteOtelParser()
@@ -62,7 +62,7 @@ func TestWriteEmpty(t *testing.T) {
 		serverLifecycle.Done()
 	}()
 
-	client, err := NewMockPrwClient(
+	client, err := newMockPrwClient(
 		cfg.Endpoint,
 		"metrics",
 		timeout,
@@ -70,7 +70,7 @@ func TestWriteEmpty(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 	require.Eventually(t, func() bool { remoteWriteServer.ready(); return true }, time.Second*10, 50*time.Millisecond)
-	require.NoError(t, client.SendWriteRequest(&prompb.WriteRequest{
+	require.NoError(t, client.sendWriteRequest(&prompb.WriteRequest{
 		Timeseries: []prompb.TimeSeries{},
 		Metadata:   []prompb.MetricMetadata{},
 	}))
@@ -83,7 +83,7 @@ func TestWriteEmpty(t *testing.T) {
 func TestWriteMany(t *testing.T) {
 	mc := make(chan<- pmetric.Metrics, 1000)
 	mockReporter := newMockReporter()
-	freePort, err := GetFreePort()
+	freePort, err := getFreePort()
 	require.NoError(t, err)
 	expectedEndpoint := fmt.Sprintf("localhost:%d", freePort)
 	parser := newPrometheusRemoteOtelParser()
@@ -113,7 +113,7 @@ func TestWriteMany(t *testing.T) {
 	}()
 	require.Eventually(t, func() bool { remoteWriteServer.ready(); return true }, time.Second*10, 50*time.Millisecond)
 
-	client, err := NewMockPrwClient(
+	client, err := newMockPrwClient(
 		cfg.Endpoint,
 		"metrics",
 		timeout,
@@ -121,9 +121,9 @@ func TestWriteMany(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 	time.Sleep(100 * time.Millisecond)
-	wqs := GetWriteRequestsOfAllTypesWithoutMetadata()
+	wqs := getWriteRequestsOfAllTypesWithoutMetadata()
 	for _, wq := range wqs {
-		require.NoError(t, client.SendWriteRequest(wq))
+		require.NoError(t, client.sendWriteRequest(wq))
 	}
 
 	require.NoError(t, mockReporter.WaitAllOnMetricsProcessedCalls(time.Second*5))


### PR DESCRIPTION
Limit the Go API exposed by the component to as little as possible.