### PR TITLE
Use underscore for rpm test packages

### DIFF
--- a/instrumentation/packaging/fpm/rpm/build.sh
+++ b/instrumentation/packaging/fpm/rpm/build.sh
@@ -27,8 +27,8 @@ if [[ -z "$VERSION" ]]; then
     VERSION="$( get_version )"
 fi
 
-# rpm doesn't like dashes in the version, replace with tildas
-VERSION="${VERSION/'-'/'~'}"
+# rpm doesn't like dashes in the version, replace with underscore
+VERSION="${VERSION/'-'/'_'}"
 VERSION="${VERSION#v}"
 
 buildroot="$(mktemp -d)"

--- a/internal/buildscripts/packaging/fpm/rpm/build.sh
+++ b/internal/buildscripts/packaging/fpm/rpm/build.sh
@@ -28,8 +28,8 @@ if [[ -z "$VERSION" ]]; then
     VERSION="$( get_version )"
 fi
 
-# rpm doesn't like dashes in the version, replace with tildas
-VERSION="${VERSION/'-'/'~'}"
+# rpm doesn't like dashes in the version, replace with underscore
+VERSION="${VERSION/'-'/'_'}"
 VERSION="${VERSION#v}"
 
 if [[ -z "$JMX_METRIC_GATHERER_RELEASE" ]]; then


### PR DESCRIPTION
Currently, the rpm packages built and released to our test repos in artifactory from the `main` branch have `~post` appended to the version. However, the `~` in the version forces the sorting to be lower than previously released packages with the same base version, i.e. `0.86.0~post` < `0.86.0`. Use `_post` instead to enforce the correct sorting order for test packages.