### PR TITLE
Run make binaries-windows_amd64 clean on Windows

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -17,7 +17,6 @@ else
 	NUM_CORES := $(shell getconf _NPROCESSORS_ONLN)
 endif
 
-
 # SRC_ROOT is the top of the source tree.
 SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -1,6 +1,23 @@
 # Explicitly define the shell we will use for commands.
 SHELL?=/bin/bash
 
+# Add support to use Makefile on Windows
+SHELL_CASE_EXP = case "$$(uname -s)" in CYGWIN*|MINGW*|MSYS*) echo "true";; esac;
+UNIX_SHELL_ON_WINDOWS := $(shell $(SHELL_CASE_EXP))
+
+ifeq ($(UNIX_SHELL_ON_WINDOWS),true)
+	# The "sed" transformation below is needed on Windows, since commands like `go list -f '{{ .Dir }}'`
+	# return Windows paths and such paths are incompatible with other *nix tools, like `find`,
+	# used by the Makefile shell.
+	# The backslash needs to be doubled so its passed correctly to the shell. 
+	NORMALIZE_DIRS = sed -e 's/^/\\//' -e 's/://' -e 's/\\\\/\\//g' | sort
+	NUM_CORES := ${NUMBER_OF_PROCESSORS}
+else
+	NORMALIZE_DIRS = sort
+	NUM_CORES := $(shell getconf _NPROCESSORS_ONLN)
+endif
+
+
 # SRC_ROOT is the top of the source tree.
 SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
@@ -19,9 +36,8 @@ LINT=golangci-lint
 IMPI=impi
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release
-NUM_CORES := $(shell getconf _NPROCESSORS_ONLN)
 
-ALL_PKG_DIRS := $(shell $(GOCMD) list -f '{{ .Dir }}' ./... | sort)
+ALL_PKG_DIRS := $(shell $(GOCMD) list -f '{{ .Dir }}' ./... | $(NORMALIZE_DIRS))
 
 ALL_SRC := $(shell find $(ALL_PKG_DIRS) -name '*.go' \
                                 -not -path '*/third_party/*' \


### PR DESCRIPTION
**Description:**
Change Makefile so `make binaries-windows_amd64` runs clean on Windows. This is the same fix done on contrib to avoid errors while running `make` on Windows.
 
**Link to Splunk idea:**
N/A

**Testing:**
- Ran it locally (only validated the target `binaries-windows_amd64`.

**Documentation:**
N/A
