### PR TITLE
disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Splunk Ideas
     url: https://ideas.splunk.com/
-    about: Proposes enhancements through Splunk Ideas (requires a Splunk.com login)
+    about: Request any enhancement, component addition, or new feature through Splunk Ideas. Requires a Splunk.com login.
   - name: Splunk Support
     url: https://splunk.my.site.com/customer/s/need-help/create-case
-    about: Report an issue or request help (requires Splunk Support entitlement)
+    about: Ask any question or report any issue by opening a support case. Requires Splunk Support entitlement.


### PR DESCRIPTION
**Description:**

While everyone here wants to be of as much help as possible, this project is not an appropriate channel for support questions. I think it's best to rely on dedicated support workflows, which to my knowledge are both invested in maintaining and improving SLAs while providing feedback and data to other stakeholders for product and process improvements. These workflows come with escalation procedures that surface otherwise undetected issues to maintainers and include prioritization policies warranting immediate action that would otherwise not be initiated by opening a GH issue directly.
