### PR TITLE
Bump all inter-module references to latest version (v0.83.0)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,10 +87,10 @@ require (
 	github.com/prometheus/prometheus v0.46.0
 	github.com/signalfx/golib/v3 v3.3.52
 	github.com/signalfx/signalfx-agent v1.0.1-0.20230222185249-54e5d1064c5b
-	github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension v0.72.0
-	github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocessor v0.72.0
-	github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver v0.72.0
-	github.com/signalfx/splunk-otel-collector/tests v0.72.0
+	github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension v0.83.0
+	github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocessor v0.83.0
+	github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver v0.83.0
+	github.com/signalfx/splunk-otel-collector/tests v0.83.0
 	github.com/spf13/cast v1.5.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4

--- a/pkg/extension/smartagentextension/go.mod
+++ b/pkg/extension/smartagentextension/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657
 	github.com/signalfx/signalfx-agent v1.0.1-0.20230104182534-9eee411fe305
-	github.com/signalfx/splunk-otel-collector/tests v0.72.0
+	github.com/signalfx/splunk-otel-collector/tests v0.83.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector/component v0.83.0
 	go.opentelemetry.io/collector/confmap v0.83.0

--- a/pkg/receiver/smartagentreceiver/go.mod
+++ b/pkg/receiver/smartagentreceiver/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657
 	github.com/signalfx/golib/v3 v3.3.52
 	github.com/signalfx/signalfx-agent v1.0.1-0.20230104182534-9eee411fe305
-	github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension v0.72.0
-	github.com/signalfx/splunk-otel-collector/tests v0.72.0
+	github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension v0.83.0
+	github.com/signalfx/splunk-otel-collector/tests v0.83.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector v0.83.0


### PR DESCRIPTION
**Description:** 

Bump version references to inter-project modules (i.e. v0.83.0).  Note: this is for cosmetic reasons primarily, because of the `go.mod` "rewrite" directives that rewrite any reference to these modules to be relative to the current directory. 

