### PR TITLE
Add AWS s3 exporter

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -88,6 +88,7 @@ The distribution offers support for the following components.
 
 | Exporters                                                                                                                   | Stability        |
 |:----------------------------------------------------------------------------------------------------------------------------|:-----------------|
+| [awss3](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awss3exporter)                 | [alpha]          |
 | [debug](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter)                         | [in development] |
 | [file](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter)                   | [alpha]          |
 | [kafka](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter)                 | [beta]           |

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/knadh/koanf v1.5.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.91.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.91.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.91.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.91.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.91.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.91.0

--- a/go.sum
+++ b/go.sum
@@ -1068,6 +1068,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnect
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.91.0/go.mod h1:CKI97YHL7IrmG++V7eFcV8Hoq7YIxMlQXjgorLhibiw=
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.91.0 h1:fJOWUu4jQytFmzJLFYU0+rcnEt1vfAyqSZ622tdd81Q=
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.91.0/go.mod h1:B0NLW0AU9C/cJgBDWsQKGKJhEI6/sCz9cQgObbfoA8U=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.91.0 h1:pcLvFlYlGebRNMv7UVLQ8Fvt294r2rVnyX5uH7lTbyU=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.91.0/go.mod h1:zIZ0u5z7DGBcC3Lt0x3gojrgHT6EXvGJoBnHqVmlb3E=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.91.0 h1:p8gP126reF8nK4HvgpQ+6R3+CVxnYohjInD67uKqfDw=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.91.0/go.mod h1:j26btuTJfz02X+urX9Qk73I13BdfuJoyjLm+edN1G94=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.91.0 h1:iU2St2YduQzbuXu68gjFB0CpPoQmo7kvl97IThw4aRE=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -18,6 +18,7 @@ package components
 import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
@@ -191,6 +192,7 @@ func Get() (otelcol.Factories, error) {
 	}
 
 	exporters, err := exporter.MakeFactoryMap(
+		awss3exporter.NewFactory(),
 		debugexporter.NewFactory(),
 		fileexporter.NewFactory(),
 		kafkaexporter.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -108,6 +108,7 @@ func TestDefaultComponents(t *testing.T) {
 		"transform",
 	}
 	expectedExporters := []component.Type{
+		"awss3",
 		"debug",
 		"file",
 		"kafka",


### PR DESCRIPTION
**Description:** 
Adds the AWS s3 exporter to the Splunk distribution

**Link to Splunk idea:**
https://ideas.splunk.com/ideas/SFXIMMID-I-389
https://ideas.splunk.com/ideas/SFXIMMID-I-548
