### PR TITLE
mark translatesfx as deprecated

### DIFF
--- a/cmd/translatesfx/README.md
+++ b/cmd/translatesfx/README.md
@@ -1,5 +1,12 @@
 # SignalFx Smart Agent Configuration Translation Tool
 
+> # :warning: End of Support (EoS) Notice
+> **The SignalFx Smart Agent has reached End of Support.**
+>
+> The [Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/opentelemetry.html) is the successor. Smart Agent monitors are available and supported through the [Smart Agent receiver](https://docs.splunk.com/Observability/gdi/opentelemetry/components/smartagent-receiver.html) in the Splunk Distribution of OpenTelemetry Collector.
+>
+> To learn how to migrate, see [Migrate from SignalFx Smart Agent to the Splunk Distribution of OpenTelemetry Collector](https://docs.splunk.com/Observability/gdi/opentelemetry/smart-agent-migration-to-otel-collector.html).
+
 This package provides a command-line tool, `translatesfx`, that translates a 
 SignalFx Smart Agent configuration file into a configuration that can be
 used by a Splunk Distribution of OpenTelemetry Collector. The `translatesfx`

--- a/cmd/translatesfx/doc.go
+++ b/cmd/translatesfx/doc.go
@@ -12,16 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Deprecated: translatesfx will be removed in a future release.
 package main
-
-import (
-	"fmt"
-	"os"
-
-	"github.com/signalfx/splunk-otel-collector/cmd/translatesfx/translatesfx"
-)
-
-func main() {
-	fmt.Println("[NOTICE] translatesfx is deprecated and will be removed from the distribution of the collector in an upcoming release.")
-	translatesfx.CLI(os.Args)
-}

--- a/cmd/translatesfx/main.go
+++ b/cmd/translatesfx/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	//nolint: staticcheck
 	"github.com/signalfx/splunk-otel-collector/cmd/translatesfx/translatesfx"
 )
 

--- a/cmd/translatesfx/translatesfx/doc.go
+++ b/cmd/translatesfx/translatesfx/doc.go
@@ -12,16 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
-
-import (
-	"fmt"
-	"os"
-
-	"github.com/signalfx/splunk-otel-collector/cmd/translatesfx/translatesfx"
-)
-
-func main() {
-	fmt.Println("[NOTICE] translatesfx is deprecated and will be removed from the distribution of the collector in an upcoming release.")
-	translatesfx.CLI(os.Args)
-}
+// Deprecated: translatesfx will be removed in a future release.
+package translatesfx


### PR DESCRIPTION
**Description:**
Add a notice statement when executing translatesfx and a few deprecation notices on the translatesfx tooling to indicate that it is now deprecated and will eventually be removed.