### PR TITLE
Update 2 link to Ansible-Galaxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ This distribution is supported on and packaged for a variety of platforms includ
 - Linux
   - [Installer script](./docs/getting-started/linux-installer.md) (recommended for single-host demo/test environments)
   - Configuration management (recommended for multi-host production environments)
-    - [Ansible](https://galaxy.ansible.com/signalfx/splunk_otel_collector)
+    - [Ansible](https://galaxy.ansible.com/ui/repo/published/signalfx/splunk_otel_collector/)
     - [Chef](https://supermarket.chef.io/cookbooks/splunk_otel_collector)
     - [Puppet](https://forge.puppet.com/modules/signalfx/splunk_otel_collector)
     - [Salt](https://github.com/signalfx/splunk-otel-collector/tree/main/deployments/salt)
@@ -127,7 +127,7 @@ This distribution is supported on and packaged for a variety of platforms includ
 - Windows
   - [Installer script](./docs/getting-started/windows-installer.md) (recommended for single-host demo/test environments)
   - Configuration management (recommended for multi-host production environments)
-    - [Ansible](https://galaxy.ansible.com/signalfx/splunk_otel_collector)
+    - [Ansible](https://galaxy.ansible.com/ui/repo/published/signalfx/splunk_otel_collector/)
     - [Chef](https://supermarket.chef.io/cookbooks/splunk_otel_collector)
     - [Puppet](https://forge.puppet.com/modules/signalfx/splunk_otel_collector)
   - [Manual](./docs/getting-started/windows-manual.md) including MSI with GUI and Powershell, Chocolatey, and Docker


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Fixing 2 links which points to a broken Ansible-Galaxy page.

before:
![image](https://github.com/signalfx/splunk-otel-collector/assets/22026079/5c681af4-1275-4819-a06d-0b8aa3d3c755)

after:
![image](https://github.com/signalfx/splunk-otel-collector/assets/22026079/19514ec7-f43e-4dfa-a0a9-7b7fb83f51fd)


**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>
nothing

**Testing:** <Describe what testing was performed and which tests were added.>
see Pictures

**Documentation:** <Describe the documentation added.>
Nothing