### PR TITLE
fix "Conditional is marked as unsafe, and cannot be evaluated."

### DIFF
--- a/deployments/ansible/roles/collector/tasks/main.yml
+++ b/deployments/ansible/roles/collector/tasks/main.yml
@@ -2,7 +2,8 @@
 
 - name: Make sure access token is provided
   ansible.builtin.assert:
-    that: "'{{ splunk_access_token }}'"
+    that:
+      - splunk_access_token
     fail_msg: splunk_access_token variable must be provided
 
 - name: Make sure host OS is supported


### PR DESCRIPTION
**Description:** ansible: fix the assert call on ansible 2.16.1 and 2.14.2

https://docs.ansible.com/ansible-core/2.16/porting_guides/porting_guide_core_2.16.html#playbook

fix error "Conditional is marked as unsafe, and cannot be evaluated." when `splunk_access_token` come from an untrusted source (like a lookup).

**Testing:** none

**Documentation:** none