### PR TITLE
ansible: Support new zero config

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Install yamllint.
         run: pip3 install yamllint
@@ -100,7 +100,7 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: "${{ github.workspace }}/requirements.txt"
 
@@ -160,7 +160,7 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: "${{ github.workspace }}/requirements.txt"
 

--- a/deployments/ansible/CHANGELOG.md
+++ b/deployments/ansible/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## unreleased
 
+## ansible-v0.24.0
+
+### 🚩 Deprecations 🚩
+
+- The `splunk_otel_auto_instrumentation_generate_service_name` and `splunk_otel_auto_instrumentation_disable_telemetry`
+  options are deprecated and only applicable if `splunk_otel_auto_instrumentation_version` is < `0.87.0`.
+
+### 💡 Enhancements 💡
+
+- Support Splunk OpenTelemetry Auto Instrumentation [v0.87.0](
+  https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.87.0) and newer (Java only).
+- Support activation and configuration of auto instrumentation for only `systemd` services.
+- Support setting the OTLP exporter endpoint for auto instrumentation (default: `http://127.0.0.1:4317`). Only
+  applicable if `splunk_otel_auto_instrumentation_version` is `latest` or >= `0.87.0`.
+
 ## ansible-v0.23.0
 
 ### 💡 Enhancements 💡

--- a/deployments/ansible/CHANGELOG.md
+++ b/deployments/ansible/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Support setting the OTLP exporter endpoint for auto instrumentation (default: `http://127.0.0.1:4317`). Only
   applicable if `splunk_otel_auto_instrumentation_version` is `latest` or >= `0.87.0`.
 
+### 🧰 Bug fixes 🧰
+
+- Ensure loop variables for Windows tasks are defined
+
 ## ansible-v0.23.0
 
 ### 💡 Enhancements 💡

--- a/deployments/ansible/galaxy.yml
+++ b/deployments/ansible/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: signalfx
 name: splunk_otel_collector
 description: Ansible collection for Splunk OpenTelemetry Collector
-version: 0.23.0
+version: 0.24.0
 readme: README.md
 authors:
   - Splunk Inc.

--- a/deployments/ansible/molecule/with_instrumentation/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation/verify.yml
@@ -23,6 +23,8 @@
         dest: /etc/ld.so.preload
         state: present
       check_mode: yes
+      register: preload
+      failed_when: preload is changed
 
     - name: Assert instrumentation config contains path to java agent
       ansible.builtin.lineinfile:
@@ -30,6 +32,8 @@
         dest: /usr/lib/splunk-instrumentation/instrumentation.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert instrumentation config contains resource attribute
       ansible.builtin.lineinfile:
@@ -37,6 +41,8 @@
         dest: /usr/lib/splunk-instrumentation/instrumentation.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert instrumentation config contains service name
       ansible.builtin.lineinfile:
@@ -44,6 +50,8 @@
         dest: /usr/lib/splunk-instrumentation/instrumentation.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert instrumentation config contains generate_service_name
       ansible.builtin.lineinfile:
@@ -51,6 +59,8 @@
         dest: /usr/lib/splunk-instrumentation/instrumentation.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert instrumentation config contains disable_telemetry
       ansible.builtin.lineinfile:
@@ -58,6 +68,8 @@
         dest: /usr/lib/splunk-instrumentation/instrumentation.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert instrumentation config contains enable_profiler
       ansible.builtin.lineinfile:
@@ -65,6 +77,8 @@
         dest: /usr/lib/splunk-instrumentation/instrumentation.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert instrumentation config contains enable_profiler_memory
       ansible.builtin.lineinfile:
@@ -72,6 +86,8 @@
         dest: /usr/lib/splunk-instrumentation/instrumentation.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert instrumentation config contains enable_metrics
       ansible.builtin.lineinfile:
@@ -79,3 +95,5 @@
         dest: /usr/lib/splunk-instrumentation/instrumentation.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_preload_custom/Dockerfile.j2
+++ b/deployments/ansible/molecule/with_instrumentation_preload_custom/Dockerfile.j2
@@ -1,0 +1,1 @@
+../default/Dockerfile.j2

--- a/deployments/ansible/molecule/with_instrumentation_preload_custom/converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_custom/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge scenario with auto-instrumentation installation
+  hosts: all
+  become: yes
+  vars:
+    splunk_access_token: fake-token
+    splunk_realm: fake-realm
+    install_splunk_otel_auto_instrumentation: true
+    splunk_otel_auto_instrumentation_ld_so_preload: "# my custom library"
+    splunk_otel_auto_instrumentation_resource_attributes: deployment.environment=test
+    splunk_otel_auto_instrumentation_service_name: test
+    splunk_otel_auto_instrumentation_enable_profiler: true
+    splunk_otel_auto_instrumentation_enable_profiler_memory: true
+    splunk_otel_auto_instrumentation_enable_metrics: true
+    splunk_otel_auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
+  tasks:
+    - name: "Include signalfx.splunk_otel_collector.collector role"
+      include_role:
+        name: "collector"

--- a/deployments/ansible/molecule/with_instrumentation_preload_custom/molecule.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_custom/molecule.yml
@@ -1,0 +1,1 @@
+# no default config provided, make sure to set --base-config molecule argument instead

--- a/deployments/ansible/molecule/with_instrumentation_preload_custom/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_custom/verify.yml
@@ -1,0 +1,110 @@
+---
+- name: Verify scenario with auto-instrumentation installation
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Populate service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert splunk-otel-collector service is running
+      assert:
+        that: ansible_facts.services['splunk-otel-collector.service'].state == 'running'
+
+    - name: Populate package facts
+      ansible.builtin.package_facts:
+
+    - name: Get splunk-otel-auto-instrumentation version
+      set_fact:
+        auto_instrumentation_version: "{{ ansible_facts.packages['splunk-otel-auto-instrumentation'][0].version }}"
+
+    - name: Check for systemd drop-in file
+      ansible.builtin.stat:
+        path: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+      register: systemd
+
+    - name: Assert systemd drop-in file does not exist
+      assert:
+        that: not systemd.stat.exists
+
+    - name: Assert /etc/ld.so.preload contains path to libsplunk.so
+      ansible.builtin.lineinfile:
+        line: /usr/lib/splunk-instrumentation/libsplunk.so
+        dest: /etc/ld.so.preload
+        state: present
+      check_mode: yes
+      register: preload
+      failed_when: preload is changed
+
+    - name: Assert /etc/ld.so.preload contains custom line
+      ansible.builtin.lineinfile:
+        line: '# my custom library'
+        dest: /etc/ld.so.preload
+        state: present
+      check_mode: yes
+      register: preload
+      failed_when: preload is changed
+
+    - name: Assert instrumentation config contains path to java agent
+      ansible.builtin.lineinfile:
+        line: JAVA_TOOL_OPTIONS=-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains OTEL_RESOURCE_ATTRIBUTES
+      ansible.builtin.lineinfile:
+        line: "OTEL_RESOURCE_ATTRIBUTES=\
+              splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }},\
+              deployment.environment=test"
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains OTEL_SERVICE_NAME
+      ansible.builtin.lineinfile:
+        line: OTEL_SERVICE_NAME=test
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains SPLUNK_PROFILER_ENABLED
+      ansible.builtin.lineinfile:
+        line: SPLUNK_PROFILER_ENABLED=true
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains SPLUNK_PROFILER_MEMORY_ENABLED
+      ansible.builtin.lineinfile:
+        line: SPLUNK_PROFILER_MEMORY_ENABLED=true
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains SPLUNK_METRICS_ENABLED
+      ansible.builtin.lineinfile:
+        line: SPLUNK_METRICS_ENABLED=true
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_ENDPOINT
+      ansible.builtin.lineinfile:
+        line: OTEL_EXPORTER_OTLP_ENDPOINT=http://0.0.0.0:4317
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_preload_default/Dockerfile.j2
+++ b/deployments/ansible/molecule/with_instrumentation_preload_default/Dockerfile.j2
@@ -1,0 +1,1 @@
+../default/Dockerfile.j2

--- a/deployments/ansible/molecule/with_instrumentation_preload_default/converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_default/converge.yml
@@ -1,0 +1,12 @@
+---
+- name: Converge scenario with auto-instrumentation installation
+  hosts: all
+  become: yes
+  vars:
+    splunk_access_token: fake-token
+    splunk_realm: fake-realm
+    install_splunk_otel_auto_instrumentation: true
+  tasks:
+    - name: "Include signalfx.splunk_otel_collector.collector role"
+      include_role:
+        name: "collector"

--- a/deployments/ansible/molecule/with_instrumentation_preload_default/molecule.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_default/molecule.yml
@@ -1,0 +1,1 @@
+# no default config provided, make sure to set --base-config molecule argument instead

--- a/deployments/ansible/molecule/with_instrumentation_preload_default/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_default/verify.yml
@@ -1,0 +1,100 @@
+---
+- name: Verify scenario with auto-instrumentation installation
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Populate service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert splunk-otel-collector service is running
+      assert:
+        that: ansible_facts.services['splunk-otel-collector.service'].state == 'running'
+
+    - name: Populate package facts
+      ansible.builtin.package_facts:
+
+    - name: Get splunk-otel-auto-instrumentation version
+      set_fact:
+        auto_instrumentation_version: "{{ ansible_facts.packages['splunk-otel-auto-instrumentation'][0].version }}"
+
+    - name: Check for systemd drop-in file
+      ansible.builtin.stat:
+        path: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+      register: systemd
+
+    - name: Assert systemd drop-in file does not exist
+      assert:
+        that: not systemd.stat.exists
+
+    - name: Assert /etc/ld.so.preload contains path to libsplunk.so
+      ansible.builtin.lineinfile:
+        line: /usr/lib/splunk-instrumentation/libsplunk.so
+        dest: /etc/ld.so.preload
+        state: present
+      check_mode: yes
+      register: preload
+      failed_when: preload is changed
+
+    - name: Assert instrumentation config contains path to java agent
+      ansible.builtin.lineinfile:
+        line: JAVA_TOOL_OPTIONS=-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains OTEL_RESOURCE_ATTRIBUTES
+      ansible.builtin.lineinfile:
+        line: "OTEL_RESOURCE_ATTRIBUTES=\
+              splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }}"
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_SERVICE_NAME
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_SERVICE_NAME.*'
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains SPLUNK_PROFILER_ENABLED
+      ansible.builtin.lineinfile:
+        line: SPLUNK_PROFILER_ENABLED=false
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains SPLUNK_PROFILER_MEMORY_ENABLED
+      ansible.builtin.lineinfile:
+        line: SPLUNK_PROFILER_MEMORY_ENABLED=false
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains SPLUNK_METRICS_ENABLED
+      ansible.builtin.lineinfile:
+        line: SPLUNK_METRICS_ENABLED=false
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_ENDPOINT
+      ansible.builtin.lineinfile:
+        line: OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_systemd_custom/Dockerfile.j2
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_custom/Dockerfile.j2
@@ -1,0 +1,1 @@
+../default/Dockerfile.j2

--- a/deployments/ansible/molecule/with_instrumentation_systemd_custom/converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_custom/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge scenario with auto-instrumentation installation
+  hosts: all
+  become: yes
+  vars:
+    splunk_access_token: fake-token
+    splunk_realm: fake-realm
+    install_splunk_otel_auto_instrumentation: true
+    splunk_otel_auto_instrumentation_systemd: true
+    splunk_otel_auto_instrumentation_resource_attributes: deployment.environment=test
+    splunk_otel_auto_instrumentation_service_name: test
+    splunk_otel_auto_instrumentation_enable_profiler: true
+    splunk_otel_auto_instrumentation_enable_profiler_memory: true
+    splunk_otel_auto_instrumentation_enable_metrics: true
+    splunk_otel_auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
+  tasks:
+    - name: "Include signalfx.splunk_otel_collector.collector role"
+      include_role:
+        name: "collector"

--- a/deployments/ansible/molecule/with_instrumentation_systemd_custom/molecule.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_custom/molecule.yml
@@ -1,0 +1,1 @@
+# no default config provided, make sure to set --base-config molecule argument instead

--- a/deployments/ansible/molecule/with_instrumentation_systemd_custom/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_custom/verify.yml
@@ -1,0 +1,91 @@
+---
+- name: Verify scenario with auto-instrumentation installation
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Populate service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert splunk-otel-collector service is running
+      assert:
+        that: ansible_facts.services['splunk-otel-collector.service'].state == 'running'
+
+    - name: Populate package facts
+      ansible.builtin.package_facts:
+
+    - name: Get splunk-otel-auto-instrumentation version
+      set_fact:
+        auto_instrumentation_version: "{{ ansible_facts.packages['splunk-otel-auto-instrumentation'][0].version }}"
+
+    - name: Assert /etc/ld.so.preload does not contain path to libsplunk.so
+      ansible.builtin.lineinfile:
+        line: /usr/lib/splunk-instrumentation/libsplunk.so
+        dest: /etc/ld.so.preload
+        state: absent
+      check_mode: yes
+      register: preload
+      failed_when: preload is changed
+
+    - name: Assert instrumentation config contains path to java agent
+      ansible.builtin.lineinfile:
+        line: "DefaultEnvironment=\"JAVA_TOOL_OPTIONS=\
+              -javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar\""
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains OTEL_RESOURCE_ATTRIBUTES
+      ansible.builtin.lineinfile:
+        line: "DefaultEnvironment=\"OTEL_RESOURCE_ATTRIBUTES=\
+              splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }}-systemd,\
+              deployment.environment=test\""
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains OTEL_SERVICE_NAME
+      ansible.builtin.lineinfile:
+        line: DefaultEnvironment="OTEL_SERVICE_NAME=test"
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains SPLUNK_PROFILER_ENABLED
+      ansible.builtin.lineinfile:
+        line: DefaultEnvironment="SPLUNK_PROFILER_ENABLED=true"
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+
+    - name: Assert instrumentation config contains SPLUNK_PROFILER_MEMORY_ENABLED
+      ansible.builtin.lineinfile:
+        line: DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED=true"
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains SPLUNK_METRICS_ENABLED
+      ansible.builtin.lineinfile:
+        line: DefaultEnvironment="SPLUNK_METRICS_ENABLED=true"
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_ENDPOINT
+      ansible.builtin.lineinfile:
+        line: DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=http://0.0.0.0:4317"
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_systemd_default/Dockerfile.j2
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_default/Dockerfile.j2
@@ -1,0 +1,1 @@
+../default/Dockerfile.j2

--- a/deployments/ansible/molecule/with_instrumentation_systemd_default/converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_default/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge scenario with auto-instrumentation installation
+  hosts: all
+  become: yes
+  vars:
+    splunk_access_token: fake-token
+    splunk_realm: fake-realm
+    install_splunk_otel_auto_instrumentation: true
+    splunk_otel_auto_instrumentation_systemd: true
+  tasks:
+    - name: "Include signalfx.splunk_otel_collector.collector role"
+      include_role:
+        name: "collector"

--- a/deployments/ansible/molecule/with_instrumentation_systemd_default/molecule.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_default/molecule.yml
@@ -1,0 +1,1 @@
+# no default config provided, make sure to set --base-config molecule argument instead

--- a/deployments/ansible/molecule/with_instrumentation_systemd_default/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_default/verify.yml
@@ -1,0 +1,92 @@
+---
+- name: Verify scenario with auto-instrumentation installation
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Populate service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert splunk-otel-collector service is running
+      assert:
+        that: ansible_facts.services['splunk-otel-collector.service'].state == 'running'
+
+    - name: Populate package facts
+      ansible.builtin.package_facts:
+
+    - name: Get splunk-otel-auto-instrumentation version
+      set_fact:
+        auto_instrumentation_version: "{{ ansible_facts.packages['splunk-otel-auto-instrumentation'][0].version }}"
+
+    - name: Assert /etc/ld.so.preload does not contain path to libsplunk.so
+      ansible.builtin.lineinfile:
+        line: /usr/lib/splunk-instrumentation/libsplunk.so
+        dest: /etc/ld.so.preload
+        state: absent
+      check_mode: yes
+      register: preload
+      failed_when: preload is changed
+
+    - name: Assert instrumentation config contains path to java agent
+      ansible.builtin.lineinfile:
+        line: "DefaultEnvironment=\"JAVA_TOOL_OPTIONS=\
+              -javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar\""
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains OTEL_RESOURCE_ATTRIBUTES
+      ansible.builtin.lineinfile:
+        line: "DefaultEnvironment=\"OTEL_RESOURCE_ATTRIBUTES=\
+              splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }}-systemd\""
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_SERVICE_NAME
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_SERVICE_NAME.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains SPLUNK_PROFILER_ENABLED
+      ansible.builtin.lineinfile:
+        line: DefaultEnvironment="SPLUNK_PROFILER_ENABLED=false"
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains SPLUNK_PROFILER_MEMORY_ENABLED
+      ansible.builtin.lineinfile:
+        line: DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED=false"
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains SPLUNK_METRICS_ENABLED
+      ansible.builtin.lineinfile:
+        line: DefaultEnvironment="SPLUNK_METRICS_ENABLED=false"
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_ENDPOINT
+      ansible.builtin.lineinfile:
+        line: DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317"
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -209,47 +209,53 @@ after installation/configuration in order for any change to take effect.
   `splunk-otel-auto-instrumentation` package to install, e.g. `0.50.0`.
   The minimum supported version is `0.48.0`. (**default:** `latest`)
 
-- `splunk_otel_auto_instrumentation_ld_so_preload` (Linux only): By default,
-  the `/etc/ld.so.preload` file on the node will be configured for the
+- `splunk_otel_auto_instrumentation_systemd` (Linux only): By default, the
+  `/etc/ld.so.preload` file on the node will be configured for the
   `/usr/lib/splunk-instrumentation/libsplunk.so` [shared object library](
-  https://github.com/signalfx/splunk-otel-collector/tree/main/instrumentation#operation)
-  provided by the `splunk-otel-auto-instrumentation` package and is required
-  for auto instrumentation. Configure this variable to include additional
-  library paths, e.g. `/path/to/my.library.so`. (**default:** ``)
+  https://github.com/signalfx/splunk-otel-collector/tree/main/instrumentation)
+  provided by the `splunk-otel-auto-instrumentation` package to activate and
+  configure auto instrumentation system-wide for all supported applications.
+  Alternatively, set this option to `true` to activate and configure auto
+  instrumentation ***only*** for supported applications running as `systemd`
+  services. If this option is set to `true`,
+  `/usr/lib/splunk-instrumentation/libsplunk.so` will not be added to
+  `/etc/ld.so.preload`. Instead, the
+  `/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf`
+  `systemd` drop-in file will be created and configured for environment
+  variables based on the default and specified options. (**default:** `false`)
+
+- `splunk_otel_auto_instrumentation_ld_so_preload` (Linux only): Configure this
+  variable to include additional library paths, e.g. `/path/to/my.library.so`,
+  to `/etc/ld.so.preload`. (**default:** ``)
 
 - `splunk_otel_auto_instrumentation_java_agent_jar` (Linux only): Path to the
   [Splunk OpenTelemetry Java agent](
   https://github.com/signalfx/splunk-otel-java). The default path is provided
   by the `splunk-otel-auto-instrumentation` package. If the path is changed
-  from the default value, the path should be an existing file on the node. The
-  specified path will be added to the
-  `/usr/lib/splunk-instrumentation/instrumentation.conf` config file on the
-  node. (**default:**
-  `/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar`)
+  from the default value, the path should be an existing file on the node.
+  (**default:** `/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar`)
 
 - `splunk_otel_auto_instrumentation_resource_attributes` (Linux only):
-  Configure the OpenTelemetry instrumentation [resource attributes](
-  https://github.com/signalfx/splunk-otel-collector/tree/main/instrumentation#configuration-file),
-  e.g. `deployment.environment=prod`. The specified resource attribute(s) will
-  be added to the `/usr/lib/splunk-instrumentation/instrumentation.conf` config
-  file on the node. (**default:** ``)
+  Configure the OpenTelemetry instrumentation resource attributes,
+  e.g. `deployment.environment=prod,my.key=value` (comma-separated
+  `key=value` pairs. (**default:** ``)
 
 - `splunk_otel_auto_instrumentation_service_name` (Linux only): Explicitly set
-  the [service name](
-  https://github.com/signalfx/splunk-otel-collector/tree/main/instrumentation#configuration-file),
-  for the instrumented Java application, e.g. `my.service`. By default, the
-  service name is automatically derived from the arguments of the Java
-  executable on the node. The specified service name will be added to the
-  `/usr/lib/splunk-instrumentation/instrumentation.conf` config file on the
-  node, overriding any generated service name. (**default:** ``)
+  the service name for ***all*** instrumented applications on the node, e.g.
+  `my.service`. By default, the service name is automatically generated for
+  each instrumented application. (**default:** ``)
 
-- `splunk_otel_auto_instrumentation_generate_service_name` (Linux only): Set
-  this option to `false` to prevent the preloader from setting the
-  `OTEL_SERVICE_NAME` environment variable. (**default:** `true`)
+- **DEPRECATED** `splunk_otel_auto_instrumentation_generate_service_name`
+  (Linux only): Set this option to `false` to prevent the preloader from
+  setting the `OTEL_SERVICE_NAME` environment variable. Only applicable if
+  `splunk_otel_auto_instrumentation_version` is < `0.87.0`.
+  (**default:** `true`)
 
-- `splunk_otel_auto_instrumentation_disable_telemetry` (Linux only): Enable or
-  disable the preloader from sending the `splunk.linux-autoinstr.executions`
-  metric to the local collector. (**default:** `false`)
+- **DEPRECATED** `splunk_otel_auto_instrumentation_disable_telemetry`
+  (Linux only): Enable or disable the preloader from sending the
+  `splunk.linux-autoinstr.executions` metric to the local collector. Only
+  applicable if `splunk_otel_auto_instrumentation_version` is < `0.87.0`.
+  (**default:** `false`)
 
 - `splunk_otel_auto_instrumentation_enable_profiler` (Linux only): Enable or
   disable AlwaysOn CPU Profiling. (**default**: `false`)
@@ -258,7 +264,12 @@ after installation/configuration in order for any change to take effect.
   Enable or disable AlwaysOn Memory Profiling. (**default:** `false`)
 
 - `splunk_otel_auto_instrumentation_enable_metrics` (Linux only): Enable or
-  disable exporting Micrometer metrics. (**default**: `false`)
+  disable exporting instrumentation metrics. (**default**: `false`)
+
+- `splunk_otel_auto_instrumentation_otlp_endpoint` (Linux only): Set the OTLP
+  gRPC endpoint for captured traces. Only applicable if
+  `splunk_otel_auto_instrumentation_version` is `latest` or >= `0.87.0`.
+  (**default:** `http://127.0.0.1:4317`)
 
 ### Auto Instrumentation for .NET on Windows
 

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -62,6 +62,7 @@ splunk_otel_collector_proxy_https: ""
 splunk_otel_collector_no_proxy: "localhost,127.0.0.1,::1"
 
 install_splunk_otel_auto_instrumentation: false
+splunk_otel_auto_instrumentation_systemd: false
 splunk_otel_auto_instrumentation_version: latest
 splunk_otel_auto_instrumentation_ld_so_preload: ""
 splunk_otel_auto_instrumentation_java_agent_jar: /usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar
@@ -72,6 +73,7 @@ splunk_otel_auto_instrumentation_disable_telemetry: false
 splunk_otel_auto_instrumentation_enable_profiler: false
 splunk_otel_auto_instrumentation_enable_profiler_memory: false
 splunk_otel_auto_instrumentation_enable_metrics: false
+splunk_otel_auto_instrumentation_otlp_endpoint: http://127.0.0.1:4317
 
 # Custom environment variables for the collector service
 splunk_otel_collector_additional_env_vars: {}

--- a/deployments/ansible/roles/collector/tasks/linux_auto_instrumentation.yml
+++ b/deployments/ansible/roles/collector/tasks/linux_auto_instrumentation.yml
@@ -1,0 +1,74 @@
+---
+
+- name: Install Splunk OpenTelemetry Auto Instrumentation with apt package manager
+  ansible.builtin.import_tasks: apt_install_auto_instrumentation.yml
+  when: ansible_os_family == "Debian"
+
+- name: Install Splunk OpenTelemetry Auto Instrumentation with yum package manager
+  ansible.builtin.import_tasks: yum_install_auto_instrumentation.yml
+  when: ansible_os_family == "RedHat"
+
+- name: Install Splunk OpenTelemetry Auto Instrumentation with zypper package manager
+  ansible.builtin.import_tasks: zypper_install_auto_instrumentation.yml
+  when: ansible_os_family == "Suse"
+
+- name: Get installed package facts
+  package_facts:
+    manager: auto
+
+- name: Get installed splunk-otel-auto-instrumentation version
+  set_fact:
+    auto_instrumentation_version: "{{ ansible_facts.packages['splunk-otel-auto-instrumentation'][0].version }}"
+
+- name: Set up /etc/ld.so.preload for Splunk OpenTelemetry Auto Instrumentation
+  ansible.builtin.template:
+    src: ld_so_preload.j2
+    dest: /etc/ld.so.preload
+    owner: root
+    group: root
+    mode: '644'
+
+- name: Delete the Splunk OpenTelemetry Auto Instrumentation systemd config
+  ansible.builtin.file:
+    path: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+    state: absent
+  when: not (splunk_otel_auto_instrumentation_systemd | bool)
+  notify: "Reload systemd daemon"
+
+- name: Set up the Splunk OpenTelemetry Auto Instrumentation config file
+  ansible.builtin.template:
+    src: splunk-otel-auto-instrumentation.conf.j2
+    dest: /usr/lib/splunk-instrumentation/instrumentation.conf
+    owner: root
+    group: root
+    mode: '644'
+  when: >
+    auto_instrumentation_version is version('0.87.0', '<') and
+    not (splunk_otel_auto_instrumentation_systemd | bool)
+
+- name: Set up the Splunk OpenTelemetry Auto Instrumentation for Java config file
+  ansible.builtin.template:
+    src: java.conf.j2
+    dest: /etc/splunk/zeroconfig/java.conf
+    owner: root
+    group: root
+    mode: '644'
+  when: >
+    auto_instrumentation_version is version('0.87.0', '>=') and
+    not (splunk_otel_auto_instrumentation_systemd | bool)
+
+- name: Ensure the system.conf.d directory exists
+  ansible.builtin.file:
+    path: /usr/lib/systemd/system.conf.d
+    state: directory
+  when: splunk_otel_auto_instrumentation_systemd | bool
+
+- name: Set up systemd for Splunk OpenTelemetry Auto Instrumentation
+  ansible.builtin.template:
+    src: 00-splunk-otel-auto-instrumentation.conf.j2
+    dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+    owner: root
+    group: root
+    mode: '644'
+  when: splunk_otel_auto_instrumentation_systemd | bool
+  notify: "Reload systemd daemon"

--- a/deployments/ansible/roles/collector/tasks/linux_install.yml
+++ b/deployments/ansible/roles/collector/tasks/linux_install.yml
@@ -67,36 +67,6 @@
   ansible.builtin.import_tasks: linux_install_fluentd.yml
   when: install_fluentd and fluentd_supported
 
-- name: Install Splunk OpenTelemetry Auto Instrumentation with apt package manager
-  ansible.builtin.import_tasks: apt_install_auto_instrumentation.yml
-  when: install_splunk_otel_auto_instrumentation and ansible_os_family == "Debian"
-
-- name: Install Splunk OpenTelemetry Auto Instrumentation with yum package manager
-  ansible.builtin.import_tasks: yum_install_auto_instrumentation.yml
-  when: install_splunk_otel_auto_instrumentation and ansible_os_family == "RedHat"
-
-- name: Install Splunk OpenTelemetry Auto Instrumentation with zypper package manager
-  ansible.builtin.import_tasks: zypper_install_auto_instrumentation.yml
-  when: install_splunk_otel_auto_instrumentation and ansible_os_family == "Suse"
-
-- name: Set up /etc/ld.so.preload for Splunk OpenTelemetry Auto Instrumentation
-  ansible.builtin.template:
-    src: ld_so_preload.j2
-    dest: /etc/ld.so.preload
-  when: install_splunk_otel_auto_instrumentation
-
-- name: Get installed package facts
-  package_facts:
-    manager: auto
-  when: install_splunk_otel_auto_instrumentation
-
-- name: Get splunk-otel-auto-instrumentation version
-  set_fact:
-    auto_instrumentation_version: "{{ ansible_facts.packages['splunk-otel-auto-instrumentation'][0].version }}"
-  when: install_splunk_otel_auto_instrumentation
-
-- name: Set up the Splunk OpenTelemetry Auto Instrumentation config file
-  ansible.builtin.template:
-    src: splunk-otel-auto-instrumentation.conf.j2
-    dest: /usr/lib/splunk-instrumentation/instrumentation.conf
+- name: Install Splunk OpenTelemetry Auto Instrumentation
+  ansible.builtin.import_tasks: linux_auto_instrumentation.yml
   when: install_splunk_otel_auto_instrumentation

--- a/deployments/ansible/roles/collector/tasks/win_install_dotnet_auto_instrumentation.yml
+++ b/deployments/ansible/roles/collector/tasks/win_install_dotnet_auto_instrumentation.yml
@@ -80,7 +80,8 @@
         {%- set value = (method + "," + signalfx_dotnet_auto_instrumentation_global_tags) | trim(",") -%}
       {%- endif -%}
       {{ (options_list | default([])) + [item.key + '=' + (value | string)] }}
-  loop: "{{ dotnet_options | combine(signalfx_dotnet_auto_instrumentation_additional_options) | dict2items }}"
+  loop: >
+    {{ dotnet_options | default({}) | combine(signalfx_dotnet_auto_instrumentation_additional_options) | dict2items }}
 
 - name: Set IIS registry value
   ansible.windows.win_regedit:
@@ -116,6 +117,7 @@
       {%- endif -%}
       {{ value | string }}
     type: string
-  loop: "{{ dotnet_options | combine(signalfx_dotnet_auto_instrumentation_additional_options) | dict2items }}"
+  loop: >
+    {{ dotnet_options | default({}) | combine(signalfx_dotnet_auto_instrumentation_additional_options) | dict2items }}
   when: signalfx_dotnet_auto_instrumentation_system_wide
   notify: "reset iis"

--- a/deployments/ansible/roles/collector/templates/00-splunk-otel-auto-instrumentation.conf.j2
+++ b/deployments/ansible/roles/collector/templates/00-splunk-otel-auto-instrumentation.conf.j2
@@ -1,0 +1,14 @@
+[Manager]
+DefaultEnvironment="JAVA_TOOL_OPTIONS=-javaagent:{{ splunk_otel_auto_instrumentation_java_agent_jar }}"
+{% if splunk_otel_auto_instrumentation_resource_attributes is defined and splunk_otel_auto_instrumentation_resource_attributes %}
+DefaultEnvironment="OTEL_RESOURCE_ATTRIBUTES=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }}-systemd,{{ splunk_otel_auto_instrumentation_resource_attributes }}"
+{% else %}
+DefaultEnvironment="OTEL_RESOURCE_ATTRIBUTES=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }}-systemd"
+{% endif %}
+{% if splunk_otel_auto_instrumentation_service_name is defined and splunk_otel_auto_instrumentation_service_name %}
+DefaultEnvironment="OTEL_SERVICE_NAME={{ splunk_otel_auto_instrumentation_service_name }}"
+{% endif %}
+DefaultEnvironment="SPLUNK_PROFILER_ENABLED={{ splunk_otel_auto_instrumentation_enable_profiler | string | lower }}"
+DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED={{ splunk_otel_auto_instrumentation_enable_profiler_memory | string | lower }}"
+DefaultEnvironment="SPLUNK_METRICS_ENABLED={{ splunk_otel_auto_instrumentation_enable_metrics | string | lower }}"
+DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT={{ splunk_otel_auto_instrumentation_otlp_endpoint }}"

--- a/deployments/ansible/roles/collector/templates/java.conf.j2
+++ b/deployments/ansible/roles/collector/templates/java.conf.j2
@@ -1,0 +1,13 @@
+JAVA_TOOL_OPTIONS=-javaagent:{{ splunk_otel_auto_instrumentation_java_agent_jar }}
+{% if splunk_otel_auto_instrumentation_resource_attributes is defined and splunk_otel_auto_instrumentation_resource_attributes %}
+OTEL_RESOURCE_ATTRIBUTES=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }},{{ splunk_otel_auto_instrumentation_resource_attributes }}
+{% else %}
+OTEL_RESOURCE_ATTRIBUTES=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }}
+{% endif %}
+{% if splunk_otel_auto_instrumentation_service_name is defined and splunk_otel_auto_instrumentation_service_name %}
+OTEL_SERVICE_NAME={{ splunk_otel_auto_instrumentation_service_name }}
+{% endif %}
+SPLUNK_PROFILER_ENABLED={{ splunk_otel_auto_instrumentation_enable_profiler | string | lower }}
+SPLUNK_PROFILER_MEMORY_ENABLED={{ splunk_otel_auto_instrumentation_enable_profiler_memory | string | lower }}
+SPLUNK_METRICS_ENABLED={{ splunk_otel_auto_instrumentation_enable_metrics | string | lower }}
+OTEL_EXPORTER_OTLP_ENDPOINT={{ splunk_otel_auto_instrumentation_otlp_endpoint }}

--- a/deployments/ansible/roles/collector/templates/ld_so_preload.j2
+++ b/deployments/ansible/roles/collector/templates/ld_so_preload.j2
@@ -1,4 +1,6 @@
+{% if splunk_otel_auto_instrumentation_systemd is defined and not splunk_otel_auto_instrumentation_systemd %}
 /usr/lib/splunk-instrumentation/libsplunk.so
+{% endif %}
 {% if splunk_otel_auto_instrumentation_ld_so_preload is defined and splunk_otel_auto_instrumentation_ld_so_preload %}
 {{ splunk_otel_auto_instrumentation_ld_so_preload }}
 {% endif %}


### PR DESCRIPTION
- See `deployments/ansible/CHANGELOG.md` for changes
- Add the `splunk.zc.method=splunk-otel-auto-instrumentation-<version>[-systemd]` resource attribute
- Add tests for default and custom options, for both the preload and systemd methods
- TODO: Add node.js support