### PR TITLE
[receiver/databricks] add retry/backoff on http 429s

### DIFF
--- a/internal/receiver/databricksreceiver/factory.go
+++ b/internal/receiver/databricksreceiver/factory.go
@@ -50,8 +50,7 @@ func newReceiverFactory() receiver.CreateMetricsFunc {
 		if err != nil {
 			return nil, fmt.Errorf("newReceiverFactory failed to create client from config: %w", err)
 		}
-		dbrClient := databricks.NewRawClient(dbrcfg.Token, dbrcfg.Endpoint, httpClient, settings.Logger)
-		dbrsvc := databricks.NewService(dbrClient, dbrcfg.MaxResults)
+		dbrsvc := databricks.NewService(databricks.NewRawClient(dbrcfg.Token, dbrcfg.Endpoint, httpClient, settings.Logger), dbrcfg.MaxResults)
 		ssvc := spark.NewService(settings.Logger, httpClient, dbrcfg.Token, dbrcfg.SparkEndpoint, dbrcfg.SparkOrgID, dbrcfg.SparkUIPort)
 		dbrScraper := scraper{
 			dbrInstanceName: dbrcfg.InstanceName,

--- a/internal/receiver/databricksreceiver/internal/databricks/raw_client.go
+++ b/internal/receiver/databricksreceiver/internal/databricks/raw_client.go
@@ -16,7 +16,6 @@ package databricks
 
 import (
 	"fmt"
-	"net/http"
 
 	"go.uber.org/zap"
 
@@ -43,9 +42,9 @@ type rawHTTPClient struct {
 	endpoint   string
 }
 
-func NewRawClient(tok, endpoint string, httpClient *http.Client, logger *zap.Logger) RawClient {
+func NewRawClient(tok, endpoint string, httpDoer httpauth.HTTPDoer, logger *zap.Logger) RawClient {
 	return rawHTTPClient{
-		authClient: httpauth.NewClient(httpClient, tok),
+		authClient: httpauth.NewClient(httpDoer, tok, logger),
 		endpoint:   endpoint,
 		logger:     logger,
 	}

--- a/internal/receiver/databricksreceiver/internal/databricks/raw_client_test.go
+++ b/internal/receiver/databricksreceiver/internal/databricks/raw_client_test.go
@@ -30,7 +30,7 @@ func TestRawHTTPClient(t *testing.T) {
 	svr := httptest.NewServer(h)
 	defer svr.Close()
 	c := rawHTTPClient{
-		authClient: httpauth.NewClient(http.DefaultClient, "abc123"),
+		authClient: httpauth.NewClient(http.DefaultClient, "abc123", zap.NewNop()),
 		endpoint:   svr.URL,
 		logger:     zap.NewNop(),
 	}

--- a/internal/receiver/databricksreceiver/internal/httpauth/client.go
+++ b/internal/receiver/databricksreceiver/internal/httpauth/client.go
@@ -15,40 +15,75 @@
 package httpauth
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"go.uber.org/zap"
 )
+
+var errTooManyRequests = errors.New("429 Too Many Requests")
 
 // Client defines an http REST client. Currently only GET is supported.
 type Client interface {
 	Get(path string) ([]byte, error)
 }
 
-func NewClient(httpClient *http.Client, tok string) Client {
-	return bearerClient{httpClient: httpClient, tok: tok}
+func NewClient(httpDoer HTTPDoer, tok string, logger *zap.Logger) Client {
+	return bearerClient{
+		httpDoer: httpDoer,
+		tok:      tok,
+		ebo:      backoff.NewExponentialBackOff(),
+		logger:   logger,
+	}
 }
 
 // bearerClient is a Client implementation that adds an Authorization Bearer +
-// token to its requests.
+// token to its requests. It also retries HTTP 429 responses with exponential backoff.
 type bearerClient struct {
-	httpClient *http.Client
-	tok        string
+	httpDoer HTTPDoer
+	ebo      backoff.BackOff
+	logger   *zap.Logger
+	tok      string
 }
 
-func (c bearerClient) Get(url string) ([]byte, error) {
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+func (c bearerClient) Get(url string) (out []byte, err error) {
+	for {
+		out, err = c.doGet(url)
+		if err != errTooManyRequests {
+			c.ebo.Reset()
+			break
+		}
+		nextBackoff := c.ebo.NextBackOff()
+		c.logger.Debug("bearerClient: rate limit exceeded, will retry", zap.Duration("nextBackoff", nextBackoff))
+		time.Sleep(nextBackoff)
+	}
+	return out, err
+}
+
+func (c bearerClient) doGet(url string) ([]byte, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("bearerCclient failed to create new request: %w", err)
 	}
 	req.Header.Add("Authorization", "Bearer "+c.tok)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpDoer.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("bearerClient failed to send http request: %w", err)
 	}
 
-	if resp.StatusCode == http.StatusForbidden {
+	switch resp.StatusCode {
+	case http.StatusForbidden:
 		return nil, ErrForbidden
+	case http.StatusTooManyRequests:
+		return nil, errTooManyRequests
 	}
 
 	// read response JSON even if the status code is not http.StatusOK

--- a/internal/receiver/databricksreceiver/internal/httpauth/client_test.go
+++ b/internal/receiver/databricksreceiver/internal/httpauth/client_test.go
@@ -15,14 +15,18 @@
 package httpauth
 
 import (
+	"bytes"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.uber.org/zap"
 )
 
 func TestBearerClient(t *testing.T) {
@@ -32,7 +36,7 @@ func TestBearerClient(t *testing.T) {
 	s := confighttp.HTTPClientSettings{}
 	httpClient, err := s.ToClient(nil, component.TelemetrySettings{})
 	require.NoError(t, err)
-	ac := NewClient(httpClient, "abc123")
+	ac := NewClient(httpClient, "abc123", zap.NewNop())
 	_, _ = ac.Get(svr.URL + "/foo")
 	req := h.Reqs[0]
 	assert.Equal(t, "GET", req.Method)
@@ -43,4 +47,103 @@ func TestBearerClient(t *testing.T) {
 func TestIsForbidden(t *testing.T) {
 	wrapper := fmt.Errorf("wrapping this error: %w", ErrForbidden)
 	assert.True(t, IsForbidden(wrapper))
+}
+
+func TestNoBackoff(t *testing.T) {
+	backoff := &fakeBackoff{}
+	c := bearerClient{
+		httpDoer: &fakeHTTPDoer{},
+		ebo:      backoff,
+		logger:   zap.NewNop(),
+	}
+	_, err := c.Get("")
+	require.NoError(t, err)
+	assert.Equal(t, 0, backoff.backoffCallCount)
+}
+
+func TestBackoff(t *testing.T) {
+	const numBackoffs = 1
+	backoff := &fakeBackoff{}
+	c := bearerClient{
+		httpDoer: &fakeHTTPDoer{numFailedRequestsBeforeSuccess: numBackoffs},
+		ebo:      backoff,
+		logger:   zap.NewNop(),
+	}
+	_, err := c.Get("")
+	require.NoError(t, err)
+	assert.Equal(t, numBackoffs, backoff.backoffCallCount)
+	assert.Equal(t, 1, backoff.resetCallCount)
+}
+
+func TestRateLimitingHTTPDoer(t *testing.T) {
+	d := &RateLimitingHTTPDoer{
+		doer:     &fakeHTTPDoer{},
+		duration: time.Second,
+	}
+	resp, err := d.Do(nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp, err = d.Do(nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+}
+
+type fakeHTTPDoer struct {
+	numFailedRequestsBeforeSuccess int
+	currRequestNumber              int
+}
+
+func (d *fakeHTTPDoer) Do(*http.Request) (*http.Response, error) {
+	out := &http.Response{
+		Body: &nopCloser{},
+	}
+	if d.currRequestNumber < d.numFailedRequestsBeforeSuccess {
+		out.StatusCode = http.StatusTooManyRequests
+	} else {
+		out.StatusCode = http.StatusOK
+	}
+	d.currRequestNumber++
+	return out, nil
+}
+
+type fakeBackoff struct {
+	backoffCallCount int
+	resetCallCount   int
+}
+
+func (b *fakeBackoff) NextBackOff() time.Duration {
+	b.backoffCallCount++
+	return 0
+}
+
+func (b *fakeBackoff) Reset() {
+	b.resetCallCount++
+}
+
+type nopCloser struct {
+	bytes.Buffer
+}
+
+func (nopCloser) Close() error {
+	return nil
+}
+
+// RateLimitingHTTPDoer lets you wrap an HTTPDoer (aka http.Client) to simulate
+// 429s for manual integration testing (because causing a web server to actually
+// send 429s can be tricky).
+type RateLimitingHTTPDoer struct {
+	doer            HTTPDoer
+	lastSuccessTime time.Time
+	duration        time.Duration
+}
+
+func (rl *RateLimitingHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	now := time.Now()
+	if now.Sub(rl.lastSuccessTime) > rl.duration {
+		rl.lastSuccessTime = now
+		return rl.doer.Do(req)
+	}
+	return &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+	}, nil
 }

--- a/internal/receiver/databricksreceiver/internal/spark/client.go
+++ b/internal/receiver/databricksreceiver/internal/spark/client.go
@@ -17,7 +17,6 @@ package spark
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 
 	"github.com/signalfx/splunk-otel-collector/internal/receiver/databricksreceiver/internal/httpauth"
 )
@@ -27,9 +26,9 @@ import (
 // unmarshalls content into go types. Although it's focused on standalone Spark,
 // this document has some additional information:
 // https://spark.apache.org/docs/latest/monitoring.html
-func newClient(httpClient *http.Client, tok, sparkEndpoint, orgID string, port int) client {
+func newClient(httpDoer httpauth.HTTPDoer, tok, sparkEndpoint, orgID string, port int) client {
 	return client{
-		rawClient: newRawHTTPClient(httpauth.NewClient(httpClient, tok), sparkEndpoint, orgID, port),
+		rawClient: newRawHTTPClient(httpauth.NewClient(httpDoer, tok, nil), sparkEndpoint, orgID, port),
 	}
 }
 

--- a/internal/receiver/databricksreceiver/internal/spark/service.go
+++ b/internal/receiver/databricksreceiver/internal/spark/service.go
@@ -16,7 +16,6 @@ package spark
 
 import (
 	"fmt"
-	"net/http"
 
 	"go.uber.org/zap"
 
@@ -38,7 +37,7 @@ type restService struct {
 
 func NewService(
 	logger *zap.Logger,
-	httpClient *http.Client,
+	httpDoer httpauth.HTTPDoer,
 	tok string,
 	sparkEndpoint string,
 	orgID string,
@@ -46,7 +45,7 @@ func NewService(
 ) Service {
 	return restService{
 		logger:      logger,
-		sparkClient: newClient(httpClient, tok, sparkEndpoint, orgID, sparkUIPort),
+		sparkClient: newClient(httpDoer, tok, sparkEndpoint, orgID, sparkUIPort),
 	}
 }
 


### PR DESCRIPTION
A customer with a presumably large Databricks deployment encountered rate limit errors (HTTP 429) while using the Databricks receiver. This change adds retry/backoff logic for when a 429 is encountered.