### PR TITLE
Use "TARGET_ENV: velocity" for msi signing job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -495,6 +495,7 @@ sign-msi:
     SIGN_TYPE: WIN
     OPTIONS: archive
     DOWNLOAD_DIR: dist/signed
+    TARGET_ENV: velocity
   before_script:
     - pushd dist && tar -czvf packages.tar.gz *.msi && popd
   after_script:


### PR DESCRIPTION
Without this var, the "signed" MSI artifact is corrupted/uninstallable.