### PR TITLE
Allow passing splunk_hec_token for log ingestion into Splunk Cloud to work.

### DIFF
--- a/deployments/ansible/README.md
+++ b/deployments/ansible/README.md
@@ -54,8 +54,11 @@ Note that this role requires root access.
         name: "signalfx.splunk_otel_collector.collector"
       vars:
         splunk_access_token: YOUR_ACCESS_TOKEN
+        splunk_hec_token: YOUR_HEC_TOKEN
         splunk_realm: SPLUNK_REALM
 ```
+
+> **_NOTE:_**  Setting splunk_hec_token is optional.
 
 Full documentation on how to configure the role:
 [Splunk OpenTelemetry Collector Role](https://github.com/signalfx/splunk-otel-collector/tree/main/deployments/ansible/roles/collector)

--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -31,8 +31,11 @@ how to use the role in a playbook with minimal required configuration:
         name: "signalfx.splunk_otel_collector.collector"
       vars:
         splunk_access_token: YOUR_ACCESS_TOKEN
+        splunk_hec_token: YOUR_HEC_TOKEN
         splunk_realm: SPLUNK_REALM
 ```
+
+> **_NOTE:_**  Setting splunk_hec_token is optional.
 
 You can disable starting the collector and fluentd services by setting 
 the argument `start_service` to `false`:

--- a/deployments/ansible/roles/collector/tasks/linux_install.yml
+++ b/deployments/ansible/roles/collector/tasks/linux_install.yml
@@ -28,6 +28,11 @@
   notify: "restart splunk-otel-collector"
   when: splunk_otel_collector_proxy_http != "" or splunk_otel_collector_proxy_https != ""
 
+- name: Set default hec token
+  set_fact:
+    splunk_hec_token: "{{splunk_access_token}}"
+  when: splunk_hec_token is not defined or (splunk_hec_token | trim) == ""
+
 - name: Set up env file for Splunk OTel Collector service
   ansible.builtin.template:
     src: splunk-otel-collector.conf.j2

--- a/deployments/ansible/roles/collector/templates/splunk-otel-collector.conf.j2
+++ b/deployments/ansible/roles/collector/templates/splunk-otel-collector.conf.j2
@@ -17,7 +17,7 @@ SPLUNK_HEC_URL={{ splunk_ingest_url + "/v1/log" }}
 {% else %}
 SPLUNK_HEC_URL={{ "https://ingest." + splunk_realm + ".signalfx.com/v1/log" }}
 {% endif %}
-SPLUNK_HEC_TOKEN={{ splunk_access_token }}
+SPLUNK_HEC_TOKEN={{ splunk_hec_token }}
 SPLUNK_MEMORY_TOTAL_MIB={{ splunk_memory_total_mib }}
 SPLUNK_BALLAST_SIZE_MIB={{ splunk_ballast_size_mib }}
 SPLUNK_LISTEN_INTERFACE={{ splunk_listen_interface }}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This patch is adding the ability to pass splunk_hec_token so that logs can be ingested into Splunk Cloud.
