### PR TITLE
ecs-metadata: support `dimensionToUpdate` config field 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- `ecs-metadata` sync the `known_status` property on the `container_id` dimension instead of lower cardinality `container_name`. This can be prevented by configuring `dimensionToUpdate` to `container_name` ([#4091](https://github.com/signalfx/splunk-otel-collector/pull/4091))
+
 ## v0.91.1
 
 ### 💡 Enhancements 💡

--- a/internal/signalfx-agent/pkg/monitors/ecs/ecs_test.go
+++ b/internal/signalfx-agent/pkg/monitors/ecs/ecs_test.go
@@ -1,0 +1,92 @@
+// Copyright  Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package ecs
+
+import (
+	"testing"
+
+	"github.com/signalfx/defaults"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/signalfx/signalfx-agent/pkg/core/common/ecs"
+	"github.com/signalfx/signalfx-agent/pkg/core/config"
+	"github.com/signalfx/signalfx-agent/pkg/neotest"
+)
+
+func TestDimensionToUpdate(t *testing.T) {
+	ctr := ecs.Container{
+		Name:     "some.container.name",
+		DockerID: "some.container.id",
+	}
+
+	for _, test := range []struct {
+		configValue      string
+		expectedDimKey   string
+		expectedDimValue string
+		expectedError    string
+	}{
+		{
+			configValue:      "container_name",
+			expectedDimKey:   "container_name",
+			expectedDimValue: "some.container.name",
+		},
+		{
+			configValue:      "container_id",
+			expectedDimKey:   "container_id",
+			expectedDimValue: "some.container.id",
+		},
+		{
+			configValue:      "default",
+			expectedDimKey:   "container_id",
+			expectedDimValue: "some.container.id",
+		},
+		{
+			configValue:   "invalid",
+			expectedError: "unsupported `dimensionToUpdate` \"invalid\". Must be one of \"container_name\" or \"container_id\"",
+		},
+	} {
+		test := test
+		t.Run(test.configValue, func(t *testing.T) {
+			cfg := &Config{
+				MetadataEndpoint: "http://localhost:0/not/real",
+				MonitorConfig: config.MonitorConfig{
+					IntervalSeconds: 1000,
+				},
+			}
+			if test.configValue != "default" {
+				cfg.DimensionToUpdate = test.configValue
+			}
+			require.NoError(t, defaults.Set(cfg))
+			monitor := &Monitor{
+				Output: neotest.NewTestOutput(),
+			}
+
+			err := monitor.Configure(cfg)
+			t.Cleanup(func() {
+				if monitor.cancel != nil {
+					monitor.cancel()
+				}
+			})
+			if test.expectedError != "" {
+				require.EqualError(t, err, test.expectedError)
+				return
+			}
+			require.NoError(t, err)
+			key, value := monitor.dimensionToUpdate(ctr)
+			assert.Equal(t, test.expectedDimKey, key)
+			assert.Equal(t, test.expectedDimValue, value)
+		})
+	}
+}

--- a/internal/signalfx-agent/pkg/neotest/output.go
+++ b/internal/signalfx-agent/pkg/neotest/output.go
@@ -6,6 +6,7 @@ import (
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/event"
 	"github.com/signalfx/golib/v3/trace"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/dpfilters"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 )
@@ -18,6 +19,11 @@ type TestOutput struct {
 	spanChan  chan []*trace.Span
 	dimChan   chan *types.Dimension
 }
+
+var _ types.Output = (*TestOutput)(nil)
+
+// Currently just satisfying the interface (noop implementation)
+var _ types.FilteringOutput = (*TestOutput)(nil)
 
 // NewTestOutput creates a new initialized TestOutput instance
 func NewTestOutput() *TestOutput {
@@ -166,4 +172,16 @@ loop:
 
 // AddDatapointExclusionFilter is a noop here.
 func (to *TestOutput) AddDatapointExclusionFilter(f dpfilters.DatapointFilter) {
+}
+
+func (to *TestOutput) EnabledMetrics() []string {
+	return nil
+}
+
+func (to *TestOutput) HasEnabledMetricInGroup(group string) bool {
+	return false
+}
+
+func (to *TestOutput) HasAnyExtraMetrics() bool {
+	return false
 }


### PR DESCRIPTION
These changes add a `dimensionToUpdate` config field to the ecs-metadata monitor to allow configuring dimension updates on either the `container_name` and `container_id` dimension. Since container_name's can be long lived, perpetuating entities to update becomes unnecessary and setting to the more ephemeral `container_id` is preferable. ~~My plan is to update the default value to `container_id` in a subsequent release but can understand wanting to here instead.~~

edit: updated to sync on `container_id` by default, w/ bw-compatibility option w/ new config field.
