### PR TITLE
Fix instrumentation tests for arm64

### DIFF
--- a/instrumentation/Makefile
+++ b/instrumentation/Makefile
@@ -74,8 +74,8 @@ tests: test-java test-nodejs
 
 .PHONY: test-java
 test-java: dist
-	(cd tests/java && ./test.sh)
+	(cd tests/java && ARCH=$(ARCH) ./test.sh)
 
 .PHONY: test-nodejs
 test-nodejs: dist
-	(cd tests/nodejs && ./test.sh)
+	(cd tests/nodejs && ARCH=$(ARCH) ./test.sh)

--- a/instrumentation/tests/java/test.sh
+++ b/instrumentation/tests/java/test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 arch="${ARCH:-amd64}"
 BASE="eclipse-temurin:11"
-if [[ arch = "arm64" ]]; then
+if [[ "$arch" = "arm64" ]]; then
   BASE="arm64v8/eclipse-temurin:11"
 fi
 
@@ -12,7 +12,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 cp "${SCRIPT_DIR}/../../dist/libsplunk_${arch}.so" libsplunk.so
 docker buildx build -q --platform linux/${arch} --build-arg BASE=$BASE -o type=image,name=zeroconfig-test-java,push=false .
-OUTPUT=$(docker run --rm zeroconfig-test-java)
+OUTPUT=$(docker run --platform linux/${arch} --rm zeroconfig-test-java)
 echo "========== OUTPUT =========="
 echo "$OUTPUT"
 echo "============================"
@@ -30,7 +30,7 @@ echo "Test absence of OTEL_EXPORTER_OTLP_ENDPOINT"
 echo "$OUTPUT" | grep -v "OTEL_EXPORTER_OTLP_ENDPOINT" > /dev/null && echo "Test passes"  || exit 1
 
 # Check we didn't inject env vars into processes outside of java.
-OUTPUT_BASH=$(docker run --rm zeroconfig-test-java /usr/bin/env)
+OUTPUT_BASH=$(docker run --platform linux/${arch} --rm zeroconfig-test-java /usr/bin/env)
 echo "======= BASH OUTPUT ========"
 echo "$OUTPUT_BASH"
 echo "============================"

--- a/instrumentation/tests/nodejs/test.sh
+++ b/instrumentation/tests/nodejs/test.sh
@@ -4,14 +4,14 @@ set -euo pipefail
 
 arch="${ARCH:-amd64}"
 BASE="node:16"
-if [[ arch = "arm64" ]]; then
+if [[ "$arch" = "arm64" ]]; then
   BASE="arm64v8/node:16"
 fi
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 cp "${SCRIPT_DIR}/../../dist/libsplunk_${arch}.so" libsplunk.so
 docker buildx build -q --platform linux/${arch} --build-arg BASE=$BASE -o type=image,name=zeroconfig-test-nodejs,push=false .
-OUTPUT=$(docker run --rm zeroconfig-test-nodejs)
+OUTPUT=$(docker run --platform linux/${arch} --rm zeroconfig-test-nodejs)
 echo "========== OUTPUT =========="
 echo "$OUTPUT"
 echo "============================"


### PR DESCRIPTION
Fix for `WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64/v4) and no specific platform was requested` when running `make tests`.