### PR TITLE
remove mesos collectd dependency

### DIFF
--- a/internal/signalfx-agent/bundle/collectd-plugins.yaml
+++ b/internal/signalfx-agent/bundle/collectd-plugins.yaml
@@ -33,10 +33,6 @@
   version: v0.0.4
   repo: signalfx/collectd-kong
 
-- name: mesos
-  version: v1.2.1
-  repo: signalfx/collectd-mesos
-
 - name: marathon
   version: v1.0.3
   repo: signalfx/collectd-marathon


### PR DESCRIPTION
**Description:**
Remove the collectd-mesos plugin, as it is not registered as a monitor nor used by another monitor.