### PR TITLE
Reduce agent-bundle cache in github workflows

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -43,6 +43,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
       - uses: actions/cache@v3
+        id: bundle-cache
         with:
           path: .cache/buildx/agent-bundle-${{ matrix.ARCH }}
           key: agent-bundle-buildx-${{ matrix.ARCH }}-${{ hashFiles('internal/signalfx-agent/bundle/**') }}
@@ -57,6 +58,7 @@ jobs:
           make docker-otelcol ARCH=${{ matrix.ARCH }}
         env:
           DOCKER_BUILDKIT: '1'
+          BUNDLE_CACHE_HIT: "${{ steps.bundle-cache.outputs.cache-hit }}"
       - run: docker save -o ./bin/image.tar otelcol:latest
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -83,6 +83,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions/cache@v3
+        id: bundle-cache
         with:
           path: .cache/buildx/agent-bundle-${{ matrix.ARCH }}
           key: agent-bundle-buildx-${{ matrix.ARCH }}-${{ hashFiles('internal/signalfx-agent/bundle/**') }}
@@ -96,6 +97,8 @@ jobs:
           image: tonistiigi/binfmt:qemu-v7.0.0
 
       - run: make -C internal/signalfx-agent/bundle agent-bundle-linux ARCH=${{ matrix.ARCH }}
+        env:
+          BUNDLE_CACHE_HIT: "${{ steps.bundle-cache.outputs.cache-hit }}"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -59,6 +59,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
       - uses: actions/cache@v3
+        id: bundle-cache
         with:
           path: .cache/buildx/agent-bundle-${{ matrix.ARCH }}
           key: agent-bundle-buildx-${{ matrix.ARCH }}-${{ hashFiles('internal/signalfx-agent/bundle/**') }}
@@ -73,6 +74,7 @@ jobs:
           make docker-otelcol ARCH=${{ matrix.ARCH }}
         env:
           DOCKER_BUILDKIT: '1'
+          BUNDLE_CACHE_HIT: "${{ steps.bundle-cache.outputs.cache-hit }}"
       - run: mkdir -p dist && docker save -o dist/image.tar otelcol:latest
       - uses: actions/upload-artifact@v3
         with:

--- a/internal/signalfx-agent/bundle/scripts/build.sh
+++ b/internal/signalfx-agent/bundle/scripts/build.sh
@@ -50,10 +50,13 @@ if [[ "$CI" = "true" || "$PUSH_CACHE" = "yes" ]]; then
     if [[ -d "$CACHE_DIR" ]]; then
         # use the restored CI cache if it exists
         CACHE_FROM_OPTS="--cache-from=type=local,src=${CACHE_DIR}"
+        USE_REGISTRY_CACHE="no"
+        if [[ "${BUNDLE_CACHE_HIT:-}" != "true" ]]; then
+            # export current build cache to temporary directory
+            CACHE_TEMP_DIR="$(mktemp -d)"
+            CACHE_TO_OPTS="--cache-to=type=local,mode=max,dest=${CACHE_TEMP_DIR}"
+        fi
     fi
-    # export current build cache to temporary directory
-    CACHE_TEMP_DIR="$(mktemp -d)"
-    CACHE_TO_OPTS="--cache-to=type=local,mode=max,dest=${CACHE_TEMP_DIR}"
 fi
 
 if [[ "$PUSH_CACHE" = "yes" ]]; then


### PR DESCRIPTION
- Reduce disk usage on github runners when building the agent-bundle by only exporting a new local cache when there are changes to agent-bundle files
- Only download and use registry cache images if the CI cache was not restored