### PR TITLE
disable staticcheck wrapped nilness linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,6 +74,9 @@ linters-settings:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
 
+  staticcheck:
+    checks: [all, -nilness]
+
   goimports:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes


### PR DESCRIPTION
Appears some dep updates are revealing a stale helper in staticcheck's [wrapped nilness](https://github.com/dominikh/go-tools/blob/aef76f4feee2fece01c0358e8fc340b7d64d2e5e/staticcheck/sa4023/sa4023.go#L26) (https://github.com/open-telemetry/opentelemetry-collector/issues/8939). The govet linter already includes the actual analyzer so this is unnecessary to enable.