### PR TITLE
Move to use 127.0.0.1 for network listeners by default in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### 🛑 Breaking changes 🛑
 
 - (Splunk) `SPLUNK_LISTEN_INTERFACE`: Move to use 127.0.0.1 for the network listen interface of the collector by default on Windows and Linux installers, as well as Chocolatey.
-  Users can override this behavior by configuring the installers and Chocolatey to use `0.0.0.0` to continue to use the previous default value.
+  Users can override this behavior by configuring the installers and Chocolatey to use `0.0.0.0` to continue to use the previous default value. Please see [Advanced Configuration](https://github.com/signalfx/splunk-otel-collector#advanced-configuration) for more information.
+
 
 ## v0.85.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- (Splunk) `SPLUNK_LISTEN_INTERFACE`: Move to use 127.0.0.1 for the network listen interface of the collector by default on Windows and Linux installers, as well as Chocolatey.
+  Users can override this behavior by configuring the installers and Chocolatey to use `0.0.0.0` to continue to use the previous default value.
+
 ## v0.85.0
 
 ***ADVANCED NOTICE - SPLUNK_LISTEN_INTERFACE DEFAULTS***

--- a/README.md
+++ b/README.md
@@ -172,7 +172,16 @@ listen to configure the `SPLUNK_DEBUG_CONFIG_SERVER_PORT` environment variable.
 You can use the environment variable `SPLUNK_LISTEN_INTERFACE` and associated installer option to configure the network
 interface on which the collector's receivers and telemetry endpoints will listen.
 The default value of `SPLUNK_LISTEN_INTERFACE` is set to `0.0.0.0`, except on Chocolatey and
-the Windows and  Linux standalone installers, where it defaults to `127.0.0.1`.
+the Windows and Linux standalone installers, where it defaults to `127.0.0.1`.
+
+The table below shows the configuration switches to use at installation time:
+
+| Method     | Command                                                                             |
+|------------|-------------------------------------------------------------------------------------|
+| Chocolatey | `choco install splunk-otel-collector --params="'/SPLUNK_LISTEN_INTERFACE:0.0.0.0'"` |
+| Linux      | `sudo install.sh  --listen-interface=0.0.0.0`                                       |
+| Windows    | `install.ps1 --network_interface=0.0.0.0`                                           |
+
 
 ## Upgrade guidelines
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,8 @@ listen to configure the `SPLUNK_DEBUG_CONFIG_SERVER_PORT` environment variable.
 
 You can use the environment variable `SPLUNK_LISTEN_INTERFACE` and associated installer option to configure the network
 interface on which the collector's receivers and telemetry endpoints will listen.
-The default value of `SPLUNK_LISTEN_INTERFACE` is set to `0.0.0.0`.
+The default value of `SPLUNK_LISTEN_INTERFACE` is set to `0.0.0.0`, except on Chocolatey and
+the Windows and  Linux standalone installers, where it defaults to `127.0.0.1`.
 
 ## Upgrade guidelines
 

--- a/internal/buildscripts/packaging/choco/splunk-otel-collector/splunk-otel-collector.nuspec
+++ b/internal/buildscripts/packaging/choco/splunk-otel-collector/splunk-otel-collector.nuspec
@@ -18,7 +18,7 @@ The following package parameters are available:
  * `/SPLUNK_HEC_URL`: URL of the Splunk HEC endpoint (e.g. `https://ingest.us1.signalfx.com/v1/log`). Default value is `https://ingest.$SPLUNK_REALM.signalfx.com/v1/log`
  * `/SPLUNK_TRACE_URL`: URL of the Splunk trace endpoint (e.g. `https://ingest.us1.signalfx.com/v2/trace`). Default value is `https://ingest.$SPLUNK_REALM.signalfx.com/v2/trace`
  * `/SPLUNK_BUNDLE_DIR`: The path to the Smart Agent bundle directory for the `smartagent` receiver and extension. The default path is provided by the Collector package. If the specified path is changed from the default value, the path should be an existing directory on the system. Default value is `\Program Files\Splunk\OpenTelemetry Collector\agent-bundle`.
- * `/SPLUNK_LISTEN_INTERFACE`: The network interface the collector receivers will listen on. Default value is `0.0.0.0`.
+ * `/SPLUNK_LISTEN_INTERFACE`: The network interface the collector receivers will listen on. Default value is `127.0.0.1`.
  * `/MODE`: This parameter is used for setting the Collector configuration file to `\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml` or `\ProgramData\Splunk\OpenTelemetry Collector\gateway_config.yaml`. Possible values are `agent` and `gateway`. Default value is `agent`.
  * `/WITH_FLUENTD`: Whether to download, install, and configure Fluentd to collect and forward log events to the Collector. Possible values are `true` and `false`. If set to `true`, the Fluentd MSI package will be downloaded from `https://packages.treasuredata.com`. Default value is `false`.
 

--- a/internal/buildscripts/packaging/choco/splunk-otel-collector/tools/chocolateyinstall.ps1
+++ b/internal/buildscripts/packaging/choco/splunk-otel-collector/tools/chocolateyinstall.ps1
@@ -135,7 +135,7 @@ try {
     }
 }
 catch {
-    $SPLUNK_LISTEN_INTERFACE = "0.0.0.0"
+    $SPLUNK_LISTEN_INTERFACE = "127.0.0.1"
     write-host "The SPLUNK_LISTEN_INTERFACE parameter is not specified. Using default configuration."
 }
 

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -41,7 +41,7 @@
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -mode "gateway"
 .PARAMETER network_interface
-    (OPTIONAL) The network interface the collector receivers listen on. (default: "0.0.0.0")
+    (OPTIONAL) The network interface the collector receivers listen on. (default: "127.0.0.1")
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -network_interface "127.0.0.1"
 .PARAMETER ingest_url
@@ -113,7 +113,7 @@ param (
     [string]$realm = "us0",
     [string]$memory = "512",
     [ValidateSet('agent','gateway')][string]$mode = "agent",
-    [string]$network_interface = "0.0.0.0",
+    [string]$network_interface = "127.0.0.1",
     [string]$ingest_url = "",
     [string]$api_url = "",
     [string]$trace_url = "",

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -90,7 +90,7 @@ td_agent_gpg_key_url="${td_agent_repo_base}/GPG-KEY-td-agent"
 default_stage="release"
 default_realm="us0"
 default_memory_size="512"
-default_listen_interface="0.0.0.0"
+default_listen_interface="127.0.0.1"
 
 default_collector_version="latest"
 default_td_agent_version="4.3.2"

--- a/internal/buildscripts/packaging/tests/installer_test.py
+++ b/internal/buildscripts/packaging/tests/installer_test.py
@@ -85,7 +85,7 @@ def verify_config_file(container, path, key, value, exists=True):
         assert not match, f"'{line}' found in {path}:\n{config}"
 
 
-def verify_env_file(container, mode="agent", config_path=None, memory=TOTAL_MEMORY, listen_addr="0.0.0.0", ballast=None):
+def verify_env_file(container, mode="agent", config_path=None, memory=TOTAL_MEMORY, listen_addr="127.0.0.1", ballast=None):
     env_path = SPLUNK_ENV_PATH
     if container.exec_run(f"test -f {OLD_SPLUNK_ENV_PATH}").exit_code == 0:
         env_path = OLD_SPLUNK_ENV_PATH
@@ -227,7 +227,7 @@ def test_installer_custom(distro, arch):
     install_cmd = " ".join((
         get_installer_cmd(),
         "--with-fluentd",
-        "--listen-interface 127.0.0.1",
+        "--listen-interface 10.0.0.1",
         "--memory 256",
         "--ballast 64",
         f"--service-user {service_owner} --service-group {service_owner}",
@@ -250,7 +250,7 @@ def test_installer_custom(distro, arch):
             assert output.decode("utf-8").strip() == f"otelcol version v{collector_version}"
 
             # verify env file created with configured parameters
-            verify_env_file(container, config_path=custom_config, memory="256", listen_addr="127.0.0.1", ballast="64")
+            verify_env_file(container, config_path=custom_config, memory="256", listen_addr="10.0.0.1", ballast="64")
 
             # verify collector service status
             assert wait_for(lambda: service_is_running(container, service_owner=service_owner))

--- a/tests/zeroconfig/windows/testdata/Dockerfile.iis.server
+++ b/tests/zeroconfig/windows/testdata/Dockerfile.iis.server
@@ -24,8 +24,7 @@ ENV ACCESS_TOKEN_TMP=$access_token
 RUN `
     $token = $Env:ACCESS_TOKEN_TMP; `
     $collector_msi_path = (dir "c:\setup\splunk-otel-collector-*.msi").FullName; `
-    [string]$network_interface = "127.0.0.1",
-    c:\setup\install.ps1 -access_token $token -msi_path $collector_msi_path -with_dotnet_instrumentation $true -deployment_env zc-iis-test -ingest_url "http://splunk-otel-collector:9943" -trace_url "http://splunk-otel-collector:7276/v2/trace" -network_interface="0.0.0.0"
+    c:\setup\install.ps1 -access_token $token -msi_path $collector_msi_path -with_dotnet_instrumentation $true -deployment_env zc-iis-test -ingest_url "http://splunk-otel-collector:9943" -trace_url "http://splunk-otel-collector:7276/v2/trace" -network_interface "0.0.0.0"
 ENV ACCESS_TOKEN_TMP=
 
 COPY apps/bin/aspnetfxapp/_PublishedWebsites/AspNet.WebApi.NetFramework/ /apps/aspnetfx

--- a/tests/zeroconfig/windows/testdata/Dockerfile.iis.server
+++ b/tests/zeroconfig/windows/testdata/Dockerfile.iis.server
@@ -24,7 +24,8 @@ ENV ACCESS_TOKEN_TMP=$access_token
 RUN `
     $token = $Env:ACCESS_TOKEN_TMP; `
     $collector_msi_path = (dir "c:\setup\splunk-otel-collector-*.msi").FullName; `
-    c:\setup\install.ps1 -access_token $token -msi_path $collector_msi_path -with_dotnet_instrumentation $true -deployment_env zc-iis-test -ingest_url "http://splunk-otel-collector:9943" -trace_url "http://splunk-otel-collector:7276/v2/trace"
+    [string]$network_interface = "127.0.0.1",
+    c:\setup\install.ps1 -access_token $token -msi_path $collector_msi_path -with_dotnet_instrumentation $true -deployment_env zc-iis-test -ingest_url "http://splunk-otel-collector:9943" -trace_url "http://splunk-otel-collector:7276/v2/trace" -network_interface="0.0.0.0"
 ENV ACCESS_TOKEN_TMP=
 
 COPY apps/bin/aspnetfxapp/_PublishedWebsites/AspNet.WebApi.NetFramework/ /apps/aspnetfx

--- a/tests/zeroconfig/windows/testdata/Dockerfile.pipeline.collector
+++ b/tests/zeroconfig/windows/testdata/Dockerfile.pipeline.collector
@@ -18,7 +18,7 @@ ENV ACCESS_TOKEN_TMP=$access_token
 RUN `
     $token = $Env:ACCESS_TOKEN_TMP; `
     $collector_msi_path = (dir "c:\setup\splunk-otel-collector-*.msi").FullName; `
-    c:\setup\install.ps1 -access_token $token -msi_path $collector_msi_path -with_fluentd $false -ingest_url "http://192.0.2.1:12345" -trace_url "http://192.0.2.1:12345"
+    c:\setup\install.ps1 -access_token $token -msi_path $collector_msi_path -with_fluentd $false -ingest_url "http://192.0.2.1:12345" -trace_url "http://192.0.2.1:12345" -network_interface "0.0.0.0"
 ENV ACCESS_TOKEN_TMP=
 RUN `
     Set-ItemProperty -force -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -name 'SPLUNK_CONFIG' -value 'C:\setup\pipeline-collector.yaml'


### PR DESCRIPTION
**Description:**
Move to use 127.0.0.1 for the network listen interface of the collector by default on Windows and Linux installers, as well as Chocolatey
