### PR TITLE
use ampere runners for arm64 installer tests

### DIFF
--- a/.github/workflows/installer-script-test.yml
+++ b/.github/workflows/installer-script-test.yml
@@ -45,7 +45,7 @@ jobs:
 
   linux-installer-script-test:
     # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
-    runs-on: ${{ fromJSON('["ubuntu-20.04", "ubuntu-22.04"]')[matrix.DISTRO == 'amazonlinux-2023'] }}
+    runs-on: ${{ matrix.ARCH == 'amd64' && fromJSON('["ubuntu-20.04", "ubuntu-22.04"]')[matrix.DISTRO == 'amazonlinux-2023'] || fromJSON('["ampere"]') }}
     timeout-minutes: 60
     needs: installer-test-matrix
     strategy:
@@ -59,13 +59,8 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v4
 
-      - uses: docker/setup-qemu-action@v3
-        if: ${{ matrix.ARCH != 'amd64' }}
-        with:
-          platforms: ${{ matrix.ARCH }}
-          image: tonistiigi/binfmt:qemu-v7.0.0
-
-      - name: Setup python
+      - if: "matrix.ARCH == 'amd64'"
+        name: Setup python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}


### PR DESCRIPTION
Attempt to use ampere runners for arm64 installer tests.