### PR TITLE
Mark old instrumentation options as deprecated in installer script usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@
   - See [Splunk OpenTelemetry Zero Configuration Auto Instrumentation for Linux](https://github.com/signalfx/splunk-otel-collector/blob/main/instrumentation/README.md)
     for manual installation/configuration details.
 
+### 🚩 Deprecations 🚩
+
+- (Splunk) The following Auto Instrumentation options for the Linux installer script are deprecated and will only apply if the `--instrumentation-version <version>`
+  option is specified for version `0.86.0` or older:
+  - `--[no-]generate-service-name`: `libsplunk.so` no longer generates service names for instrumented applications. The default behavior is for the activated Java
+    and/or Node.js Auto Instrumentation agents to automatically generate service names. Use the `--service-name <name>` option to override the auto-generated service
+    names for all instrumented applications.
+  - `--[enable|disable]-telemetry`: `libsplunk.so` no longer generates the `splunk.linux-autoinstr.executions` telemetry metric.
+
 ### 💡 Enhancements 💡
 
 - (Splunk) Update golang to 1.20.10 ([#3770](https://github.com/signalfx/splunk-otel-collector/pull/3770))

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -901,13 +901,15 @@ Auto Instrumentation:
                                         Only applicable if the '--with-systemd-instrumentation' option is also specified.
                                         (default: http://LISTEN_INTERFACE:4317 where LISTEN_INTERFACE is the value from
                                         the --listen-interface option if specified, or "127.0.0.1" otherwise)
-  --[no-]generate-service-name          Specify '--no-generate-service-name' to prevent the preloader from setting the
-                                        OTEL_SERVICE_NAME environment variable.
-                                        Only applicable if the '--with-instrumentation' option is also specified.
+  --[no-]generate-service-name          DEPRECATED: Specify '--no-generate-service-name' to prevent the preloader from
+                                        setting the OTEL_SERVICE_NAME environment variable.
+                                        Only applicable if the '--with-instrumentation' option is also specified and the
+                                        '--instrumentation-version' value is 0.86.0 or older.
                                         (default: --generate-service-name)
-  --[enable|disable]-telemetry          Enable or disable the instrumentation preloader from sending the
+  --[enable|disable]-telemetry          DEPRECATED: Enable or disable the instrumentation preloader from sending the
                                         'splunk.linux-autoinstr.executions' metric to the collector.
-                                        Only applicable if the '--with-instrumentation' option is also specified.
+                                        Only applicable if the '--with-instrumentation' option is also specified and the
+                                        '--instrumentation-version' value is 0.86.0 or older.
                                         (default: --enable-telemetry)
   --[enable|disable]-profiler           Enable or disable AlwaysOn Profiling.
                                         Only applicable if the '--with-instrumentation' or


### PR DESCRIPTION
Since the new `libsplunk.so` will no longer generate the service name (the instrumentation agents will handle it) or the `splunk.linux-autoinstr.executions` metric, the `--[no-]generate-service-name` and `--[enable|disable]-telemetry` options will no longer be applicable.