### PR TITLE
Simple lint fixes to help support newer version of  github.com/golangci/golangci-lint in /internal/tools

### DIFF
--- a/internal/signalfx-agent/pkg/core/common/httpclient/http_test.go
+++ b/internal/signalfx-agent/pkg/core/common/httpclient/http_test.go
@@ -3,7 +3,6 @@ package httpclient
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -152,7 +151,7 @@ func TestHttpTimeout(t *testing.T) {
 		}
 		req.Error(err)
 		var uerr *url.Error
-		req.True(errors.As(err, &uerr))
+		req.ErrorAs(err, &uerr)
 		req.True(uerr.Timeout())
 	})
 }

--- a/internal/signalfx-agent/pkg/core/config/config_test.go
+++ b/internal/signalfx-agent/pkg/core/config/config_test.go
@@ -20,10 +20,10 @@ func TestWriterOutputValidation(t *testing.T) {
 				{ProcPath: "/proc"},
 			},
 		}
-		require.Nil(t, defaults.Set(c))
+		require.NoError(t, defaults.Set(c))
 
 		err := c.validate()
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Contains(t, err.Error(), "output are disabled")
 	})
 
@@ -37,9 +37,9 @@ func TestWriterOutputValidation(t *testing.T) {
 				{ProcPath: "/proc"},
 			},
 		}
-		require.Nil(t, defaults.Set(c))
+		require.NoError(t, defaults.Set(c))
 
 		err := c.validate()
-		require.Nil(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/internal/signalfx-agent/pkg/core/config/filters_test.go
+++ b/internal/signalfx-agent/pkg/core/config/filters_test.go
@@ -184,7 +184,7 @@ func TestNewFilters(t *testing.T) {
 				},
 			},
 		})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		assert.True(t, f.Matches(&datapoint.Datapoint{Metric: "disk.utilization"}))
 		assert.True(t, f.Matches(&datapoint.Datapoint{

--- a/internal/signalfx-agent/pkg/core/config/sources/vault/auth/gcp.go
+++ b/internal/signalfx-agent/pkg/core/config/sources/vault/auth/gcp.go
@@ -1,7 +1,7 @@
 package auth
 
 import (
-	"fmt"
+	"strconv"
 
 	gcpauth "github.com/hashicorp/vault-plugin-auth-gcp/plugin"
 	"github.com/hashicorp/vault/api"
@@ -61,7 +61,7 @@ func (ic *GCPConfig) GetToken(client *api.Client) (*api.Secret, error) {
 		data["credentials"] = *ic.Credentials
 	}
 	if ic.JWTExp != nil {
-		data["jwt_exp"] = fmt.Sprintf("%d", *ic.JWTExp)
+		data["jwt_exp"] = strconv.Itoa(*ic.JWTExp)
 	}
 	if ic.ServiceAccount != nil {
 		data["service_account"] = *ic.ServiceAccount

--- a/internal/signalfx-agent/pkg/core/dpfilters/filter.go
+++ b/internal/signalfx-agent/pkg/core/dpfilters/filter.go
@@ -13,7 +13,7 @@ import (
 type DatapointFilter interface {
 	// Matches takes a datapoint and returns whether it is matched by the
 	// filter
-	Matches(datapointFilter *datapoint.Datapoint) bool
+	Matches(dp *datapoint.Datapoint) bool
 }
 
 // BasicDatapointFilter is designed to filter SignalFx datapoint objects.  It

--- a/internal/signalfx-agent/pkg/core/dpfilters/filter.go
+++ b/internal/signalfx-agent/pkg/core/dpfilters/filter.go
@@ -13,7 +13,7 @@ import (
 type DatapointFilter interface {
 	// Matches takes a datapoint and returns whether it is matched by the
 	// filter
-	Matches(*datapoint.Datapoint) bool
+	Matches(datapointFilter *datapoint.Datapoint) bool
 }
 
 // BasicDatapointFilter is designed to filter SignalFx datapoint objects.  It

--- a/internal/signalfx-agent/pkg/core/propfilters/filter_test.go
+++ b/internal/signalfx-agent/pkg/core/propfilters/filter_test.go
@@ -16,7 +16,7 @@ func TestFilters(t *testing.T) {
 		filteredProperties := f.FilterProperties(properties)
 
 		expectedProperties := map[string]string{"replicaSet": "abc"}
-		assert.Equal(t, filteredProperties, expectedProperties)
+		assert.Equal(t, expectedProperties, filteredProperties)
 	})
 
 	t.Run("Filter a regex property name", func(t *testing.T) {
@@ -27,7 +27,7 @@ func TestFilters(t *testing.T) {
 		filteredProperties := f.FilterProperties(properties)
 
 		expectedProperties := map[string]string{"replicaSet": "abc"}
-		assert.Equal(t, filteredProperties, expectedProperties)
+		assert.Equal(t, expectedProperties, filteredProperties)
 	})
 
 	t.Run("Filter a globbed property name", func(t *testing.T) {
@@ -38,7 +38,7 @@ func TestFilters(t *testing.T) {
 		filteredProperties := f.FilterProperties(properties)
 
 		expectedProperties := map[string]string{"replicaSet": "abc"}
-		assert.Equal(t, filteredProperties, expectedProperties)
+		assert.Equal(t, expectedProperties, filteredProperties)
 	})
 
 	t.Run("Filter a single property value", func(t *testing.T) {
@@ -49,7 +49,7 @@ func TestFilters(t *testing.T) {
 		filteredProperties := f.FilterProperties(properties)
 
 		expectedProperties := map[string]string{"replicaSet": "abc"}
-		assert.Equal(t, filteredProperties, expectedProperties)
+		assert.Equal(t, expectedProperties, filteredProperties)
 	})
 
 	t.Run("Filter a regex property value", func(t *testing.T) {
@@ -60,7 +60,7 @@ func TestFilters(t *testing.T) {
 		filteredProperties := f.FilterProperties(properties)
 
 		expectedProperties := map[string]string{"replicaSet": "abc"}
-		assert.Equal(t, filteredProperties, expectedProperties)
+		assert.Equal(t, expectedProperties, filteredProperties)
 	})
 
 	t.Run("Filter a globbed property value", func(t *testing.T) {
@@ -71,7 +71,7 @@ func TestFilters(t *testing.T) {
 		filteredProperties := f.FilterProperties(properties)
 
 		expectedProperties := map[string]string{"replicaSet": "abc"}
-		assert.Equal(t, filteredProperties, expectedProperties)
+		assert.Equal(t, expectedProperties, filteredProperties)
 	})
 
 	t.Run("Filter a property name and value", func(t *testing.T) {
@@ -82,7 +82,7 @@ func TestFilters(t *testing.T) {
 		filteredProperties := f.FilterProperties(properties)
 
 		expectedProperties := map[string]string{"replicaSet": "abc"}
-		assert.Equal(t, filteredProperties, expectedProperties)
+		assert.Equal(t, expectedProperties, filteredProperties)
 	})
 
 	t.Run("Filter a single dimension name", func(t *testing.T) {
@@ -171,7 +171,7 @@ func TestFilters(t *testing.T) {
 		filteredDimension := f.FilterDimension(dim)
 
 		expectedProperties := map[string]string{"replicaSet": "abc"}
-		assert.Equal(t, filteredDimension.Properties, expectedProperties)
+		assert.Equal(t, expectedProperties, filteredDimension.Properties)
 	})
 
 	t.Run("Filter a dimension object given property value", func(t *testing.T) {
@@ -189,7 +189,7 @@ func TestFilters(t *testing.T) {
 		filteredDimension := f.FilterDimension(dim)
 
 		expectedProperties := map[string]string{"replicaSet": "abc"}
-		assert.Equal(t, filteredDimension.Properties, expectedProperties)
+		assert.Equal(t, expectedProperties, filteredDimension.Properties)
 	})
 
 	t.Run("Filter a dimension object given property name and value", func(t *testing.T) {
@@ -205,7 +205,7 @@ func TestFilters(t *testing.T) {
 		}
 		filteredDimension := f.FilterDimension(dim)
 		expectedProperties := map[string]string{"replicaSet": "abc", "service_uid": "123"}
-		assert.Equal(t, filteredDimension.Properties, expectedProperties)
+		assert.Equal(t, expectedProperties, filteredDimension.Properties)
 	})
 
 	t.Run("Filter a dimension object given dimension value", func(t *testing.T) {
@@ -245,8 +245,8 @@ func TestFilters(t *testing.T) {
 		filteredDimension := f.FilterDimension(dim)
 		nodeFilteredDimension := f.FilterDimension(dimNode)
 		expectedProperties := map[string]string{"replicaSet": "abc", "service_uid": "123"}
-		assert.Equal(t, filteredDimension.Properties, expectedProperties)
-		assert.Equal(t, nodeFilteredDimension.Properties, properties)
+		assert.Equal(t, expectedProperties, filteredDimension.Properties)
+		assert.Equal(t, properties, nodeFilteredDimension.Properties)
 	})
 
 	// negation tests
@@ -258,7 +258,7 @@ func TestFilters(t *testing.T) {
 		filteredProperties := f.FilterProperties(properties)
 
 		expectedProperties := map[string]string{"pod-template-hash": "123"}
-		assert.Equal(t, filteredProperties, expectedProperties)
+		assert.Equal(t, expectedProperties, filteredProperties)
 	})
 
 	t.Run("Filter a single negated property value", func(t *testing.T) {
@@ -269,7 +269,7 @@ func TestFilters(t *testing.T) {
 		filteredProperties := f.FilterProperties(properties)
 
 		expectedProperties := map[string]string{"pod-template-hash": "123"}
-		assert.Equal(t, filteredProperties, expectedProperties)
+		assert.Equal(t, expectedProperties, filteredProperties)
 	})
 
 	t.Run("Match a negated dimension name", func(t *testing.T) {

--- a/internal/signalfx-agent/pkg/monitors/helpers_test.go
+++ b/internal/signalfx-agent/pkg/monitors/helpers_test.go
@@ -28,7 +28,7 @@ type DynamicConfig struct {
 }
 
 type MockMonitor interface {
-	SetConfigHook(func(types.MonitorID, MockMonitor))
+	SetConfigHook(configHook func(types.MonitorID, MockMonitor))
 	AddShutdownHook(fn func())
 	Type() string
 	MyVar() string

--- a/internal/signalfx-agent/pkg/monitors/postgresql/monitor.go
+++ b/internal/signalfx-agent/pkg/monitors/postgresql/monitor.go
@@ -96,6 +96,8 @@ type Monitor struct {
 	logger logrus.FieldLogger
 }
 
+const dbNamePrefix = " dbname="
+
 // Configure the monitor and kick off metric collection
 func (m *Monitor) Configure(conf *Config) error {
 	m.conf = conf
@@ -118,7 +120,7 @@ func (m *Monitor) Configure(conf *Config) error {
 	m.connectionString = connStr
 	m.Output.AddExtraDimension("postgres_port", port)
 
-	connectionStringWithMasterDB := m.connectionString + " dbname=" + m.conf.MasterDBName
+	connectionStringWithMasterDB := m.connectionString + dbNamePrefix + m.conf.MasterDBName
 
 	var dbFilter filter.StringFilter
 	if len(conf.Databases) > 0 {
@@ -235,7 +237,7 @@ func (m *Monitor) startMonitoringDatabase(name string) (*sql.Monitor, error) {
 
 	return sqlMon, sqlMon.Configure(&sql.Config{
 		MonitorConfig:    m.conf.MonitorConfig,
-		ConnectionString: m.connectionString + " dbname=" + name,
+		ConnectionString: m.connectionString + dbNamePrefix + name,
 		DBDriver:         "postgres",
 		Queries:          makeDefaultDBQueries(name),
 		LogQueries:       m.conf.LogQueries,
@@ -338,7 +340,7 @@ func (m *Monitor) monitorReplication() (*sql.Monitor, error) {
 
 	return sqlMon, sqlMon.Configure(&sql.Config{
 		MonitorConfig:    m.conf.MonitorConfig,
-		ConnectionString: connStr + " dbname=" + m.conf.MasterDBName,
+		ConnectionString: connStr + dbNamePrefix + m.conf.MasterDBName,
 		DBDriver:         "postgres",
 		Queries:          defaultReplicationQueries,
 		LogQueries:       m.conf.LogQueries,

--- a/internal/signalfx-agent/pkg/monitors/processlist/processlist_linux_test.go
+++ b/internal/signalfx-agent/pkg/monitors/processlist/processlist_linux_test.go
@@ -12,8 +12,8 @@ func TestProcessListLinux(t *testing.T) {
 	cache := initOSCache()
 
 	tps, err := ProcessList(&Config{}, cache, nil)
-	require.Nil(t, err)
-	require.Greater(t, len(tps), 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, len(tps))
 
 	selfPID := os.Getpid()
 	for _, proc := range tps {

--- a/internal/signalfx-agent/pkg/monitors/prometheusexporter/conversion.go
+++ b/internal/signalfx-agent/pkg/monitors/prometheusexporter/conversion.go
@@ -30,17 +30,17 @@ func convertMetricFamily(mf *dto.MetricFamily) []*datapoint.Datapoint {
 	}
 	switch *mf.Type {
 	case dto.MetricType_GAUGE:
-		return makeSimpleDatapoints(*mf.Name, mf.Metric, sfxclient.GaugeF, gaugeExtractor)
+		return makeSimpleDatapoints(mf.GetName(), mf.GetMetric(), sfxclient.GaugeF, gaugeExtractor)
 	case dto.MetricType_COUNTER:
-		return makeSimpleDatapoints(*mf.Name, mf.Metric, sfxclient.CumulativeF, counterExtractor)
+		return makeSimpleDatapoints(mf.GetName(), mf.GetMetric(), sfxclient.CumulativeF, counterExtractor)
 	case dto.MetricType_UNTYPED:
-		return makeSimpleDatapoints(*mf.Name, mf.Metric, sfxclient.GaugeF, untypedExtractor)
+		return makeSimpleDatapoints(mf.GetName(), mf.GetMetric(), sfxclient.GaugeF, untypedExtractor)
 	case dto.MetricType_SUMMARY:
-		return makeSummaryDatapoints(*mf.Name, mf.Metric)
+		return makeSummaryDatapoints(mf.GetName(), mf.GetMetric())
 	// TODO: figure out how to best convert histograms, in particular the
 	// upper bound value
 	case dto.MetricType_HISTOGRAM:
-		return makeHistogramDatapoints(*mf.Name, mf.Metric)
+		return makeHistogramDatapoints(mf.GetName(), mf.GetMetric())
 	default:
 		return nil
 	}
@@ -49,7 +49,7 @@ func convertMetricFamily(mf *dto.MetricFamily) []*datapoint.Datapoint {
 func makeSimpleDatapoints(name string, ms []*dto.Metric, dpf dpFactory, e extractor) []*datapoint.Datapoint {
 	dps := make([]*datapoint.Datapoint, len(ms))
 	for i, m := range ms {
-		dps[i] = dpf(name, labelsToDims(m.Label), e(m))
+		dps[i] = dpf(name, labelsToDims(m.GetLabel()), e(m))
 	}
 	return dps
 }
@@ -57,7 +57,7 @@ func makeSimpleDatapoints(name string, ms []*dto.Metric, dpf dpFactory, e extrac
 func makeSummaryDatapoints(name string, ms []*dto.Metric) []*datapoint.Datapoint {
 	var dps []*datapoint.Datapoint
 	for _, m := range ms {
-		dims := labelsToDims(m.Label)
+		dims := labelsToDims(m.GetLabel())
 		s := m.GetSummary()
 		if s == nil {
 			continue
@@ -85,7 +85,7 @@ func makeSummaryDatapoints(name string, ms []*dto.Metric) []*datapoint.Datapoint
 func makeHistogramDatapoints(name string, ms []*dto.Metric) []*datapoint.Datapoint {
 	var dps []*datapoint.Datapoint
 	for _, m := range ms {
-		dims := labelsToDims(m.Label)
+		dims := labelsToDims(m.GetLabel())
 		h := m.GetHistogram()
 		if h == nil {
 			continue

--- a/internal/signalfx-agent/pkg/monitors/subproc/core.go
+++ b/internal/signalfx-agent/pkg/monitors/subproc/core.go
@@ -192,8 +192,8 @@ func makePipes() (*messageReadWriter, io.ReadCloser, io.WriteCloser, error) {
 // subprocess.  MontiorCore.ConfigureInSubproc handles configuring the
 // subprocess monitor and collecting the result.
 type MessageHandler interface {
-	ProcessMessages(context context.Context, messageReceiver MessageReceiver)
-	HandleLogMessage(reader io.Reader) error
+	ProcessMessages(ctx context.Context, messageReceiver MessageReceiver)
+	HandleLogMessage(r io.Reader) error
 }
 
 // ConfigureInSubproc sends the given config to the subproc and returns whether

--- a/internal/signalfx-agent/pkg/monitors/subproc/core.go
+++ b/internal/signalfx-agent/pkg/monitors/subproc/core.go
@@ -192,8 +192,8 @@ func makePipes() (*messageReadWriter, io.ReadCloser, io.WriteCloser, error) {
 // subprocess.  MontiorCore.ConfigureInSubproc handles configuring the
 // subprocess monitor and collecting the result.
 type MessageHandler interface {
-	ProcessMessages(context.Context, MessageReceiver)
-	HandleLogMessage(io.Reader) error
+	ProcessMessages(context context.Context, messageReceiver MessageReceiver)
+	HandleLogMessage(reader io.Reader) error
 }
 
 // ConfigureInSubproc sends the given config to the subproc and returns whether

--- a/internal/signalfx-agent/pkg/monitors/telegraf/common/emitter/emitter.go
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/common/emitter/emitter.go
@@ -9,11 +9,11 @@ import (
 // Emitter interface to telegraf accumulator for processing metrics from
 // telegraf
 type Emitter interface {
-	// Add is a function used by the telegraf accumulator to emit events
-	// through the agent.  Pleaes note that if the emitter is a BatchEmitter
+	// AddMetric Add is a function used by the telegraf accumulator to emit events
+	// through the agent.  Please note that if the emitter is a BatchEmitter
 	// you will have to invoke the Send() function to send the batch of
 	// datapoints and events collected by the Emit function
-	AddMetric(telegraf.Metric)
+	AddMetric(metric telegraf.Metric)
 	// AddTag adds a key/value pair to all measurement tags.  If a key conflicts
 	// the key value pair in AddTag will override the original key on the
 	// measurement

--- a/internal/signalfx-agent/pkg/monitors/telegraf/common/emitter/emitter.go
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/common/emitter/emitter.go
@@ -13,7 +13,7 @@ type Emitter interface {
 	// through the agent.  Please note that if the emitter is a BatchEmitter
 	// you will have to invoke the Send() function to send the batch of
 	// datapoints and events collected by the Emit function
-	AddMetric(metric telegraf.Metric)
+	AddMetric(m telegraf.Metric)
 	// AddTag adds a key/value pair to all measurement tags.  If a key conflicts
 	// the key value pair in AddTag will override the original key on the
 	// measurement

--- a/internal/signalfx-agent/pkg/monitors/types/output.go
+++ b/internal/signalfx-agent/pkg/monitors/types/output.go
@@ -14,7 +14,7 @@ import (
 type Output interface {
 	Copy() Output
 	SendDatapoints(...*datapoint.Datapoint)
-	SendEvent(event *event.Event)
+	SendEvent(e *event.Event)
 	SendSpans(...*trace.Span)
 	SendDimensionUpdate(*Dimension)
 	AddExtraDimension(key string, value string)

--- a/internal/signalfx-agent/pkg/monitors/types/output.go
+++ b/internal/signalfx-agent/pkg/monitors/types/output.go
@@ -14,14 +14,14 @@ import (
 type Output interface {
 	Copy() Output
 	SendDatapoints(...*datapoint.Datapoint)
-	SendEvent(*event.Event)
+	SendEvent(event *event.Event)
 	SendSpans(...*trace.Span)
 	SendDimensionUpdate(*Dimension)
-	AddExtraDimension(key, value string)
+	AddExtraDimension(key string, value string)
 	RemoveExtraDimension(key string)
-	AddExtraSpanTag(key, value string)
+	AddExtraSpanTag(key string, value string)
 	RemoveExtraSpanTag(key string)
-	AddDefaultSpanTag(key, value string)
+	AddDefaultSpanTag(key string, value string)
 	RemoveDefaultSpanTag(key string)
 }
 

--- a/internal/signalfx-agent/pkg/monitors/vsphere/service/inventory_test.go
+++ b/internal/signalfx-agent/pkg/monitors/vsphere/service/inventory_test.go
@@ -15,7 +15,7 @@ func TestNopFilter(t *testing.T) {
 	svc := NewInventorySvc(gateway, testLog, f, model.GuestIP)
 	inv, err := svc.RetrieveInventory()
 	require.NoError(t, err)
-	require.Equal(t, 4, len(inv.Objects))
+	assert.Len(t, inv.Objects, 4)
 }
 
 func TestExprFilterOutAllInventory(t *testing.T) {
@@ -24,8 +24,8 @@ func TestExprFilterOutAllInventory(t *testing.T) {
 	require.NoError(t, err)
 	svc := NewInventorySvc(gateway, testLog, f, model.GuestIP)
 	inv, err := svc.RetrieveInventory()
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(inv.Objects))
+	require.NoError(t, err)
+	assert.Len(t, inv.Objects, 0)
 }
 
 func TestExprFilterInAllInventoryInClusters(t *testing.T) {
@@ -34,8 +34,8 @@ func TestExprFilterInAllInventoryInClusters(t *testing.T) {
 	require.NoError(t, err)
 	svc := NewInventorySvc(gateway, testLog, f, model.GuestIP)
 	inv, err := svc.RetrieveInventory()
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(inv.Objects))
+	require.NoError(t, err)
+	assert.Len(t, inv.Objects, 2)
 }
 
 func TestExprFilterInAllInventory(t *testing.T) {
@@ -45,8 +45,8 @@ func TestExprFilterInAllInventory(t *testing.T) {
 	require.NoError(t, err)
 	svc := NewInventorySvc(gateway, testLog, f, model.GuestIP)
 	inv, err := svc.RetrieveInventory()
-	assert.NoError(t, err)
-	assert.Equal(t, 4, len(inv.Objects))
+	require.NoError(t, err)
+	assert.Len(t, inv.Objects, 4)
 }
 
 func TestFilterInInventory(t *testing.T) {
@@ -55,8 +55,8 @@ func TestFilterInInventory(t *testing.T) {
 	require.NoError(t, err)
 	svc := NewInventorySvc(gateway, testLog, f, model.GuestIP)
 	inv, err := svc.RetrieveInventory()
-	assert.NoError(t, err)
-	assert.True(t, len(inv.Objects) > 0)
+	require.NoError(t, err)
+	assert.Greater(t, len(inv.Objects), 0)
 }
 
 func TestFilterEmptyDC(t *testing.T) {
@@ -65,8 +65,8 @@ func TestFilterEmptyDC(t *testing.T) {
 	require.NoError(t, err)
 	svc := NewInventorySvc(gateway, testLog, f, model.GuestIP)
 	inv, err := svc.RetrieveInventory()
-	assert.NoError(t, err)
-	assert.True(t, len(inv.Objects) > 0)
+	require.NoError(t, err)
+	assert.Greater(t, len(inv.Objects), 0)
 }
 
 func TestRetrieveInventory(t *testing.T) {

--- a/internal/signalfx-agent/pkg/monitors/vsphere/service/multi_perf_fetcher_test.go
+++ b/internal/signalfx-agent/pkg/monitors/vsphere/service/multi_perf_fetcher_test.go
@@ -15,7 +15,7 @@ import (
 func TestTooManyInvObjects(t *testing.T) {
 	g := fakePaginatorGateway{}
 	_, err := g.queryPerf(invObjs(100), 1)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestNumPages(t *testing.T) {
@@ -33,23 +33,23 @@ func TestMultiPage1(t *testing.T) {
 	p := multiPagePerfFetcher{pageSize: 4, gateway: &fakePaginatorGateway{}, log: testLog}
 	it := p.invIterator(invObjs(4), 1)
 	page, hasNext, err := it.nextInvPage()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.False(t, hasNext)
-	require.Equal(t, 4, len(page))
+	require.Len(t, page, 4)
 }
 
 func TestMultiPage2(t *testing.T) {
 	p := multiPagePerfFetcher{pageSize: 4, gateway: &fakePaginatorGateway{}, log: testLog}
 	it := p.invIterator(invObjs(5), 1)
 	page, hasNext, err := it.nextInvPage()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, hasNext)
-	require.Equal(t, 4, len(page))
+	require.Len(t, page, 4)
 
 	page, hasNext, err = it.nextInvPage()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.False(t, hasNext)
-	require.Equal(t, 1, len(page))
+	require.Len(t, page, 1)
 }
 
 func invObjs(n int) []*model.InventoryObject {

--- a/internal/signalfx-agent/pkg/monitors/vsphere/service/util_test.go
+++ b/internal/signalfx-agent/pkg/monitors/vsphere/service/util_test.go
@@ -10,5 +10,5 @@ func TestUpdateMap(t *testing.T) {
 	target := map[string]string{"foo": "bar"}
 	updates := map[string]string{"baz": "glarch"}
 	updateMap(target, updates)
-	require.Equal(t, target, map[string]string{"foo": "bar", "baz": "glarch"})
+	require.Equal(t, map[string]string{"foo": "bar", "baz": "glarch"}, target)
 }

--- a/internal/signalfx-agent/pkg/utils/filter/filter.go
+++ b/internal/signalfx-agent/pkg/utils/filter/filter.go
@@ -15,12 +15,12 @@ import (
 
 // StringFilter matches against simple strings
 type StringFilter interface {
-	Matches(stringFilter string) bool
+	Matches(str string) bool
 }
 
 // StringMapFilter matches against the values of a map[string]string.
 type StringMapFilter interface {
-	Matches(stringMapFilter map[string]string) bool
+	Matches(str map[string]string) bool
 }
 
 // BasicStringFilter will match if any one of the given strings is a match.

--- a/internal/signalfx-agent/pkg/utils/filter/filter.go
+++ b/internal/signalfx-agent/pkg/utils/filter/filter.go
@@ -15,12 +15,12 @@ import (
 
 // StringFilter matches against simple strings
 type StringFilter interface {
-	Matches(string) bool
+	Matches(stringFilter string) bool
 }
 
 // StringMapFilter matches against the values of a map[string]string.
 type StringMapFilter interface {
-	Matches(map[string]string) bool
+	Matches(stringMapeFilter map[string]string) bool
 }
 
 // BasicStringFilter will match if any one of the given strings is a match.

--- a/internal/signalfx-agent/pkg/utils/filter/filter.go
+++ b/internal/signalfx-agent/pkg/utils/filter/filter.go
@@ -20,7 +20,7 @@ type StringFilter interface {
 
 // StringMapFilter matches against the values of a map[string]string.
 type StringMapFilter interface {
-	Matches(stringMapeFilter map[string]string) bool
+	Matches(stringMapFilter map[string]string) bool
 }
 
 // BasicStringFilter will match if any one of the given strings is a match.

--- a/internal/signalfx-agent/pkg/utils/filter/filter_test.go
+++ b/internal/signalfx-agent/pkg/utils/filter/filter_test.go
@@ -108,9 +108,9 @@ func TestBasicStringFilter(t *testing.T) {
 	} {
 		f, err := NewBasicStringFilter(tc.filter)
 		if tc.shouldError {
-			assert.NotNil(t, err, spew.Sdump(tc))
+			assert.Error(t, err, spew.Sdump(tc))
 		} else {
-			assert.Nil(t, err, spew.Sdump(tc))
+			assert.NoError(t, err, spew.Sdump(tc))
 		}
 
 		assert.Equal(t, tc.shouldMatch, f.Matches(tc.input), "%s\n%s", spew.Sdump(tc), spew.Sdump(f))
@@ -196,9 +196,9 @@ func TestStringMapFilter(t *testing.T) {
 	} {
 		f, err := NewStringMapFilter(tc.filter)
 		if tc.shouldError {
-			assert.NotNil(t, err, spew.Sdump(tc))
+			assert.Error(t, err, spew.Sdump(tc))
 		} else {
-			assert.Nil(t, err, spew.Sdump(tc))
+			assert.NoError(t, err, spew.Sdump(tc))
 		}
 
 		assert.Equal(t, tc.shouldMatch, f.Matches(tc.input), "%s\n%s", spew.Sdump(tc), spew.Sdump(f))

--- a/internal/signalfx-agent/pkg/utils/filter/overridable_test.go
+++ b/internal/signalfx-agent/pkg/utils/filter/overridable_test.go
@@ -132,9 +132,9 @@ func TestOverridableStringFilter(t *testing.T) {
 	} {
 		f, err := NewOverridableStringFilter(tc.filter)
 		if tc.shouldError {
-			assert.NotNil(t, err, spew.Sdump(tc))
+			assert.Error(t, err, spew.Sdump(tc))
 		} else {
-			assert.Nil(t, err, spew.Sdump(tc))
+			assert.NoError(t, err, spew.Sdump(tc))
 		}
 		for i := range tc.inputs {
 			assert.Equal(t, tc.shouldMatch[i], f.Matches(tc.inputs[i]), "input[%d] of %s\n%s", i, spew.Sdump(tc), spew.Sdump(f))


### PR DESCRIPTION
**Description:** 
- First PR for the easy lint updates to support bumping the golangci-lint version.
- A second PR will come out with less easy updates that will be needed which will involve updating prometheus exporter code.