### PR TITLE
Update fluentd url for windows

### DIFF
--- a/deployments/ansible/roles/collector/tasks/win_fluentd_install.yml
+++ b/deployments/ansible/roles/collector/tasks/win_fluentd_install.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set fluentd package sources
   ansible.builtin.set_fact:
-    td_agent_base_url: https://packages.treasuredata.com
+    td_agent_base_url: https://s3.amazonaws.com/packages.treasuredata.com
     win_fluentd_msi: td-agent-{{td_agent_version}}-x64.msi
 
 - name: Push Custom Config file for fluentd, if provided

--- a/deployments/chef/attributes/default.rb
+++ b/deployments/chef/attributes/default.rb
@@ -26,7 +26,6 @@ default['splunk_otel_collector']['splunk_listen_interface'] = '0.0.0.0'
 default['splunk_otel_collector']['collector_config'] = {}
 
 default['splunk_otel_collector']['with_fluentd'] = false
-default['splunk_otel_collector']['fluentd_base_url'] = 'https://packages.treasuredata.com'
 default['splunk_otel_collector']['fluentd_version'] = if platform_family?('debian')
                                                         case node['lsb']['codename']
                                                         when 'stretch'
@@ -52,6 +51,7 @@ if platform_family?('windows')
   default['splunk_otel_collector']['splunk_bundle_dir'] = "#{collector_install_dir}\\agent-bundle"
   default['splunk_otel_collector']['splunk_collectd_dir'] = "#{node['splunk_otel_collector']['splunk_bundle_dir']}\\run\\collectd"
 
+  default['splunk_otel_collector']['fluentd_base_url'] = 'https://s3.amazonaws.com/packages.treasuredata.com'
   default['splunk_otel_collector']['fluentd_config_source'] = 'file:///' + "#{collector_install_dir}\\fluentd\\td-agent.conf"
   default['splunk_otel_collector']['fluentd_config_dest'] = "#{ENV['SystemDrive']}\\opt\\td-agent\\etc\\td-agent\\td-agent.conf"
   default['splunk_otel_collector']['fluentd_version_file'] = "#{collector_install_dir}\\fluentd_version.txt"
@@ -83,6 +83,7 @@ elsif platform_family?('debian', 'rhel', 'amazon', 'suse')
   default['splunk_otel_collector']['user'] = 'splunk-otel-collector'
   default['splunk_otel_collector']['group'] = 'splunk-otel-collector'
 
+  default['splunk_otel_collector']['fluentd_base_url'] = 'https://packages.treasuredata.com'
   default['splunk_otel_collector']['fluentd_config_source'] = 'file:///etc/otel/collector/fluentd/fluent.conf'
   default['splunk_otel_collector']['fluentd_config_dest'] = '/etc/otel/collector/fluentd/fluent.conf'
 

--- a/deployments/puppet/manifests/init.pp
+++ b/deployments/puppet/manifests/init.pp
@@ -25,7 +25,7 @@ class splunk_otel_collector (
   $apt_gpg_key             = 'https://splunk.jfrog.io/splunk/otel-collector-deb/splunk-B3CD4420.gpg',
   $yum_gpg_key             = 'https://splunk.jfrog.io/splunk/otel-collector-rpm/splunk-B3CD4420.pub',
   $with_fluentd            = false,
-  $fluentd_repo_base       = 'https://packages.treasuredata.com',
+  $fluentd_repo_base       = $splunk_otel_collector::params::fluentd_base_url,
   $fluentd_gpg_key         = 'https://packages.treasuredata.com/GPG-KEY-td-agent',
   $fluentd_version         = $splunk_otel_collector::params::fluentd_version,
   $fluentd_config_source   = $splunk_otel_collector::params::fluentd_config_source,

--- a/deployments/puppet/manifests/params.pp
+++ b/deployments/puppet/manifests/params.pp
@@ -12,6 +12,7 @@ class splunk_otel_collector::params {
     $splunk_collectd_dir = "${splunk_bundle_dir}/run/collectd"
     $collector_config_source = "${collector_config_dir}/agent_config.yaml"
     $collector_config_dest = $collector_config_source
+    $fluentd_base_url = 'https://packages.treasuredata.com'
     if $::osfamily == 'debian' {
       $fluentd_version = downcase($facts['os']['distro']['codename']) ? {
         'stretch' => $fluentd_version_stretch,
@@ -33,6 +34,7 @@ class splunk_otel_collector::params {
     $splunk_collectd_dir = "${splunk_bundle_dir}\\run\\collectd"
     $collector_config_source = "${collector_install_dir}\\agent_config.yaml"
     $collector_config_dest = "${collector_config_dir}\\agent_config.yaml"
+    $fluentd_base_url = 'https://s3.amazonaws.com/packages.treasuredata.com'
     $fluentd_version = $fluentd_version_default
     $fluentd_config_source = "${collector_install_dir}\\fluentd\\td-agent.conf"
     $fluentd_config_dest = ''

--- a/internal/buildscripts/packaging/choco/splunk-otel-collector/tools/fluentd.ps1
+++ b/internal/buildscripts/packaging/choco/splunk-otel-collector/tools/fluentd.ps1
@@ -1,5 +1,5 @@
 $fluentd_msi_name = "td-agent-4.3.2-x64.msi"
-$fluentd_dl_url = "https://packages.treasuredata.com/4/windows/$fluentd_msi_name"
+$fluentd_dl_url = "https://s3.amazonaws.com/packages.treasuredata.com/4/windows/$fluentd_msi_name"
 
 try {
     Resolve-Path $env:TEMP 2>&1>$null

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -163,7 +163,7 @@ try {
 $regkey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
 
 $fluentd_msi_name = "td-agent-4.3.2-x64.msi"
-$fluentd_dl_url = "https://packages.treasuredata.com/4/windows/$fluentd_msi_name"
+$fluentd_dl_url = "https://s3.amazonaws.com/packages.treasuredata.com/4/windows/$fluentd_msi_name"
 try {
     Resolve-Path $env:SYSTEMDRIVE 2>&1>$null
     $fluentd_base_dir = "${env:SYSTEMDRIVE}\opt\td-agent"


### PR DESCRIPTION
Changed fluentd url to download directly from https://s3.amazonaws.com/packages.treasuredata.com for windows, instead of being redirected from https://packages.treasuredata.com.

https://packages.treasuredata.com was recently updated to TLS 1.3, which is unsupported on [Windows 2012](https://learn.microsoft.com/en-us/windows/win32/secauthn/protocols-in-tls-ssl--schannel-ssp-).

