### PR TITLE
Include splunk.zc.method attribute for windows installer script

### DIFF
--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -158,6 +158,22 @@ jobs:
           name: msi-build
           path: ./tests/zeroconfig/windows/testdata/docker-setup/
 
+      - name: Get latest signalfx-dotnet-tracing release
+        id: dotnet-tracing
+        uses: pozetroninc/github-action-get-latest-release@v0.7.0
+        with:
+          owner: signalfx
+          repo: signalfx-dotnet-tracing
+          excludes: prerelease, draft
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set SIGNALFX_DOTNET_TRACING_VERSION
+        run: |
+          version="${{ steps.dotnet-tracing.outputs.release }}"
+          sed -i "s|SIGNALFX_DOTNET_TRACING_VERSION|${version#v}|" tests/zeroconfig/windows/testdata/resource_traces/aspnetcore.yaml
+          sed -i "s|SIGNALFX_DOTNET_TRACING_VERSION|${version#v}|" tests/zeroconfig/windows/testdata/resource_traces/aspnetfx.yaml
+        shell: bash
+
       - name: Run the test script
         working-directory: tests/zeroconfig/windows/
         run: |

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -669,6 +669,13 @@ if ($with_dotnet_instrumentation) {
         echo "SIGNALFX_ENV environment variable not set. Unless otherwise defined, will appear as 'unknown' in the UI."
     }
 
+    try {
+        $dotnet_version = (Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where { $_.DisplayName -eq "SignalFx .NET Tracing 64-bit" }).DisplayVersion
+        update_registry -path "$regkey" -name "SIGNALFX_GLOBAL_TAGS" "splunk.zc.method:signalfx-dotnet-tracing-${dotnet_version}"
+    } catch {
+        continue
+    }
+
     $message = "
 SignalFx .NET Instrumentation has been installed and configured to forward traces to the Splunk OpenTelemetry Collector.
 By default, .NET Instrumentation will automatically generate traces for applications running on IIS.

--- a/tests/zeroconfig/windows/testdata/resource_traces/aspnetcore.yaml
+++ b/tests/zeroconfig/windows/testdata/resource_traces/aspnetcore.yaml
@@ -21,3 +21,4 @@ resource_spans:
         net.peer.ip: <ANY>
         signalfx.tracing.library: dotnet-tracing
         signalfx.tracing.version: <ANY>
+        splunk.zc.method: <ANY>

--- a/tests/zeroconfig/windows/testdata/resource_traces/aspnetcore.yaml
+++ b/tests/zeroconfig/windows/testdata/resource_traces/aspnetcore.yaml
@@ -21,4 +21,4 @@ resource_spans:
         net.peer.ip: <ANY>
         signalfx.tracing.library: dotnet-tracing
         signalfx.tracing.version: <ANY>
-        splunk.zc.method: <ANY>
+        splunk.zc.method: signalfx-dotnet-tracing-SIGNALFX_DOTNET_TRACING_VERSION

--- a/tests/zeroconfig/windows/testdata/resource_traces/aspnetfx.yaml
+++ b/tests/zeroconfig/windows/testdata/resource_traces/aspnetfx.yaml
@@ -18,7 +18,7 @@ resource_spans:
         net.peer.ip: <ANY>
         signalfx.tracing.library: dotnet-tracing
         signalfx.tracing.version: <ANY>
-        splunk.zc.method: <ANY>
+        splunk.zc.method: signalfx-dotnet-tracing-SIGNALFX_DOTNET_TRACING_VERSION
     - name: GET /api/values/{id}
       attributes:
         aspnet.controller: values
@@ -29,4 +29,4 @@ resource_spans:
         http.url: http://localhost/aspnetfxapp/api/values/4
         http.user_agent: Go-http-client/1.1
         net.peer.ip: <ANY>
-        splunk.zc.method: <ANY>
+        splunk.zc.method: signalfx-dotnet-tracing-SIGNALFX_DOTNET_TRACING_VERSION

--- a/tests/zeroconfig/windows/testdata/resource_traces/aspnetfx.yaml
+++ b/tests/zeroconfig/windows/testdata/resource_traces/aspnetfx.yaml
@@ -18,6 +18,7 @@ resource_spans:
         net.peer.ip: <ANY>
         signalfx.tracing.library: dotnet-tracing
         signalfx.tracing.version: <ANY>
+        splunk.zc.method: <ANY>
     - name: GET /api/values/{id}
       attributes:
         aspnet.controller: values
@@ -28,3 +29,4 @@ resource_spans:
         http.url: http://localhost/aspnetfxapp/api/values/4
         http.user_agent: Go-http-client/1.1
         net.peer.ip: <ANY>
+        splunk.zc.method: <ANY>


### PR DESCRIPTION
Set `HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\SIGNALFX_GLOBAL_TAGS` with `splunk.zc.method:signalfx-dotnet-tracing-<version>` when installing `with_dotnet_instrumentation`.