### PR TITLE
fix some cruft in the java zero-config tests

### DIFF
--- a/instrumentation/tests/java/Dockerfile
+++ b/instrumentation/tests/java/Dockerfile
@@ -6,8 +6,6 @@ COPY Main.java .
 RUN javac Main.java && \
     jar cfe Main.jar Main Main.class
 
-RUN mkdir -p /etc/splunk/zerconfig
-
 COPY zeroconfig.conf /etc/splunk/zeroconfig/java.conf
 
 CMD java -jar Main.jar


### PR DESCRIPTION
Remove a line that was not needed and had a typo, and remove an empty Makefile.