### PR TITLE
helm test: remove cleared clusterReceiver rattrs

### DIFF
--- a/tests/helm/helm_test.go
+++ b/tests/helm/helm_test.go
@@ -110,13 +110,6 @@ splunkObservability:
   tracesEnabled: false
   logsEnabled: false
 
-clusterReceiver:
-  config:
-    receivers:
-      k8s_cluster:
-        # required until breaking opencensus.resourcetype is released
-        # https://github.com/signalfx/splunk-otel-collector-chart/commit/1c06636ec4f0beff90c54773cb3e645df048261e
-        resource_attributes: null
 agent:
   config:
     receivers:


### PR DESCRIPTION
The incompatible `opencensus.resourcetype` disabling rule was removed in 0.87.0 release so we can use default values.