### PR TITLE
do not exit in usage, so exit 1 can trigger

### DIFF
--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -931,7 +931,6 @@ Uninstall:
                                         OpenTelemetry Auto Instrumentation packages, if installed.
 
 EOH
-  exit 0
 }
 
 distro_is_supported() {


### PR DESCRIPTION
**Description:**
From https://github.com/signalfx/splunk-otel-collector/pull/3841#discussion_r1370858777

We should not exit on usage output directly, but in the calling script so we can exit 1.