### PR TITLE
localhost on agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛑 Breaking changes 🛑
 
-- (Splunk) Set `SPLUNK_LISTEN_INTERFACE` environment variable value to 127.0.0.1 for agent mode by default, as determined by config path. 0.0.0.0 will be set otherwise, with existing environment values respected. The installers have been updated to only set the environment variable for collector service if configured directly.
+- (Splunk) Set `SPLUNK_LISTEN_INTERFACE` environment variable value to 127.0.0.1 for [agent mode](https://docs.splunk.com/observability/en/gdi/opentelemetry/deployment-modes.html#host-monitoring-agent-mode) by default, as determined by config path. 0.0.0.0 will be set otherwise, with existing environment values respected. The installers have been updated to only set the environment variable for collector service if configured directly.
 
 ## v0.85.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- (Splunk) Set `SPLUNK_LISTEN_INTERFACE` environment variable value to 127.0.0.1 for agent mode by default, as determined by config path. 0.0.0.0 will be set otherwise, with existing environment values respected. The installers have been updated to only set the environment variable for collector service if configured directly.
+
 ## v0.85.0
 
 ***ADVANCED NOTICE - SPLUNK_LISTEN_INTERFACE DEFAULTS***

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ listen to configure the `SPLUNK_DEBUG_CONFIG_SERVER_PORT` environment variable.
 
 You can use the environment variable `SPLUNK_LISTEN_INTERFACE` and associated installer option to configure the network
 interface on which the collector's receivers and telemetry endpoints will listen.
-The default value of `SPLUNK_LISTEN_INTERFACE` is set to `0.0.0.0`.
+The default value of `SPLUNK_LISTEN_INTERFACE` is set to `127.0.0.1` for the default agent configuration and `0.0.0.0` otherwise.
 
 ## Upgrade guidelines
 

--- a/deployments/ansible/CHANGELOG.md
+++ b/deployments/ansible/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### 💡 Enhancements 💡
+
+- Only propagate `splunk_listen_interface` to target SPLUNK_LISTEN_INTERFACE service environment variable if set.
+
 ## ansible-v0.22.0
 
 ### 💡 Enhancements 💡

--- a/deployments/ansible/molecule/custom_vars/converge.yml
+++ b/deployments/ansible/molecule/custom_vars/converge.yml
@@ -13,7 +13,7 @@
     splunk_service_group: custom-group
     splunk_memory_total_mib: 256
     splunk_ballast_size_mib: 100
-    splunk_listen_interface: 127.0.0.1
+    splunk_listen_interface: 1.2.3.4
     splunk_fluentd_config: /etc/otel/collector/fluentd/custom_fluentd.conf
     splunk_fluentd_config_source: ./custom_fluentd_config.conf
     install_fluentd: yes

--- a/deployments/ansible/molecule/custom_vars/verify.yml
+++ b/deployments/ansible/molecule/custom_vars/verify.yml
@@ -95,7 +95,7 @@
 
     - name: Assert SPLUNK_LISTEN_INTERFACE env var is set
       ansible.builtin.lineinfile:
-        line: SPLUNK_LISTEN_INTERFACE=127.0.0.1
+        line: SPLUNK_LISTEN_INTERFACE=1.2.3.4
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes

--- a/deployments/ansible/molecule/custom_vars/windows-converge.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-converge.yml
@@ -14,7 +14,7 @@
     splunk_memory_total_mib: 256
     splunk_ballast_size_mib: 100
     install_fluentd: yes
-    splunk_listen_interface: 127.0.0.1
+    splunk_listen_interface: 1.2.3.4
     splunk_fluentd_config: '{{ansible_env.ProgramFiles}}\Splunk\OpenTelemetry Collector\fluentd\custom_config.conf'
     splunk_fluentd_config_source: ./custom_fluentd_config.conf
     splunk_otel_collector_additional_env_vars:

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -31,7 +31,7 @@ splunk_memory_total_mib: 512
 # 1/3 of memory_mib by default
 splunk_ballast_size_mib: ""
 
-splunk_listen_interface: "0.0.0.0"
+splunk_listen_interface: ""
 install_fluentd: false
 # Whether to start the services installed by the role (splunk-otel-collector and td-agent).
 start_service: true

--- a/deployments/ansible/roles/collector/tasks/otel_win_reg.yml
+++ b/deployments/ansible/roles/collector/tasks/otel_win_reg.yml
@@ -76,6 +76,7 @@
     name: SPLUNK_LISTEN_INTERFACE
     data: "{{splunk_listen_interface}}"
     type: string
+  when: splunk_listen_interface is defined and not (splunk_listen_interface | trim) == ""
 
 - name: Set registry values
   ansible.windows.win_regedit:

--- a/deployments/ansible/roles/collector/templates/splunk-otel-collector.conf.j2
+++ b/deployments/ansible/roles/collector/templates/splunk-otel-collector.conf.j2
@@ -20,7 +20,9 @@ SPLUNK_HEC_URL={{ "https://ingest." + splunk_realm + ".signalfx.com/v1/log" }}
 SPLUNK_HEC_TOKEN={{ splunk_hec_token }}
 SPLUNK_MEMORY_TOTAL_MIB={{ splunk_memory_total_mib }}
 SPLUNK_BALLAST_SIZE_MIB={{ splunk_ballast_size_mib }}
+{% if splunk_listen_interface is defined and splunk_listen_interface %}
 SPLUNK_LISTEN_INTERFACE={{ splunk_listen_interface }}
+{% endif %}
 SPLUNK_BUNDLE_DIR={{ splunk_bundle_dir }}
 SPLUNK_COLLECTD_DIR={{ splunk_collectd_dir }}
 {% if splunk_otel_collector_additional_env_vars is not none %}

--- a/deployments/chef/CHANGELOG.md
+++ b/deployments/chef/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## unreleased
+
+- Update `splunk_listen_interface` default to only set target SPLUNK_LISTEN_INTERFACE environment variable if
+  configure.
+
 ## chef-v0.7.0
 
 - Add support for the `splunk_listen_interface` option to configure the network interface the collector receivers

--- a/deployments/chef/attributes/default.rb
+++ b/deployments/chef/attributes/default.rb
@@ -21,7 +21,7 @@ default['splunk_otel_collector']['splunk_hec_url'] = "#{node['splunk_otel_collec
 default['splunk_otel_collector']['splunk_hec_token'] = "#{node['splunk_otel_collector']['splunk_access_token']}"
 default['splunk_otel_collector']['splunk_memory_total_mib'] = '512'
 default['splunk_otel_collector']['splunk_ballast_size_mib'] = ''
-default['splunk_otel_collector']['splunk_listen_interface'] = '0.0.0.0'
+default['splunk_otel_collector']['splunk_listen_interface'] = ''
 
 default['splunk_otel_collector']['collector_config'] = {}
 

--- a/deployments/chef/kitchen.windows.yml
+++ b/deployments/chef/kitchen.windows.yml
@@ -54,6 +54,7 @@ suites:
         splunk_api_url: https://fake-splunk-api.com
         splunk_memory_total_mib: "256"
         splunk_hec_token: fake-hec-token
+        splunk_listen_interface: "0.0.0.0"
         collector_version: 0.48.0
         collector_additional_env_vars:
           MY_CUSTOM_VAR1: value1

--- a/deployments/chef/kitchen.yml
+++ b/deployments/chef/kitchen.yml
@@ -153,6 +153,7 @@ suites:
         splunk_api_url: https://fake-splunk-api.com
         splunk_memory_total_mib: "256"
         splunk_hec_token: fake-hec-token
+        splunk_listen_interface: "0.0.0.0"
         user: custom-user
         group: custom-group
         collector_additional_env_vars:

--- a/deployments/chef/recipes/collector_win_registry.rb
+++ b/deployments/chef/recipes/collector_win_registry.rb
@@ -12,10 +12,13 @@ registry_values = [
   { name: 'SPLUNK_HEC_TOKEN', type: :string, data: node['splunk_otel_collector']['splunk_hec_token'].to_s },
   { name: 'SPLUNK_MEMORY_TOTAL_MIB', type: :string, data: node['splunk_otel_collector']['splunk_memory_total_mib'].to_s },
   { name: 'SPLUNK_BALLAST_SIZE_MIB', type: :string, data: node['splunk_otel_collector']['splunk_ballast_size_mib'].to_s },
-  { name: 'SPLUNK_LISTEN_INTERFACE', type: :string, data: node['splunk_otel_collector']['splunk_listen_interface'].to_s },
   { name: 'SPLUNK_BUNDLE_DIR', type: :string, data: node['splunk_otel_collector']['splunk_bundle_dir'].to_s },
   { name: 'SPLUNK_COLLECTD_DIR', type: :string, data: node['splunk_otel_collector']['splunk_collectd_dir'].to_s },
 ]
+
+unless node['splunk_otel_collector']['splunk_listen_interface'].to_s.strip.empty?
+  registry_values.push({ name: 'SPLUNK_LISTEN_INTERFACE', type: :string, data: node['splunk_otel_collector']['splunk_listen_interface'].to_s })
+end
 
 node['splunk_otel_collector']['collector_additional_env_vars'].each do |key, value|
   registry_values.push({ name: key, type: :string, data: value.to_s })

--- a/deployments/chef/templates/splunk-otel-collector.conf.erb
+++ b/deployments/chef/templates/splunk-otel-collector.conf.erb
@@ -28,8 +28,10 @@ SPLUNK_HEC_TOKEN=<%= node['splunk_otel_collector']['splunk_hec_token'] %>
 # the value calculated by `SPLUNK_MEMORY_TOTAL_MIB`.
 SPLUNK_MEMORY_TOTAL_MIB=<%= node['splunk_otel_collector']['splunk_memory_total_mib'] %>
 
+<% unless node['splunk_otel_collector']['splunk_listen_interface'].to_s.strip.empty? -%>
 # The network interface the collector receivers will listen on.
 SPLUNK_LISTEN_INTERFACE=<%= node['splunk_otel_collector']['splunk_listen_interface'] %>
+<% end -%>
 
 # How much memory to allocate to the ballast. This should be set to 1/3 to 1/2 of configured memory.
 SPLUNK_BALLAST_SIZE_MIB=<%= node['splunk_otel_collector']['splunk_ballast_size_mib'] %>

--- a/deployments/chef/test/integration/custom_vars/inspec/custom_vars_spec.rb
+++ b/deployments/chef/test/integration/custom_vars/inspec/custom_vars_spec.rb
@@ -6,6 +6,7 @@ splunk_trace_url = "#{splunk_ingest_url}/v2/trace"
 splunk_hec_url = "#{splunk_ingest_url}/v1/log"
 splunk_hec_token = 'fake-hec-token'
 splunk_memory_total = '256'
+splunk_listen_interface = '0.0.0.0'
 
 describe service('splunk-otel-collector') do
   it { should be_enabled }
@@ -25,6 +26,7 @@ if os[:family] == 'windows'
     its('SPLUNK_HEC_TOKEN') { should eq splunk_hec_token }
     its('SPLUNK_HEC_URL') { should eq splunk_hec_url }
     its('SPLUNK_INGEST_URL') { should eq splunk_ingest_url }
+    its('SPLUNK_LISTEN_INTERFACE') { should eq splunk_listen_interface }
     its('SPLUNK_MEMORY_TOTAL_MIB') { should eq splunk_memory_total }
     its('SPLUNK_REALM') { should eq splunk_realm }
     its('SPLUNK_TRACE_URL') { should eq splunk_trace_url }
@@ -48,6 +50,7 @@ else
     its('content') { should match /^SPLUNK_HEC_TOKEN=#{splunk_hec_token}$/ }
     its('content') { should match /^SPLUNK_HEC_URL=#{splunk_hec_url}$/ }
     its('content') { should match /^SPLUNK_INGEST_URL=#{splunk_ingest_url}$/ }
+    its('content') { should match /^SPLUNK_LISTEN_INTERFACE=#{splunk_listen_interface}$/ }
     its('content') { should match /^SPLUNK_MEMORY_TOTAL_MIB=#{splunk_memory_total}$/ }
     its('content') { should match /^SPLUNK_REALM=test$/ }
     its('content') { should match /^SPLUNK_TRACE_URL=#{splunk_trace_url}$/ }

--- a/deployments/chef/test/integration/default/inspec/default_spec.rb
+++ b/deployments/chef/test/integration/default/inspec/default_spec.rb
@@ -28,6 +28,7 @@ if os[:family] == 'windows'
     its('SPLUNK_MEMORY_TOTAL_MIB') { should eq splunk_memory_total }
     its('SPLUNK_REALM') { should eq splunk_realm }
     its('SPLUNK_TRACE_URL') { should eq splunk_trace_url }
+    it { should_not have_property('SPLUNK_LISTEN_INTERFACE') }
   end
   describe service('fluentdwinsvc') do
     it { should_not be_enabled }
@@ -49,6 +50,7 @@ else
     its('content') { should match /^SPLUNK_MEMORY_TOTAL_MIB=#{splunk_memory_total}$/ }
     its('content') { should match /^SPLUNK_REALM=test$/ }
     its('content') { should match /^SPLUNK_TRACE_URL=#{splunk_trace_url}$/ }
+    its('content') { should_not match /^SPLUNK_LISTEN_INTERFACE=.*$/ }
   end
   describe file('/etc/systemd/system/splunk-otel-collector.service.d/service-owner.conf') do
     its('content') { should match /^User=splunk-otel-collector$/ }

--- a/deployments/puppet/CHANGELOG.md
+++ b/deployments/puppet/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add support for `splunk_listen_interface` used by default configurations as `SPLUNK_LISTEN_INTERFACE` environment variable.
+- Update fluentd url for Windows.
+
 ## puppet-v0.10.0
 
 - **Breaking Changes**: Fluentd installation ***disabled*** by default.

--- a/deployments/puppet/manifests/collector_win_registry.pp
+++ b/deployments/puppet/manifests/collector_win_registry.pp
@@ -27,12 +27,14 @@ class splunk_otel_collector::collector_win_registry () {
     require => Registry_key[$registry_key],
   }
 
+  unless $splunk_otel_collector::splunk_listen_interface.strip().empty {
     registry_value { "${registry_key}\\SPLUNK_LISTEN_INTERFACE":
       ensure  => 'present',
       type    => 'string',
       data    => $splunk_otel_collector::splunk_listen_interface,
       require => Registry_key[$registry_key],
     }
+  }
 
   registry_value { "${registry_key}\\SPLUNK_BUNDLE_DIR":
     ensure  => 'present',

--- a/deployments/puppet/manifests/init.pp
+++ b/deployments/puppet/manifests/init.pp
@@ -11,7 +11,7 @@ class splunk_otel_collector (
   $splunk_collectd_dir     = $splunk_otel_collector::params::splunk_collectd_dir,
   $splunk_memory_total_mib = '512',
   $splunk_ballast_size_mib = '',
-  $splunk_listen_interface = '0.0.0.0',
+  $splunk_listen_interface = '',
   $collector_version       = $splunk_otel_collector::params::collector_version,
   $collector_config_source = $splunk_otel_collector::params::collector_config_source,
   $collector_config_dest   = $splunk_otel_collector::params::collector_config_dest,

--- a/deployments/puppet/templates/splunk-otel-collector.conf.erb
+++ b/deployments/puppet/templates/splunk-otel-collector.conf.erb
@@ -8,7 +8,9 @@ SPLUNK_HEC_TOKEN=<%= @splunk_hec_token %>
 SPLUNK_HEC_URL=<%= @splunk_hec_url %>
 SPLUNK_INGEST_URL=<%= @splunk_ingest_url %>
 SPLUNK_MEMORY_TOTAL_MIB=<%= @splunk_memory_total_mib %>
+<% unless @splunk_listen_interface.to_s.strip.empty? -%>
 SPLUNK_LISTEN_INTERFACE=<%= @splunk_listen_interface %>
+<% end -%>
 SPLUNK_REALM=<%= @splunk_realm %>
 SPLUNK_TRACE_URL=<%= @splunk_trace_url %>
 

--- a/deployments/salt/README.md
+++ b/deployments/salt/README.md
@@ -98,7 +98,7 @@ splunk-otel-collector:
   OTel Collector. (**default:** 1/3 of `splunk_memory_total_mib`)
 
 - `splunk_listen_interface`: The network interface the collector receivers will listen
-  on. (**default:** `0.0.0.0`)
+  on. (**default:** `127.0.0.1` for agent config, `0.0.0.0` otherwise)
 
 - `collector_additional_env_vars`: Dictionary of additional environment
   variables from the collector configuration file for the collector service

--- a/deployments/salt/splunk-otel-collector/collector_config.sls
+++ b/deployments/salt/splunk-otel-collector/collector_config.sls
@@ -26,7 +26,7 @@
 
 {% set splunk_ballast_size_mib = salt['pillar.get']('splunk-otel-collector:splunk_ballast_size_mib', '') %}
 
-{% set splunk_listen_interface = salt['pillar.get']('splunk-otel-collector:splunk_listen_interface', '0.0.0.0') %}
+{% set splunk_listen_interface = salt['pillar.get']('splunk-otel-collector:splunk_listen_interface', '') %}
 
 {% set collector_additional_env_vars = salt['pillar.get']('splunk-otel-collector:collector_additional_env_vars', {}) %}
 
@@ -43,7 +43,9 @@
         SPLUNK_HEC_TOKEN={{ splunk_hec_token }}
         SPLUNK_MEMORY_TOTAL_MIB={{ splunk_memory_total_mib }}
         SPLUNK_BALLAST_SIZE_MIB={{ splunk_ballast_size_mib }}
+        {% if splunk_listen_interface -%}
         SPLUNK_LISTEN_INTERFACE={{ splunk_listen_interface }}
+        {% endif -%}
         SPLUNK_BUNDLE_DIR={{ splunk_bundle_dir }}
         SPLUNK_COLLECTD_DIR={{ splunk_collectd_dir }}
 {% for key, value in collector_additional_env_vars.items() %}

--- a/internal/buildscripts/packaging/choco/splunk-otel-collector/splunk-otel-collector.nuspec
+++ b/internal/buildscripts/packaging/choco/splunk-otel-collector/splunk-otel-collector.nuspec
@@ -18,7 +18,7 @@ The following package parameters are available:
  * `/SPLUNK_HEC_URL`: URL of the Splunk HEC endpoint (e.g. `https://ingest.us1.signalfx.com/v1/log`). Default value is `https://ingest.$SPLUNK_REALM.signalfx.com/v1/log`
  * `/SPLUNK_TRACE_URL`: URL of the Splunk trace endpoint (e.g. `https://ingest.us1.signalfx.com/v2/trace`). Default value is `https://ingest.$SPLUNK_REALM.signalfx.com/v2/trace`
  * `/SPLUNK_BUNDLE_DIR`: The path to the Smart Agent bundle directory for the `smartagent` receiver and extension. The default path is provided by the Collector package. If the specified path is changed from the default value, the path should be an existing directory on the system. Default value is `\Program Files\Splunk\OpenTelemetry Collector\agent-bundle`.
- * `/SPLUNK_LISTEN_INTERFACE`: The network interface the collector receivers will listen on. Default value is `0.0.0.0`.
+ * `/SPLUNK_LISTEN_INTERFACE`: The network interface the collector receivers will listen on. Default value is `127.0.0.1` for agent mode and `0.0.0.0` for gateway.
  * `/MODE`: This parameter is used for setting the Collector configuration file to `\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml` or `\ProgramData\Splunk\OpenTelemetry Collector\gateway_config.yaml`. Possible values are `agent` and `gateway`. Default value is `agent`.
  * `/WITH_FLUENTD`: Whether to download, install, and configure Fluentd to collect and forward log events to the Collector. Possible values are `true` and `false`. If set to `true`, the Fluentd MSI package will be downloaded from `https://packages.treasuredata.com`. Default value is `false`.
 

--- a/internal/buildscripts/packaging/choco/splunk-otel-collector/tools/chocolateyinstall.ps1
+++ b/internal/buildscripts/packaging/choco/splunk-otel-collector/tools/chocolateyinstall.ps1
@@ -135,8 +135,6 @@ try {
     }
 }
 catch {
-    $SPLUNK_LISTEN_INTERFACE = "0.0.0.0"
-    write-host "The SPLUNK_LISTEN_INTERFACE parameter is not specified. Using default configuration."
 }
 
 try {
@@ -167,7 +165,9 @@ try {
 
 update_registry -path "$regkey" -name "SPLUNK_API_URL" -value "$SPLUNK_API_URL"
 update_registry -path "$regkey" -name "SPLUNK_BUNDLE_DIR" -value "$SPLUNK_BUNDLE_DIR"
-update_registry -path "$regkey" -name "SPLUNK_LISTEN_INTERFACE" -value "$SPLUNK_LISTEN_INTERFACE"
+if ($SPLUNK_LISTEN_INTERFACE) {
+    update_registry -path "$regkey" -name "SPLUNK_LISTEN_INTERFACE" -value "$SPLUNK_LISTEN_INTERFACE"
+}
 update_registry -path "$regkey" -name "SPLUNK_HEC_TOKEN" -value "$SPLUNK_HEC_TOKEN"
 update_registry -path "$regkey" -name "SPLUNK_HEC_URL" -value "$SPLUNK_HEC_URL"
 update_registry -path "$regkey" -name "SPLUNK_INGEST_URL" -value "$SPLUNK_INGEST_URL"

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -41,7 +41,7 @@
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -mode "gateway"
 .PARAMETER network_interface
-    (OPTIONAL) The network interface the collector receivers listen on. (default: "0.0.0.0")
+    (OPTIONAL) The network interface the collector receivers listen on. (default: "127.0.0.1" for agent mode and "0.0.0.0" otherwise)
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -network_interface "127.0.0.1"
 .PARAMETER ingest_url
@@ -113,7 +113,7 @@ param (
     [string]$realm = "us0",
     [string]$memory = "512",
     [ValidateSet('agent','gateway')][string]$mode = "agent",
-    [string]$network_interface = "0.0.0.0",
+    [string]$network_interface = "",
     [string]$ingest_url = "",
     [string]$api_url = "",
     [string]$trace_url = "",
@@ -582,7 +582,9 @@ update_registry -path "$regkey" -name "SPLUNK_HEC_TOKEN" -value "$hec_token"
 update_registry -path "$regkey" -name "SPLUNK_HEC_URL" -value "$hec_url"
 update_registry -path "$regkey" -name "SPLUNK_INGEST_URL" -value "$ingest_url"
 update_registry -path "$regkey" -name "SPLUNK_MEMORY_TOTAL_MIB" -value "$memory"
-update_registry -path "$regkey" -name "SPLUNK_LISTEN_INTERFACE" -value "$network_interface"
+if ($network_interface -Ne "") {
+  update_registry -path "$regkey" -name "SPLUNK_LISTEN_INTERFACE" -value "$network_interface"
+}
 update_registry -path "$regkey" -name "SPLUNK_REALM" -value "$realm"
 update_registry -path "$regkey" -name "SPLUNK_TRACE_URL" -value "$trace_url"
 
@@ -701,6 +703,6 @@ if ($with_fluentd) {
     echo "- Started"
 }
 
-if ($network_interface -Eq "0.0.0.0") {
-    echo "[NOTICE] Starting with version 0.86.0, the collector installer will change its default network listening interface from 0.0.0.0 to 127.0.0.1. Please consult the release notes for more information and configuration options."
+if (($network_interface -Eq "") -And ($mode -Eq "agent")) {
+    echo "[NOTICE] Starting with version 0.86.0, the collector installer changed its default network listening interface from 0.0.0.0 to 127.0.0.1 for agent mode. Please consult the release notes for more information and configuration options."
 }

--- a/internal/settings/settings_windows_test.go
+++ b/internal/settings/settings_windows_test.go
@@ -1,0 +1,51 @@
+// Copyright  Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// go:build windows
+
+package settings
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetDefaultEnvVarsSetsInterfaceFromConfigOptionWithProgramData(t *testing.T) {
+	pd := os.Getenv("ProgramData")
+	for _, tc := range []struct{ config, expectedIP string }{
+		{filepath.Join(pd, "Splunk", "OpenTelemetry Collector", "agent_config.yaml"), "127.0.0.1"},
+		{fmt.Sprintf("file:%s", filepath.Join(pd, "Splunk", "OpenTelemetry Collector", "agent_config.yaml")), "127.0.0.1"},
+		{"\\some-other-config.yaml", "0.0.0.0"},
+		{"file:\\some-other-config.yaml", "0.0.0.0"},
+	} {
+		tc := tc
+		t.Run(fmt.Sprintf("%v->%v", tc.config, tc.expectedIP), func(t *testing.T) {
+			t.Cleanup(clearEnv(t))
+			os.Setenv("SPLUNK_REALM", "noop")
+			os.Setenv("SPLUNK_ACCESS_TOKEN", "noop")
+			s, err := parseArgs([]string{"--config", tc.config})
+			require.NoError(t, err)
+			require.NoError(t, setDefaultEnvVars(s))
+
+			val, ok := os.LookupEnv("SPLUNK_LISTEN_INTERFACE")
+			assert.True(t, ok)
+			assert.Equal(t, tc.expectedIP, val)
+		})
+	}
+}

--- a/tests/general/default_config_test.go
+++ b/tests/general/default_config_test.go
@@ -242,13 +242,13 @@ func TestDefaultAgentConfig(t *testing.T) {
 			},
 		},
 		"extensions": map[string]any{
-			"health_check": map[string]any{"endpoint": "0.0.0.0:13133"},
+			"health_check": map[string]any{"endpoint": "127.0.0.1:13133"},
 			"http_forwarder": map[string]any{
 				"egress": map[string]any{
 					"endpoint": "https://api.not.real.signalfx.com",
 				},
 				"ingress": map[string]any{
-					"endpoint": "0.0.0.0:6060",
+					"endpoint": "127.0.0.1:6060",
 				},
 			},
 			"memory_ballast": map[string]any{"size_mib": "168"},
@@ -285,14 +285,14 @@ func TestDefaultAgentConfig(t *testing.T) {
 			},
 			"jaeger": map[string]any{
 				"protocols": map[string]any{
-					"grpc":           map[string]any{"endpoint": "0.0.0.0:14250"},
-					"thrift_binary":  map[string]any{"endpoint": "0.0.0.0:6832"},
-					"thrift_compact": map[string]any{"endpoint": "0.0.0.0:6831"},
-					"thrift_http":    map[string]any{"endpoint": "0.0.0.0:14268"}}},
+					"grpc":           map[string]any{"endpoint": "127.0.0.1:14250"},
+					"thrift_binary":  map[string]any{"endpoint": "127.0.0.1:6832"},
+					"thrift_compact": map[string]any{"endpoint": "127.0.0.1:6831"},
+					"thrift_http":    map[string]any{"endpoint": "127.0.0.1:14268"}}},
 			"otlp": map[string]any{
 				"protocols": map[string]any{
-					"grpc": map[string]any{"endpoint": "0.0.0.0:4317"},
-					"http": map[string]any{"endpoint": "0.0.0.0:4318"},
+					"grpc": map[string]any{"endpoint": "127.0.0.1:4317"},
+					"http": map[string]any{"endpoint": "127.0.0.1:4318"},
 				},
 			},
 			"prometheus/internal": map[string]any{
@@ -310,23 +310,23 @@ func TestDefaultAgentConfig(t *testing.T) {
 							"scrape_interval": "10s",
 							"static_configs": []any{
 								map[string]any{
-									"targets": []any{"0.0.0.0:8888"},
+									"targets": []any{"127.0.0.1:8888"},
 								},
 							},
 						},
 					},
 				},
 			},
-			"signalfx":               map[string]any{"endpoint": "0.0.0.0:9943"},
+			"signalfx":               map[string]any{"endpoint": "127.0.0.1:9943"},
 			"smartagent/processlist": map[string]any{"type": "processlist"},
 			"smartagent/signalfx-forwarder": map[string]any{
-				"listenAddress": "0.0.0.0:9080",
+				"listenAddress": "127.0.0.1:9080",
 				"type":          "signalfx-forwarder",
 			},
 			"zipkin": map[string]any{
-				"endpoint": "0.0.0.0:9411"}},
+				"endpoint": "127.0.0.1:9411"}},
 		"service": map[string]any{
-			"telemetry":  map[string]any{"metrics": map[string]any{"address": "0.0.0.0:8888"}},
+			"telemetry":  map[string]any{"metrics": map[string]any{"address": "127.0.0.1:8888"}},
 			"extensions": []any{"health_check", "http_forwarder", "zpages", "memory_ballast", "smartagent"},
 			"pipelines": map[string]any{
 				"logs": map[string]any{

--- a/tests/zeroconfig/windows/testdata/Dockerfile.iis.server
+++ b/tests/zeroconfig/windows/testdata/Dockerfile.iis.server
@@ -24,7 +24,7 @@ ENV ACCESS_TOKEN_TMP=$access_token
 RUN `
     $token = $Env:ACCESS_TOKEN_TMP; `
     $collector_msi_path = (dir "c:\setup\splunk-otel-collector-*.msi").FullName; `
-    c:\setup\install.ps1 -access_token $token -msi_path $collector_msi_path -with_dotnet_instrumentation $true -deployment_env zc-iis-test -ingest_url "http://splunk-otel-collector:9943" -trace_url "http://splunk-otel-collector:7276/v2/trace"
+    c:\setup\install.ps1 -access_token $token -msi_path $collector_msi_path -with_dotnet_instrumentation $true -deployment_env zc-iis-test -ingest_url "http://splunk-otel-collector:9943" -trace_url "http://splunk-otel-collector:7276/v2/trace" -network_interface "0.0.0.0"
 ENV ACCESS_TOKEN_TMP=
 
 COPY apps/bin/aspnetfxapp/_PublishedWebsites/AspNet.WebApi.NetFramework/ /apps/aspnetfx

--- a/tests/zeroconfig/windows/testdata/Dockerfile.pipeline.collector
+++ b/tests/zeroconfig/windows/testdata/Dockerfile.pipeline.collector
@@ -18,7 +18,7 @@ ENV ACCESS_TOKEN_TMP=$access_token
 RUN `
     $token = $Env:ACCESS_TOKEN_TMP; `
     $collector_msi_path = (dir "c:\setup\splunk-otel-collector-*.msi").FullName; `
-    c:\setup\install.ps1 -access_token $token -msi_path $collector_msi_path -with_fluentd $false -ingest_url "http://192.0.2.1:12345" -trace_url "http://192.0.2.1:12345"
+    c:\setup\install.ps1 -access_token $token -msi_path $collector_msi_path -with_fluentd $false -ingest_url "http://192.0.2.1:12345" -trace_url "http://192.0.2.1:12345" -network_interface "0.0.0.0"
 ENV ACCESS_TOKEN_TMP=
 RUN `
     Set-ItemProperty -force -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -name 'SPLUNK_CONFIG' -value 'C:\setup\pipeline-collector.yaml'


### PR DESCRIPTION
**Description:**
These changes update the `SPLUNK_LISTEN_INTERFACE` environment variable to be 127.0.0.1 for the default agent config locations where it was otherwise 0.0.0.0 in all cases. They also update the installers to only forward the env var to the target service if configured by the user.

supersedes https://github.com/signalfx/splunk-otel-collector/pull/3639

**Testing:**
Updated unit and integration tests.

**Documentation:**
Updated readmes
