### PR TITLE
Give module its correct full name

### DIFF
--- a/examples/signalfxgatewayprometheusremotewritereceiver/go.mod
+++ b/examples/signalfxgatewayprometheusremotewritereceiver/go.mod
@@ -1,4 +1,4 @@
-module fake-metrics-generator
+module github.com/signalfx/splunk-otel-collector/examples/signalfxgatewayprometheusremotewritereceiver/fake-metrics-generator
 
 go 1.19
 


### PR DESCRIPTION
**Description:** 

Give newly created module its fully qualified name.

Necessary for go-multimod to be able to correctly "discard" this module from versioned modules. Needed for third parties who are trying to build their own versions of the collector using these modules.
