### PR TITLE
Oracledb discovery tweaks (remove static endpoint)

### DIFF
--- a/cmd/otelcol/config/collector/config.d.linux/receivers/oracledb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/oracledb.discovery.yaml
@@ -14,7 +14,6 @@
 #     k8s_observer: type == "port" and pod.name matches "(?i)oracle"
 #   config:
 #     default:
-#       endpoint: splunk.discovery.default
 #       username: splunk.discovery.default
 #       password: splunk.discovery.default
 #       service: splunk.discovery.default

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/oracledb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/oracledb.discovery.yaml
@@ -14,7 +14,6 @@
 #     k8s_observer: type == "port" and pod.name matches "(?i)oracle"
 #   config:
 #     default:
-#       endpoint: '`endpoint`'
 #       username: splunk.discovery.default
 #       password: splunk.discovery.default
 #       service: splunk.discovery.default

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/oracledb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/oracledb.discovery.yaml
@@ -14,6 +14,7 @@
 #     k8s_observer: type == "port" and pod.name matches "(?i)oracle"
 #   config:
 #     default:
+#       endpoint: '`endpoint`'
 #       username: splunk.discovery.default
 #       password: splunk.discovery.default
 #       service: splunk.discovery.default

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml
@@ -10,7 +10,6 @@ oracledb:
     k8s_observer: type == "port" and pod.name matches "(?i)oracle"
   config:
     default:
-      endpoint: splunk.discovery.default
       username: splunk.discovery.default
       password: splunk.discovery.default
       service: splunk.discovery.default

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml
@@ -10,6 +10,7 @@ oracledb:
     k8s_observer: type == "port" and pod.name matches "(?i)oracle"
   config:
     default:
+      endpoint: '`endpoint`'
       username: splunk.discovery.default
       password: splunk.discovery.default
       service: splunk.discovery.default

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml
@@ -10,7 +10,6 @@ oracledb:
     k8s_observer: type == "port" and pod.name matches "(?i)oracle"
   config:
     default:
-      endpoint: '`endpoint`'
       username: splunk.discovery.default
       password: splunk.discovery.default
       service: splunk.discovery.default

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml.tmpl
@@ -6,7 +6,6 @@
     k8s_observer: type == "port" and pod.name matches "(?i)oracle"
   config:
     default:
-      endpoint: {{ defaultValue }}
       username: {{ defaultValue }}
       password: {{ defaultValue }}
       service: {{ defaultValue }}

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml.tmpl
@@ -6,7 +6,6 @@
     k8s_observer: type == "port" and pod.name matches "(?i)oracle"
   config:
     default:
-      endpoint: '`endpoint`'
       username: {{ defaultValue }}
       password: {{ defaultValue }}
       service: {{ defaultValue }}

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml.tmpl
@@ -6,6 +6,7 @@
     k8s_observer: type == "port" and pod.name matches "(?i)oracle"
   config:
     default:
+      endpoint: '`endpoint`'
       username: {{ defaultValue }}
       password: {{ defaultValue }}
       service: {{ defaultValue }}

--- a/tests/receivers/oracledb/bundled_test.go
+++ b/tests/receivers/oracledb/bundled_test.go
@@ -41,7 +41,6 @@ func TestOracledbDockerObserver(t *testing.T) {
 			},
 			func(collector testutils.Collector) testutils.Collector {
 				return collector.WithEnv(map[string]string{
-					"ORACLEDB_URL":              "oracle://otel:password@localhost:1521/XE",
 					"SPLUNK_DISCOVERY_DURATION": "10s",
 					// confirm that debug logging doesn't affect runtime
 					"SPLUNK_DISCOVERY_LOG_LEVEL": "debug",
@@ -50,7 +49,6 @@ func TestOracledbDockerObserver(t *testing.T) {
 					"--discovery",
 					"--set", "splunk.discovery.receivers.oracledb.config.username=otel",
 					"--set", "splunk.discovery.receivers.oracledb.config.password='${ORACLE_PASSWORD}'",
-					"--set", "splunk.discovery.receivers.oracledb.config.endpoint=localhost:1521",
 					"--set", "splunk.discovery.receivers.oracledb.config.service=XE",
 					"--set", `splunk.discovery.extensions.k8s_observer.enabled=false`,
 					"--set", `splunk.discovery.extensions.host_observer.enabled=false`,

--- a/tests/receivers/oracledb/testdata/resource_metrics/bundled.yaml
+++ b/tests/receivers/oracledb/testdata/resource_metrics/bundled.yaml
@@ -2,7 +2,7 @@ resource_metrics:
   - attributes:
       container.image.name: <ANY>
       container.name: oracledb
-      oracledb.instance.name: localhost:1521/XE
+      oracledb.instance.name: <ANY>
     scope_metrics:
       - instrumentation_scope:
           attributes: {}


### PR DESCRIPTION
**Description:** 
Discovery bundled testing for oracle was relying on an `endpoint` definition. We can remove this to better test discovery