### PR TITLE
Fix run as service detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### 🧰 Bug fixes 🧰
+
+- (Splunk) `cmd/otelcol`: Fix the code detecting if the collector is running as a service on Windows. The fix should make
+  setting the `NO_WINDOWS_SERVICE` environment variable unnecessary. ([]())
+
 ## v0.89.0
 
 ### 🛑 Breaking changes 🛑

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🧰 Bug fixes 🧰
 
 - (Splunk) `cmd/otelcol`: Fix the code detecting if the collector is running as a service on Windows. The fix should make
-  setting the `NO_WINDOWS_SERVICE` environment variable unnecessary. ([]())
+  setting the `NO_WINDOWS_SERVICE` environment variable unnecessary. ([#4002](https://github.com/signalfx/splunk-otel-collector/pull/4002))
 
 ## v0.89.0
 

--- a/cmd/otelcol/Dockerfile.windows
+++ b/cmd/otelcol/Dockerfile.windows
@@ -47,9 +47,6 @@ RUN setx /M PATH $(${Env:PATH} + \";${Env:JAVA_PATH}\")
 # Setting environment variables
 ENV SPLUNK_BUNDLE_DIR="C:\Program Files\Splunk\OpenTelemetry Collector\agent-bundle"
 ENV SPLUNK_CONFIG="C:\ProgramData\Splunk\OpenTelemetry Collector\gateway_config.yaml"
-# Category ENV_VAR: Forcing interactive mode instead of running as a service. 
-# Reference - https://github.com/signalfx/splunk-otel-collector/pull/254
-ENV NO_WINDOWS_SERVICE="1"
 
 ENTRYPOINT [ "otelcol.exe" ]
 EXPOSE 13133 14250 14268 4317 6060 8888 9411 9443 9080

--- a/cmd/otelcol/main_windows.go
+++ b/cmd/otelcol/main_windows.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"syscall"
 
 	"go.opentelemetry.io/collector/otelcol"
@@ -45,8 +46,8 @@ func run(params otelcol.CollectorSettings) error {
 		return runInteractive(params)
 	}
 
-	// do not need to supply service name when startup is invoked through
-	// Service Control Manager directly
+	// No need to supply service name when startup is invoked through
+	// the Service Control Manager directly.
 	if err := svc.Run("", otelcol.NewSvcHandler(params)); err != nil {
 		errno, ok := err.(syscall.Errno)
 		if ok && errno == windows.ERROR_FAILED_SERVICE_CONTROLLER_CONNECT {

--- a/cmd/otelcol/main_windows.go
+++ b/cmd/otelcol/main_windows.go
@@ -20,41 +20,21 @@ package main
 
 import (
 	"fmt"
-	"os"
+	"syscall"
 
 	"go.opentelemetry.io/collector/otelcol"
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 )
 
 func run(params otelcol.CollectorSettings) error {
-	if useInteractiveMode, err := checkUseInteractiveMode(); err != nil {
-		return err
-	} else if useInteractiveMode {
-		return runInteractive(params)
-	} else {
-		return runService(params)
-	}
-}
-
-func checkUseInteractiveMode() (bool, error) {
-	// If environment variable NO_WINDOWS_SERVICE is set with any value other
-	// than 0, use interactive mode instead of running as a service. This should
-	// be set in case running as a service is not possible or desired even
-	// though the current session is not detected to be interactive
-	if value, present := os.LookupEnv("NO_WINDOWS_SERVICE"); present && value != "0" {
-		return true, nil
-	}
-
-	if isInteractiveSession, err := svc.IsAnInteractiveSession(); err != nil {
-		return false, fmt.Errorf("failed to determine if we are running in an interactive session %w", err)
-	} else {
-		return isInteractiveSession, nil
-	}
-}
-
-func runService(params otelcol.CollectorSettings) error {
 	// do not need to supply service name when startup is invoked through Service Control Manager directly
 	if err := svc.Run("", otelcol.NewSvcHandler(params)); err != nil {
+		errno, ok := err.(syscall.Errno)
+		if ok && errno == windows.ERROR_FAILED_SERVICE_CONTROLLER_CONNECT {
+			return runInteractive(params)
+		}
+
 		return fmt.Errorf("failed to start service: %w", err)
 	}
 

--- a/cmd/otelcol/main_windows_test.go
+++ b/cmd/otelcol/main_windows_test.go
@@ -1,0 +1,24 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/collector/otelcol"
+	"golang.org/x/sys/windows/svc"
+)
+
+var svcRunError error // A global variable to prevent the compiler from optimizing the benchmark away.
+func BenchmarkSvcRunFail(b *testing.B) {
+	var err error
+	params := otelcol.CollectorSettings{}
+	for i := 0; i < b.N; i++ {
+		err = svc.Run("", otelcol.NewSvcHandler(params))
+		if err == nil {
+			b.Fatal("svc.Run should have failed")
+		}
+	}
+	svcRunError = err
+}

--- a/cmd/otelcol/main_windows_test.go
+++ b/cmd/otelcol/main_windows_test.go
@@ -1,3 +1,18 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build windows
 // +build windows
 


### PR DESCRIPTION
**Description:**
Fix run as a service detection on Windows. Instead of trying to detect if it is a service or not, for which both `svc.IsAnInteractiveSession()` and `svc.IsWindowsService()` are somehow broken, try to run as a Windows service, if it fails fallback to run as an interactive process. This will add a small cost, which on my machine is under 5 microseconds, to startup in the interactive mode compared to using the `NO_WINDOWS_SERVICE` environment variable. While this value seems fine for startup I'm keeping the `NO_WINDOWS_SERVICE` option instead of deprecating it (it doesn't seem worth the trouble of deprecating it).

**Link to Splunk idea:**
N/A

**Testing:**
Added benchmark to measure the cost of trying to start as a service (notice that when running as a service there is no extra cost).

**Documentation:**
Added entry in changelog.
