### PR TITLE
Add a github issue template to send folks to support and splunk ideas

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Splunk Ideas
+    url: https://ideas.splunk.com/
+    about: Proposes enhancements through Splunk Ideas (requires a Splunk.com login)
+  - name: Splunk Support
+    url: https://splunk.my.site.com/customer/s/need-help/create-case
+    about: Open a support case (requires Splunk Support entitlement)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Splunk Ideas
     url: https://ideas.splunk.com/

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: Proposes enhancements through Splunk Ideas (requires a Splunk.com login)
   - name: Splunk Support
     url: https://splunk.my.site.com/customer/s/need-help/create-case
-    about: Open a support case (requires Splunk Support entitlement)
+    about: Report an issue or request help (requires Splunk Support entitlement)


### PR DESCRIPTION
This will redirect users to open support tickets and ideas instead of Github issues.