### PR TITLE
Prepare release v0.88.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This Splunk OpenTelemetry Collector release includes changes from the [opentelem
 
 
 ### 💡 Enhancements 💡
-
+- (Splunk) Add an option, `-msi_public_properties`, to allow passing MSI public properties when installing the Splunk OpenTelemetry Collector using the Windows installer script ([#3921](https://github.com/signalfx/splunk-otel-collector/pull/3921))
 - (Splunk) Add support for config map providers in discovery configuration. ([#3874](https://github.com/signalfx/splunk-otel-collector/pull/3874))
 - (Splunk) Add zero config support for chef deployments ([#3903](https://github.com/signalfx/splunk-otel-collector/pull/3903))
 - (Splunk) Add zero config support for puppet deployments ([#3922](https://github.com/signalfx/splunk-otel-collector/pull/3922))
@@ -216,7 +216,7 @@ Suffixes can be disabled by setting add_metric_suffixes to false on the exporter
 - (Contrib) `pkg/ottl`: Add converters to convert time to unix nanoseconds, unix microseconds, unix milliseconds or unix seconds ([#24686](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24686))
 - (Contrib) `receiver/hostmetrics`: Don't collect connections data from the host if system.network.connections metric is disabled to not waste CPU cycles. ([#25815](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/25815))
 - (Contrib) `jaegerreceiver`,`jaegerremotesamplingextension`: Add featuregates to replace Thrift-gen with Proto-gen types for sampling strategies ([#18401](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18401))
-  
+
   Available featuregates are:
   * `extension.jaegerremotesampling.replaceThriftWithProto`
   *  `receiver.jaegerreceiver.replaceThriftWithProto`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,47 @@
 # Changelog
 
-## Unreleased
+## v0.88.0
+
+This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.88.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.88.0) and the [opentelemetry-collector-contrib v0.88.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.88.0) releases where appropriate.
 
 ### 🛑 Breaking changes 🛑
 
 - (Splunk) `smartagent`: Respect `JAVA_HOME` environment variable instead of enforcing bundle-relative value ([#3877](https://github.com/signalfx/splunk-otel-collector/pull/3877))
+- (Contrib) `k8sclusterreceiver`: Remove opencensus.resourcetype resource attribute ([#26487](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26487))
+- (Contrib) `splunkhecexporter`: Remove `max_connections` configuration setting. ([#27610](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27610))
+  - use `max_idle_conns` or `max_idle_conns_per_host` instead.
+- (Contrib) `signalfxexporter`: Remove `max_connections` configuration setting. ([#27610](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27610))
+  - use `max_idle_conns` or `max_idle_conns_per_host` instead.
+
+### 💡 Enhancements 💡
+
+- (Splunk) Add support for config map providers in discovery configuration. ([#3874](https://github.com/signalfx/splunk-otel-collector/pull/3874))
+- (Splunk) Add zero config support for chef deployments ([#3903](https://github.com/signalfx/splunk-otel-collector/pull/3903))
+- (Splunk) Add zero config support for puppet deployments ([#3922](https://github.com/signalfx/splunk-otel-collector/pull/3922))
+- (Contrib) `receiver/prometheus`: Warn instead of failing when users rename using metric_relabel_configs in the prometheus receiver ([#5001](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5001))
+- (Contrib) `k8sobjectsreceiver`: Move k8sobjectsreceiver from Alpha stability to Beta stability for logs. ([#27635](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27635))
+- (Contrib) `doubleconverter`: Adding a double converter into pkg/ottl ([#22056](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22056))
+- (Contrib) `syslogreceiver`: validate protocol name ([#27581](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27581))
+- (Contrib) `entension/storage/filestorage`: Add support for setting bbolt fsync option ([#20266](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20266))
+- (Contrib) `filelogreceiver`: Add a new "top_n" option to specify the number of files to track when using ordering criteria ([#23788](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23788))
+- (Contrib) `k8sclusterreceiver`: add optional k8s.pod.qos_class resource attribute ([#27483](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27483))
+- (Contrib) `pkg/stanza`: Log warning, instead of error, when Windows Event Log publisher metadata is not available and cache the successfully retrieved ones. ([#27658](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27658))
+- (Contrib) `pkg/ottl`: Add optional Converter parameters to replacement Editors ([#27235](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27235))
+- (Contrib) `signalfxexporter`: Add an option to control the dimension client timeout ([#27815](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27815))
+- (Contrib) `signalfxexporter`: Add the build version to the user agent of the SignalFx exporter ([#16841](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16841))
+- (Contrib) `splunkentreceiver`: Users can now use auth settings and basicauth extension to connect to their Splunk enterprise deployments ([#27026](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27026))
+
+### 🧰 Bug fixes 🧰
+
+- (Splunk) Fix Tanzu Tile to properly set proxy exclusions. ([#3902](https://github.com/signalfx/splunk-otel-collector/pull/3902))
+- (Contrib) `syslog`: add integration tests and fix related bugs ([#21245](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21245))
+- (Contrib) `processor/resourcedetection`: Don't parse the field `cpuInfo.Model` if it's blank. ([#27678](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27678))
+- (Contrib) `k8sclusterreceiver`: Change clusterquota and resourcequota metrics to use {resource} unit ([#10553](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10553))
+- (Contrib) `pkg/ottl`: Fix bug where named parameters needed a space after the equal sign (`=`). ([#28511](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/28511))
+- (Contrib) `filelogreceiver`: Fix issue where batching of files could result in ignoring start_at setting. ([#27773](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27773))
+- (Core) `exporterhelper`: make enqueue failures available for otel metrics ([#8673](https://github.com/open-telemetry/opentelemetry-collector/issues/8673))
+- (Core) `exporterhelper`: Fix nil pointer dereference when stopping persistent queue after a start encountered an error ([#8718](https://github.com/open-telemetry/opentelemetry-collector/issues/8718))
+
 
 ## v0.87.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This Splunk OpenTelemetry Collector release includes changes from the [opentelem
   - use `max_idle_conns` or `max_idle_conns_per_host` instead.
 - (Contrib) `signalfxexporter`: Remove `max_connections` configuration setting. ([#27610](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27610))
   - use `max_idle_conns` or `max_idle_conns_per_host` instead.
+- (Core) `exporterhelper`: make enqueue failures available for otel metrics ([#8673](https://github.com/open-telemetry/opentelemetry-collector/issues/8673)). This will prevent internal Collector `otelcol_exporter_enqueue_failed_<telemetry_type>` metrics from being reported unless greater than 0.
+
 
 ### 💡 Enhancements 💡
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ This Splunk OpenTelemetry Collector release includes changes from the [opentelem
 - (Contrib) `k8sclusterreceiver`: Change clusterquota and resourcequota metrics to use {resource} unit ([#10553](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10553))
 - (Contrib) `pkg/ottl`: Fix bug where named parameters needed a space after the equal sign (`=`). ([#28511](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/28511))
 - (Contrib) `filelogreceiver`: Fix issue where batching of files could result in ignoring start_at setting. ([#27773](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27773))
-- (Core) `exporterhelper`: make enqueue failures available for otel metrics ([#8673](https://github.com/open-telemetry/opentelemetry-collector/issues/8673))
 - (Core) `exporterhelper`: Fix nil pointer dereference when stopping persistent queue after a start encountered an error ([#8718](https://github.com/open-telemetry/opentelemetry-collector/pull/8718))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,26 +21,25 @@ This Splunk OpenTelemetry Collector release includes changes from the [opentelem
 - (Contrib) `receiver/prometheus`: Warn instead of failing when users rename using metric_relabel_configs in the prometheus receiver ([#5001](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5001))
 - (Contrib) `k8sobjectsreceiver`: Move k8sobjectsreceiver from Alpha stability to Beta stability for logs. ([#27635](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27635))
 - (Contrib) `doubleconverter`: Adding a double converter into pkg/ottl ([#22056](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22056))
-- (Contrib) `syslogreceiver`: validate protocol name ([#27581](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27581))
+- (Contrib) `syslogreceiver`: validate protocol name ([#27581](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27581))
 - (Contrib) `entension/storage/filestorage`: Add support for setting bbolt fsync option ([#20266](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20266))
 - (Contrib) `filelogreceiver`: Add a new "top_n" option to specify the number of files to track when using ordering criteria ([#23788](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23788))
 - (Contrib) `k8sclusterreceiver`: add optional k8s.pod.qos_class resource attribute ([#27483](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27483))
-- (Contrib) `pkg/stanza`: Log warning, instead of error, when Windows Event Log publisher metadata is not available and cache the successfully retrieved ones. ([#27658](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27658))
-- (Contrib) `pkg/ottl`: Add optional Converter parameters to replacement Editors ([#27235](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27235))
-- (Contrib) `signalfxexporter`: Add an option to control the dimension client timeout ([#27815](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27815))
+- (Contrib) `pkg/stanza`: Log warning, instead of error, when Windows Event Log publisher metadata is not available and cache the successfully retrieved ones. ([#27658](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27658))
+- (Contrib) `pkg/ottl`: Add optional Converter parameters to replacement Editors ([#27235](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27235))
+- (Contrib) `signalfxexporter`: Add an option to control the dimension client timeout ([#27815](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27815))
 - (Contrib) `signalfxexporter`: Add the build version to the user agent of the SignalFx exporter ([#16841](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16841))
-- (Contrib) `splunkentreceiver`: Users can now use auth settings and basicauth extension to connect to their Splunk enterprise deployments ([#27026](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27026))
 
 ### 🧰 Bug fixes 🧰
 
 - (Splunk) Fix Tanzu Tile to properly set proxy exclusions. ([#3902](https://github.com/signalfx/splunk-otel-collector/pull/3902))
 - (Contrib) `syslog`: add integration tests and fix related bugs ([#21245](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21245))
-- (Contrib) `processor/resourcedetection`: Don't parse the field `cpuInfo.Model` if it's blank. ([#27678](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27678))
+- (Contrib) `processor/resourcedetection`: Don't parse the field `cpuInfo.Model` if it's blank. ([#27678](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27678))
 - (Contrib) `k8sclusterreceiver`: Change clusterquota and resourcequota metrics to use {resource} unit ([#10553](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10553))
-- (Contrib) `pkg/ottl`: Fix bug where named parameters needed a space after the equal sign (`=`). ([#28511](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/28511))
-- (Contrib) `filelogreceiver`: Fix issue where batching of files could result in ignoring start_at setting. ([#27773](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27773))
+- (Contrib) `pkg/ottl`: Fix bug where named parameters needed a space after the equal sign (`=`). ([#28511](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/28511))
+- (Contrib) `filelogreceiver`: Fix issue where batching of files could result in ignoring start_at setting. ([#27773](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27773))
 - (Core) `exporterhelper`: make enqueue failures available for otel metrics ([#8673](https://github.com/open-telemetry/opentelemetry-collector/issues/8673))
-- (Core) `exporterhelper`: Fix nil pointer dereference when stopping persistent queue after a start encountered an error ([#8718](https://github.com/open-telemetry/opentelemetry-collector/issues/8718))
+- (Core) `exporterhelper`: Fix nil pointer dereference when stopping persistent queue after a start encountered an error ([#8718](https://github.com/open-telemetry/opentelemetry-collector/pull/8718))
 
 
 ## v0.87.0


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Updates changelog with all relevant updates to the Splunk, Contrib, and Core distributions of the OpenTelemetry Collector.

Release is blocked by #3921
