### PR TITLE
Workaround for apt-key failure in agent bundle

### DIFF
--- a/internal/signalfx-agent/bundle/Dockerfile
+++ b/internal/signalfx-agent/bundle/Dockerfile
@@ -154,7 +154,10 @@ RUN sed -i -e '/^deb-src/d' /etc/apt/sources.list &&\
       zlib1g-dev
 
 RUN wget -nv https://dev.mysql.com/get/mysql-apt-config_0.8.12-1_all.deb && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29 && \
+    mkdir -p ~/.gnupg && \
+    chmod 700 ~/.gnupg && \
+    echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf && \
+    apt-key adv --homedir ~/.gnupg --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29 && \
     dpkg -i mysql-apt-config_0.8.12-1_all.deb && \
     rm -f mysql-apt-config_0.8.12-1_all.deb && \
     apt-get update -qq && apt-get install -qq -y libmysqlclient-dev libcurl4-gnutls-dev


### PR DESCRIPTION
Disable ipv6 when importing mysql key.  Workaround for agent bundle build failure:
```
gpg: keyserver receive failed: Cannot assign requested address
```
