### PR TITLE
Fix use of grep -v

### DIFF
--- a/instrumentation/tests/java/test.sh
+++ b/instrumentation/tests/java/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euox pipefail
 
 arch="${ARCH:-amd64}"
 BASE="eclipse-temurin:11"
@@ -25,13 +25,14 @@ echo "$OUTPUT" | grep "SPLUNK_METRICS_ENABLED=abcd" > /dev/null && echo "Test pa
 echo "Test presence of ANOTHER_VAR"
 echo "$OUTPUT" | grep "ANOTHER_VAR=foo" > /dev/null && echo "Test passes"  || exit 1
 echo "Test absence of FOO"
-echo "$OUTPUT" | grep -v "FOO" > /dev/null && echo "Test passes"  || exit 1
+echo "$OUTPUT" | (grep FOO || echo "") | grep -v "FOO" > /dev/null && echo "Test passes"  || exit 1
 echo "Test absence of OTEL_EXPORTER_OTLP_ENDPOINT"
-echo "$OUTPUT" | grep -v "OTEL_EXPORTER_OTLP_ENDPOINT" > /dev/null && echo "Test passes"  || exit 1
+echo "$OUTPUT" | (grep "OTEL_EXPORTER_OTLP_ENDPOINT" || echo "") | grep -v "OTEL_EXPORTER_OTLP_ENDPOINT" > /dev/null && echo "Test passes"  || exit 1
 
 # Check we didn't inject env vars into processes outside of java.
 OUTPUT_BASH=$(docker run --platform linux/${arch} --rm zeroconfig-test-java /usr/bin/env)
 echo "======= BASH OUTPUT ========"
 echo "$OUTPUT_BASH"
 echo "============================"
-echo "$OUTPUT_BASH" | grep -v "OTEL_RESOURCE_ATTRIBUTES" | grep -v "OTEL_SERVICE_NAME" | grep -v "SPLUNK_METRICS_ENABLED" > /dev/null && echo "Test passes"  || exit 1
+echo "$OUTPUT_BASH" | (grep OTEL_RESOURCE_ATTRIBUTES || echo "") | grep -v "OTEL_RESOURCE_ATTRIBUTES" > /dev/null && echo "Test passes"  || exit 1
+echo "$OUTPUT_BASH" | (grep SPLUNK_METRICS_ENABLED || echo "") | grep -v "SPLUNK_METRICS_ENABLED" > /dev/null && echo "Test passes"  || exit 1

--- a/instrumentation/tests/nodejs/test.sh
+++ b/instrumentation/tests/nodejs/test.sh
@@ -16,12 +16,12 @@ echo "========== OUTPUT =========="
 echo "$OUTPUT"
 echo "============================"
 echo "Test presence of OTEL_RESOURCE_ATTRIBUTES"
-echo $OUTPUT | grep "OTEL_RESOURCE_ATTRIBUTES=foo=bar,this=that" > /dev/null && echo "Test passes"  || exit 1
+echo "$OUTPUT" | grep "OTEL_RESOURCE_ATTRIBUTES=foo=bar,this=that" > /dev/null && echo "Test passes"  || exit 1
 echo "Test presence of OTEL_SERVICE_NAME"
-echo $OUTPUT | grep "OTEL_SERVICE_NAME=myservice" > /dev/null && echo "Test passes"  || exit 1
+echo "$OUTPUT" | grep "OTEL_SERVICE_NAME=myservice" > /dev/null && echo "Test passes"  || exit 1
 echo "Test presence of SPLUNK_METRICS_ENABLED"
-echo $OUTPUT | grep "SPLUNK_METRICS_ENABLED=abcd" > /dev/null && echo "Test passes"  || exit 1
+echo "$OUTPUT" | grep "SPLUNK_METRICS_ENABLED=abcd" > /dev/null && echo "Test passes"  || exit 1
 echo "Test absence of FOO"
-echo $OUTPUT | grep -v "FOO" > /dev/null && echo "Test passes"  || exit 1
+echo "$OUTPUT" | (grep FOO || echo "") | grep -v "FOO" > /dev/null && echo "Test passes"  || exit 1
 echo "Test absence of OTEL_EXPORTER_OTLP_ENDPOINT"
-echo $OUTPUT | grep -v "OTEL_EXPORTER_OTLP_ENDPOINT" > /dev/null && echo "Test passes"  || exit 1
+echo "$OUTPUT" | (grep "OTEL_EXPORTER_OTLP_ENDPOINT" || echo "") | grep -v "OTEL_EXPORTER_OTLP_ENDPOINT" > /dev/null && echo "Test passes"  || exit 1


### PR DESCRIPTION
As identified in https://github.com/signalfx/splunk-otel-collector/pull/3932#discussion_r1411312062, tests do not work well to check absence of an environment variable. This is an attempt to ensure the tests work properly.