### PR TITLE
Deprecate marathon

### DIFF
--- a/internal/signalfx-agent/pkg/monitors/collectd/marathon/marathon.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/marathon/marathon.go
@@ -64,6 +64,7 @@ type Monitor struct {
 
 // Configure configures and runs the plugin in collectd
 func (m *Monitor) Configure(conf *Config) error {
+	m.Logger().Warning("This plugin is deprecated and will be removed in a future release")
 	conf.pyConf = &python.Config{
 		MonitorConfig: conf.MonitorConfig,
 		Host:          conf.Host,


### PR DESCRIPTION
**Description:**

Marathon is no longer maintained ; this plugin will eventually be removed at a later date.

This PR adds a warning log when the monitor starts to warn users that this plugin is now deprecated.