### PR TITLE
[Tanzu Tile] Fix proxy exclusions bug

### DIFF
--- a/deployments/cloudfoundry/bosh/DEVELOPMENT.md
+++ b/deployments/cloudfoundry/bosh/DEVELOPMENT.md
@@ -55,12 +55,16 @@ https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-bionic-go_agent?v=1.71
 # Check release script for more environment variables that can be set.
 export IS_DEV_RELEASE=1
 ./release
+bosh -e <director-name> upload-release latest-release.tgz
 ```
 
 ## BOSH Release Usage
 
 ```shell
-bosh -d splunk-otel-collector deploy deployment.yaml
+# Deploy BOSH Release
+bosh -e <director-name> -d splunk-otel-collector deploy deployment.yaml
+# Delete BOSH Release
+bosh -e <director-name> delete-deployment -d splunk-otel-collector
 ```
 Further explanation of the `deployment.yaml` file is found [here.](#deployment-config)
 
@@ -124,7 +128,7 @@ splunk.access_token: "..."
 Note: Depending on configuration, all `bosh` commands may require the director name to be explicitly provided.
 This is the `-e <director-name>` option.
 ```shell
-# Ensure director is up and running
+# Ensure director is up and running. Director name is "vbox" if created using automated script.
 $ bosh -e <director-name> env
 
 # View all bosh releases
@@ -167,4 +171,7 @@ $ exec /var/vcap/packages/splunk_otel_collector/splunk_otel_collector \
 # Useful VM log files:
 /var/vcap/sys/log/splunk-otel-collector/splunk-otel-collector.stdout.log
 /var/vcap/sys/log/splunk-otel-collector/splunk-otel-collector.stderr.log
+
+# Proxy settings
+/var/vcap/jobs/splunk-otel-collector/bin/config/splunk-otel-collector.conf
 ```

--- a/deployments/cloudfoundry/bosh/jobs/splunk-otel-collector/spec
+++ b/deployments/cloudfoundry/bosh/jobs/splunk-otel-collector/spec
@@ -51,15 +51,15 @@ properties:
     # See also https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter#proxy-support
     otel.proxy.http:
         description: |
-            URL used as the proxy URL for HTTP requests unless overridden by otel.proxy.no.
+            URL used as the proxy URL for HTTP requests unless overridden by otel.proxy.exclusions.
         required: false
 
     otel.proxy.https:
         description: |
-            URL used as the proxy URL for HTTPS requests unless overridden by otel.proxy.no.
+            URL used as the proxy URL for HTTPS requests unless overridden by otel.proxy.exclusions.
         required: false
 
-    otel.proxy.no:
+    otel.proxy.exclusions:
         description: |
             specifies a string that contains comma-separated values specifying hosts that should be excluded
             from proxying. Each value is represented by an IP address prefix (1.2.3.4), an IP address prefix

--- a/deployments/cloudfoundry/bosh/jobs/splunk-otel-collector/templates/splunk-otel-collector.conf.erb
+++ b/deployments/cloudfoundry/bosh/jobs/splunk-otel-collector/templates/splunk-otel-collector.conf.erb
@@ -1,9 +1,10 @@
 <% if p('otel.proxy.http', '').length > 0 %>
 export HTTP_PROXY=<%= p('otel.proxy.http') %>
+export http_proxy=<%= p('otel.proxy.http') %>
 <% end %>
 <% if p('otel.proxy.https', '').length > 0 %>
 export HTTPS_PROXY=<%= p('otel.proxy.https') %>
 <% end %>
-<% if p('otel.proxy.no', '').length > 0 %>
-export NO_PROXY=<%= p('otel.proxy.no') %>
+<% if p('otel.proxy.exclusions', '').length > 0 %>
+export NO_PROXY=<%= p('otel.proxy.exclusions') %>
 <% end %>

--- a/deployments/cloudfoundry/tile/tile.yml
+++ b/deployments/cloudfoundry/tile/tile.yml
@@ -48,7 +48,7 @@ packages:
             proxy:
               http: (( .properties.otel_proxy_http.value ))
               https: (( .properties.otel_proxy_https.value ))
-              no: (( .properties.otel_proxy_no.value ))
+              exclusions: (( .properties.otel_proxy_exclusions.value ))
           splunk:
             access_token: (( .properties.splunk_access_token.value ))
             api_url: (( .properties.splunk_api_url.value ))
@@ -94,16 +94,16 @@ forms:
   - name: otel_proxy_http
     type: string
     label: HTTP proxy URL
-    description: URL used as the proxy URL for HTTP requests unless overridden by otel_proxy_no
+    description: URL used as the proxy URL for HTTP requests unless overridden by "Proxy exclusions"
     optional: true
 
   - name: otel_proxy_https
     type: string
     label: HTTPS proxy URL
-    description: URL used as the proxy for HTTPS requests unless overridden by otel_proxy_no
+    description: URL used as the proxy for HTTPS requests unless overridden by "Proxy exclusions"
     optional: true
 
-  - name: otel_proxy_no
+  - name: otel_proxy_exclusions
     type: string
     label: Proxy exclusions
     description: Comma-separated hosts that should be excluded from proxying. Hosts should be in the form of an IP address prefix (regular or CIDR notation), a domain name, or a special DNS label (*).


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The NO_PROXY environment variable was previously not being set properly by the Tanzu Tile configuration option. This was because the input variable's name was being automatically converted from otel_proxy_no to otel_proxy_false internally, but the variable setting logic was still checking otel_proxy_no. Change name to otel_proxy_exclusions to avoid this.

**Testing:** <Describe what testing was performed and which tests were added.>
Manually tested both the BOSH job and Tanzu Tile to ensure changes work properly.

**Documentation:** <Describe the documentation added.>
Added some more 