### PR TITLE
Update mysql repo gpg key

### DIFF
--- a/internal/signalfx-agent/bundle/Dockerfile
+++ b/internal/signalfx-agent/bundle/Dockerfile
@@ -158,7 +158,7 @@ RUN wget -nv https://dev.mysql.com/get/mysql-apt-config_0.8.12-1_all.deb && \
     mkdir -p ~/.gnupg && \
     chmod 700 ~/.gnupg && \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf && \
-    apt-key adv --homedir ~/.gnupg --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29 && \
+    apt-key adv --homedir ~/.gnupg --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && \
     dpkg -i mysql-apt-config_0.8.12-1_all.deb && \
     rm -f mysql-apt-config_0.8.12-1_all.deb && \
     apt-get update -qq && apt-get install -qq -y libmysqlclient-dev libcurl4-gnutls-dev


### PR DESCRIPTION
Fixes agent bundle builds due to expired gpg key for the mysql apt repo.