### PR TITLE
source SPLUNK_LISTEN_INTERFACE on all host endpoints

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -36,7 +36,7 @@ extensions:
 
 receivers:
   fluentforward:
-    endpoint: 127.0.0.1:8006
+    endpoint: "${SPLUNK_LISTEN_INTERFACE}:8006"
   hostmetrics:
     collection_interval: 10s
     scrapers:

--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -42,7 +42,7 @@ receivers:
       - job_name: 'otel-collector'
         scrape_interval: 10s
         static_configs:
-        - targets: ['0.0.0.0:8888']
+        - targets: ['${SPLUNK_LISTEN_INTERFACE}:8888']
         metric_relabel_configs:
           - source_labels: [ __name__ ]
             regex: '.*grpc_io.*'

--- a/tests/general/default_config_test.go
+++ b/tests/general/default_config_test.go
@@ -17,6 +17,7 @@
 package tests
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -27,340 +28,367 @@ import (
 )
 
 func TestDefaultGatewayConfig(t *testing.T) {
-	tc := testutils.NewTestcase(t)
-	defer tc.PrintLogsOnFailure()
-	defer tc.ShutdownOTLPReceiverSink()
+	for _, ip := range []string{"default", "0.0.0.0", "127.2.3.4"} {
+		ip := ip
+		t.Run(ip, func(t *testing.T) {
+			tc := testutils.NewTestcase(t)
+			defer tc.PrintLogsOnFailure()
+			defer tc.ShutdownOTLPReceiverSink()
 
-	collector, shutdown := tc.SplunkOtelCollectorContainer(
-		"",
-		func(collector testutils.Collector) testutils.Collector {
-			return collector.WithArgs().WithEnv(map[string]string{
-				"SPLUNK_ACCESS_TOKEN": "not.real",
-				"SPLUNK_REALM":        "not.real",
-			})
-		},
-	)
-	defer shutdown()
+			collector, shutdown := tc.SplunkOtelCollectorContainer(
+				"",
+				func(collector testutils.Collector) testutils.Collector {
+					env := map[string]string{
+						"SPLUNK_ACCESS_TOKEN": "not.real",
+						"SPLUNK_REALM":        "not.real",
+					}
+					if ip != "default" {
+						env["SPLUNK_LISTEN_INTERFACE"] = ip
+					}
+					return collector.WithArgs().WithEnv(env)
+				},
+			)
+			defer shutdown()
 
-	config := collector.EffectiveConfig(t, 55554)
-	require.Equal(t, map[string]any{
-		"exporters": map[string]any{
-			"sapm": map[string]any{
-				"access_token": "<redacted>",
-				"endpoint":     "https://ingest.not.real.signalfx.com/v2/trace",
-				"sending_queue": map[string]any{
-					"num_consumers": 32,
-				},
-			},
-			"signalfx": map[string]any{
-				"access_token": "<redacted>",
-				"realm":        "not.real",
-				"sending_queue": map[string]any{
-					"num_consumers": 32,
-				},
-			},
-			"signalfx/internal": map[string]any{
-				"access_token":       "<redacted>",
-				"realm":              "not.real",
-				"sync_host_metadata": true,
-			},
-			"splunk_hec": map[string]any{
-				"endpoint":               "https://ingest.not.real.signalfx.com/v1/log",
-				"source":                 "otel",
-				"sourcetype":             "otel",
-				"token":                  "<redacted>",
-				"profiling_data_enabled": false,
-			},
-			"splunk_hec/profiling": map[string]any{
-				"endpoint":         "https://ingest.not.real.signalfx.com/v1/log",
-				"token":            "<redacted>",
-				"log_data_enabled": false,
-			},
-		},
-		"extensions": map[string]any{
-			"health_check": map[string]any{
-				"endpoint": "0.0.0.0:13133",
-			},
-			"http_forwarder": map[string]any{
-				"egress": map[string]any{
-					"endpoint": "https://api.not.real.signalfx.com",
-				},
-				"ingress": map[string]any{
-					"endpoint": "0.0.0.0:6060",
-				},
-			},
-			"memory_ballast": map[string]any{
-				"size_mib": "168",
-			},
-			"zpages": map[string]any{
-				"endpoint": "0.0.0.0:55679",
-			},
-		},
-		"processors": map[string]any{
-			"batch": nil,
-			"memory_limiter": map[string]any{
-				"check_interval": "2s",
-				"limit_mib":      "460",
-			},
-			"resourcedetection/internal": map[string]any{
-				"detectors": []any{"gcp", "ecs", "ec2", "azure", "system"},
-				"override":  true,
-			},
-		},
-		"receivers": map[string]any{
-			"jaeger": map[string]any{
-				"protocols": map[string]any{
-					"grpc":           map[string]any{"endpoint": "0.0.0.0:14250"},
-					"thrift_binary":  map[string]any{"endpoint": "0.0.0.0:6832"},
-					"thrift_compact": map[string]any{"endpoint": "0.0.0.0:6831"},
-					"thrift_http":    map[string]any{"endpoint": "0.0.0.0:14268"},
-				},
-			},
-			"otlp": map[string]any{
-				"protocols": map[string]any{
-					"grpc": map[string]any{"endpoint": "0.0.0.0:4317"},
-					"http": map[string]any{"endpoint": "0.0.0.0:4318"},
-				},
-			},
-			"prometheus/internal": map[string]any{
-				"config": map[string]any{
-					"scrape_configs": []any{map[string]any{
-						"job_name": "otel-collector",
-						"metric_relabel_configs": []any{
-							map[string]any{
-								"action":        "drop",
-								"regex":         ".*grpc_io.*",
-								"source_labels": []any{"__name__"},
-							},
+			// expected default
+			if ip == "default" {
+				ip = "0.0.0.0"
+			}
+
+			config := collector.EffectiveConfig(t, 55554)
+			require.Equal(t, map[string]any{
+				"exporters": map[string]any{
+					"sapm": map[string]any{
+						"access_token": "<redacted>",
+						"endpoint":     "https://ingest.not.real.signalfx.com/v2/trace",
+						"sending_queue": map[string]any{
+							"num_consumers": 32,
 						},
-						"scrape_interval": "10s",
-						"static_configs": []any{
-							map[string]any{
-								"targets": []any{"0.0.0.0:8888"},
+					},
+					"signalfx": map[string]any{
+						"access_token": "<redacted>",
+						"realm":        "not.real",
+						"sending_queue": map[string]any{
+							"num_consumers": 32,
+						},
+					},
+					"signalfx/internal": map[string]any{
+						"access_token":       "<redacted>",
+						"realm":              "not.real",
+						"sync_host_metadata": true,
+					},
+					"splunk_hec": map[string]any{
+						"endpoint":               "https://ingest.not.real.signalfx.com/v1/log",
+						"source":                 "otel",
+						"sourcetype":             "otel",
+						"token":                  "<redacted>",
+						"profiling_data_enabled": false,
+					},
+					"splunk_hec/profiling": map[string]any{
+						"endpoint":         "https://ingest.not.real.signalfx.com/v1/log",
+						"token":            "<redacted>",
+						"log_data_enabled": false,
+					},
+				},
+				"extensions": map[string]any{
+					"health_check": map[string]any{
+						"endpoint": fmt.Sprintf("%s:13133", ip),
+					},
+					"http_forwarder": map[string]any{
+						"egress": map[string]any{
+							"endpoint": "https://api.not.real.signalfx.com",
+						},
+						"ingress": map[string]any{
+							"endpoint": fmt.Sprintf("%s:6060", ip),
+						},
+					},
+					"memory_ballast": map[string]any{
+						"size_mib": "168",
+					},
+					"zpages": map[string]any{
+						"endpoint": fmt.Sprintf("%s:55679", ip),
+					},
+				},
+				"processors": map[string]any{
+					"batch": nil,
+					"memory_limiter": map[string]any{
+						"check_interval": "2s",
+						"limit_mib":      "460",
+					},
+					"resourcedetection/internal": map[string]any{
+						"detectors": []any{"gcp", "ecs", "ec2", "azure", "system"},
+						"override":  true,
+					},
+				},
+				"receivers": map[string]any{
+					"jaeger": map[string]any{
+						"protocols": map[string]any{
+							"grpc":           map[string]any{"endpoint": fmt.Sprintf("%s:14250", ip)},
+							"thrift_binary":  map[string]any{"endpoint": fmt.Sprintf("%s:6832", ip)},
+							"thrift_compact": map[string]any{"endpoint": fmt.Sprintf("%s:6831", ip)},
+							"thrift_http":    map[string]any{"endpoint": fmt.Sprintf("%s:14268", ip)},
+						},
+					},
+					"otlp": map[string]any{
+						"protocols": map[string]any{
+							"grpc": map[string]any{"endpoint": fmt.Sprintf("%s:4317", ip)},
+							"http": map[string]any{"endpoint": fmt.Sprintf("%s:4318", ip)},
+						},
+					},
+					"prometheus/internal": map[string]any{
+						"config": map[string]any{
+							"scrape_configs": []any{map[string]any{
+								"job_name": "otel-collector",
+								"metric_relabel_configs": []any{
+									map[string]any{
+										"action":        "drop",
+										"regex":         ".*grpc_io.*",
+										"source_labels": []any{"__name__"},
+									},
+								},
+								"scrape_interval": "10s",
+								"static_configs": []any{
+									map[string]any{
+										"targets": []any{fmt.Sprintf("%s:8888", ip)},
+									},
+								},
+							},
 							},
 						},
 					},
+					"sapm": map[string]any{
+						"endpoint": fmt.Sprintf("%s:7276", ip),
+					},
+					"signalfx": map[string]any{
+						"endpoint": fmt.Sprintf("%s:9943", ip),
+					},
+					"zipkin": map[string]any{
+						"endpoint": fmt.Sprintf("%s:9411", ip),
 					},
 				},
-			},
-			"sapm": map[string]any{
-				"endpoint": "0.0.0.0:7276",
-			},
-			"signalfx": map[string]any{
-				"endpoint": "0.0.0.0:9943",
-			},
-			"zipkin": map[string]any{
-				"endpoint": "0.0.0.0:9411",
-			},
-		},
-		"service": map[string]any{
-			"telemetry":  map[string]any{"metrics": map[string]any{"address": "0.0.0.0:8888"}},
-			"extensions": []any{"health_check", "http_forwarder", "zpages", "memory_ballast"},
-			"pipelines": map[string]any{
-				"logs": map[string]any{
-					"exporters":  []any{"splunk_hec", "splunk_hec/profiling"},
-					"processors": []any{"memory_limiter", "batch"},
-					"receivers":  []any{"otlp"},
+				"service": map[string]any{
+					"telemetry":  map[string]any{"metrics": map[string]any{"address": fmt.Sprintf("%s:8888", ip)}},
+					"extensions": []any{"health_check", "http_forwarder", "zpages", "memory_ballast"},
+					"pipelines": map[string]any{
+						"logs": map[string]any{
+							"exporters":  []any{"splunk_hec", "splunk_hec/profiling"},
+							"processors": []any{"memory_limiter", "batch"},
+							"receivers":  []any{"otlp"},
+						},
+						"logs/signalfx": map[string]any{
+							"exporters":  []any{"signalfx"},
+							"processors": []any{"memory_limiter", "batch"},
+							"receivers":  []any{"signalfx"},
+						},
+						"metrics": map[string]any{
+							"exporters":  []any{"signalfx"},
+							"processors": []any{"memory_limiter", "batch"},
+							"receivers":  []any{"otlp", "signalfx"},
+						},
+						"metrics/internal": map[string]any{
+							"exporters":  []any{"signalfx/internal"},
+							"processors": []any{"memory_limiter", "batch", "resourcedetection/internal"},
+							"receivers":  []any{"prometheus/internal"},
+						},
+						"traces": map[string]any{
+							"exporters":  []any{"sapm"},
+							"processors": []any{"memory_limiter", "batch"},
+							"receivers":  []any{"jaeger", "otlp", "sapm", "zipkin"},
+						},
+					},
 				},
-				"logs/signalfx": map[string]any{
-					"exporters":  []any{"signalfx"},
-					"processors": []any{"memory_limiter", "batch"},
-					"receivers":  []any{"signalfx"},
-				},
-				"metrics": map[string]any{
-					"exporters":  []any{"signalfx"},
-					"processors": []any{"memory_limiter", "batch"},
-					"receivers":  []any{"otlp", "signalfx"},
-				},
-				"metrics/internal": map[string]any{
-					"exporters":  []any{"signalfx/internal"},
-					"processors": []any{"memory_limiter", "batch", "resourcedetection/internal"},
-					"receivers":  []any{"prometheus/internal"},
-				},
-				"traces": map[string]any{
-					"exporters":  []any{"sapm"},
-					"processors": []any{"memory_limiter", "batch"},
-					"receivers":  []any{"jaeger", "otlp", "sapm", "zipkin"},
-				},
-			},
-		},
-	}, config)
+			}, config)
+		})
+	}
 }
 
 func TestDefaultAgentConfig(t *testing.T) {
-	tc := testutils.NewTestcase(t)
-	defer tc.PrintLogsOnFailure()
-	defer tc.ShutdownOTLPReceiverSink()
+	for _, ip := range []string{"default", "0.0.0.0", "127.2.3.4"} {
+		ip := ip
+		t.Run(ip, func(t *testing.T) {
+			tc := testutils.NewTestcase(t)
+			defer tc.PrintLogsOnFailure()
+			defer tc.ShutdownOTLPReceiverSink()
 
-	collector, shutdown := tc.SplunkOtelCollectorContainer(
-		"",
-		func(collector testutils.Collector) testutils.Collector {
-			return collector.WithArgs(
-				"--config", "/etc/otel/collector/agent_config.yaml",
-			).WithEnv(map[string]string{
-				"SPLUNK_ACCESS_TOKEN": "not.real",
-				"SPLUNK_REALM":        "not.real",
-			})
-		},
-	)
-	defer shutdown()
+			collector, shutdown := tc.SplunkOtelCollectorContainer(
+				"",
+				func(collector testutils.Collector) testutils.Collector {
+					env := map[string]string{
+						"SPLUNK_ACCESS_TOKEN": "not.real",
+						"SPLUNK_REALM":        "not.real",
+					}
+					if ip != "default" {
+						env["SPLUNK_LISTEN_INTERFACE"] = ip
+					}
+					return collector.WithArgs(
+						"--config", "/etc/otel/collector/agent_config.yaml",
+					).WithEnv(env)
+				},
+			)
+			defer shutdown()
 
-	config := collector.EffectiveConfig(t, 55554)
-	require.Equal(t, map[string]any{
-		"exporters": map[string]any{
-			"debug": map[string]any{
-				"verbosity": "detailed",
-			},
-			"otlp": map[string]any{
-				"endpoint": ":4317",
-				"tls": map[string]any{
-					"insecure": true,
+			// expected default
+			if ip == "default" {
+				ip = "127.0.0.1"
+			}
+
+			config := collector.EffectiveConfig(t, 55554)
+			require.Equal(t, map[string]any{
+				"exporters": map[string]any{
+					"debug": map[string]any{
+						"verbosity": "detailed",
+					},
+					"otlp": map[string]any{
+						"endpoint": ":4317",
+						"tls": map[string]any{
+							"insecure": true,
+						},
+					},
+					"sapm": map[string]any{
+						"access_token": "<redacted>",
+						"endpoint":     "https://ingest.not.real.signalfx.com/v2/trace",
+					},
+					"signalfx": map[string]any{
+						"access_token":       "<redacted>",
+						"api_url":            "https://api.not.real.signalfx.com",
+						"correlation":        nil,
+						"ingest_url":         "https://ingest.not.real.signalfx.com",
+						"sync_host_metadata": true,
+					},
+					"splunk_hec": map[string]any{
+						"endpoint":               "https://ingest.not.real.signalfx.com/v1/log",
+						"source":                 "otel",
+						"sourcetype":             "otel",
+						"token":                  "<redacted>",
+						"profiling_data_enabled": false,
+					},
+					"splunk_hec/profiling": map[string]any{
+						"endpoint":         "https://ingest.not.real.signalfx.com/v1/log",
+						"token":            "<redacted>",
+						"log_data_enabled": false,
+					},
 				},
-			},
-			"sapm": map[string]any{
-				"access_token": "<redacted>",
-				"endpoint":     "https://ingest.not.real.signalfx.com/v2/trace",
-			},
-			"signalfx": map[string]any{
-				"access_token":       "<redacted>",
-				"api_url":            "https://api.not.real.signalfx.com",
-				"correlation":        nil,
-				"ingest_url":         "https://ingest.not.real.signalfx.com",
-				"sync_host_metadata": true,
-			},
-			"splunk_hec": map[string]any{
-				"endpoint":               "https://ingest.not.real.signalfx.com/v1/log",
-				"source":                 "otel",
-				"sourcetype":             "otel",
-				"token":                  "<redacted>",
-				"profiling_data_enabled": false,
-			},
-			"splunk_hec/profiling": map[string]any{
-				"endpoint":         "https://ingest.not.real.signalfx.com/v1/log",
-				"token":            "<redacted>",
-				"log_data_enabled": false,
-			},
-		},
-		"extensions": map[string]any{
-			"health_check": map[string]any{"endpoint": "127.0.0.1:13133"},
-			"http_forwarder": map[string]any{
-				"egress": map[string]any{
-					"endpoint": "https://api.not.real.signalfx.com",
+				"extensions": map[string]any{
+					"health_check": map[string]any{"endpoint": fmt.Sprintf("%s:13133", ip)},
+					"http_forwarder": map[string]any{
+						"egress": map[string]any{
+							"endpoint": "https://api.not.real.signalfx.com",
+						},
+						"ingress": map[string]any{
+							"endpoint": fmt.Sprintf("%s:6060", ip),
+						},
+					},
+					"memory_ballast": map[string]any{"size_mib": "168"},
+					"smartagent": map[string]any{
+						"bundleDir": "/usr/lib/splunk-otel-collector/agent-bundle",
+						"collectd": map[string]any{
+							"configDir": "/usr/lib/splunk-otel-collector/agent-bundle/run/collectd",
+						},
+					},
+					"zpages": nil,
 				},
-				"ingress": map[string]any{
-					"endpoint": "127.0.0.1:6060",
-				},
-			},
-			"memory_ballast": map[string]any{"size_mib": "168"},
-			"smartagent": map[string]any{
-				"bundleDir": "/usr/lib/splunk-otel-collector/agent-bundle",
-				"collectd": map[string]any{
-					"configDir": "/usr/lib/splunk-otel-collector/agent-bundle/run/collectd",
-				},
-			},
-			"zpages": nil,
-		},
-		"processors": map[string]any{
-			"batch": nil,
-			"memory_limiter": map[string]any{
-				"check_interval": "2s",
-				"limit_mib":      "460",
-			},
-			"resourcedetection": map[string]any{"detectors": []any{"gcp", "ecs", "ec2", "azure", "system"},
-				"override": true,
-			}},
-		"receivers": map[string]any{"fluentforward": map[string]any{"endpoint": "127.0.0.1:8006"},
-			"hostmetrics": map[string]any{
-				"collection_interval": "10s",
-				"scrapers": map[string]any{
-					"cpu":        nil,
-					"disk":       nil,
-					"filesystem": nil,
-					"load":       nil,
-					"memory":     nil,
-					"network":    nil,
-					"paging":     nil,
-					"processes":  nil,
-				},
-			},
-			"jaeger": map[string]any{
-				"protocols": map[string]any{
-					"grpc":           map[string]any{"endpoint": "127.0.0.1:14250"},
-					"thrift_binary":  map[string]any{"endpoint": "127.0.0.1:6832"},
-					"thrift_compact": map[string]any{"endpoint": "127.0.0.1:6831"},
-					"thrift_http":    map[string]any{"endpoint": "127.0.0.1:14268"}}},
-			"otlp": map[string]any{
-				"protocols": map[string]any{
-					"grpc": map[string]any{"endpoint": "127.0.0.1:4317"},
-					"http": map[string]any{"endpoint": "127.0.0.1:4318"},
-				},
-			},
-			"prometheus/internal": map[string]any{
-				"config": map[string]any{
-					"scrape_configs": []any{
-						map[string]any{
-							"job_name": "otel-collector",
-							"metric_relabel_configs": []any{
+				"processors": map[string]any{
+					"batch": nil,
+					"memory_limiter": map[string]any{
+						"check_interval": "2s",
+						"limit_mib":      "460",
+					},
+					"resourcedetection": map[string]any{"detectors": []any{"gcp", "ecs", "ec2", "azure", "system"},
+						"override": true,
+					}},
+				"receivers": map[string]any{"fluentforward": map[string]any{"endpoint": fmt.Sprintf("%s:8006", ip)},
+					"hostmetrics": map[string]any{
+						"collection_interval": "10s",
+						"scrapers": map[string]any{
+							"cpu":        nil,
+							"disk":       nil,
+							"filesystem": nil,
+							"load":       nil,
+							"memory":     nil,
+							"network":    nil,
+							"paging":     nil,
+							"processes":  nil,
+						},
+					},
+					"jaeger": map[string]any{
+						"protocols": map[string]any{
+							"grpc":           map[string]any{"endpoint": fmt.Sprintf("%s:14250", ip)},
+							"thrift_binary":  map[string]any{"endpoint": fmt.Sprintf("%s:6832", ip)},
+							"thrift_compact": map[string]any{"endpoint": fmt.Sprintf("%s:6831", ip)},
+							"thrift_http":    map[string]any{"endpoint": fmt.Sprintf("%s:14268", ip)}}},
+					"otlp": map[string]any{
+						"protocols": map[string]any{
+							"grpc": map[string]any{"endpoint": fmt.Sprintf("%s:4317", ip)},
+							"http": map[string]any{"endpoint": fmt.Sprintf("%s:4318", ip)},
+						},
+					},
+					"prometheus/internal": map[string]any{
+						"config": map[string]any{
+							"scrape_configs": []any{
 								map[string]any{
-									"action":        "drop",
-									"regex":         ".*grpc_io.*",
-									"source_labels": []any{"__name__"},
-								},
-							},
-							"scrape_interval": "10s",
-							"static_configs": []any{
-								map[string]any{
-									"targets": []any{"127.0.0.1:8888"},
+									"job_name": "otel-collector",
+									"metric_relabel_configs": []any{
+										map[string]any{
+											"action":        "drop",
+											"regex":         ".*grpc_io.*",
+											"source_labels": []any{"__name__"},
+										},
+									},
+									"scrape_interval": "10s",
+									"static_configs": []any{
+										map[string]any{
+											"targets": []any{fmt.Sprintf("%s:8888", ip)},
+										},
+									},
 								},
 							},
 						},
 					},
+					"signalfx":               map[string]any{"endpoint": fmt.Sprintf("%s:9943", ip)},
+					"smartagent/processlist": map[string]any{"type": "processlist"},
+					"smartagent/signalfx-forwarder": map[string]any{
+						"listenAddress": fmt.Sprintf("%s:9080", ip),
+						"type":          "signalfx-forwarder",
+					},
+					"zipkin": map[string]any{"endpoint": fmt.Sprintf("%s:9411", ip)}},
+				"service": map[string]any{
+					"telemetry":  map[string]any{"metrics": map[string]any{"address": fmt.Sprintf("%s:8888", ip)}},
+					"extensions": []any{"health_check", "http_forwarder", "zpages", "memory_ballast", "smartagent"},
+					"pipelines": map[string]any{
+						"logs": map[string]any{
+							"exporters":  []any{"splunk_hec", "splunk_hec/profiling"},
+							"processors": []any{"memory_limiter", "batch", "resourcedetection"},
+							"receivers":  []any{"fluentforward", "otlp"}},
+						"logs/signalfx": map[string]any{
+							"exporters":  []any{"signalfx"},
+							"processors": []any{"memory_limiter", "batch", "resourcedetection"},
+							"receivers":  []any{"signalfx", "smartagent/processlist"}},
+						"metrics": map[string]any{
+							"exporters":  []any{"signalfx"},
+							"processors": []any{"memory_limiter", "batch", "resourcedetection"},
+							"receivers":  []any{"hostmetrics", "otlp", "signalfx", "smartagent/signalfx-forwarder"}},
+						"metrics/internal": map[string]any{
+							"exporters":  []any{"signalfx"},
+							"processors": []any{"memory_limiter", "batch", "resourcedetection"},
+							"receivers":  []any{"prometheus/internal"}},
+						"traces": map[string]any{
+							"exporters":  []any{"sapm", "signalfx"},
+							"processors": []any{"memory_limiter", "batch", "resourcedetection"},
+							"receivers":  []any{"jaeger", "otlp", "smartagent/signalfx-forwarder", "zipkin"},
+						},
+					},
 				},
-			},
-			"signalfx":               map[string]any{"endpoint": "127.0.0.1:9943"},
-			"smartagent/processlist": map[string]any{"type": "processlist"},
-			"smartagent/signalfx-forwarder": map[string]any{
-				"listenAddress": "127.0.0.1:9080",
-				"type":          "signalfx-forwarder",
-			},
-			"zipkin": map[string]any{
-				"endpoint": "127.0.0.1:9411"}},
-		"service": map[string]any{
-			"telemetry":  map[string]any{"metrics": map[string]any{"address": "127.0.0.1:8888"}},
-			"extensions": []any{"health_check", "http_forwarder", "zpages", "memory_ballast", "smartagent"},
-			"pipelines": map[string]any{
-				"logs": map[string]any{
-					"exporters":  []any{"splunk_hec", "splunk_hec/profiling"},
-					"processors": []any{"memory_limiter", "batch", "resourcedetection"},
-					"receivers":  []any{"fluentforward", "otlp"}},
-				"logs/signalfx": map[string]any{
-					"exporters":  []any{"signalfx"},
-					"processors": []any{"memory_limiter", "batch", "resourcedetection"},
-					"receivers":  []any{"signalfx", "smartagent/processlist"}},
-				"metrics": map[string]any{
-					"exporters":  []any{"signalfx"},
-					"processors": []any{"memory_limiter", "batch", "resourcedetection"},
-					"receivers":  []any{"hostmetrics", "otlp", "signalfx", "smartagent/signalfx-forwarder"}},
-				"metrics/internal": map[string]any{
-					"exporters":  []any{"signalfx"},
-					"processors": []any{"memory_limiter", "batch", "resourcedetection"},
-					"receivers":  []any{"prometheus/internal"}},
-				"traces": map[string]any{
-					"exporters":  []any{"sapm", "signalfx"},
-					"processors": []any{"memory_limiter", "batch", "resourcedetection"},
-					"receivers":  []any{"jaeger", "otlp", "smartagent/signalfx-forwarder", "zipkin"},
-				},
-			},
-		},
-	}, config)
+			}, config)
 
-	require.Eventually(t, func() bool {
-		for _, log := range tc.ObservedLogs.All() {
-			// confirm the smartagent extension's config has been sourced by receiver instance.
-			if strings.Contains(log.Message, "Smart Agent Config provider configured") {
-				return true
-			}
-		}
-		return false
-	}, 20*time.Second, time.Second)
+			require.Eventually(t, func() bool {
+				for _, log := range tc.ObservedLogs.All() {
+					// confirm the smartagent extension's config has been sourced by receiver instance.
+					if strings.Contains(log.Message, "Smart Agent Config provider configured") {
+						return true
+					}
+				}
+				return false
+			}, 20*time.Second, time.Second)
+		})
+	}
 }


### PR DESCRIPTION
**Description:**
These changes update two endpoints (one in both the agent and gateway configs) to source the `SPLUNK_LISTEN_INTERFACE` env var. They should resolve issues associated with listening on non-default addresses like missing internal metrics issues on the gateway. 

**Testing:**
Updated the existing cases* to exercise the env var flow for three conditions including the default, "all interfaces", and an additional loopback ip.