### PR TITLE
testutils: add nested directive expansion to logs and metrics

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/google/uuid v1.3.1
+	github.com/knadh/koanf v1.5.0
 	github.com/shirou/gopsutil/v3 v3.23.8
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.3
 	github.com/signalfx/signalfx-go v1.33.0
@@ -91,7 +92,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
-	github.com/knadh/koanf v1.5.0 // indirect
 	github.com/knadh/koanf/v2 v2.0.1 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lithammer/dedent v1.1.0 // indirect

--- a/tests/testutils/telemetry/logs.go
+++ b/tests/testutils/telemetry/logs.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/knadh/koanf/maps"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"gopkg.in/yaml.v2"
 
@@ -75,6 +76,20 @@ func LoadResourceLogs(path string) (*ResourceLogs, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	for _, rl := range loaded.ResourceLogs {
+		if rl.Resource.Attributes != nil {
+			maps.IntfaceKeysToStrings(*rl.Resource.Attributes)
+		}
+		for _, sl := range rl.ScopeLogs {
+			for _, l := range sl.Logs {
+				if l.Attributes != nil {
+					maps.IntfaceKeysToStrings(*l.Attributes)
+				}
+			}
+		}
+	}
+
 	loaded.FillDefaultValues()
 	err = loaded.Validate() // in lieu of json/yaml schema adoption
 	if err != nil {

--- a/tests/testutils/telemetry/logs_test.go
+++ b/tests/testutils/telemetry/logs_test.go
@@ -51,7 +51,10 @@ func TestLoadLogsHappyPath(t *testing.T) {
 	require.NotNil(t, firstRLAttrs["one_attr"])
 	assert.Equal(t, "one_value", firstRLAttrs["one_attr"])
 	require.NotNil(t, firstRLAttrs["two_attr"])
-	assert.Equal(t, "two_value", firstRLAttrs["two_attr"])
+	assert.Equal(t, map[string]any{
+		"nested_attr_a": "one_nested_value",
+		"nested_attr_b": "two_nested_value",
+	}, firstRLAttrs["two_attr"])
 
 	assert.Equal(t, 2, len(firstRL.ScopeLogs))
 	firstRLFirstSL := firstRL.ScopeLogs[0]
@@ -79,7 +82,10 @@ func TestLoadLogsHappyPath(t *testing.T) {
 	require.NotNil(t, firstRLSecondSLFirstLogAttrs["one_attr"])
 	assert.Equal(t, "one_value", firstRLSecondSLFirstLogAttrs["one_attr"])
 	require.NotNil(t, firstRLSecondSLFirstLogAttrs["two_attr"])
-	assert.Equal(t, "two_value", firstRLSecondSLFirstLogAttrs["two_attr"])
+	assert.Equal(t, map[string]any{
+		"nested_attr_a": "one_nested_value",
+		"nested_attr_b": "two_nested_value",
+	}, firstRLSecondSLFirstLogAttrs["two_attr"])
 
 	firstRLSecondScopeLogSecondLog := firstRLSecondSL.Logs[1]
 	require.NotNil(t, firstRLSecondScopeLogSecondLog)
@@ -109,6 +115,10 @@ func TestLoadLogsHappyPath(t *testing.T) {
 		"log_attr_a": "one_value",
 		"log_attr_b": "this should match another RE2 directive",
 		"log_attr_c": "this should match an ANY directive",
+		"log_attr_d": map[string]any{
+			"nested_attr_a": 123,
+			"nested_attr_b": "this should match yet another RE2 directive",
+		},
 	}, secondRLFirstSLFirstLog.Attributes)
 
 	secondRLFirstScopeLogSecondLog := secondRLFirstSL.Logs[1]
@@ -362,8 +372,19 @@ func TestLogContainsAllNoBijection(t *testing.T) {
 	require.False(t, containsAll)
 	require.Error(t, err)
 	require.Contains(t, err.Error(),
-		"Missing Logs: [body: this should match an RE2 directive\nattributes:\n  log_attr_a: one_value\n  log_attr_b: this should match another RE2 directive\n  log_attr_c: this should match an ANY directive\nseverity: 24\nseverity_text: arbitrary\n body: 0.123\nseverity: 9\n]",
-	)
+		`Missing Logs: [body: this should match an RE2 directive
+attributes:
+  log_attr_a: one_value
+  log_attr_b: this should match another RE2 directive
+  log_attr_c: this should match an ANY directive
+  log_attr_d:
+    nested_attr_a: 123
+    nested_attr_b: this should match yet another RE2 directive
+severity: 24
+severity_text: arbitrary
+ body: 0.123
+severity: 9
+]`)
 }
 
 func TestLogContainsAllSeverityTextNeverReceived(t *testing.T) {

--- a/tests/testutils/telemetry/metrics.go
+++ b/tests/testutils/telemetry/metrics.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/knadh/koanf/maps"
 	"gopkg.in/yaml.v2"
 
 	"github.com/signalfx/splunk-otel-collector/tests/internal/version"
@@ -120,6 +121,20 @@ func LoadResourceMetrics(path string) (*ResourceMetrics, error) {
 	if err = yaml.UnmarshalStrict(by, &loaded); err != nil {
 		return nil, err
 	}
+
+	for _, rm := range loaded.ResourceMetrics {
+		if rm.Resource.Attributes != nil {
+			maps.IntfaceKeysToStrings(*rm.Resource.Attributes)
+		}
+		for _, sm := range rm.ScopeMetrics {
+			for _, m := range sm.Metrics {
+				if m.Attributes != nil {
+					maps.IntfaceKeysToStrings(*m.Attributes)
+				}
+			}
+		}
+	}
+
 	loaded.FillDefaultValues()
 	err = loaded.Validate() // in lieu of json/yaml schema adoption
 	if err != nil {

--- a/tests/testutils/telemetry/metrics_test.go
+++ b/tests/testutils/telemetry/metrics_test.go
@@ -50,7 +50,10 @@ func TestLoadMetricsHappyPath(t *testing.T) {
 	require.NotNil(t, firstRMAttrs["one_attr"])
 	assert.Equal(t, "one_value", firstRMAttrs["one_attr"])
 	require.NotNil(t, firstRMAttrs["two_attr"])
-	assert.Equal(t, "two_value", firstRMAttrs["two_attr"])
+	assert.Equal(t, map[string]any{
+		"nested_attr_a": "one_nested_value",
+		"nested_attr_b": "two_nested_value",
+	}, firstRMAttrs["two_attr"])
 
 	assert.Equal(t, 2, len(firstRM.ScopeMetrics))
 	firstRMFirstSM := firstRM.ScopeMetrics[0]
@@ -409,9 +412,20 @@ func TestMetricContainsAllNoBijection(t *testing.T) {
 	containsAll, err = expected.ContainsAll(received)
 	require.False(t, containsAll)
 	require.Error(t, err)
-	require.Contains(t, err.Error(),
-		"Missing Metrics: [attributes:\n  metric_attr_a: one_value\n  metric_attr_b: this should match an RE2 directive\n  metric_attr_c: this should match an ANY directive\nname: another_int_gauge\ntype: IntGauge\nvalue: 456\n name: another_double_gauge\ntype: DoubleGauge\nvalue: 567.89\n",
-	)
+	require.Contains(t, err.Error(), `Missing Metrics: [attributes:
+  metric_attr_a: one_value
+  metric_attr_b: this should match an RE2 directive
+  metric_attr_c: this should match an ANY directive
+  metric_attr_d:
+    nested_attr_a: 123
+    nested_attr_b: this should match yet another RE2 directive
+name: another_int_gauge
+type: IntGauge
+value: 456
+ name: another_double_gauge
+type: DoubleGauge
+value: 567.89
+]`)
 }
 
 func TestMetricContainsAllValueNeverReceived(t *testing.T) {

--- a/tests/testutils/telemetry/pdata_common.go
+++ b/tests/testutils/telemetry/pdata_common.go
@@ -14,7 +14,10 @@
 
 package telemetry
 
-import "gopkg.in/yaml.v2"
+import (
+	"github.com/knadh/koanf/maps"
+	"gopkg.in/yaml.v2"
+)
 
 // sanitizeAttributes helps ensure that unmarshaled yaml mappings and
 // pcommon.Map items have the same map[string]any representation
@@ -28,5 +31,6 @@ func sanitizeAttributes(attributes map[string]any) map[string]any {
 	if err = yaml.Unmarshal(b, &sanitized); err != nil {
 		panic(err)
 	}
+	maps.IntfaceKeysToStrings(sanitized)
 	return sanitized
 }

--- a/tests/testutils/telemetry/testdata/logs/expected-logs.yaml
+++ b/tests/testutils/telemetry/testdata/logs/expected-logs.yaml
@@ -9,5 +9,8 @@ resource_logs:
               log_attr_a: one_value
               log_attr_b: <RE2(^this.*match an.* RE2.*$)>
               log_attr_c: <ANY>
+              log_attr_d:
+                nested_attr_a: <ANY>
+                nested_attr_b: <RE2(^this should match yet.*RE2.*$)>
             severity_text: arbitrary
           - body: 0.123

--- a/tests/testutils/telemetry/testdata/logs/resource-logs.yaml
+++ b/tests/testutils/telemetry/testdata/logs/resource-logs.yaml
@@ -1,7 +1,9 @@
 resource_logs:
   - attributes:
       one_attr: one_value
-      two_attr: two_value
+      two_attr:
+        nested_attr_a: one_nested_value
+        nested_attr_b: two_nested_value
     scope_logs:
       - instrumentation_scope:
           name: without_logs
@@ -24,6 +26,9 @@ resource_logs:
               log_attr_a: one_value
               log_attr_b: this should match another RE2 directive
               log_attr_c: this should match an ANY directive
+              log_attr_d:
+                nested_attr_a: 123
+                nested_attr_b: this should match yet another RE2 directive
             severity: 24
             severity_text: arbitrary
           - body: 0.123

--- a/tests/testutils/telemetry/testdata/metrics/expected-metrics.yaml
+++ b/tests/testutils/telemetry/testdata/metrics/expected-metrics.yaml
@@ -8,6 +8,9 @@ resource_metrics:
               metric_attr_a: one_value
               metric_attr_b: <RE2(^this.*match an RE2.*$)>
               metric_attr_c: <ANY>
+              metric_attr_d:
+                nested_attr_a: <ANY>
+                nested_attr_b: <RE2(^this should match yet.*RE2.*$)>
             name: another_int_gauge
             type: IntGauge
           - name: another_double_gauge

--- a/tests/testutils/telemetry/testdata/metrics/resource-metrics.yaml
+++ b/tests/testutils/telemetry/testdata/metrics/resource-metrics.yaml
@@ -1,7 +1,9 @@
 resource_metrics:
   - attributes:
       one_attr: one_value
-      two_attr: two_value
+      two_attr:
+        nested_attr_a: one_nested_value
+        nested_attr_b: two_nested_value
     scope_metrics:
       - instrumentation_scope:
           name: without_metrics
@@ -24,6 +26,9 @@ resource_metrics:
               metric_attr_a: one_value
               metric_attr_b: this should match an RE2 directive
               metric_attr_c: this should match an ANY directive
+              metric_attr_d:
+                nested_attr_a: 123
+                nested_attr_b: this should match yet another RE2 directive
             name: another_int_gauge
             type: IntGauge
             value: 456


### PR DESCRIPTION
**Description:**
These changes add support for using the testutils directives for nested attributes, which are currently limited to root level maps. They will be necessary to vet entity events that embed endpoint information in an `otel.entity.attributes` log record attribute.