### PR TITLE
Convert loglevel to verbosity on logging exporter

### DIFF
--- a/internal/configconverter/loglevel_to_verbosity.go
+++ b/internal/configconverter/loglevel_to_verbosity.go
@@ -29,10 +29,10 @@ type LogLevelToVerbosity struct{}
 
 func (LogLevelToVerbosity) Convert(_ context.Context, in *confmap.Conf) error {
 	if in == nil {
-		return fmt.Errorf("cannot MoveHecTLS on nil *confmap.Conf")
+		return fmt.Errorf("cannot LogLevelToVerbosity on nil *confmap.Conf")
 	}
 
-	const expression = "exporters::logging(/\\w+)?::loglevel"
+	const expression = "exporters::logging(/.+)?::loglevel"
 	re := regexp.MustCompile(expression)
 	out := map[string]any{}
 	unsupportedKeyFound := false

--- a/internal/configconverter/loglevel_to_verbosity.go
+++ b/internal/configconverter/loglevel_to_verbosity.go
@@ -1,0 +1,93 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configconverter
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+
+	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/confmap"
+	"go.uber.org/zap/zapcore"
+)
+
+type LogLevelToVerbosity struct{}
+
+func (LogLevelToVerbosity) Convert(_ context.Context, in *confmap.Conf) error {
+	if in == nil {
+		return fmt.Errorf("cannot MoveHecTLS on nil *confmap.Conf")
+	}
+
+	const expression = "exporters::logging(/\\w+)?::loglevel"
+	re := regexp.MustCompile(expression)
+	out := map[string]any{}
+	unsupportedKeyFound := false
+	for _, k := range in.AllKeys() {
+		v := in.Get(k)
+		match := re.FindStringSubmatch(k)
+		if match == nil {
+			out[k] = v
+		} else {
+			// check if verbosity is also set:
+			verbosityKey := fmt.Sprintf("exporters::logging%s::verbosity", match[1])
+			if in.Get(verbosityKey) == nil {
+				log.Printf("Deprecated key found: %s. Translating to %s\n", k, verbosityKey)
+				var l zapcore.Level
+				if err := l.UnmarshalText([]byte(v.(string))); err != nil {
+					log.Printf("Could not read loglevel: %v", err)
+					out[k] = v
+				} else {
+					var verbosityLevel configtelemetry.Level
+					if verbosityLevel, err = mapLevel(l); err != nil {
+						log.Printf("Could not map loglevel to verbosity: %v", err)
+						out[k] = v
+					} else {
+						out[verbosityKey] = verbosityLevel.String()
+					}
+				}
+			} else {
+				log.Printf("Deprecated key found: %s. Found new key %s", k, verbosityKey)
+			}
+			unsupportedKeyFound = true
+		}
+	}
+	if unsupportedKeyFound {
+		log.Println(
+			"[WARNING] `exporters` -> `logging` -> `loglevel` " +
+				"is deprecated and moved to verbosity. Please update your config. " +
+				"https://github.com/open-telemetry/opentelemetry-collector/pull/6334",
+		)
+	}
+
+	*in = *confmap.NewFromStringMap(out)
+	return nil
+}
+
+func mapLevel(level zapcore.Level) (configtelemetry.Level, error) {
+	switch level {
+	case zapcore.DebugLevel:
+		return configtelemetry.LevelDetailed, nil
+	case zapcore.InfoLevel:
+		return configtelemetry.LevelNormal, nil
+	case zapcore.WarnLevel, zapcore.ErrorLevel,
+		zapcore.DPanicLevel, zapcore.PanicLevel, zapcore.FatalLevel:
+		// Anything above info is mapped to 'basic' level.
+		return configtelemetry.LevelBasic, nil
+	default:
+		return configtelemetry.LevelNone, fmt.Errorf("log level %q is not supported", level)
+	}
+}

--- a/internal/configconverter/loglevel_to_verbosity_test.go
+++ b/internal/configconverter/loglevel_to_verbosity_test.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configconverter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+)
+
+func TestLogLevelToVerbosity(t *testing.T) {
+	cfgMap, err := confmaptest.LoadConf("testdata/logging_loglevel.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, cfgMap)
+
+	err = LogLevelToVerbosity{}.Convert(context.Background(), cfgMap)
+	require.NoError(t, err)
+
+	assert.False(t, cfgMap.IsSet("exporters::logging::loglevel"))
+	assert.Equal(t, "Detailed", cfgMap.Get("exporters::logging::verbosity"))
+
+	assert.False(t, cfgMap.IsSet("exporters::logging/info::loglevel"))
+	assert.Equal(t, "Normal", cfgMap.Get("exporters::logging/info::verbosity"))
+}

--- a/internal/configconverter/loglevel_to_verbosity_test.go
+++ b/internal/configconverter/loglevel_to_verbosity_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -28,12 +27,12 @@ func TestLogLevelToVerbosity(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfgMap)
 
+	expectedCfgMap, err := confmaptest.LoadConf("testdata/logging_loglevel-after.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, expectedCfgMap)
+
 	err = LogLevelToVerbosity{}.Convert(context.Background(), cfgMap)
 	require.NoError(t, err)
 
-	assert.False(t, cfgMap.IsSet("exporters::logging::loglevel"))
-	assert.Equal(t, "Detailed", cfgMap.Get("exporters::logging::verbosity"))
-
-	assert.False(t, cfgMap.IsSet("exporters::logging/info::loglevel"))
-	assert.Equal(t, "Normal", cfgMap.Get("exporters::logging/info::verbosity"))
+	require.Equal(t, expectedCfgMap, cfgMap)
 }

--- a/internal/configconverter/testdata/logging_loglevel-after.yaml
+++ b/internal/configconverter/testdata/logging_loglevel-after.yaml
@@ -21,11 +21,10 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: Detailed
   logging/info:
-    loglevel: info
+    verbosity: Normal
   logging/with_verbosity:
-    loglevel: info
     verbosity: normal
   logging/invalid:
     loglevel: foo

--- a/internal/configconverter/testdata/logging_loglevel-after.yaml
+++ b/internal/configconverter/testdata/logging_loglevel-after.yaml
@@ -28,6 +28,10 @@ exporters:
     verbosity: normal
   logging/invalid:
     loglevel: foo
+  logging/invalid_verbosity:
+    verbosity: false
+  logging/loglevel_with_invalid_verbosity:
+    verbosity: false
 
 service:
   pipelines:

--- a/internal/configconverter/testdata/logging_loglevel.yaml
+++ b/internal/configconverter/testdata/logging_loglevel.yaml
@@ -1,0 +1,40 @@
+receivers:
+  fluentforward:
+    endpoint: 127.0.0.1:8006
+  otlp:
+    protocols:
+      grpc:
+      http:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'otel-collector'
+          scrape_interval: 10s
+          static_configs:
+            - targets: ['127.0.0.1:8888']
+
+processors:
+  memory_limiter:
+    ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
+    check_interval: 2s
+    limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+
+exporters:
+  logging:
+    loglevel: debug
+  logging/info:
+    loglevel: info
+  logging/with_verbosity:
+    loglevel: info
+    verbosity: normal
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp, prometheus]
+      processors: [memory_limiter]
+      exporters: [logging/info]
+    logs:
+      receivers: [fluentforward, otlp]
+      processors: [memory_limiter]
+      exporters: [logging, logging/with_verbosity]

--- a/internal/configconverter/testdata/logging_loglevel.yaml
+++ b/internal/configconverter/testdata/logging_loglevel.yaml
@@ -29,6 +29,11 @@ exporters:
     verbosity: normal
   logging/invalid:
     loglevel: foo
+  logging/invalid_verbosity:
+    verbosity: false
+  logging/loglevel_with_invalid_verbosity:
+    loglevel: info
+    verbosity: false
 
 service:
   pipelines:

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -214,6 +214,7 @@ func (s *Settings) ConfMapConverters() []confmap.Converter {
 			configconverter.MoveHecTLS{},
 			configconverter.RenameK8sTagger{},
 			configconverter.NormalizeGcp{},
+			configconverter.LogLevelToVerbosity{},
 		)
 	}
 	return confMapConverters

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -179,6 +179,7 @@ func TestNewSettingsConvertConfig(t *testing.T) {
 		configconverter.MoveHecTLS{},
 		configconverter.RenameK8sTagger{},
 		configconverter.NormalizeGcp{},
+		configconverter.LogLevelToVerbosity{},
 	}, settings.ConfMapConverters())
 	require.Equal(t, []string{"--feature-gates", "foo", "--feature-gates", "-bar"}, settings.ColCoreArgs())
 }


### PR DESCRIPTION
Add a converter that takes loglevel and translates it over to verbosity.