### PR TITLE
Exclude pulsarexporter from link checker

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - '**.md'
       - '.github/workflows/lychee.yml'
+      - '.lychee.toml'
   pull_request:
     paths:
       - '**.md'
       - '.github/workflows/lychee.yml'
+      - '.lychee.toml'
   schedule:
     - cron: "0 0 * * 1"
 

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -15,4 +15,5 @@ exclude = [
     ".*.cf-app.com",
     "https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.63.1",  # release was deleted
     "ideas.splunk.com",
+    "https://github.com/signalfx/splunk-otel-collector/tree/main/internal/exporter/pulsarexporter",  # exprter was deleted
 ]


### PR DESCRIPTION
Don't fail the lychee job for references in the changelog.