### PR TITLE
Change installer flag to use `--with[out]-instrumentation-sdk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,13 @@
     the `libsplunk.so` shared object library (default: `--without-systemd-instrumentation`)
   - Initial support for [Splunk OpenTelemetry Auto Instrumentation for Node.js](https://github.com/signalfx/splunk-otel-js):
     - Activated by default if the `--with-instrumentation` or `--with-systemd-instrumentation` option is specified.
-    - Use the `--without-node-instrumentation` option to explicitly skip Node.js.
+    - Use the `--without-instrumentation-sdk node` option to explicitly skip Node.js.
     - `npm` is required to install the Node.js Auto Instrumentation package. If the `npm` is not installed, Node.js will
       be skipped automatically.
     - By default, the Node.js Auto Instrumentation package is installed with the `npm install --global` command. Use the
       `--npm-command "<command>"` option to specify a custom command.
   - Auto Instrumentation for Java is also activated by default if the `--with-instrumentation` or
-    `--with-systemd-instrumentation` option is specified. Use the `--without-java-instrumentation` option to skip Java.
+    `--with-systemd-instrumentation` option is specified. Use the `--without-instrumentation-sdk java` option to skip Java.
   - `--otlp-endpoint host:port`: Set the OTLP gRPC endpoint for captured traces (default: `http://LISTEN_INTERFACE:4317`
     where `LISTEN_INTERFACE` is the value from the `--listen-interface` option if specified, or `127.0.0.1` otherwise)
   - See [Linux Installer Script](https://github.com/signalfx/splunk-otel-collector/blob/main/docs/getting-started/linux-installer.md)

--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -332,11 +332,11 @@ of the following options:
 
 By default, both the Java and Node.js Auto Instrumentation agents will be
 installed and activated. Run the installer script with either the
-`--without-java-instrumentation` or `--without-node-instrumentation` option to
+`--without-instrumentation-sdk java` or `--without-instrumentation-sdk node` option to
 skip installation and activation of the respective agent. For example:
 ```sh
 curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-collector.sh && \
-sudo sh /tmp/splunk-otel-collector.sh --with-instrumentation --without-node-instrumentation --realm SPLUNK_REALM -- SPLUNK_ACCESS_TOKEN
+sudo sh /tmp/splunk-otel-collector.sh --with-instrumentation --without-instrumentation-sdk node --realm SPLUNK_REALM -- SPLUNK_ACCESS_TOKEN
 ```
 
 Additional options include:
@@ -363,7 +363,7 @@ following are required:
   `npm` is not installed or not found in the user's default `PATH`, the
   installer script will automatically skip installation and configuration of
   the Node.js agent. Run the installer script with the
-  `--without-node-instrumentation` option to explicitly skip Node.js.
+  `--without-instrumentation-sdk node` option to explicitly skip Node.js.
 - By default, the Node.js Auto Instrumentation package will be installed with
   the `npm install --global` command. Run the installer script with the
   `--npm-command "<command>"` option to specify a custom command (wrapped in

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -1217,8 +1217,8 @@ parse_args_and_install() {
             elif [[ "$lang" -eq "node" ]]; then
                 with_node_instrumentation="false"
             else
-                echo "Unknown instrumentation SDK $1" >&2
                 usage
+                echo "[ERROR] Unknown instrumentation SDK: $lang" >&2
                 exit 1
             fi
         done

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -1315,7 +1315,7 @@ parse_args_and_install() {
     fi
   elif [ "$with_systemd_instrumentation" = "true" ]; then
     if [ "$with_java_instrumentation" = "false" ] && [ "$with_node_instrumentation" = "false" ]; then
-      echo "[ERROR] The --with-systemd-instrumentation option was specified, but both --without-instrumentation-sdk java,node was also specified." >&2
+      echo "[ERROR] The --with-systemd-instrumentation option was specified, but --without-instrumentation-sdk java,node was also specified." >&2
       echo "[ERROR] At least one language must be enabled for auto instrumentation" >&2
       exit 1
     fi

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -1203,7 +1203,7 @@ parse_args_and_install() {
                 with_java_instrumentation="true"
             elif [[ "$lang" -eq "node" ]]; then
                 with_node_instrumentation="true"
-            else then
+            else
                 echo "Unknown instrumentation SDK $1" >&2
                 usage
             fi
@@ -1215,7 +1215,7 @@ parse_args_and_install() {
                 with_java_instrumentation="false"
             elif [[ "$lang" -eq "node" ]]; then
                 with_node_instrumentation="false"
-            else then
+            else
                 echo "Unknown instrumentation SDK $1" >&2
                 usage
             fi

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -1212,7 +1212,7 @@ parse_args_and_install() {
         shift 1
         ;;
       --without-instrumentation-sdk)
-        echo "$2" | tr ',' '\n' | while read lang; do
+        for lang in $(echo "$2" | tr ',' ' '); do
             if [ "$lang" = "java" ]; then
                 with_java_instrumentation="false"
             elif [ "$lang" = "node" ]; then

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -1204,8 +1204,8 @@ parse_args_and_install() {
             elif [[ "$lang" -eq "node" ]]; then
                 with_node_instrumentation="true"
             else
-                echo "Unknown instrumentation SDK $1" >&2
                 usage
+                echo "[ERROR] Unknown instrumentation SDK: $lang" >&2
                 exit 1
             fi
         done

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -1223,6 +1223,7 @@ parse_args_and_install() {
                 exit 1
             fi
         done
+        shift 1
         ;;
       --npm-command)
         npm_command="$2"

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -1199,9 +1199,9 @@ parse_args_and_install() {
         with_java_instrumentation="false"
         with_node_instrumentation="false"
         for lang in $(echo "$2" | tr ',' ' '); do
-            if [[ "$lang" -eq "java" ]]; then
+            if [ "$lang" = "java" ]; then
                 with_java_instrumentation="true"
-            elif [[ "$lang" -eq "node" ]]; then
+            elif [ "$lang" = "node" ]; then
                 with_node_instrumentation="true"
             else
                 usage

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -1309,7 +1309,7 @@ parse_args_and_install() {
 
   if [ "$with_instrumentation" = "true" ]; then
     if [ "$with_java_instrumentation" = "false" ] && [ "$with_node_instrumentation" = "false" ]; then
-      echo "[ERROR] The --with-instrumentation option was specified, but --without-instrumentation-sdk java,node options was also specified." >&2
+      echo "[ERROR] The --with-instrumentation option was specified, but --without-instrumentation-sdk java,node was also specified." >&2
       echo "[ERROR] At least one language must be enabled for auto instrumentation" >&2
       exit 1
     fi

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -874,6 +874,8 @@ Auto Instrumentation:
   --with[out]-instrumentation-sdk "<s>" Whether to enable Auto Instrumentation for a specific language. This option
                                         takes a comma separated set of values representing supported
                                         auto-instrumentation SDKs. Currently supported: java,node.
+                                        Use --with-instrumentation-sdk to enable only the specified language(s),
+                                        for example "--with-instrumentation-sdk java".
                                         (default: --with-instrumentation-sdk "java,node" if --with-instrumentation or
                                         --with-systemd-instrumentation is also specified)
   --npm-command "<command>"             If Auto Instrumentation for Node.js is enabled, npm is required to install the

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -1206,6 +1206,7 @@ parse_args_and_install() {
             else
                 echo "Unknown instrumentation SDK $1" >&2
                 usage
+                exit 1
             fi
         done
         ;;
@@ -1218,6 +1219,7 @@ parse_args_and_install() {
             else
                 echo "Unknown instrumentation SDK $1" >&2
                 usage
+                exit 1
             fi
         done
         ;;

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -1209,6 +1209,7 @@ parse_args_and_install() {
                 exit 1
             fi
         done
+        shift 1
         ;;
       --without-instrumentation-sdk)
         echo "$2" | tr ',' '\n' | while read lang; do

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -1198,7 +1198,7 @@ parse_args_and_install() {
       --with-instrumentation-sdk)
         with_java_instrumentation="false"
         with_node_instrumentation="false"
-        echo "$2" | tr ',' '\n' | while read lang; do
+        for lang in $(echo "$2" | tr ',' ' '); do
             if [[ "$lang" -eq "java" ]]; then
                 with_java_instrumentation="true"
             elif [[ "$lang" -eq "node" ]]; then

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -1213,9 +1213,9 @@ parse_args_and_install() {
         ;;
       --without-instrumentation-sdk)
         echo "$2" | tr ',' '\n' | while read lang; do
-            if [[ "$lang" -eq "java" ]]; then
+            if [ "$lang" = "java" ]; then
                 with_java_instrumentation="false"
-            elif [[ "$lang" -eq "node" ]]; then
+            elif [ "$lang" = "node" ]; then
                 with_node_instrumentation="false"
             else
                 usage


### PR DESCRIPTION
**Description:**
Instead of using flags per language, condense the instrumentation SDK selection using a `--with[out]-instrumentation-sdk` flag.