### PR TITLE
make loggers final

### DIFF
--- a/internal/signalfx-agent/bundle/java/jmx/src/main/java/com/signalfx/agent/SignalFxMonitorRunner.java
+++ b/internal/signalfx-agent/bundle/java/jmx/src/main/java/com/signalfx/agent/SignalFxMonitorRunner.java
@@ -9,7 +9,7 @@ import java.util.logging.Logger;
 import com.signalfx.agent.logging.Handler;
 
 public class SignalFxMonitorRunner<T extends MonitorConfig> {
-    private static Logger logger = Logger.getLogger(SignalFxMonitorRunner.class.getName());
+    private static final Logger logger = Logger.getLogger(SignalFxMonitorRunner.class.getName());
 
     private final SignalFxMonitor monitor;
     private final Class configCls;

--- a/internal/signalfx-agent/bundle/java/jmx/src/main/java/com/signalfx/agent/jmx/Client.java
+++ b/internal/signalfx-agent/bundle/java/jmx/src/main/java/com/signalfx/agent/jmx/Client.java
@@ -18,7 +18,7 @@ import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 
 public class Client {
-    private static Logger logger = Logger.getLogger(Client.class.getName());
+    private static final Logger logger = Logger.getLogger(Client.class.getName());
 
     private final JMXServiceURL url;
     private final String username;

--- a/internal/signalfx-agent/bundle/java/jmx/src/main/java/com/signalfx/agent/jmx/GroovyRunner.java
+++ b/internal/signalfx-agent/bundle/java/jmx/src/main/java/com/signalfx/agent/jmx/GroovyRunner.java
@@ -20,7 +20,7 @@ import groovy.lang.GroovyShell;
 import groovy.lang.Script;
 
 public class GroovyRunner {
-    private static Logger logger = Logger.getLogger(GroovyRunner.class.getName());
+    private static final Logger logger = Logger.getLogger(GroovyRunner.class.getName());
 
     private final GroovyShell gshell = new GroovyShell();
 

--- a/internal/signalfx-agent/bundle/java/jmx/src/main/java/com/signalfx/agent/jmx/JMXMonitor.java
+++ b/internal/signalfx-agent/bundle/java/jmx/src/main/java/com/signalfx/agent/jmx/JMXMonitor.java
@@ -14,7 +14,7 @@ import com.signalfx.agent.MonitorUtil;
 import org.apache.commons.lang3.StringUtils;
 
 public class JMXMonitor implements SignalFxMonitor<JMXMonitor.JMXConfig> {
-    private static Logger logger = Logger.getLogger(JMXMonitor.class.getName());
+    private static final Logger logger = Logger.getLogger(JMXMonitor.class.getName());
 
     private final Timer timer = new Timer();
 


### PR DESCRIPTION
Following best practices, marking loggers as final.