### PR TITLE
Update bundle caching in CI to save time and disk space

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -216,10 +216,6 @@ agent-bundle-linux:
         TAG: arm
   tags:
     - $TAG
-  cache:
-    key: agent-bundle-${ARCH}
-    paths:
-      - .cache/buildx/agent-bundle-${ARCH}
   script:
     - *docker-reader-role
     - docker login -u $CIRCLECI_QUAY_USERNAME -p $CIRCLECI_QUAY_PASSWORD quay.io


### PR DESCRIPTION
- No need to export local cache in gitlab
- Ensure local cache is exported and saved if there are changes in github