### PR TITLE
Update splunk-hec-traces example

### DIFF
--- a/examples/splunk-hec-traces/docker-compose.yml
+++ b/examples/splunk-hec-traces/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - ./spans_time_comparisons.xml:/opt/splunk/etc/apps/search/local/data/ui/views/spans_time_comparisons.xml
   # OpenTelemetry Collector
   otelcollector:
-    image: quay.io/signalfx/splunk-otel-collector:0.59.1
+    image: quay.io/signalfx/splunk-otel-collector:0.83.0
     container_name: otelcollector
     command: ["--config=/etc/otel-collector-config.yml", "--set=service.telemetry.logs.level=debug"]
     volumes:

--- a/examples/splunk-hec-traces/otel-collector-config.yml
+++ b/examples/splunk-hec-traces/otel-collector-config.yml
@@ -25,7 +25,8 @@ exporters:
         timeout: 10s
         # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
         # For this demo, we use a self-signed certificate on the Splunk docker instance, so this flag is set to true.
-        insecure_skip_verify: true
+        tls:
+          insecure_skip_verify: true
     logging:
       verbosity: detailed
       sampling_initial: 5

--- a/examples/splunk-hec-traces/tracing/Dockerfile
+++ b/examples/splunk-hec-traces/tracing/Dockerfile
@@ -9,4 +9,4 @@ RUN go get
 
 RUN go build
 
-CMD /go/src/app/app
+CMD /go/src/app/tracing

--- a/examples/splunk-hec-traces/tracing/go.mod
+++ b/examples/splunk-hec-traces/tracing/go.mod
@@ -22,10 +22,7 @@ require (
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/grpc v1.55.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace (
-	golang.org/x/crypto => golang.org/x/crypto v0.5.0
-	gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.0
-)
+replace golang.org/x/crypto => golang.org/x/crypto v0.5.0

--- a/examples/splunk-hec-traces/tracing/go.sum
+++ b/examples/splunk-hec-traces/tracing/go.sum
@@ -157,7 +157,8 @@ google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
-gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
- Bump `gopkg.in/yaml.v3` to v3.0.1 for CVE-2022-28948
- Bump collector image to 0.83.0
- Use `tls/insecure_skip_verify` in config
- Fix app name