### PR TITLE
add start timestamps

### DIFF
--- a/internal/receiver/lightprometheusreceiver/scraper.go
+++ b/internal/receiver/lightprometheusreceiver/scraper.go
@@ -160,6 +160,7 @@ func (s *scraper) convertMetricFamilies(metricFamilies []*dto.MetricFamily, rm p
 			for _, fm := range family.GetMetric() {
 				dp := sum.DataPoints().AppendEmpty()
 				dp.SetTimestamp(now)
+				dp.SetStartTimestamp(now)
 				dp.SetDoubleValue(fm.GetCounter().GetValue())
 				for _, l := range fm.GetLabel() {
 					if l.GetValue() != "" {
@@ -173,6 +174,7 @@ func (s *scraper) convertMetricFamilies(metricFamilies []*dto.MetricFamily, rm p
 				dp := gauge.DataPoints().AppendEmpty()
 				dp.SetDoubleValue(fm.GetGauge().GetValue())
 				dp.SetTimestamp(now)
+				dp.SetStartTimestamp(now)
 				for _, l := range fm.GetLabel() {
 					if l.GetValue() != "" {
 						dp.Attributes().PutStr(l.GetName(), l.GetValue())
@@ -185,6 +187,7 @@ func (s *scraper) convertMetricFamilies(metricFamilies []*dto.MetricFamily, rm p
 			for _, fm := range family.Metric {
 				dp := histogram.DataPoints().AppendEmpty()
 				dp.SetTimestamp(now)
+				dp.SetStartTimestamp(now)
 
 				// Translate histogram buckets from Prometheus to the OTLP schema.
 				// The bucket counts in Prometheus are cumulative, while in OTLP they are not.
@@ -219,6 +222,7 @@ func (s *scraper) convertMetricFamilies(metricFamilies []*dto.MetricFamily, rm p
 			for _, fm := range family.Metric {
 				dp := sum.DataPoints().AppendEmpty()
 				dp.SetTimestamp(now)
+				dp.SetStartTimestamp(now)
 				for _, q := range fm.GetSummary().GetQuantile() {
 					newQ := dp.QuantileValues().AppendEmpty()
 					newQ.SetValue(q.GetValue())
@@ -238,6 +242,7 @@ func (s *scraper) convertMetricFamilies(metricFamilies []*dto.MetricFamily, rm p
 				dp := gauge.DataPoints().AppendEmpty()
 				dp.SetDoubleValue(fm.GetUntyped().GetValue())
 				dp.SetTimestamp(now)
+				dp.SetStartTimestamp(now)
 				for _, l := range fm.GetLabel() {
 					if l.GetValue() != "" {
 						dp.Attributes().PutStr(l.GetName(), l.GetValue())

--- a/internal/receiver/lightprometheusreceiver/scraper.go
+++ b/internal/receiver/lightprometheusreceiver/scraper.go
@@ -34,10 +34,11 @@ import (
 )
 
 type scraper struct {
-	client   *http.Client
-	settings component.TelemetrySettings
-	cfg      *Config
-	name     string
+	startTime pcommon.Timestamp
+	client    *http.Client
+	settings  component.TelemetrySettings
+	cfg       *Config
+	name      string
 }
 
 func newScraper(
@@ -54,6 +55,7 @@ func newScraper(
 }
 
 func (s *scraper) start(_ context.Context, host component.Host) error {
+	s.startTime = pcommon.NewTimestampFromTime(time.Now())
 	var err error
 	s.client, err = s.cfg.ToClient(host, s.settings)
 	return err
@@ -160,7 +162,7 @@ func (s *scraper) convertMetricFamilies(metricFamilies []*dto.MetricFamily, rm p
 			for _, fm := range family.GetMetric() {
 				dp := sum.DataPoints().AppendEmpty()
 				dp.SetTimestamp(now)
-				dp.SetStartTimestamp(now)
+				dp.SetStartTimestamp(s.startTime)
 				dp.SetDoubleValue(fm.GetCounter().GetValue())
 				for _, l := range fm.GetLabel() {
 					if l.GetValue() != "" {
@@ -174,7 +176,7 @@ func (s *scraper) convertMetricFamilies(metricFamilies []*dto.MetricFamily, rm p
 				dp := gauge.DataPoints().AppendEmpty()
 				dp.SetDoubleValue(fm.GetGauge().GetValue())
 				dp.SetTimestamp(now)
-				dp.SetStartTimestamp(now)
+				dp.SetStartTimestamp(s.startTime)
 				for _, l := range fm.GetLabel() {
 					if l.GetValue() != "" {
 						dp.Attributes().PutStr(l.GetName(), l.GetValue())
@@ -187,7 +189,7 @@ func (s *scraper) convertMetricFamilies(metricFamilies []*dto.MetricFamily, rm p
 			for _, fm := range family.Metric {
 				dp := histogram.DataPoints().AppendEmpty()
 				dp.SetTimestamp(now)
-				dp.SetStartTimestamp(now)
+				dp.SetStartTimestamp(s.startTime)
 
 				// Translate histogram buckets from Prometheus to the OTLP schema.
 				// The bucket counts in Prometheus are cumulative, while in OTLP they are not.
@@ -222,7 +224,7 @@ func (s *scraper) convertMetricFamilies(metricFamilies []*dto.MetricFamily, rm p
 			for _, fm := range family.Metric {
 				dp := sum.DataPoints().AppendEmpty()
 				dp.SetTimestamp(now)
-				dp.SetStartTimestamp(now)
+				dp.SetStartTimestamp(s.startTime)
 				for _, q := range fm.GetSummary().GetQuantile() {
 					newQ := dp.QuantileValues().AppendEmpty()
 					newQ.SetValue(q.GetValue())
@@ -242,7 +244,7 @@ func (s *scraper) convertMetricFamilies(metricFamilies []*dto.MetricFamily, rm p
 				dp := gauge.DataPoints().AppendEmpty()
 				dp.SetDoubleValue(fm.GetUntyped().GetValue())
 				dp.SetTimestamp(now)
-				dp.SetStartTimestamp(now)
+				dp.SetStartTimestamp(s.startTime)
 				for _, l := range fm.GetLabel() {
 					if l.GetValue() != "" {
 						dp.Attributes().PutStr(l.GetName(), l.GetValue())

--- a/internal/receiver/lightprometheusreceiver/scraper.go
+++ b/internal/receiver/lightprometheusreceiver/scraper.go
@@ -34,11 +34,11 @@ import (
 )
 
 type scraper struct {
-	startTime pcommon.Timestamp
-	client    *http.Client
 	settings  component.TelemetrySettings
+	client    *http.Client
 	cfg       *Config
 	name      string
+	startTime pcommon.Timestamp
 }
 
 func newScraper(


### PR DESCRIPTION
**Description:**
Add capture of start timestamp to metrics expressed by the lightprometheusreceiver.
**Testing:**
Can add tests once https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29718 is implemented.
