### PR TITLE
remove code outside of execution path

### DIFF
--- a/internal/signalfx-agent/bundle/java/jmx/src/main/java/com/signalfx/agent/SignalFxMonitorRunner.java
+++ b/internal/signalfx-agent/bundle/java/jmx/src/main/java/com/signalfx/agent/SignalFxMonitorRunner.java
@@ -53,11 +53,6 @@ public class SignalFxMonitorRunner<T extends MonitorConfig> {
                             shutdownMsg.type));
         }
         monitor.shutdown();
-        return;
-    }
-
-    public void runDebug() {
-
     }
 
     private void setUpLogging(AgentOutput output) {


### PR DESCRIPTION
Remove a `return;` statement and a method, `runDebug()`, which is not used.