### PR TITLE
discovery: add all utilized observers to receiver creator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🧰 Bug fixes 🧰
+
+- (Splunk) Discovery mode: Ensure all successful observers are used in resulting receiver creator instance ([#3391](https://github.com/signalfx/splunk-otel-collector/pull/3391))
+
 ## v0.81.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.81.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.81.0) and the [opentelemetry-collector-contrib v0.81.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.81.0) releases where appropriate.

--- a/internal/confmapprovider/discovery/discoverer.go
+++ b/internal/confmapprovider/discovery/discoverer.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -481,9 +482,19 @@ func (d *discoverer) discoveryConfig(cfg *Config) (map[string]any, error) {
 	}
 
 	if len(observers) > 0 {
+		sort.Strings(observers)
 		if err := dCfg.Merge(
 			confmap.NewFromStringMap(
-				map[string]any{"service": map[string]any{discovery.DiscoExtensionsKey: observers}},
+				map[string]any{
+					"receivers": map[string]any{
+						"receiver_creator/discovery": map[string]any{
+							"watch_observers": observers,
+						},
+					},
+					"service": map[string]any{
+						discovery.DiscoExtensionsKey: observers,
+					},
+				},
 			),
 		); err != nil {
 			return nil, fmt.Errorf("failed forming suggested discovery observer extensions array: %w", err)

--- a/tests/general/discoverymode/testdata/host-observer-config.d/extensions/host-observer-with-name.discovery.yaml
+++ b/tests/general/discoverymode/testdata/host-observer-config.d/extensions/host-observer-with-name.discovery.yaml
@@ -1,0 +1,3 @@
+host_observer/with-name:
+  config:
+    refresh_interval: 1s

--- a/tests/general/discoverymode/testdata/host-observer-config.d/receivers/internal-prometheus.discovery.yaml
+++ b/tests/general/discoverymode/testdata/host-observer-config.d/receivers/internal-prometheus.discovery.yaml
@@ -1,6 +1,7 @@
 prometheus_simple:
   rule:
     host_observer: type == "hostport" and command contains "otelcol" and port == ${INTERNAL_PROMETHEUS_PORT}
+    host_observer/with-name: type == "hostport" and command contains "otelcol" and port == ${INTERNAL_PROMETHEUS_PORT}
   config:
     default:
       collection_interval: invalid
@@ -8,6 +9,10 @@ prometheus_simple:
         label_one: ${LABEL_ONE_VALUE}
         label_three: overwritten by discovery property
     host_observer:
+      collection_interval: 1s
+      labels:
+        label_two: ${LABEL_TWO_VALUE}
+    host_observer/with-name:
       collection_interval: 1s
       labels:
         label_two: ${LABEL_TWO_VALUE}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -30,6 +30,7 @@ require (
 	go.uber.org/atomic v1.11.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.24.0
+	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.27.3

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1235,6 +1235,7 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20191002040644-a1355ae1e2c3/go.mod h1:NOZ3BPKG0ec/BKJQgnvsSFpcKLM5xXVWnvZS97DWHgE=
+golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 h1:tnebWN09GYg9OLPss1KXj8txwZc6X6uMr6VFdcGNbHw=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=


### PR DESCRIPTION
These changes fix a bug in discovery mode where multiple observer-discovered receiver instances don't end up using all the applicable observers in the receiver creator `watch_observers` sequence.