### PR TITLE
testutils: log attr key for re2 compilation failure

### DIFF
--- a/tests/testutils/telemetry/common.go
+++ b/tests/testutils/telemetry/common.go
@@ -76,7 +76,7 @@ func populateDirectives(attrs *map[string]any) {
 			pattern := subs[1]
 			rec, err := regexp.Compile(pattern)
 			if err != nil {
-				panic(fmt.Errorf("failed compiling resource attributes RE2: %w", err))
+				panic(fmt.Errorf("failed compiling resource attributes RE2 (%s): %w", k, err))
 			}
 			attributes[k] = rec
 		}


### PR DESCRIPTION
**Description:**
These changes add invalid re2 attribute key names to the panic to make invalid patterns easier to find.

**Testing:**
Added missing unit tests for happy and error path.

