### PR TITLE
[deployment/cloudfoundry] Add missing system resource detection

### DIFF
--- a/deployments/cloudfoundry/bosh/jobs/splunk-otel-collector/templates/otel-collector-config.yaml.erb
+++ b/deployments/cloudfoundry/bosh/jobs/splunk-otel-collector/templates/otel-collector-config.yaml.erb
@@ -24,6 +24,7 @@ receivers:
 
 processors:
   resourcedetection:
+    detectors: [system]
 
 exporters:
   signalfx:


### PR DESCRIPTION
The BOSH release and Tanzu Tile config file for the collector were missing the system detector in the resource detection processor. This meant that metrics coming from Cloud Foundry environments were unable to be filtered based on host. This fix allows metrics to be filtered by host. This is tested and works in TAS v2+.