### PR TITLE
Deprecate httpsinkexporter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,3 +110,9 @@ linters:
     - staticcheck
     - unconvert
     - unparam
+
+issues:
+  exclude-rules:
+    - text: "SA1019: \"github.com/signalfx/splunk-otel-collector/internal/exporter/httpsinkexporter"
+      linters:
+        - staticcheck

--- a/internal/exporter/httpsinkexporter/doc.go
+++ b/internal/exporter/httpsinkexporter/doc.go
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Deprecated: This exporter is only used for testing and should not be relied upon for production data.
+package httpsinkexporter

--- a/internal/exporter/httpsinkexporter/factory.go
+++ b/internal/exporter/httpsinkexporter/factory.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Deprecated: This exporter is only used for testing and should not be relied upon for production data.
 package httpsinkexporter
 
 import (

--- a/internal/exporter/httpsinkexporter/factory.go
+++ b/internal/exporter/httpsinkexporter/factory.go
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Deprecated: This exporter is only used for testing and should not be relied upon for production data.
 package httpsinkexporter
 
 import (

--- a/internal/exporter/httpsinkexporter/httpsink_exporter.go
+++ b/internal/exporter/httpsinkexporter/httpsink_exporter.go
@@ -39,6 +39,7 @@ type httpSinkExporter struct {
 }
 
 func newExporter(logger *zap.Logger, endpoint string) *httpSinkExporter {
+	logger.Warn("This component is deprecated and must be used for testing purposes only. It does not redact or filter any telemetry content it exposes and should not be used with production data.")
 	return &httpSinkExporter{sink: newSink(logger, endpoint)}
 }
 


### PR DESCRIPTION
httpsinkexporter is used for testing in our SDKs, but it should not be used by customers. It is no longer developed and will be kept around as deprecated until such time it is no longer used, and will then be removed.