### PR TITLE
Update installation prefix for splunk-otel-js

### DIFF
--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -98,7 +98,8 @@ jobs:
           fi
           distro=$(for d in $dockerfiles; do echo -n "\"$d\","; done)
           arch="\"amd64\", \"arm64\""
-          matrix="{\"DISTRO\": [${distro%,}], \"ARCH\": [${arch}]}"
+          testcase="\"express\",\"tomcat\""
+          matrix="{\"DISTRO\": [${distro%,}], \"ARCH\": [${arch}], \"TESTCASE\": [${testcase}]}"
           echo "$matrix" | jq
           echo "matrix=${matrix}" >> $GITHUB_OUTPUT
     outputs:
@@ -169,7 +170,8 @@ jobs:
             # workaround for pytest substring matching
             distro="amazonlinux-2 and not amazonlinux-2023"
           fi
-          python3 -u -m pytest -s --verbose -k "$distro and ${{ matrix.ARCH }}" \
+          testcase="${{ matrix.TESTCASE }} or uninstall"
+          python3 -u -m pytest -s --verbose -k "$distro and ${{ matrix.ARCH }} and ($testcase)" \
             internal/buildscripts/packaging/tests/instrumentation/instrumentation_test.py
 
       # qemu, networking, running systemd in containers, etc., can be flaky
@@ -181,6 +183,7 @@ jobs:
             # workaround for pytest substring matching
             distro="amazonlinux-2 and not amazonlinux-2023"
           fi
-          python3 -u -m pytest -s --verbose -k "$distro and ${{ matrix.ARCH }}" \
+          testcase="${{ matrix.TESTCASE }} or uninstall"
+          python3 -u -m pytest -s --verbose -k "$distro and ${{ matrix.ARCH }} and ($testcase)" \
             --last-failed \
             internal/buildscripts/packaging/tests/instrumentation/instrumentation_test.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- (Splunk) Node.js Auto Instrumentation:
+  - The `NODE_OPTIONS` environment variable in the default config file has been updated to load the Node.js SDK from an absolute path (`/usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument`).
+  - The Linux installer script now installs the Node.js SDK to `/usr/lib/splunk-instrumentation/splunk-otel-js` instead of globally.
+  - The `--npm-command` Linux installer script option is no longer supported. To specify a custom path to `npm`, use the `--npm-path <path>` option.
+
 ## v0.90.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.90.1](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.90.1) and the [opentelemetry-collector-contrib v0.90.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.90.0) releases where appropriate.

--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -449,12 +449,13 @@ https://github.com/signalfx/splunk-otel-collector/releases)). To update the
 Node.js agent to the latest provided version, run the following command
 (requires `npm`):
 ```
-sudo npm install --prefix /usr/lib/splunk-instrumentation/splunk-otel-js /usr/lib/splunk-instrumentation/splunk-otel-js.tgz
+cd /usr/lib/splunk-instrumentation/splunk-otel-js && \
+sudo npm install /usr/lib/splunk-instrumentation/splunk-otel-js.tgz
 
 # WARNING: The default Auto Instrumentation configuration expects the Node.js
-# agent to be installed under the /usr/lib/splunk-instrumentation/splunk-otel-js
-# prefix, as specified the command above. If the prefix is changed to a
-# different path, manually update the path for the NODE_OPTIONS
+# agent to be installed the /usr/lib/splunk-instrumentation/splunk-otel-js
+# directory, as specified the command above. If the installation is changed to
+# a different path, manually update the path for the NODE_OPTIONS
 # environment variable in either /etc/splunk/zeroconfig/node.conf or
 # /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
 # accordingly.

--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -360,26 +360,26 @@ Auto Instrumentation to take effect.
 If running the installer script ***with*** Node.js Auto Instrumentation, the
 following are required:
 - `npm` is required to install the Node.js Auto Instrumentation package. If
-  `npm` is not installed or not found in the user's default `PATH`, the
-  installer script will automatically skip installation and configuration of
-  the Node.js agent. Run the installer script with the
-  `--without-instrumentation-sdk node` option to explicitly skip Node.js.
-- By default, the Node.js Auto Instrumentation package will be installed with
-  the `npm install --global` command. Run the installer script with the
-  `--npm-command "<command>"` option to specify a custom command (wrapped in
-  quotes). For example:
+  `npm` is not installed or not found with the `command -v npm` shell command,
+  the installer script will automatically skip installation and configuration
+  of the Node.js agent. Use the `--npm-path <path>` option to specify a custom
+  path to `npm`. For example:
   ```
   curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-collector.sh && \
-  sudo sh /tmp/splunk-otel-collector.sh --with-instrumentation --npm-command "/path/to/npm install --prefix /my/custom/path" --realm SPLUNK_REALM -- SPLUNK_ACCESS_TOKEN
+  sudo sh /tmp/splunk-otel-collector.sh --with-instrumentation --npm-path /path/to/npm --realm SPLUNK_REALM -- SPLUNK_ACCESS_TOKEN
   ```
-- Ensure that all Node.js applications/services to be instrumented have access
-  to the installation path of the Node.js Auto Instrumentation package.
 - For `arm64/aarch64` architectures, the following package groups will
   automatically be installed in order to build/compile the Node.js Auto
   Instrumentation package:
   - Debian/Ubuntu: `build-essential`
   - CentOS/Oracle/Red Hat/Amazon: `Development Tools`
   - Suse: `devel_basis` and `devel_C_C++`
+- To explicitly skip Node.js Auto Instrumentation, run the installer script
+  with the `--without-instrumentation-sdk node` option. For example:
+  ```
+  curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-collector.sh && \
+  sudo sh /tmp/splunk-otel-collector.sh --with-instrumentation --without-instrumentation-sdk node --realm SPLUNK_REALM -- SPLUNK_ACCESS_TOKEN
+  ```
 
 #### Post-Install Configuration
 
@@ -441,6 +441,24 @@ system (requires `root` privileges):
     sudo zypper refresh
     sudo zypper update splunk-otel-auto-instrumentation
     ```
+
+The latest `splunk-otel-auto-instrumentation` deb/rpm package may provide an
+updated version of the Node.js Auto Instrumentation agent (check the
+[GitHub Release notes](
+https://github.com/signalfx/splunk-otel-collector/releases)). To update the
+Node.js agent to the latest provided version, run the following command
+(requires `npm`):
+```
+sudo npm install --prefix /usr/lib/splunk-instrumentation/splunk-otel-js /usr/lib/splunk-instrumentation/splunk-otel-js.tgz
+
+# WARNING: The default Auto Instrumentation configuration expects the Node.js
+# agent to be installed under the /usr/lib/splunk-instrumentation/splunk-otel-js
+# prefix, as specified the command above. If the prefix is changed to a
+# different path, manually update the path for the NODE_OPTIONS
+# environment variable in either /etc/splunk/zeroconfig/node.conf or
+# /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+# accordingly.
+```
 
 **Important**: After the `splunk-otel-auto-instrumentation` is upgraded, the
 `/usr/lib/splunk-instrumentation/libsplunk.so` shared object library path will

--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -348,14 +348,15 @@ To manually activate and configure the Auto Instrumentation agents:
    `/usr/lib/splunk-instrumentation/splunk-otel-js.tgz` Node.js package with
    the following commands (requires `npm`):
    ```sh
-   sudo mkdir -p /usr/lib/splunk-instrumentation/splunk-otel-js
-   sudo npm install --prefix /usr/lib/splunk-instrumentation/splunk-otel-js /usr/lib/splunk-instrumentation/splunk-otel-js.tgz
+   sudo mkdir -p /usr/lib/splunk-instrumentation/splunk-otel-js && \
+   cd /usr/lib/splunk-instrumentation/splunk-otel-js && \
+   sudo npm install /usr/lib/splunk-instrumentation/splunk-otel-js.tgz
    ```
    > **Notes:**
    > - The default configuration files expect the Node.js package to be
-   >   installed with the `/usr/lib/splunk-instrumentation/splunk-otel-js`
-   >   prefix. If installing the Node.js package globally or with a different
-   >   prefix, update the path for `NODE_OPTIONS` in the configuration files
+   >   installed in the `/usr/lib/splunk-instrumentation/splunk-otel-js`
+   >   directory. If installing the Node.js package globally or in a different
+   >   directory, update the path for `NODE_OPTIONS` in the configuration files
    >   accordingly.
    > - On `arm64` architectures, it may be necessary to build/compile the
    >   Node.js package when installing with `npm`. Ensure that any required

--- a/docs/getting-started/linux-manual.md
+++ b/docs/getting-started/linux-manual.md
@@ -346,13 +346,17 @@ To manually activate and configure the Auto Instrumentation agents:
    - [Node.js](https://docs.splunk.com/Observability/en/gdi/get-data-in/application/nodejs/nodejs-otel-requirements.html)
 2. If Auto Instrumentation for Node.js is required, install the provided
    `/usr/lib/splunk-instrumentation/splunk-otel-js.tgz` Node.js package with
-   `npm`. For example:
+   the following commands (requires `npm`):
    ```sh
-   sudo npm install --global /usr/lib/splunk-instrumentation/splunk-otel-js.tgz
+   sudo mkdir -p /usr/lib/splunk-instrumentation/splunk-otel-js
+   sudo npm install --prefix /usr/lib/splunk-instrumentation/splunk-otel-js /usr/lib/splunk-instrumentation/splunk-otel-js.tgz
    ```
    > **Notes:**
-   > - Ensure that all Node.js applications/services to be instrumented have
-   >   access to the installation path of the Node.js package.
+   > - The default configuration files expect the Node.js package to be
+   >   installed with the `/usr/lib/splunk-instrumentation/splunk-otel-js`
+   >   prefix. If installing the Node.js package globally or with a different
+   >   prefix, update the path for `NODE_OPTIONS` in the configuration files
+   >   accordingly.
    > - On `arm64` architectures, it may be necessary to build/compile the
    >   Node.js package when installing with `npm`. Ensure that any required
    >   tools/libraries are installed on these systems, for example,

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -71,7 +71,7 @@ The following methods are supported to manually activate and configure Auto Inst
      ```
    - `/etc/splunk/zeroconfig/node.conf`:
      ```
-     NODE_OPTIONS=-r @splunk/otel/instrument
+     NODE_OPTIONS=-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument
      ```
    Configuration of the respective agents is supported by the adding/updating the following environment variables in
    each of these files (***any environment variable not in this list will be ignored***):
@@ -113,7 +113,7 @@ The following methods are supported to manually activate and configure Auto Inst
      ```
    - Node.js:
      ```
-     DefaultEnvironment="NODE_OPTIONS=-r @splunk/otel/instrument"
+     DefaultEnvironment="NODE_OPTIONS=-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument"
      ```
 2. To configure the activated agents, add/update [`DefaultEnvironment`](
    https://www.freedesktop.org/software/systemd/man/systemd-system.conf.html#DefaultEnvironment=) within the target file

--- a/instrumentation/packaging/fpm/etc/splunk/zeroconfig/node.conf
+++ b/instrumentation/packaging/fpm/etc/splunk/zeroconfig/node.conf
@@ -1,1 +1,1 @@
-NODE_OPTIONS=-r @splunk/otel/instrument
+NODE_OPTIONS=-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument

--- a/instrumentation/packaging/fpm/examples/systemd/00-splunk-otel-auto-instrumentation.conf
+++ b/instrumentation/packaging/fpm/examples/systemd/00-splunk-otel-auto-instrumentation.conf
@@ -42,7 +42,7 @@
 DefaultEnvironment="JAVA_TOOL_OPTIONS=-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar"
 
 # Required to activate Splunk OpenTelemetry Auto Instrumentation for Node.js
-DefaultEnvironment="NODE_OPTIONS=-r @splunk/otel/instrument"
+DefaultEnvironment="NODE_OPTIONS=-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument"
 
 # Examples of common configuration options.
 # The environment variables defined in this file will apply to all activated agents.

--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -335,7 +335,7 @@ ensure_not_installed() {
       echo "Please uninstall auto instrumentation, or try running this script with the '--uninstall' option." >&2
       exit 1
     fi
-    if [ -n "$npm_path" ] && $npm_path ls --prefix $node_install_prefix @splunk/otel >/dev/null 2>&1; then
+    if [ -n "$npm_path" ] && (cd $node_install_prefix && $npm_path ls @splunk/otel >/dev/null 2>&1); then
       echo "The @splunk/otel npm package is already installed in $node_install_prefix." >&2
       echo "Please uninstall @splunk/otel, or try running this script with the '--uninstall' option." >&2
       exit 1
@@ -569,8 +569,8 @@ install_node_package() {
 
   echo "Installing the Node.js Auto Instrumentation package ..."
   mkdir -p $node_install_prefix
-  echo "Running '$npm_path install --prefix $node_install_prefix $node_package_path':"
-  $npm_path install --prefix $node_install_prefix $node_package_path
+  echo "Running 'cd $node_install_prefix && $npm_path install $node_package_path':"
+  (cd $node_install_prefix && $npm_path install $node_package_path)
 }
 
 create_zeroconfig_node() {
@@ -788,8 +788,8 @@ uninstall() {
     fi
   done
 
-  if command -v npm >/dev/null 2>&1 && npm ls --prefix $node_install_prefix @splunk/otel >/dev/null 2>&1; then
-    npm uninstall --prefix $node_install_prefix @splunk/otel
+  if command -v npm >/dev/null 2>&1 && (cd $node_install_prefix && npm ls @splunk/otel >/dev/null 2>&1); then
+    (cd $node_install_prefix && npm uninstall @splunk/otel)
     echo "Successfully uninstalled the @splunk/otel npm package from $node_install_prefix"
   fi
 }

--- a/internal/buildscripts/packaging/tests/installer_test.py
+++ b/internal/buildscripts/packaging/tests/installer_test.py
@@ -339,7 +339,7 @@ def get_zc_method(container, distro, method):
 
 
 def node_package_installed(container):
-    return container.exec_run(f"sh -l -c 'npm ls --prefix {NODE_PREFIX} @splunk/otel'").exit_code == 0
+    return container.exec_run(f"sh -l -c 'cd {NODE_PREFIX} && npm ls @splunk/otel'").exit_code == 0
 
 
 @pytest.mark.installer

--- a/internal/buildscripts/packaging/tests/instrumentation/instrumentation_test.py
+++ b/internal/buildscripts/packaging/tests/instrumentation/instrumentation_test.py
@@ -335,7 +335,7 @@ def test_express_instrumentation(distro, arch):
 
         # install splunk-otel-js to /usr/lib/splunk-instrumentation/splunk-otel-js
         run_container_cmd(container, f"mkdir -p {LIB_DIR}/splunk-otel-js")
-        run_container_cmd(container, f"bash -l -c 'npm install --prefix {LIB_DIR}/splunk-otel-js {NODE_AGENT_PATH}'")
+        run_container_cmd(container, f"bash -l -c 'cd {LIB_DIR}/splunk-otel-js && npm install {NODE_AGENT_PATH}'")
 
         for method in ["systemd", "libsplunk"]:
             # attributes from default config

--- a/internal/buildscripts/packaging/tests/instrumentation/instrumentation_test.py
+++ b/internal/buildscripts/packaging/tests/instrumentation/instrumentation_test.py
@@ -333,8 +333,9 @@ def test_express_instrumentation(distro, arch):
             # downgrade npm to support python 3.5
             run_container_cmd(container, "bash -l -c 'npm install --global npm@^6'")
 
-        # install splunk-otel-js
-        run_container_cmd(container, f"bash -l -c 'npm install --global {NODE_AGENT_PATH}'")
+        # install splunk-otel-js to /usr/lib/splunk-instrumentation/splunk-otel-js
+        run_container_cmd(container, f"mkdir -p {LIB_DIR}/splunk-otel-js")
+        run_container_cmd(container, f"bash -l -c 'npm install --prefix {LIB_DIR}/splunk-otel-js {NODE_AGENT_PATH}'")
 
         for method in ["systemd", "libsplunk"]:
             # attributes from default config

--- a/internal/buildscripts/packaging/tests/instrumentation/libsplunk-node-test.conf
+++ b/internal/buildscripts/packaging/tests/instrumentation/libsplunk-node-test.conf
@@ -1,4 +1,4 @@
-NODE_OPTIONS=-r @splunk/otel/instrument
+NODE_OPTIONS=-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument
 OTEL_RESOURCE_ATTRIBUTES=deployment.environment=deployment_environment_from_libsplunk_node
 OTEL_SERVICE_NAME=service_name_from_libsplunk_node
 SPLUNK_METRICS_ENABLED=true


### PR DESCRIPTION
- Update `NODE_OPTIONS` to `-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument` in the ZC config files
- Update installer script to install `splunk-otel-js` with `cd /usr/lib/splunk-instrumentation/splunk-otel-js && npm install` instead of `--global`
- Replace the `--npm-command` installer script option with `--npm-path`
- Update docs and tests