### PR TITLE
Revert "Bump signalfx/splunk-otel-collector (#3600)"

### DIFF
--- a/examples/prometheusexec-migration/Dockerfile
+++ b/examples/prometheusexec-migration/Dockerfile
@@ -1,3 +1,3 @@
-FROM quay.io/signalfx/splunk-otel-collector:0.84.0
+FROM quay.io/signalfx/splunk-otel-collector:0.82.0
 COPY --from=quay.io/prometheus/node-exporter:v1.6.1 --chown=999 /bin/node_exporter /usr/bin/node_exporter
 CMD ["otelcol"]


### PR DESCRIPTION
The `prometheusexec` receiver was removed in 0.83.0, which breaks the ["pre-migration" example](https://github.com/signalfx/splunk-otel-collector/blob/main/examples/prometheusexec-migration/README.md?plain=1#L6).