### PR TITLE
Revert "Update urllib3 requirement from <2,>=1.26.18 to >=1.26.18,<3 in /internal/signalfx-agent/bundle/scripts"

### DIFF
--- a/internal/signalfx-agent/bundle/scripts/security-requirements.txt
+++ b/internal/signalfx-agent/bundle/scripts/security-requirements.txt
@@ -1,3 +1,3 @@
 certifi>=2023.07.22
 requests>=2.31.0
-urllib3>=1.26.18,<3
+urllib3>=1.26.18,<2


### PR DESCRIPTION
Reverts signalfx/splunk-otel-collector#3949 - Not certain if collectd plugins are impacted by the [changes since v2](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#200-2023-04-26)