### PR TITLE
add --discovery to install.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - (Splunk) Package default discovery configuration in reference form in `/etc/otel/collector/config.d` ([#3311](https://github.com/signalfx/splunk-otel-collector/pull/3311))
 - (Splunk) Add bundled collectd/nginx Smart Agent receiver discovery rules ([#3321](https://github.com/signalfx/splunk-otel-collector/pull/3321))
 - (Splunk) Support custom `--discovery-properties` file ([#3334](https://github.com/signalfx/splunk-otel-collector/pull/3334))
+- (Splunk) Add `--discovery` to the Linux installer script ([#3365](https://github.com/signalfx/splunk-otel-collector/pull/3365))
 
 ## v0.80.0
 

--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -359,6 +359,11 @@ system (requires `root` privileges):
 **Note:** After successful upgrade, the Java application(s) on the host need to
 be manually started/restarted in order for the changes to take effect.
 
+### Discovery mode
+
+If you wish to start the collector with discovery mode you can add the `--discovery` installation option.
+For more information see the discovery config provider [documentation](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/confmapprovider/discovery#discovery-mode).
+
 ### Uninstall
 
 If you wish to uninstall the Collector, Fluentd, and Auto Instrumentation

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -641,6 +641,7 @@ Options:
                                         effect.
   --collector-version <version>         The splunk-otel-collector package version to install.
                                         (default: "$default_collector_version")
+  --discovery                           Enable discovery mode on collector startup (disabled by default).
   --hec-token <token>                   Set the HEC token if different than the specified access_token.
   --hec-url <url>                       Set the HEC endpoint URL explicitly instead of the endpoint inferred from the
                                         specified realm.
@@ -854,6 +855,7 @@ parse_args_and_install() {
   local with_instrumentation="false"
   local instrumentation_version="$default_instrumentation_version"
   local deployment_environment="$default_deployment_environment"
+  local discovery=
 
   while [ -n "${1-}" ]; do
     case $1 in
@@ -997,6 +999,9 @@ parse_args_and_install() {
         ;;
       --disable-metrics)
         enable_metrics="false"
+        ;;
+      --discovery)
+        discovery="true"
         ;;
       --)
         access_token="$2"
@@ -1162,6 +1167,10 @@ parse_args_and_install() {
     configure_env_file "SPLUNK_COLLECTD_DIR" "$collectd_config_dir" "$collector_env_path"
     # ensure the collector service owner has access to the collectd dir
     chown -R $service_user:$service_group "$(dirname $collectd_config_dir)"
+  fi
+
+  if [ "$discovery" = "true" ]; then
+    configure_env_file "OTELCOL_OPTIONS" "--discovery" "$collector_env_path"
   fi
 
   # ensure the collector service owner has access to the config dir


### PR DESCRIPTION
These changes add and document a `--discovery` option for the linux install script.