### PR TITLE
OTL-2195: Fluentd disabled by default for salt

### DIFF
--- a/.github/workflows/salt-test.yml
+++ b/.github/workflows/salt-test.yml
@@ -21,7 +21,6 @@ concurrency:
 env:
   PYTHON_VERSION: '3.10'
   REQUIREMENTS_PATH: "internal/buildscripts/packaging/tests/requirements.txt"
-  RESULT_PATH: "~/testresults"
 
 jobs:
   salt-lint-test:
@@ -36,15 +35,37 @@ jobs:
         run: |
           make -C deployments/salt lint
 
+  salt-test-matrix:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Get matrix
+        id: get-matrix
+        run: |
+          # create test matrix for distro
+          dockerfiles=$(find internal/buildscripts/packaging/tests/deployments/salt/images/ -name "Dockerfile.*" | cut -d '.' -f2- | sort -u)
+          if [ -z "$dockerfiles" ]; then
+            echo "Failed to get dockerfiles from internal/buildscripts/packaging/tests/deployments/salt/images!" >&2
+            exit 1
+          fi
+          distro=$(for d in $dockerfiles; do echo -n "\"$d\","; done)
+          arch="\"amd64\", \"arm64\""
+          matrix="{\"DISTRO\": [${distro%,}]}"
+          echo "$matrix" | jq
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+    outputs:
+      matrix: ${{ steps.get-matrix.outputs.matrix }}
+
   salt-test:
     name: salt-test
     # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
-    runs-on: ubuntu-20.04
-    needs: [salt-lint-test]
+    runs-on: ${{ fromJSON('["ubuntu-20.04", "ubuntu-22.04"]')[matrix.DISTRO == 'amazonlinux-2023'] }}
+    needs: [salt-lint-test, salt-test-matrix]
     strategy:
-      matrix:
-        PACKAGE_TYPE: [ "deb", "rpm" ]
-        TEST_CASE: [ "with_fluentd", "without_fluentd", "with_instrumentation", "service_owner", "custom_env_vars" ]
+      matrix: ${{ fromJSON(needs.salt-test-matrix.outputs.matrix) }}
+      fail-fast: false
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v3
@@ -62,16 +83,9 @@ jobs:
       - name: Test salt deployment
         timeout-minutes: 45
         run: |
-          mkdir -p ${{ env.RESULT_PATH }}
-          pytest -n2 --verbose -m ${{ matrix.PACKAGE_TYPE }} \
-            -k ${{ matrix.TEST_CASE }} \
-            --junitxml=${{ env.RESULT_PATH }}/results.xml \
-            --html=${{ env.RESULT_PATH }}/results.html \
-            --self-contained-html \
-            internal/buildscripts/packaging/tests/deployments/salt/salt_test.py
-
-      - name: Uploading test result
-        uses: actions/upload-artifact@v3
-        with:
-          name: salt-test-${{ matrix.TEST_CASE}}-${{ matrix.PACKAGE_TYPE }}-result
-          path: ${{ env.RESULT_PATH }}
+          distro="${{ matrix.DISTRO }}"
+          if [[ "$distro" = "amazonlinux-2" ]]; then
+            # workaround for pytest substring matching
+            distro="amazonlinux-2 and not amazonlinux-2023"
+          fi
+          pytest -svx --verbose -k "$distro" internal/buildscripts/packaging/tests/deployments/salt/salt_test.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- (Splunk) Fluentd installation ***disabled*** by default for the [`splunk-otel-collector` salt formula](https://github.com/signalfx/splunk-otel-collector/tree/main/deployments/salt)
+  - Specify the `install_fluentd: True` attribute in your pillar to enable installation
+
 ## v0.82.0
 
 ### 🛑 Breaking changes 🛑

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛑 Breaking changes 🛑
 
-- (Splunk) Fluentd installation ***disabled*** by default for the [`splunk-otel-collector` salt formula](https://github.com/signalfx/splunk-otel-collector/tree/main/deployments/salt)
+- (Splunk) Fluentd installation ***disabled*** by default for the [`splunk-otel-collector` salt formula](https://github.com/signalfx/splunk-otel-collector/tree/main/deployments/salt) ([#3448](https://github.com/signalfx/splunk-otel-collector/pull/3448))
   - Specify the `install_fluentd: True` attribute in your pillar to enable installation
 
 ## v0.82.0

--- a/deployments/salt/README.md
+++ b/deployments/salt/README.md
@@ -7,8 +7,8 @@ Observability Cloud](https://www.splunk.com/en_us/observability.html).
 ## Linux
 Currently, the following Linux distributions and versions are supported:
 
-- Amazon Linux: 2
-- CentOS / Red Hat / Oracle: 7, 8
+- Amazon Linux: 2, 2023 (**Note:** Log collection with Fluentd not currently supported for Amazon Linux 2023.)
+- CentOS / Red Hat / Oracle: 7, 8, 9
 - Debian: 9, 10, 11
 - SUSE: 12, 15 (**Note:** Only for collector versions v0.34.0 or higher. Log collection with fluentd not currently supported.)
 - Ubuntu: 16.04, 18.04, 20.04, 22.04
@@ -32,7 +32,6 @@ splunk-otel-collector:
   splunk_otel_collector_config: '/etc/otel/collector/agent_config.yaml'
   splunk_service_user: splunk-otel-collector
   splunk_service_group: splunk-otel-collector
-
 ```
 
 ## This Salt Formula accepts the following attributes:
@@ -121,7 +120,7 @@ splunk-otel-collector:
   [fluent-plugin-systemd](
   https://github.com/fluent-plugin-systemd/fluent-plugin-systemd) for systemd
   journal log collection, and the required libraries/development tools.
-  (**default:** `True`)
+  (**default:** `False`)
 
 - `td_agent_version`: Version of [td-agent](
   https://td-agent-package-browser.herokuapp.com/) (fluentd package) that will

--- a/deployments/salt/splunk-otel-collector/fluentd.sls
+++ b/deployments/salt/splunk-otel-collector/fluentd.sls
@@ -68,7 +68,7 @@ Install FluentD Linux capability module dependencies:
     - pkgs:
       - libcap-ng
       - libcap-ng-devel
-{%- if grains['osmajorrelease'] == 8 %}
+{%- if grains['osmajorrelease'] == 8 or grains['osmajorrelease'] == 9 %}
       - pkgconf-pkg-config
 {%- else %}
       - pkgconfig

--- a/deployments/salt/splunk-otel-collector/init.sls
+++ b/deployments/salt/splunk-otel-collector/init.sls
@@ -15,11 +15,11 @@ Check splunk_realm:
     - failhard: True
 {% endif %}
 
-{% set install_fluentd = salt['pillar.get']('splunk-otel-collector:install_fluentd', True) | to_bool %}
+{% set install_fluentd = salt['pillar.get']('splunk-otel-collector:install_fluentd', False) | to_bool %}
 {% set install_auto_instrumentation = salt['pillar.get']('splunk-otel-collector:install_auto_instrumentation', False) | to_bool %}
 
 include:
-{% if grains['os_family'] == 'Suse' or install_fluentd == False %}
+{% if grains['os_family'] == 'Suse' or install_fluentd == False or (grains['os'] == 'Amazon' and grains['osrelease'] == '2023') %}
   - splunk-otel-collector.install
   - splunk-otel-collector.service_owner
   - splunk-otel-collector.config

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.amazonlinux-2023
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.amazonlinux-2023
@@ -1,0 +1,30 @@
+FROM amazonlinux:2023
+
+ENV container docker
+
+RUN yum install -y systemd procps initscripts python3-pip python3-devel gcc
+
+# Only the "amazon/2" repo is currently available, but seems to work for 2023
+RUN rpm --import https://repo.saltproject.io/salt/py3/amazon/2/x86_64/SALT-PROJECT-GPG-PUBKEY-2023.pub
+RUN curl -fsSL https://repo.saltproject.io/salt/py3/amazon/2/x86_64/latest.repo | tee /etc/yum.repos.d/salt-amzn.repo
+
+RUN yum install -y salt-minion
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
+	"systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
+	rm -f /lib/systemd/system/multi-user.target.wants/*;\
+	rm -f /lib/systemd/system/local-fs.target.wants/*; \
+	rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+	rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+	rm -f /lib/systemd/system/basic.target.wants/*;\
+	rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+COPY internal/buildscripts/packaging/tests/deployments/salt/minion /etc/salt/minion
+COPY deployments/salt/splunk-otel-collector /srv/salt/splunk-otel-collector
+COPY deployments/salt/templates /srv/salt/templates
+COPY internal/buildscripts/packaging/tests/deployments/salt/top.sls /srv/pillar/top.sls
+COPY internal/buildscripts/packaging/tests/deployments/salt/top.sls /srv/salt/top.sls
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.centos-9
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.centos-9
@@ -1,0 +1,31 @@
+FROM quay.io/centos/centos:stream9
+
+ENV container docker
+
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+RUN echo 'fastestmirror=1' >> /etc/yum.conf
+
+RUN dnf install -y systemd procps initscripts python3-pip python3-devel gcc
+
+RUN rpm --import https://repo.saltproject.io/salt/py3/redhat/9/x86_64/SALT-PROJECT-GPG-PUBKEY-2023.pub
+RUN curl -fsSL https://repo.saltproject.io/salt/py3/redhat/9/x86_64/latest.repo | tee /etc/yum.repos.d/salt.repo
+
+RUN dnf install -y salt-minion
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
+	"systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
+	rm -f /lib/systemd/system/multi-user.target.wants/*;\
+	rm -f /lib/systemd/system/local-fs.target.wants/*; \
+	rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+	rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+	rm -f /lib/systemd/system/basic.target.wants/*;\
+	rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+COPY internal/buildscripts/packaging/tests/deployments/salt/minion /etc/salt/minion
+COPY deployments/salt/splunk-otel-collector /srv/salt/splunk-otel-collector
+COPY deployments/salt/templates /srv/salt/templates
+COPY internal/buildscripts/packaging/tests/deployments/salt/top.sls /srv/pillar/top.sls
+COPY internal/buildscripts/packaging/tests/deployments/salt/top.sls /srv/salt/top.sls
+
+VOLUME [ "/sys/fs/cgroup" ]
+CMD ["/usr/sbin/init"]


### PR DESCRIPTION
- Update tests and workflow
- Include RHEL 9 and Amazon Linux 2023 to supported distros