### PR TITLE
Add warnings regarding the change of default value from 0.0.0.0 to 127.0.0.1 in installers

### DIFF
--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -574,10 +574,6 @@ if ($config_path -Eq "") {
     }
 }
 
-if ($network_interface -Eq "0.0.0.0") {
-    echo "Starting with version 0.86.0, the collector installer will change its default network listening interface from 0.0.0.0 to 127.0.0.1. Please consult the release notes for more information and configuration options."
-}
-
 update_registry -path "$regkey" -name "SPLUNK_ACCESS_TOKEN" -value "$access_token"
 update_registry -path "$regkey" -name "SPLUNK_API_URL" -value "$api_url"
 update_registry -path "$regkey" -name "SPLUNK_BUNDLE_DIR" -value "$bundle_dir"
@@ -696,4 +692,8 @@ if ($with_fluentd) {
     stop_service -name "$fluentd_service_name"
     start_service -name "$fluentd_service_name" -config_path "$fluentd_config_path"
     echo "- Started"
+}
+
+if ($network_interface -Eq "0.0.0.0") {
+    echo "[NOTICE] Starting with version 0.86.0, the collector installer will change its default network listening interface from 0.0.0.0 to 127.0.0.1. Please consult the release notes for more information and configuration options."
 }

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -574,6 +574,10 @@ if ($config_path -Eq "") {
     }
 }
 
+if ($network_interface -Eq "0.0.0.0") {
+    echo "Starting with version 0.86.0, the collector installer will change its default network listening interface from 0.0.0.0 to 127.0.0.1. Please consult the release notes for more information and configuration options."
+}
+
 update_registry -path "$regkey" -name "SPLUNK_ACCESS_TOKEN" -value "$access_token"
 update_registry -path "$regkey" -name "SPLUNK_API_URL" -value "$api_url"
 update_registry -path "$regkey" -name "SPLUNK_BUNDLE_DIR" -value "$bundle_dir"

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -1103,9 +1103,6 @@ parse_args_and_install() {
     echo "Ballast Size in MIB: $ballast"
   fi
   echo "Memory Size in MIB: $memory"
-  if [ "$listen_interface" = "0.0.0.0" ]; then
-    echo "Starting with version 0.86.0, the collector installer will change its default network listening interface from 0.0.0.0 to 127.0.0.1. Please consult the release notes for more information and configuration options."
-  fi
   echo "Listen network interface: $listen_interface"
   echo "Realm: $realm"
   echo "Ingest Endpoint: $ingest_url"
@@ -1306,6 +1303,10 @@ EOH
 WARNING: Fluentd was not installed since it is currently not supported for ${distro}:${distro_version} ${distro_arch}
 
 EOH
+  fi
+
+  if [ "$listen_interface" = "0.0.0.0" ]; then
+    echo "[NOTICE] Starting with version 0.86.0, the collector installer will change its default network listening interface from 0.0.0.0 to 127.0.0.1. Please consult the release notes for more information and configuration options."
   fi
 
   exit 0

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -1103,6 +1103,9 @@ parse_args_and_install() {
     echo "Ballast Size in MIB: $ballast"
   fi
   echo "Memory Size in MIB: $memory"
+  if [ "$listen_interface" = "0.0.0.0" ]; then
+    echo "Starting with version 0.86.0, the collector installer will change its default network listening interface from 0.0.0.0 to 127.0.0.1. Please consult the release notes for more information and configuration options."
+  fi
   echo "Listen network interface: $listen_interface"
   echo "Realm: $realm"
   echo "Ingest Endpoint: $ingest_url"


### PR DESCRIPTION
**Description:**
Add warnings regarding the change of default value from `0.0.0.0` to `127.0.0.1` in installers.

This logs a message when the value of the listen interface is set to `0.0.0.0` during installation, on Linux and Windows, in preparation of incoming changes to installer default values.
