### PR TITLE
Add CLA action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,30 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  ContributorLicenseAgreement:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: cla-assistant/github-action@v2.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PAT_CLATOOL }}
+        with:
+          remote-organization-name: splunk
+          remote-repository-name: cla-agreement
+          branch: main
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://github.com/splunk/cla-agreement/blob/main/CLA.md
+          allowlist: dependabot[bot],renovate[bot]


### PR DESCRIPTION
Adds a CLA action to run for any new PR to make sure we identify and request CLA signature ahead of contributions from others. This rollout is a general rollout across splunk and signalfx repositories.