### PR TITLE
update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## v0.91.2.1
+
+### 🧰 Bug fixes 🧰
+- (Splunk) Fixes changelog association with commit/digests/versions in our release pipeline; this release is otherwise identical to v0.91.2
+
 ## v0.91.2
 
 ### 🛑 Breaking changes 🛑


### PR DESCRIPTION
Testing some non-happy path release automation, wanted to see if we can cut a revision/segment release.  Only chocolatey seems to enforce immutable versions, but have not tested the github release since that's downstream of chocolatey.