### PR TITLE
testutils: update cluster.Delete() for manifests

### DIFF
--- a/tests/general/discoverymode/k8s_observer_discovery_test.go
+++ b/tests/general/discoverymode/k8s_observer_discovery_test.go
@@ -45,7 +45,7 @@ func TestK8sObserver(t *testing.T) {
 	defer tc.ShutdownOTLPReceiverSink()
 
 	cluster := kubeutils.NewKindCluster(tc)
-	defer cluster.Delete()
+	defer cluster.Teardown()
 	cluster.Create()
 	cluster.LoadLocalCollectorImageIfNecessary()
 

--- a/tests/receivers/discovery/k8s_observer_test.go
+++ b/tests/receivers/discovery/k8s_observer_test.go
@@ -45,7 +45,7 @@ func TestDiscoveryReceiverWithK8sObserverProvidesEndpointLogs(t *testing.T) {
 	defer tc.ShutdownOTLPReceiverSink()
 
 	cluster := kubeutils.NewKindCluster(tc)
-	defer cluster.Delete()
+	defer cluster.Teardown()
 	cluster.Create()
 	cluster.LoadLocalCollectorImageIfNecessary()
 
@@ -119,7 +119,7 @@ func TestDiscoveryReceiverWithK8sObserverAndSmartAgentRedisReceiverProvideStatus
 	defer tc.ShutdownOTLPReceiverSink()
 
 	cluster := kubeutils.NewKindCluster(tc)
-	defer cluster.Delete()
+	defer cluster.Teardown()
 	cluster.Create()
 	cluster.LoadLocalCollectorImageIfNecessary()
 

--- a/tests/receivers/smartagent/collectd-mysql/bundled_test.go
+++ b/tests/receivers/smartagent/collectd-mysql/bundled_test.go
@@ -44,7 +44,7 @@ func TestK8sObserver(t *testing.T) {
 	defer tc.ShutdownOTLPReceiverSink()
 
 	cluster := testCluster{kubeutils.NewKindCluster(tc)}
-	defer cluster.Delete()
+	defer cluster.Teardown()
 	cluster.Create()
 	cluster.LoadLocalCollectorImageIfNecessary()
 

--- a/tests/receivers/smartagent/postgresql/bundled_test.go
+++ b/tests/receivers/smartagent/postgresql/bundled_test.go
@@ -45,7 +45,7 @@ func TestK8sObserver(t *testing.T) {
 	defer tc.ShutdownOTLPReceiverSink()
 
 	cluster := testCluster{kubeutils.NewKindCluster(tc)}
-	defer cluster.Delete()
+	defer cluster.Teardown()
 	cluster.Create()
 	cluster.LoadLocalCollectorImageIfNecessary()
 

--- a/tests/testutils/kubeutils/kind_cluster_integration_test.go
+++ b/tests/testutils/kubeutils/kind_cluster_integration_test.go
@@ -44,7 +44,7 @@ func TestKindCluster(t *testing.T) {
 	cluster.ExposedPorts[portTwo] = 23456
 
 	defer func() {
-		cluster.Delete()
+		cluster.Teardown()
 
 		// confirm node unavailable
 		_, err := cluster.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
@@ -90,4 +90,21 @@ nodes:
 	require.Equal(t, "test-namespace", ns.Name)
 
 	require.NotEmpty(t, cluster.GetDefaultGatewayIP())
+
+	nsManifest := `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: another-namespace
+`
+
+	stdout, stderr, err := cluster.Apply(nsManifest)
+	require.NoError(t, err)
+	require.Equal(t, "namespace/another-namespace created\n", stdout.String())
+	require.Empty(t, stderr.String())
+
+	stdout, stderr, err = cluster.Delete(nsManifest)
+	require.NoError(t, err)
+	require.Equal(t, "namespace \"another-namespace\" deleted\n", stdout.String())
+	require.Empty(t, "", stderr.String())
 }


### PR DESCRIPTION
**Description:**
These changes add a `kubectl delete -f` helper to the kind cluster, relocating the previous `cluster.Delete()` to `cluster.Teardown()`

**Testing:**
Add testutils integration and update existing.