### PR TITLE
fix: use proper key formating as per stanza persister

### DIFF
--- a/cmd/migratecheckpoint/log_library.go
+++ b/cmd/migratecheckpoint/log_library.go
@@ -30,8 +30,8 @@ type Fingerprint struct {
 
 type Reader struct {
 	Fingerprint    *Fingerprint
-	Offset         int64
 	FileAttributes map[string]any
+	Offset         int64
 }
 
 type journaldCursor struct {

--- a/cmd/migratecheckpoint/log_library.go
+++ b/cmd/migratecheckpoint/log_library.go
@@ -29,8 +29,9 @@ type Fingerprint struct {
 }
 
 type Reader struct {
-	Fingerprint *Fingerprint
-	Offset      int64
+	Fingerprint    *Fingerprint
+	Offset         int64
+	FileAttributes map[string]any
 }
 
 type journaldCursor struct {

--- a/cmd/migratecheckpoint/main.go
+++ b/cmd/migratecheckpoint/main.go
@@ -86,7 +86,7 @@ func (m *Migrator) MigrateContainerPos(lines []string) {
 	defer client.Close()
 	_, buf := m.ConvertFilePos(lines)
 
-	err = client.Set("$.file_input.knownFiles", buf.Bytes())
+	err = client.Set("file_input.knownFiles", buf.Bytes())
 	if err != nil {
 		log.Printf("error storing container checkpoints: %v", err)
 	}
@@ -110,7 +110,7 @@ func (m *Migrator) MigrateCustomPos(matches []string) {
 				if err != nil {
 					log.Printf("error creating a new DB client for host file checkpoints: %v", err)
 				}
-				err = client.Set("$.file_input.knownFiles", buf.Bytes())
+				err = client.Set("file_input.knownFiles", buf.Bytes())
 				if err != nil {
 					log.Printf("error storing host file checkpoints: %v", err)
 				}
@@ -141,7 +141,7 @@ func (m *Migrator) MigrateJournaldPos(matches []string) {
 			if err != nil {
 				log.Printf("error creating a new DB client for journald checkpoints: %v", err)
 			}
-			err = client.Set("$.journald_input.lastReadCursor", []byte(cursor.Cursor))
+			err = client.Set("journald_input.lastReadCursor", []byte(cursor.Cursor))
 			if err != nil {
 				log.Printf("error storing journald checkpoints: %v", err)
 			}
@@ -218,8 +218,9 @@ func convertToOtel(path string, hexPos string) (*Reader, error) {
 	}
 
 	reader := &Reader{
-		Fingerprint: fp,
-		Offset:      offset,
+		Fingerprint:    fp,
+		Offset:         offset,
+		FileAttributes: map[string]any{},
 	}
 	return reader, nil
 }


### PR DESCRIPTION
**Description:** Migrating offsets from SCK to SCK-Otel doesn't work. This is because of incorrect keys we use to populate the boltdb cache. 
The proper keys should be
`file_input.knownFiles`, `journald_input.lastReadCursor`
But we prepend `$.` to them and it causes log replication. 
Refer [scoped persister](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.88.0/pkg/stanza/operator/persister.go#L30-L38) for the current format.


~~**Note: I'm currently in the process of testing this on my Mac. I'd appreciate you're review on this by then**~~
Testing: Manually tested it on SCK and SCK-OTeL with locally built image