### PR TITLE
fix makefile path typo in github workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ on:
       - 'pkg/**'
       - 'tests/**'
       - 'Makefile'
-      - 'Makefile.common'
+      - 'Makefile.Common'
       - 'go.mod'
       - 'go.sum'
       - '!**.md'
@@ -167,7 +167,7 @@ jobs:
           mkdir -p unit-test-results/junit
           trap "go-junit-report  -set-exit-code < unit-test-results/go-unit-tests.out > unit-test-results/junit/results.xml" EXIT
           make for-all CMD="make test" | tee unit-test-results/go-unit-tests.out
-      
+
       - name: Uploading artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -193,7 +193,7 @@ jobs:
         run: |
           make install-tools
           make test-with-cover
-      
+
       - name: Uploading artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -226,7 +226,7 @@ jobs:
       - name: Build Collector
         run: |
           make ${{ matrix.SYS_BINARIES }}
-      
+
       - name: Uploading binaries
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/darwin-test.yml
+++ b/.github/workflows/darwin-test.yml
@@ -12,7 +12,7 @@ on:
       - 'pkg/**'
       - 'tests/**'
       - 'Makefile'
-      - 'Makefile.common'
+      - 'Makefile.Common'
       - 'go.mod'
       - 'go.sum'
       - '!**.md'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@ on:
       - 'pkg/**'
       - 'tests/**'
       - 'Makefile'
-      - 'Makefile.common'
+      - 'Makefile.Common'
       - 'go.mod'
       - 'go.sum'
       - '!**.md'

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -17,7 +17,7 @@ on:
       - 'internal/buildscripts/packaging/tests/requirements.txt'
       - 'internal/signalfx-agent/bundle/**'
       - 'Makefile'
-      - 'Makefile.common'
+      - 'Makefile.Common'
       - '!**.md'
 
 concurrency:

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -14,7 +14,7 @@ on:
       - 'internal/buildscripts/packaging/msi/**'
       - 'internal/signalfx-agent/bundle/**'
       - 'Makefile'
-      - 'Makefile.common'
+      - 'Makefile.Common'
       - 'tests/zeroconfig/windows/**'
       - '!**.md'
 
@@ -149,7 +149,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v3.2.0
         with:
-          dotnet-version: | 
+          dotnet-version: |
             6.0.407
 
       - name: Download Splunk OTel Collector msi


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Fixes a typo in the filename used in github workflows.

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
