### PR TITLE
Respect JAVA_HOME in smartagent receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- (Splunk) `smartagent`: Respect `JAVA_HOME` environment variable instead of enforcing bundle-relative value ([#3877](https://github.com/signalfx/splunk-otel-collector/pull/3877))
+
 ## v0.87.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.87.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.87.0) and the [opentelemetry-collector-contrib v0.87.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.87.0) releases where appropriate.

--- a/pkg/receiver/smartagentreceiver/receiver.go
+++ b/pkg/receiver/smartagentreceiver/receiver.go
@@ -254,7 +254,9 @@ func (r *receiver) setUpSmartAgentConfigProvider(extensions map[component.ID]ote
 
 func setUpEnvironment() {
 	if runtime.GOOS != "windows" { // Agent bundle doesn't include jre for Windows
-		os.Setenv("JAVA_HOME", filepath.Join(saConfig.BundleDir, "jre"))
+		if _, ok := os.LookupEnv("JAVA_HOME"); !ok {
+			os.Setenv("JAVA_HOME", filepath.Join(saConfig.BundleDir, "jre"))
+		}
 	}
 
 	hostfs.SetEnvMap(common.EnvMap{


### PR DESCRIPTION
**Description:**
These changes make sure that `JAVA_HOME` is only set in the smart agent receiver if currently unset. This breaking change will avoid the scenario where the jmx receiver's target java version isn't configurable otherwise.

**Documentation:**
Since this is a bug fix I haven't documented more than a changelog entry but appreciate suggestions.