### PR TITLE
Fix .NET Zero Config tests

### DIFF
--- a/tests/zeroconfig/windows/testdata/resource_traces/aspnetcore.yaml
+++ b/tests/zeroconfig/windows/testdata/resource_traces/aspnetcore.yaml
@@ -1,7 +1,6 @@
 resource_spans:
 - attributes:
     deployment.environment: zc-iis-test
-    host.id: <ANY>
     host.name: <ANY>
     os.type: windows
     service.name: AspNetCore.WebApi.Net

--- a/tests/zeroconfig/windows/testdata/resource_traces/aspnetfx.yaml
+++ b/tests/zeroconfig/windows/testdata/resource_traces/aspnetfx.yaml
@@ -1,7 +1,6 @@
 resource_spans:
 - attributes:
     deployment.environment: zc-iis-test
-    host.id: <ANY>
     host.name: <ANY>
     os.type: windows
     service.name: Default Web Site/aspnetfxapp


### PR DESCRIPTION
After pulling contrib changes making `host.id` resource attribute optional