### PR TITLE
remove initialize methods on Config and WriterConfig, as well as its dependent methods

### DIFF
--- a/internal/signalfx-agent/pkg/core/config/config.go
+++ b/internal/signalfx-agent/pkg/core/config/config.go
@@ -18,7 +18,6 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
 	"github.com/signalfx/signalfx-agent/pkg/core/config/sources"
 	"github.com/signalfx/signalfx-agent/pkg/core/config/validation"
-	"github.com/signalfx/signalfx-agent/pkg/utils"
 	"github.com/signalfx/signalfx-agent/pkg/utils/hostfs"
 	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 )
@@ -167,42 +166,6 @@ type Config struct {
 	SysPath string `yaml:"sysPath" default:"/sys"`
 }
 
-func (c *Config) initialize() (*Config, error) {
-	if c.SignalFxRealm != "" {
-		if c.IngestURL == "" {
-			c.IngestURL = fmt.Sprintf("https://ingest.%s.signalfx.com", c.SignalFxRealm)
-		}
-		if c.APIURL == "" {
-			c.APIURL = fmt.Sprintf("https://api.%s.signalfx.com", c.SignalFxRealm)
-		}
-	}
-
-	if c.BundleDir == "" {
-		c.BundleDir = os.Getenv(constants.BundleDirEnvVar)
-	}
-	if c.BundleDir == "" {
-		exePath, err := os.Executable()
-		if err != nil {
-			panic("Cannot determine agent executable path, cannot continue")
-		}
-		c.BundleDir, err = filepath.Abs(filepath.Join(filepath.Dir(exePath), ".."))
-		if err != nil {
-			panic("Cannot determine absolute path of executable parent dir " + exePath)
-		}
-	}
-
-	c.propagateValuesDown()
-
-	if err := c.validate(); err != nil {
-		return nil, fmt.Errorf("configuration is invalid: %v", err)
-	}
-
-	c.Writer.initialize()
-	c.setupEnvironment()
-
-	return c, nil
-}
-
 // Setup envvars that will be used by collectd to use the bundled dependencies
 // instead of looking to the normal system paths.
 func (c *Config) setupEnvironment() {
@@ -258,39 +221,6 @@ func (c *Config) validate() error {
 	}
 
 	return c.Writer.Validate()
-}
-
-// Send values from the top of the config down to nested configs that might
-// need them
-func (c *Config) propagateValuesDown() {
-	for i := range c.Monitors {
-		if c.Monitors[i].ValidateDiscoveryRule == nil {
-			c.Monitors[i].ValidateDiscoveryRule = c.ValidateDiscoveryRules
-		}
-		if c.Monitors[i].ProcPath == "" {
-			c.Monitors[i].ProcPath = c.ProcPath
-		}
-	}
-
-	anyCollectdMonitors := false
-	for i := range c.Monitors {
-		anyCollectdMonitors = anyCollectdMonitors || c.Monitors[i].IsCollectdBased()
-	}
-
-	c.Collectd.DisableCollectd = c.Collectd.DisableCollectd || !anyCollectdMonitors
-	c.Collectd.IntervalSeconds = utils.FirstNonZero(c.Collectd.IntervalSeconds, c.IntervalSeconds)
-	c.Collectd.BundleDir = c.BundleDir
-
-	c.Writer.MetricsToInclude = c.MetricsToInclude
-	c.Writer.MetricsToExclude = c.MetricsToExclude
-	c.Writer.PropertiesToExclude = c.PropertiesToExclude
-	c.Writer.IngestURL = c.IngestURL
-	c.Writer.APIURL = c.APIURL
-	c.Writer.EventEndpointURL = c.EventEndpointURL
-	c.Writer.TraceEndpointURL = c.TraceEndpointURL
-	c.Writer.SignalFxAccessToken = c.SignalFxAccessToken
-	c.Writer.GlobalDimensions = c.GlobalDimensions
-	c.Writer.GlobalSpanTags = c.GlobalSpanTags
 }
 
 // CustomConfigurable should be implemented by config structs that have the

--- a/internal/signalfx-agent/pkg/core/config/config_test.go
+++ b/internal/signalfx-agent/pkg/core/config/config_test.go
@@ -8,22 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfigPropagation(t *testing.T) {
-	t.Run("ProcPath is passed down if not present", func(t *testing.T) {
-		c := &Config{
-			ProcPath: "/hostfs/proc",
-			Monitors: []MonitorConfig{
-				{},
-				{ProcPath: "/proc"},
-			},
-		}
-		c.propagateValuesDown()
-
-		require.Equal(t, c.Monitors[0].ProcPath, "/hostfs/proc")
-		require.Equal(t, c.Monitors[1].ProcPath, "/proc")
-	})
-}
-
 func TestWriterOutputValidation(t *testing.T) {
 	t.Run("one of SignalFx or Splunk output is required", func(t *testing.T) {
 		c := &Config{

--- a/internal/signalfx-agent/pkg/core/config/writer.go
+++ b/internal/signalfx-agent/pkg/core/config/writer.go
@@ -143,26 +143,6 @@ type WriterConfig struct {
 	PropertiesToExclude []PropertyFilterConfig `yaml:"-"`
 }
 
-func (wc *WriterConfig) initialize() {
-	if wc.DatapointMaxRequests != 0 {
-		wc.MaxRequests = wc.DatapointMaxRequests
-	} else {
-		wc.DatapointMaxRequests = wc.MaxRequests
-	}
-
-	if wc.Splunk != nil {
-		if wc.Splunk.MaxBuffered == 0 {
-			wc.Splunk.MaxBuffered = wc.MaxDatapointsBuffered
-		}
-		if wc.Splunk.MaxRequests == 0 {
-			wc.Splunk.MaxRequests = wc.MaxRequests
-		}
-		if wc.Splunk.MaxBatchSize == 0 {
-			wc.Splunk.MaxBatchSize = wc.DatapointMaxBatchSize
-		}
-	}
-}
-
 func (wc *WriterConfig) IsSplunkOutputEnabled() bool {
 	return wc.Splunk != nil && wc.Splunk.Enabled
 }

--- a/internal/signalfx-agent/pkg/utils/strings.go
+++ b/internal/signalfx-agent/pkg/utils/strings.go
@@ -20,32 +20,6 @@ func FirstNonEmpty(s ...string) string {
 	return ""
 }
 
-// FirstNonZero returns the first int in `ns` that is not zero.
-func FirstNonZero(ns ...int) int {
-	for _, n := range ns {
-		if n != 0 {
-			return n
-		}
-	}
-	return 0
-}
-
-// IndentLines indents all lines in `ss` by `spaces` number of spaces
-func IndentLines(ss string, spaces int) string {
-	var output string
-	for i := range ss {
-		switch {
-		case i == 0:
-			output += strings.Repeat(" ", spaces) + string(ss[i])
-		case ss[i] == '\n' && i != len(ss)-1:
-			output += "\n" + strings.Repeat(" ", spaces)
-		default:
-			output += string(ss[i])
-		}
-	}
-	return output
-}
-
 // LowercaseFirstChar make the first character of a string lowercase
 func LowercaseFirstChar(s string) string {
 	for i, v := range s {


### PR DESCRIPTION
The `initialize` methods are not called, removing them as well as dependent methods.
