### PR TITLE
deprecate collect/cpu explicitly

### DIFF
--- a/internal/signalfx-agent/pkg/monitors/collectd/cpu/cpu.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/cpu/cpu.go
@@ -31,5 +31,5 @@ type Monitor struct {
 
 // Configure configures and runs the plugin in collectd
 func (m *Monitor) Configure(conf *Config) error {
-	return m.SetConfigurationAndRun(conf)
+	return m.SetConfigurationAndRun(conf, collectd.WithDeprecationWarningLog("cpu"))
 }


### PR DESCRIPTION
**Description:**
Officially deprecate the `collect/cpu` plugin in favor of the `cpu` monitor. The `collectd/cpu` plugin will be removed in a future release of the collector.

The `collectd/cpu` plugin was originally marked as deprecated in Jan 2020 with https://github.com/signalfx/signalfx-agent/pull/1147.