### PR TITLE
Update caching for agent bundle builds

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           path: .cache/buildx/agent-bundle-${{ matrix.ARCH }}
           key: agent-bundle-buildx-${{ matrix.ARCH }}-${{ hashFiles('internal/signalfx-agent/bundle/**') }}
+          restore-keys: |
+            agent-bundle-buildx-${{ matrix.ARCH }}-
       - uses: docker/setup-qemu-action@v2
         if: ${{ matrix.ARCH != 'amd64' }}
         with:

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -86,6 +86,8 @@ jobs:
         with:
           path: .cache/buildx/agent-bundle-${{ matrix.ARCH }}
           key: agent-bundle-buildx-${{ matrix.ARCH }}-${{ hashFiles('internal/signalfx-agent/bundle/**') }}
+          restore-keys: |
+            agent-bundle-buildx-${{ matrix.ARCH }}-
 
       - uses: docker/setup-qemu-action@v2
         if: ${{ matrix.ARCH != 'amd64' }}

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -62,6 +62,8 @@ jobs:
         with:
           path: .cache/buildx/agent-bundle-${{ matrix.ARCH }}
           key: agent-bundle-buildx-${{ matrix.ARCH }}-${{ hashFiles('internal/signalfx-agent/bundle/**') }}
+          restore-keys: |
+            agent-bundle-buildx-${{ matrix.ARCH }}-
       - uses: docker/setup-qemu-action@v2
         if: ${{ matrix.ARCH != 'amd64' }}
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -202,8 +202,12 @@ libsplunk:
       - instrumentation/dist/libsplunk_*.so
 
 agent-bundle-linux:
-  extends: .trigger-filter
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+    - if: $CI_PIPELINE_SOURCE == "schedule"
   stage: build
+  resource_group: agent-bundle-linux-${ARCH}
   parallel:
     matrix:
       - ARCH: amd64
@@ -213,14 +217,13 @@ agent-bundle-linux:
   tags:
     - $TAG
   cache:
-    key:
-      files:
-        - internal/signalfx-agent/bundle/**
+    key: agent-bundle-${ARCH}
     paths:
       - .cache/buildx/agent-bundle-${ARCH}
   script:
     - *docker-reader-role
-    - make -C internal/signalfx-agent/bundle agent-bundle-linux ARCH=${ARCH} DOCKER_REPO=${DOCKER_HUB_REPO}
+    - docker login -u $CIRCLECI_QUAY_USERNAME -p $CIRCLECI_QUAY_PASSWORD quay.io
+    - PUSH_CACHE=yes make -C internal/signalfx-agent/bundle agent-bundle-linux ARCH=${ARCH} DOCKER_REPO=${DOCKER_HUB_REPO}
   artifacts:
     paths:
       - dist/agent-bundle_linux_${ARCH}.tar.gz


### PR DESCRIPTION
- Build and push inline cache images for each agent bundle stage to `quay.io/signalfx/agent-bundle-stage-cache` from gitlab, and use these images as caches for builds
- Allow using previous CI caches (if available) without snowballing
- Reduces agent bundle build time by at least 50% if there is a local cache miss in CI