### PR TITLE
otlp_config_linux.yaml - add otlphttp for metrics

### DIFF
--- a/cmd/otelcol/config/collector/otlp_config_linux.yaml
+++ b/cmd/otelcol/config/collector/otlp_config_linux.yaml
@@ -76,6 +76,7 @@ processors:
 exporters:
   # Traces
   otlphttp:
+    metrics_endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com/v2/datapoint/otlp"
     traces_endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com/v2/trace/otlp"
     compression: gzip
     headers:
@@ -117,7 +118,7 @@ service:
     metrics:
       receivers: [otlp, signalfx, smartagent/signalfx-forwarder]
       processors: [memory_limiter, batch]
-      exporters: [signalfx]
+      exporters: [otlphttp, signalfx]
     metrics/internal:
       receivers: [prometheus/internal]
       processors: [memory_limiter, batch, resourcedetection/internal]


### PR DESCRIPTION
**Description:** Add example how to send metrics over otlphttp

**Link to Splunk idea:** Based on created example for https://github.com/signalfx/tracing-examples/pull/169

**Testing:** Tested in https://github.com/signalfx/tracing-examples/pull/169

**Documentation:** N/A?
