### PR TITLE
linux installer script: use --global=false for npm

### DIFF
--- a/internal/buildscripts/packaging/installer/install.sh
+++ b/internal/buildscripts/packaging/installer/install.sh
@@ -335,7 +335,7 @@ ensure_not_installed() {
       echo "Please uninstall auto instrumentation, or try running this script with the '--uninstall' option." >&2
       exit 1
     fi
-    if [ -n "$npm_path" ] && (cd $node_install_prefix && $npm_path ls @splunk/otel >/dev/null 2>&1); then
+    if [ -n "$npm_path" ] && (cd $node_install_prefix && $npm_path ls --global=false @splunk/otel >/dev/null 2>&1); then
       echo "The @splunk/otel npm package is already installed in $node_install_prefix." >&2
       echo "Please uninstall @splunk/otel, or try running this script with the '--uninstall' option." >&2
       exit 1
@@ -568,9 +568,9 @@ install_node_package() {
   fi
 
   echo "Installing the Node.js Auto Instrumentation package ..."
-  mkdir -p $node_install_prefix
-  echo "Running 'cd $node_install_prefix && $npm_path install $node_package_path':"
-  (cd $node_install_prefix && $npm_path install $node_package_path)
+  mkdir -p ${node_install_prefix}/node_modules
+  echo "Running 'cd $node_install_prefix && $npm_path install --global=false $node_package_path':"
+  (cd $node_install_prefix && $npm_path install --global=false $node_package_path)
 }
 
 create_zeroconfig_node() {
@@ -788,8 +788,8 @@ uninstall() {
     fi
   done
 
-  if command -v npm >/dev/null 2>&1 && (cd $node_install_prefix && npm ls @splunk/otel >/dev/null 2>&1); then
-    (cd $node_install_prefix && npm uninstall @splunk/otel)
+  if command -v npm >/dev/null 2>&1 && (cd $node_install_prefix && npm ls --global=false @splunk/otel >/dev/null 2>&1); then
+    (cd $node_install_prefix && npm uninstall --global=false @splunk/otel)
     echo "Successfully uninstalled the @splunk/otel npm package from $node_install_prefix"
   fi
 }

--- a/internal/buildscripts/packaging/tests/installer_test.py
+++ b/internal/buildscripts/packaging/tests/installer_test.py
@@ -339,7 +339,11 @@ def get_zc_method(container, distro, method):
 
 
 def node_package_installed(container):
-    return container.exec_run(f"sh -l -c 'cd {NODE_PREFIX} && npm ls @splunk/otel'").exit_code == 0
+    cmd = f"sh -l -c 'cd {NODE_PREFIX} && npm ls --global=false @splunk/otel'"
+    print(f"Running '{cmd}':")
+    rc, output = container.exec_run(cmd)
+    print(output.decode("utf-8"))
+    return rc == 0
 
 
 @pytest.mark.installer
@@ -377,6 +381,9 @@ def test_installer_with_instrumentation_default(distro, arch, method):
             # npm installed with node v16 only supports python 3.6+, but these distros only provide python 3.5
             # downgrade npm to support python 3.5 in order to build/compile splunk-otel-js
             run_container_cmd(container, "bash -l -c 'npm install --global npm@^6'")
+
+        # set global=true for npm to test that splunk-otel-js is still installed locally
+        run_container_cmd(container, "sh -l -c 'npm config set global true'")
 
         install_cmd = " ".join((
             get_installer_cmd(),
@@ -493,6 +500,9 @@ def test_installer_with_instrumentation_custom(distro, arch, method, sdk):
             # npm installed with node v16 only supports python 3.6+, but these distros only provide python 3.5
             # downgrade npm to support python 3.5 in order to build/compile splunk-otel-js
             run_container_cmd(container, "bash -l -c 'npm install --global npm@^6'")
+
+        # set global=true for npm to test that splunk-otel-js is still installed locally
+        run_container_cmd(container, "sh -l -c 'npm config set global true'")
 
         service_name = f"service_name_from_{method}"
         environment = f"deployment_environment_from_{method}"


### PR DESCRIPTION
Also, create the `node_modules` subdir under `/usr/lib/splunk-instrumentation/splunk-otel-js` since some npm versions/configurations require it for local installs.