### PR TITLE
skip telegraf/proctstat test on arm

### DIFF
--- a/tests/receivers/smartagent/telegraf-procstat/telegraf_procstat_test.go
+++ b/tests/receivers/smartagent/telegraf-procstat/telegraf_procstat_test.go
@@ -27,6 +27,7 @@ func TestTelegrafProcstatReceiverProvidesAllMetrics(t *testing.T) {
 	expectedMetrics := "all.yaml"
 	// telegraf/procstat is missing cpu metrics on arm64 as an apparently unsupported platform.
 	if testutils.CollectorImageIsForArm(t) {
+		t.Skip("intermittent metric availability on arm qemu")
 		expectedMetrics = "arm64.yaml"
 	}
 	testutils.AssertAllMetricsReceived(t, expectedMetrics, "all_metrics_config.yaml", nil, nil)


### PR DESCRIPTION
The limited set of expected metrics appears to vary (seen in testing https://github.com/signalfx/splunk-otel-collector/pull/3262), so skipping for now. When we have actual arm runners expected behavior can be refined.