### PR TITLE
Add a deprecation notice to collectd-etcd

### DIFF
--- a/internal/signalfx-agent/pkg/monitors/collectd/etcd/etcd.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/etcd/etcd.go
@@ -57,6 +57,7 @@ type Monitor struct {
 
 // Configure configures and runs the plugin in collectd
 func (m *Monitor) Configure(conf *Config) error {
+	m.Logger().Warn("The ectd-collectd plugin is deprecated. It will be removed in a future release.")
 	conf.pyConf = &python.Config{
 		MonitorConfig: conf.MonitorConfig,
 		Host:          conf.Host,


### PR DESCRIPTION
This PR has a companion PR on the collectd-etcd repository:
https://github.com/signalfx/collectd-etcd/pull/7

The collectd plugin doesn't support modern versions of etcd and Prometheus should be used instead.

This PR adds a warning notice when starting the monitor to let users know that this monitor is now deprecated and may be removed soon.