### PR TITLE
Ignore doc-only changes for deployment workflows

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - '.github/workflows/ansible.yml'
       - 'deployments/ansible/**'
+      - '!**.md'
 
 concurrency:
   group: ansible-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - '.github/workflows/chef-test.yml'
       - 'deployments/chef/**'
+      - '!**.md'
 
 concurrency:
   group: chef-test-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/puppet-test.yml
+++ b/.github/workflows/puppet-test.yml
@@ -12,6 +12,7 @@ on:
       - 'internal/buildscripts/packaging/tests/deployments/puppet/**'
       - 'internal/buildscripts/packaging/tests/helpers/**'
       - 'internal/buildscripts/packaging/tests/requirements.txt'
+      - '!**.md'
 
 concurrency:
   group: puppet-test-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/salt-test.yml
+++ b/.github/workflows/salt-test.yml
@@ -12,6 +12,7 @@ on:
       - 'internal/buildscripts/packaging/tests/deployments/salt/**'
       - 'internal/buildscripts/packaging/tests/helpers/**'
       - 'internal/buildscripts/packaging/tests/requirements.txt'
+      - '!**.md'
 
 concurrency:
   group: salt-test-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
No need to run the entire test suite for PRs with only doc changes.