### PR TITLE
Set explicit stemcell requirement for Tanzu Tile

### DIFF
--- a/deployments/cloudfoundry/tile/tile.yml
+++ b/deployments/cloudfoundry/tile/tile.yml
@@ -16,6 +16,10 @@ description: |
   This also includes a BOSH release of the Splunk OpenTelemetry Collector, called "splunk-otel-collector"
   that can be used in deployments to put the collector on individual VMs.
 
+stemcell_criteria:
+  os: 'ubuntu-jammy'
+  version: '1.148'
+
 # Specify the packages to be included in the tile.
 packages:
   - name: splunk_collector_firehose_nozzle


### PR DESCRIPTION
To allow the Tanzu Tile to work in TAS v3+ environments, the stemcell version must be explicitly set, or it won't run. [Reference for context.](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/tile-generator.html#stemcells-13)

Tested on TAS v2.13, v3.0, and v4.0