### PR TITLE
salt: Support new zero config

### DIFF
--- a/deployments/salt/README.md
+++ b/deployments/salt/README.md
@@ -156,46 +156,50 @@ effect.
   `splunk-otel-auto-instrumentation` package to install, e.g. `0.50.0`. The
   minimum supported version is `0.48.0`. (**default:** `latest`)
 
-- `auto_instrumentation_ld_so_preload`: By default, the `/etc/ld.so.preload`
-  file on the node will be configured for the
+- `auto_instrumentation_systemd`: By default, the `/etc/ld.so.preload` file on
+  the node will be configured for the
   `/usr/lib/splunk-instrumentation/libsplunk.so` [shared object library](
-  https://github.com/signalfx/splunk-otel-collector/tree/main/instrumentation#operation)
-  provided by the `splunk-otel-auto-instrumentation` package and is required
-  for auto instrumentation. Configure this variable to include additional
-  library paths, e.g. `/path/to/my.library.so`. (**default:** `None`)
+  https://github.com/signalfx/splunk-otel-collector/tree/main/instrumentation)
+  provided by the `splunk-otel-auto-instrumentation` package to activate and
+  configure auto instrumentation system-wide for all supported applications.
+  Alternatively, set this option to `True` to activate and configure auto
+  instrumentation ***only*** for supported applications running as `systemd`
+  services. If this option is set to `True`,
+  `/usr/lib/splunk-instrumentation/libsplunk.so` will not be added to
+  `/etc/ld.so.preload`. Instead, the
+  `/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf`
+  `systemd` drop-in file will be created and configured for environment
+  variables based on the default and specified options. (**default:** `False`)
+
+- `auto_instrumentation_ld_so_preload`: Configure this variable to include
+  additional library paths, e.g. `/path/to/my.library.so`, to
+  `/etc/ld.so.preload`. (**default:** `None`)
 
 - `auto_instrumentation_java_agent_path`: Path to the [Splunk OpenTelemetry
   Java agent](https://github.com/signalfx/splunk-otel-java). The default path
   is provided by the `splunk-otel-auto-instrumentation` package. If the path is
   changed from the default value, the path should be an existing file on the
-  node. The specified path will be added to the
-  `/usr/lib/splunk-instrumentation/instrumentation.conf` config file on the
-  node. (**default:**
-  `/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar`)
+  node. (**default:** `/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar`)
 
-- `auto_instrumentation_resource_attributes`: Configure the OpenTelemetry
-  instrumentation [resource attributes](
-  https://github.com/signalfx/splunk-otel-collector/tree/main/instrumentation#configuration-file),
-  e.g. `deployment.environment=prod`. The specified resource attribute(s) will
-  be added to the `/usr/lib/splunk-instrumentation/instrumentation.conf` config
-  file on the node. (**default:** `None`)
+- `auto_instrumentation_resource_attributes`: Configure the OpenTelemetry auto
+  instrumentation resource attributes, e.g.
+  `deployment.environment=prod,my.key=value` (comma-separated `key=value` pairs.).
+  (**default:** `None`)
 
-- `auto_instrumentation_service_name`: Explicitly set the [service name](
-  https://github.com/signalfx/splunk-otel-collector/tree/main/instrumentation#configuration-file)
-  for the instrumented Java application, e.g. `my.service`. By default, the
-  service name is automatically derived from the arguments of the Java
-  executable on the node. However, if this variable is set to a non-empty
-  value, the value will override the derived service name and be added to the
-  `/usr/lib/splunk-instrumentation/instrumentation.conf` config file on the
-  node. (**default:** `None`)
+- `auto_instrumentation_service_name`: Explicitly set the service name for
+  ***all*** instrumented applications on the node, e.g. `my.service`. By
+  default, the service name is automatically generated for each instrumented
+  application. (**default:** `None`)
 
-- `auto_instrumentation_generate_service_name`: Set this option to `False` to
-  prevent the preloader from setting the `OTEL_SERVICE_NAME` environment
-  variable. (**default:** `True`)
+- **DEPRECATED** `auto_instrumentation_generate_service_name`: Set this option
+  to `False` to prevent the preloader from setting the `OTEL_SERVICE_NAME`
+  environment variable. Only applicable if `auto_instrumentation_version` is <
+  `0.87.0`. (**default:** `True`)
 
-- `auto_instrumentation_disable_telemetry`: Enable or disable the preloader
-  from sending the `splunk.linux-autoinstr.executions` metric to the local
-  collector. (**default:** `False`)
+- **DEPRECATED**` auto_instrumentation_disable_telemetry`: Enable or disable
+  the preloader from sending the `splunk.linux-autoinstr.executions` metric to
+  the local collector. Only applicable if `auto_instrumentation_version` is <
+  `0.87.0`. (**default:** `False`)
 
 - `auto_instrumentation_enable_profiler`: Enable or disable AlwaysOn CPU
   Profiling. (**default**: `False`)
@@ -204,4 +208,8 @@ effect.
   Memory Profiling. (**default:** `False`)
 
 - `auto_instrumentation_enable_metrics`: Enable or disable exporting
-  Micrometer metrics. (**default**: `False`)
+  instrumentation metrics. (**default**: `False`)
+
+- `auto_instrumentation_otlp_endpoint`: Set the OTLP gRPC endpoint for captured
+  traces. Only applicable if `auto_instrumentation_version` is `latest` or >=
+  `0.87.0`. (**default:** `http://127.0.0.1:4317`)

--- a/deployments/salt/splunk-otel-collector/auto_instrumentation.sls
+++ b/deployments/salt/splunk-otel-collector/auto_instrumentation.sls
@@ -1,4 +1,5 @@
 {% set auto_instrumentation_version = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_version', 'latest') %}
+{% set auto_instrumentation_systemd = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_systemd', False) | to_bool %}
 {% set auto_instrumentation_java_agent_path = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_java_agent_path', '/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar') %}
 {% set auto_instrumentation_ld_so_preload = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_ld_so_preload') %}
 {% set auto_instrumentation_resource_attributes = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_resource_attributes') %}
@@ -8,6 +9,7 @@
 {% set auto_instrumentation_enable_profiler = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_enable_profiler', False) | to_bool %}
 {% set auto_instrumentation_enable_profiler_memory = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_enable_profiler_memory', False) | to_bool %}
 {% set auto_instrumentation_enable_metrics = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_enable_metrics', False) | to_bool %}
+{% set auto_instrumentation_otlp_endpoint = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_otlp_endpoint', 'http://127.0.0.1:4317') %}
 
 Install Splunk OpenTelemetry Auto Instrumentation:
   pkg.installed:
@@ -18,25 +20,76 @@ Install Splunk OpenTelemetry Auto Instrumentation:
 
 /etc/ld.so.preload:
   file.managed:
-    - contents:
-        - /usr/lib/splunk-instrumentation/libsplunk.so
-{% if auto_instrumentation_ld_so_preload %}
-        - {{ auto_instrumentation_ld_so_preload }}
-{% endif %}
+    - contents: |
+        {% if not auto_instrumentation_systemd %}
+        /usr/lib/splunk-instrumentation/libsplunk.so
+        {% endif %}
+        {% if auto_instrumentation_ld_so_preload != "" %}
+        {{ auto_instrumentation_ld_so_preload }}
+        {% endif %}
     - makedirs: True
     - require:
       - pkg: splunk-otel-auto-instrumentation
 
+{% if auto_instrumentation_systemd %}
+/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf:
+  file.managed:
+    - contents:
+        - "[Manager]"
+        - DefaultEnvironment="JAVA_TOOL_OPTIONS=-javaagent:{{ auto_instrumentation_java_agent_path }}"
+        {% if auto_instrumentation_resource_attributes != "" %}
+        - DefaultEnvironment="OTEL_RESOURCE_ATTRIBUTES=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }}-systemd,{{ auto_instrumentation_resource_attributes }}"
+        {% else %}
+        - DefaultEnvironment="OTEL_RESOURCE_ATTRIBUTES=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }}-systemd"
+        {% endif %}
+        {% if auto_instrumentation_service_name != "" %}
+        - DefaultEnvironment="OTEL_SERVICE_NAME={{ auto_instrumentation_service_name }}"
+        {% endif %}
+        - DefaultEnvironment="SPLUNK_PROFILER_ENABLED={{ auto_instrumentation_enable_profiler | string | lower }}"
+        - DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED={{ auto_instrumentation_enable_profiler_memory | string | lower }}"
+        - DefaultEnvironment="SPLUNK_METRICS_ENABLED={{ auto_instrumentation_enable_metrics | string | lower }}"
+        - DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT={{ auto_instrumentation_otlp_endpoint }}"
+    - makedirs: True
+    - require:
+      - pkg: splunk-otel-auto-instrumentation
+{% else %}
+Delete auto instrumentation systemd config:
+  file.absent:
+    - name: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+
+{% if auto_instrumentation_version == 'latest' or salt['pkg.version_cmp'](auto_instrumentation_version, '0.87.0') >= 0 %}
+/etc/splunk/zeroconfig/java.conf:
+  file.managed:
+    - contents:
+        - JAVA_TOOL_OPTIONS=-javaagent:{{ auto_instrumentation_java_agent_path }}
+        {% if auto_instrumentation_resource_attributes != "" %}
+        - OTEL_RESOURCE_ATTRIBUTES=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }},{{ auto_instrumentation_resource_attributes }}
+        {% else %}
+        - OTEL_RESOURCE_ATTRIBUTES=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }}
+        {% endif %}
+        {% if auto_instrumentation_service_name != "" %}
+        - OTEL_SERVICE_NAME={{ auto_instrumentation_service_name }}
+        {% endif %}
+        - SPLUNK_PROFILER_ENABLED={{ auto_instrumentation_enable_profiler | string | lower }}
+        - SPLUNK_PROFILER_MEMORY_ENABLED={{ auto_instrumentation_enable_profiler_memory | string | lower }}
+        - SPLUNK_METRICS_ENABLED={{ auto_instrumentation_enable_metrics | string | lower }}
+        - OTEL_EXPORTER_OTLP_ENDPOINT={{ auto_instrumentation_otlp_endpoint }}
+    - makedirs: True
+    - require:
+      - pkg: splunk-otel-auto-instrumentation
+{% else %}
 /usr/lib/splunk-instrumentation/instrumentation.conf:
   file.managed:
     - contents:
         - java_agent_jar={{ auto_instrumentation_java_agent_path }}
-{% if auto_instrumentation_resource_attributes %}
-        - resource_attributes={{ auto_instrumentation_resource_attributes }}
-{% endif %}
-{% if auto_instrumentation_service_name %}
+        {% if auto_instrumentation_resource_attributes != "" %}
+        - resource_attributes=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }},{{ auto_instrumentation_resource_attributes }}
+        {% else %}
+        - resource_attributes=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }}
+        {% endif %}
+        {% if auto_instrumentation_service_name %}
         - service_name={{ auto_instrumentation_service_name }}
-{% endif %}
+        {% endif %}
         - generate_service_name={{ auto_instrumentation_generate_service_name | string | lower }}
         - disable_telemetry={{ auto_instrumentation_disable_telemetry | string | lower }}
         - enable_profiler={{ auto_instrumentation_enable_profiler | string | lower }}
@@ -45,3 +98,11 @@ Install Splunk OpenTelemetry Auto Instrumentation:
     - makedirs: True
     - require:
       - pkg: splunk-otel-auto-instrumentation
+{% endif %}
+{% endif %}
+
+Reload systemd:
+  cmd.run:
+    - name: systemctl daemon-reload
+    - onchanges:
+        - file: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf


### PR DESCRIPTION
- Support new java config for `splunk-otel-auto-instrumentation` v0.87.0
- Support auto instrumentation for systemd
- Add the `splunk.zc.method=splunk-otel-auto-instrumentation-<version>[-systemd]` resource attribute
- Add tests for default and custom options, for both the preload and systemd methods
- TODO: Add node.js support
