### PR TITLE
Support confmap providers in discovery config

### DIFF
--- a/internal/confmapprovider/discovery/README.md
+++ b/internal/confmapprovider/discovery/README.md
@@ -170,12 +170,16 @@ These properties can be in `config.d/properties.discovery.yaml` or specified at 
 
 You can also specify a `--discovery-properties=<filepath.yaml>` argument to disregard `config.d/properties.discovery.yaml` properties and load properties not to be shared with another Collector service, while still benefiting from existing discovery component definitions.
 
-The `config.d/properties.discovery.yaml` file supports specifying the property values directly as well within a mapped form:
+The `config.d/properties.discovery.yaml` file supports specifying the property values directly as well within a mapped form. The property values can also be environment
+variables:
 
 ```yaml
 # --set form will take priority to mapped values
 splunk.discovery.receivers.prometheus_simple.config.labels::my_label: my_label_value
 splunk.discovery.receivers.prometheus_simple.enabled: true
+
+splunk.discovery.receivers.smartagent/postgresql.config.params::username: '${env:PG_USERNAME}'
+splunk.discovery.receivers.smartagent/postgresql.config.params::password: '${env:PG_PASSWORD}'
 
 # mapped property form
 splunk.discovery:

--- a/tests/general/discoverymode/host_observer_discovery_test.go
+++ b/tests/general/discoverymode/host_observer_discovery_test.go
@@ -175,7 +175,7 @@ func TestHostObserver(t *testing.T) {
 							"config": map[string]any{
 								"collection_interval": "1s",
 								"labels": map[string]any{
-									"label_one":   "${LABEL_ONE_VALUE}",
+									"label_one":   "${env:LABEL_ONE_VALUE}",
 									"label_two":   "${LABEL_TWO_VALUE}",
 									"label_three": "actual.label.three.value.from.cmdline.property",
 								},
@@ -301,7 +301,7 @@ receivers:
         config:
           collection_interval: 1s
           labels:
-            label_one: ${LABEL_ONE_VALUE}
+            label_one: ${env:LABEL_ONE_VALUE}
             label_three: actual.label.three.value.from.env.var.property
             label_two: ${LABEL_TWO_VALUE}
         resource_attributes: {}

--- a/tests/general/discoverymode/testdata/host-observer-config.d/receivers/internal-prometheus.discovery.yaml
+++ b/tests/general/discoverymode/testdata/host-observer-config.d/receivers/internal-prometheus.discovery.yaml
@@ -6,7 +6,7 @@ prometheus_simple:
     default:
       collection_interval: invalid
       labels:
-        label_one: ${LABEL_ONE_VALUE}
+        label_one: '${env:LABEL_ONE_VALUE}'
         label_three: overwritten by discovery property
     host_observer:
       collection_interval: 1s

--- a/tests/receivers/smartagent/postgresql/bundled_test.go
+++ b/tests/receivers/smartagent/postgresql/bundled_test.go
@@ -399,8 +399,8 @@ func (cluster testCluster) daemonSetManifest(namespace, serviceAccount, configMa
 				Image: testutils.GetCollectorImageOrSkipTest(cluster.Testcase),
 				Command: []string{
 					"/otelcol", "--config=/config/config.yaml", "--discovery",
-					"--set", "splunk.discovery.receivers.smartagent/postgresql.config.params::username='${PG_USERNAME}'",
-					"--set", "splunk.discovery.receivers.smartagent/postgresql.config.params::password='${PG_PASSWORD}'",
+					"--set", "splunk.discovery.receivers.smartagent/postgresql.config.params::username='${env:PG_USERNAME}'",
+					"--set", "splunk.discovery.receivers.smartagent/postgresql.config.params::password='${env:PG_PASSWORD}'",
 					"--set", "splunk.discovery.receivers.smartagent/postgresql.config.masterDBName=test_db",
 					"--set", `splunk.discovery.receivers.smartagent/postgresql.config.extraMetrics=["*"]`,
 				},


### PR DESCRIPTION
Adding option for arbitrary env var to authenticate for dbs on discovery mode

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to Splunk idea:** 

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
