### PR TITLE
pass BundleDir as part of config, not as env var

### DIFF
--- a/internal/signalfx-agent/pkg/core/config/config.go
+++ b/internal/signalfx-agent/pkg/core/config/config.go
@@ -390,8 +390,7 @@ var (
 // BundlePythonHomeEnvvar returns an envvar string that sets the PYTHONHOME envvar to
 // the bundled Python runtime.  It is in a form that is ready to append to
 // cmd.Env.
-func BundlePythonHomeEnvvar() string {
-	bundleDir := os.Getenv(constants.BundleDirEnvVar)
+func BundlePythonHomeEnvvar(bundleDir string) string {
 	if runtime.GOOS == "windows" {
 		return "PYTHONHOME=" + filepath.Join(bundleDir, "python")
 	}

--- a/internal/signalfx-agent/pkg/core/config/monitor.go
+++ b/internal/signalfx-agent/pkg/core/config/monitor.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"regexp"
 	"strings"
@@ -11,7 +10,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
 	"github.com/signalfx/signalfx-agent/pkg/core/dpfilters"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 )
@@ -144,6 +142,7 @@ type MonitorConfig struct {
 	// so that diagnostics can output it.
 	ValidationError string          `yaml:"-" json:"-" hash:"ignore"`
 	MonitorID       types.MonitorID `yaml:"-" hash:"ignore"`
+	BundleDir       string          `yaml:"-" json:"-"`
 }
 
 var _ CustomConfigurable = &MonitorConfig{}
@@ -235,11 +234,6 @@ func (mc *MonitorConfig) Hash() uint64 {
 		return 0
 	}
 	return hash
-}
-
-// BundleDir returns the path to the agent's bundle directory.
-func (mc *MonitorConfig) BundleDir() string {
-	return os.Getenv(constants.BundleDirEnvVar)
 }
 
 // IsCollectdBased returns whether this montior type depends on the

--- a/internal/signalfx-agent/pkg/monitors/collectd/collectd.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/collectd.go
@@ -491,7 +491,7 @@ func (cm *Manager) makeChildCommand() (*exec.Cmd, io.ReadCloser) {
 	cmd.Stdout = w
 	cmd.Stderr = w
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, config.BundlePythonHomeEnvvar())
+	cmd.Env = append(cmd.Env, config.BundlePythonHomeEnvvar(cm.conf.BundleDir))
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		// This is Linux-specific and will cause collectd to be killed by the OS if

--- a/internal/signalfx-agent/pkg/monitors/collectd/consul/consul.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/consul/consul.go
@@ -74,8 +74,8 @@ func (m *Monitor) Configure(conf *Config) error {
 		Host:          conf.Host,
 		Port:          conf.Port,
 		ModuleName:    "consul_plugin",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("consul")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "consul")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"ApiHost":           conf.Host,
 			"ApiPort":           conf.Port,

--- a/internal/signalfx-agent/pkg/monitors/collectd/couchbase/couchbase.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/couchbase/couchbase.go
@@ -82,8 +82,8 @@ func (m *Monitor) Configure(conf *Config) error {
 		Host:          conf.Host,
 		Port:          conf.Port,
 		ModuleName:    "couchbase",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("couchbase")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "couchbase")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"Host":          conf.Host,
 			"Port":          conf.Port,

--- a/internal/signalfx-agent/pkg/monitors/collectd/elasticsearch/elasticsearch.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/elasticsearch/elasticsearch.go
@@ -80,8 +80,8 @@ func (m *Monitor) Configure(conf *Config) error {
 		Host:          conf.Host,
 		Port:          conf.Port,
 		ModuleName:    "elasticsearch_collectd",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("elasticsearch")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "elasticsearch")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"Host":                 conf.Host,
 			"Port":                 conf.Port,

--- a/internal/signalfx-agent/pkg/monitors/collectd/etcd/etcd.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/etcd/etcd.go
@@ -62,8 +62,8 @@ func (m *Monitor) Configure(conf *Config) error {
 		Host:          conf.Host,
 		Port:          conf.Port,
 		ModuleName:    "etcd_plugin",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("etcd")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "etcd")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"Host":     conf.Host,
 			"Port":     conf.Port,

--- a/internal/signalfx-agent/pkg/monitors/collectd/hadoop/hadoop.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/hadoop/hadoop.go
@@ -53,8 +53,8 @@ func (m *Monitor) Configure(conf *Config) error {
 		Host:          conf.Host,
 		Port:          conf.Port,
 		ModuleName:    "hadoop_plugin",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("hadoop")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "hadoop")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"ResourceManagerURL":  fmt.Sprintf("http://%s", conf.Host),
 			"ResourceManagerPort": conf.Port,

--- a/internal/signalfx-agent/pkg/monitors/collectd/healthchecker/healthchecker.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/healthchecker/healthchecker.go
@@ -80,8 +80,8 @@ func (m *Monitor) Configure(conf *Config) error {
 		Host:          conf.Host,
 		Port:          conf.Port,
 		ModuleName:    "health_checker",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("health_checker")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "health_checker")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"Instance": conf.Name,
 			"JSONKey":  conf.JSONKey,

--- a/internal/signalfx-agent/pkg/monitors/collectd/jenkins/jenkins.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/jenkins/jenkins.go
@@ -75,8 +75,8 @@ func (m *Monitor) Configure(conf *Config) error {
 		Host:          conf.Host,
 		Port:          conf.Port,
 		ModuleName:    "jenkins",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("jenkins")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "jenkins")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"Host":                conf.Host,
 			"Port":                conf.Port,

--- a/internal/signalfx-agent/pkg/monitors/collectd/kong/kong.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/kong/kong.go
@@ -202,8 +202,8 @@ func (m *Monitor) Configure(c *Config) error {
 		Host:          conf.Host,
 		Port:          conf.Port,
 		ModuleName:    "kong_plugin",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("kong")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "kong")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"URL":                    conf.URL,
 			"Interval":               conf.IntervalSeconds,

--- a/internal/signalfx-agent/pkg/monitors/collectd/marathon/marathon.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/marathon/marathon.go
@@ -69,8 +69,8 @@ func (m *Monitor) Configure(conf *Config) error {
 		Host:          conf.Host,
 		Port:          conf.Port,
 		ModuleName:    "marathon",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("marathon")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "marathon")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"verbose": false,
 		},

--- a/internal/signalfx-agent/pkg/monitors/collectd/mongodb/mongodb.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/mongodb/mongodb.go
@@ -112,8 +112,8 @@ func (m *Monitor) Configure(conf *Config) error {
 		Host:          conf.Host,
 		Port:          conf.Port,
 		ModuleName:    "mongodb",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("mongodb")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "mongodb")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"Host":                     conf.Host,
 			"Port":                     conf.Port,

--- a/internal/signalfx-agent/pkg/monitors/collectd/openstack/openstack.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/openstack/openstack.go
@@ -79,8 +79,8 @@ func (m *Monitor) Configure(conf *Config) error {
 	}
 	conf.pyConf = &python.Config{
 		ModuleName:    "openstack_metrics",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("openstack")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "openstack")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.MonitorConfig.BundleDir)},
 		MonitorConfig: conf.MonitorConfig,
 		PluginConfig: map[string]interface{}{
 			"AuthURL":                   conf.AuthURL,

--- a/internal/signalfx-agent/pkg/monitors/collectd/python/python.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/python/python.go
@@ -96,7 +96,7 @@ func (m *PyMonitor) Configure(conf PyConfig) error {
 	// get the python config from the supplied config
 	pyconf := conf.PythonConfig()
 	if len(pyconf.TypesDBPaths) == 0 {
-		pyconf.TypesDBPaths = append(pyconf.TypesDBPaths, collectd.DefaultTypesDBPath())
+		pyconf.TypesDBPaths = append(pyconf.TypesDBPaths, collectd.DefaultTypesDBPath(conf.MonitorConfigCore().BundleDir))
 	}
 
 	for k := range pyconf.PluginConfig {
@@ -132,7 +132,7 @@ func (m *PyMonitor) Configure(conf PyConfig) error {
 		}
 	}
 
-	runtimeConf := subproc.DefaultPythonRuntimeConfig("sfxcollectd")
+	runtimeConf := subproc.DefaultPythonRuntimeConfig(conf.MonitorConfigCore().BundleDir, "sfxcollectd")
 	pyBin := conf.PythonConfig().PythonBinary
 	if pyBin != "" {
 		args := strings.Fields(pyBin)

--- a/internal/signalfx-agent/pkg/monitors/collectd/rabbitmq/rabbitmq.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/rabbitmq/rabbitmq.go
@@ -103,8 +103,8 @@ func (m *Monitor) Configure(conf *Config) error {
 		Host:          conf.Host,
 		Port:          conf.Port,
 		ModuleName:    "rabbitmq",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("rabbitmq")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "rabbitmq")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"Host":               conf.Host,
 			"Port":               conf.Port,

--- a/internal/signalfx-agent/pkg/monitors/collectd/redis/redis.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/redis/redis.go
@@ -90,8 +90,8 @@ func (rm *Monitor) Configure(conf *Config) error {
 		Host:          conf.Host,
 		Port:          conf.Port,
 		ModuleName:    "redis_info",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("redis")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "redis")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"Host":     conf.Host,
 			"Port":     conf.Port,

--- a/internal/signalfx-agent/pkg/monitors/collectd/solr/solr.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/solr/solr.go
@@ -62,8 +62,8 @@ func (m *Monitor) Configure(conf *Config) error {
 		Host:          conf.Host,
 		Port:          conf.Port,
 		ModuleName:    "solr_collectd",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("solr")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "solr")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"Host":            conf.Host,
 			"Port":            conf.Port,

--- a/internal/signalfx-agent/pkg/monitors/collectd/spark/spark.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/spark/spark.go
@@ -91,8 +91,8 @@ func (m *Monitor) Configure(conf *Config) error {
 		Host:          conf.Host,
 		Port:          conf.Port,
 		ModuleName:    "spark_plugin",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("spark")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "spark")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"Host":    conf.Host,
 			"Port":    conf.Port,

--- a/internal/signalfx-agent/pkg/monitors/collectd/systemd/systemd.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/systemd/systemd.go
@@ -85,8 +85,8 @@ func (m *Monitor) Configure(conf *Config) error {
 	conf.pyConf = &python.Config{
 		MonitorConfig: conf.MonitorConfig,
 		ModuleName:    "collectd_systemd",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("systemd")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "systemd")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		PluginConfig: map[string]interface{}{
 			"Service":       services,
 			"Interval":      conf.IntervalSeconds,

--- a/internal/signalfx-agent/pkg/monitors/collectd/util.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/util.go
@@ -1,22 +1,18 @@
 package collectd
 
 import (
-	"os"
 	"path/filepath"
-
-	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
 )
 
 // MakePythonPluginPath takes file path components below the BundleDir for
-// Python plugins and returns an os appropriate file path.  The environment
-// variable SIGNALFX_BUNDLE_DIR is used as the root of the path
-func MakePythonPluginPath(components ...string) string {
-	components = append([]string{os.Getenv(constants.BundleDirEnvVar), "collectd-python"}, components...)
+// Python plugins and returns an os appropriate file path.
+func MakePythonPluginPath(bundleDir string, components ...string) string {
+	components = append([]string{bundleDir, "collectd-python"}, components...)
 	return filepath.Join(components...)
 }
 
 // DefaultTypesDBPath returns the default types.db path based on the bundle dir
 // envvar.
-func DefaultTypesDBPath() string {
-	return filepath.Join(os.Getenv(constants.BundleDirEnvVar), "types.db")
+func DefaultTypesDBPath(bundleDir string) string {
+	return filepath.Join(bundleDir, "types.db")
 }

--- a/internal/signalfx-agent/pkg/monitors/collectd/zookeeper/zookeeper.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/zookeeper/zookeeper.go
@@ -50,8 +50,8 @@ func (rm *Monitor) Configure(conf *Config) error {
 	conf.pyConf = &python.Config{
 		MonitorConfig: conf.MonitorConfig,
 		ModuleName:    "zk-collectd",
-		ModulePaths:   []string{collectd.MakePythonPluginPath("zookeeper")},
-		TypesDBPaths:  []string{collectd.DefaultTypesDBPath()},
+		ModulePaths:   []string{collectd.MakePythonPluginPath(conf.BundleDir, "zookeeper")},
+		TypesDBPaths:  []string{collectd.DefaultTypesDBPath(conf.BundleDir)},
 		Host:          conf.Host,
 		Port:          conf.Port,
 		PluginConfig: map[string]interface{}{

--- a/internal/signalfx-agent/pkg/monitors/jmx/jmx.go
+++ b/internal/signalfx-agent/pkg/monitors/jmx/jmx.go
@@ -70,7 +70,7 @@ func (m *Monitor) Configure(conf *Config) error {
 		MonitorConfig: conf.MonitorConfig,
 		Host:          conf.Host,
 		Port:          conf.Port,
-		JarFilePath:   filepath.Join(conf.BundleDir(), "lib/jmx-monitor.jar"),
+		JarFilePath:   filepath.Join(conf.BundleDir, "lib/jmx-monitor.jar"),
 		CustomConfig: map[string]interface{}{
 			"serviceURL":         serviceURL,
 			"groovyScript":       conf.GroovyScript,

--- a/internal/signalfx-agent/pkg/monitors/subproc/darwin.go
+++ b/internal/signalfx-agent/pkg/monitors/subproc/darwin.go
@@ -4,11 +4,8 @@
 package subproc
 
 import (
-	"os"
 	"path/filepath"
 	"syscall"
-
-	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
 )
 
 // The Darwin specific process attribute that make the Python runner be in the
@@ -17,8 +14,8 @@ func procAttrs() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{}
 }
 
-func defaultPythonBinaryExecutable() string {
-	return filepath.Join(os.Getenv(constants.BundleDirEnvVar), "bin/python")
+func defaultPythonBinaryExecutable(bundleDir string) string {
+	return filepath.Join(bundleDir, "bin/python")
 }
 
 func defaultPythonBinaryArgs(pkgName string) []string {

--- a/internal/signalfx-agent/pkg/monitors/subproc/linux.go
+++ b/internal/signalfx-agent/pkg/monitors/subproc/linux.go
@@ -4,11 +4,8 @@
 package subproc
 
 import (
-	"os"
 	"path/filepath"
 	"syscall"
-
-	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
 )
 
 // The Linux specific process attribute that make the Python runner be in the
@@ -21,8 +18,8 @@ func procAttrs() *syscall.SysProcAttr {
 	}
 }
 
-func defaultPythonBinaryExecutable() string {
-	return filepath.Join(os.Getenv(constants.BundleDirEnvVar), "bin", "python")
+func defaultPythonBinaryExecutable(bundleDir string) string {
+	return filepath.Join(bundleDir, "bin", "python")
 }
 
 func defaultPythonBinaryArgs(pkgName string) []string {

--- a/internal/signalfx-agent/pkg/monitors/subproc/python.go
+++ b/internal/signalfx-agent/pkg/monitors/subproc/python.go
@@ -8,13 +8,13 @@ import (
 
 // DefaultPythonRuntimeConfig returns the runtime config that uses the bundled Python
 // runtime.
-func DefaultPythonRuntimeConfig(pkgName string) *RuntimeConfig {
+func DefaultPythonRuntimeConfig(bundleDir string, pkgName string) *RuntimeConfig {
 	// The PYTHONHOME envvar is set in agent core when config is processed.
 	env := os.Environ()
-	env = append(env, config.BundlePythonHomeEnvvar())
+	env = append(env, config.BundlePythonHomeEnvvar(bundleDir))
 
 	return &RuntimeConfig{
-		Binary: defaultPythonBinaryExecutable(),
+		Binary: defaultPythonBinaryExecutable(bundleDir),
 		Args:   defaultPythonBinaryArgs(pkgName),
 		Env:    env,
 	}

--- a/internal/signalfx-agent/pkg/monitors/subproc/signalfx/python/signalfx.go
+++ b/internal/signalfx-agent/pkg/monitors/subproc/signalfx/python/signalfx.go
@@ -87,7 +87,7 @@ type PyMonitor struct {
 
 // Configure starts the subprocess and configures the plugin
 func (m *PyMonitor) Configure(conf *Config) error {
-	runtimeConf := subproc.DefaultPythonRuntimeConfig("sfxmonitor")
+	runtimeConf := subproc.DefaultPythonRuntimeConfig(conf.BundleDir, "sfxmonitor")
 	if conf.PythonBinary != "" {
 		runtimeConf.Binary = conf.PythonBinary
 		runtimeConf.Env = os.Environ()

--- a/internal/signalfx-agent/pkg/monitors/subproc/windows.go
+++ b/internal/signalfx-agent/pkg/monitors/subproc/windows.go
@@ -4,11 +4,8 @@
 package subproc
 
 import (
-	"os"
 	"path/filepath"
 	"syscall"
-
-	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
 )
 
 // The Windows specific process attributes
@@ -18,8 +15,8 @@ func procAttrs() *syscall.SysProcAttr {
 	}
 }
 
-func defaultPythonBinaryExecutable() string {
-	return filepath.Join(os.Getenv(constants.BundleDirEnvVar), "python", "python.exe")
+func defaultPythonBinaryExecutable(bundleDir string) string {
+	return filepath.Join(bundleDir, "python", "python.exe")
 }
 
 func defaultPythonBinaryArgs(pkgName string) []string {

--- a/pkg/receiver/smartagentreceiver/receiver.go
+++ b/pkg/receiver/smartagentreceiver/receiver.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 
 	"github.com/shirou/gopsutil/v3/common"
-	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
 	saconfig "github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/collectd"
@@ -131,6 +130,7 @@ func (r *receiver) Start(_ context.Context, host component.Host) error {
 	}
 
 	configCore.ProcPath = saConfig.ProcPath
+	configCore.BundleDir = saConfig.BundleDir
 
 	return saconfig.CallConfigure(r.monitor, r.config.monitorConfig)
 }
@@ -253,7 +253,6 @@ func (r *receiver) setUpSmartAgentConfigProvider(extensions map[component.ID]ote
 }
 
 func setUpEnvironment() {
-	os.Setenv(constants.BundleDirEnvVar, saConfig.BundleDir)
 	if runtime.GOOS != "windows" { // Agent bundle doesn't include jre for Windows
 		os.Setenv("JAVA_HOME", filepath.Join(saConfig.BundleDir, "jre"))
 	}

--- a/pkg/receiver/smartagentreceiver/receiver_test.go
+++ b/pkg/receiver/smartagentreceiver/receiver_test.go
@@ -342,9 +342,6 @@ func TestSmartAgentConfigProviderOverrides(t *testing.T) {
 		WriteServerQuery:     "",
 	}, saConfig.Collectd)
 
-	// Ensure envs are setup.
-	require.Equal(t, "/opt/", os.Getenv("SIGNALFX_BUNDLE_DIR"))
-
 	if runtime.GOOS == "windows" {
 		require.NotEqual(t, filepath.Join("/opt", "jre"), os.Getenv("JAVA_HOME"))
 	} else {


### PR DESCRIPTION
This env var is used as a global variable in the code, when it should be passed in as parameter from the configuration.