### PR TITLE
Add tools 1.21 toolchain

### DIFF
--- a/tests/tools/go.mod
+++ b/tests/tools/go.mod
@@ -1,6 +1,8 @@
 module github.com/signalfx/splunk-otel-collector/tests/tools
 
-go 1.20
+go 1.21
+
+toolchain go1.21.0
 
 require github.com/Songmu/gotesplit v0.3.1
 


### PR DESCRIPTION
**Description:**
The new version of `gotesplit` requires 1.21.

Go 1.21 introduces the notion of Go toolchain for binaries installation.

This setting is added automatically by IntelliJ when reviewing the project files.