### PR TITLE
[chore] Fix dead links in CloudFoundry deployment

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -17,5 +17,4 @@ exclude = [
     "ideas.splunk.com",
     "https://github.com/signalfx/splunk-otel-collector/tree/main/internal/exporter/pulsarexporter",  # exporter was deleted
     "https://github.com/signalfx/splunk-otel-collector/tree/main/cmd/translatesfx", # translatesfx was deleted
-    "docs.pivotal.io", # bad certificate and no alternatives
 ]

--- a/deployments/cloudfoundry/bosh/README.md
+++ b/deployments/cloudfoundry/bosh/README.md
@@ -1,7 +1,7 @@
 # Splunk OpenTelemetry Collector BOSH Release
 
 This directory contains a BOSH Release of the [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector).
-The BOSH release can be used to deploy the collector so that it will act as a [Loggregator Firehose nozzle](https://docs.pivotal.io/tiledev/2-2/nozzle.html).
+The BOSH release can be used to deploy the collector so that it will act as a [Loggregator Firehose nozzle](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/nozzle.html).
 
 ## Releasing
 

--- a/deployments/cloudfoundry/buildpack/README.md
+++ b/deployments/cloudfoundry/buildpack/README.md
@@ -5,7 +5,7 @@ the Splunk OpenTelemetry Collector for use with PCF apps.
 
 The buildpack's default functionality, as described in this document, is to deploy the OpenTelemetry Collector
 as a sidecar for the given app that's being deployed. The Collector is able to observe the app as a 
-[nozzle](https://docs.pivotal.io/tiledev/2-10/nozzle.html#nozzle) to
+[nozzle](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/nozzle.html) to
 the [Loggregator Firehose](https://docs.cloudfoundry.org/loggregator/architecture.html).
 The Loggregator Firehose is one of the architectures Cloud Foundry
 uses to emit logs and metrics. This means that the Splunk OpenTelemetry Collector will be observing all

--- a/deployments/cloudfoundry/tile/DEVELOPMENT.md
+++ b/deployments/cloudfoundry/tile/DEVELOPMENT.md
@@ -2,15 +2,15 @@
 
 ## VMware Tanzu Tile Documentation
 
-[Tanzu Tile Introduction](https://docs.pivotal.io/tiledev/2-10/tile-basics.html)
+[Tanzu Tile Introduction](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/tile-basics.html)
 
-[How Tiles Work](https://docs.pivotal.io/tiledev/2-10/tile-structure.html)
+[How Tiles Work](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/tile-structure.html)
 
 ## Tile Software Dependencies
 
-[Tile Generator](https://docs.pivotal.io/tiledev/2-10/tile-generator.html)
+[Tile Generator](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/tile-generator.html)
 
-[PCF CLI](https://docs.pivotal.io/tiledev/2-10/pcf-command.html)
+[PCF CLI](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/pcf-command.html)
 
 ## Development Workflow
 
@@ -134,7 +134,7 @@ is currently unsupported due to metric name format changes.
     - Check logs to make sure no errors are showing up
     - Check metrics manually coming from Tanzu to see if they match charts.
       - Follow steps to
-      [Access Metrics Using the Firehose PLugin](https://docs.pivotal.io/application-service/2-13/loggregator/data-sources.html#cf-nozzle)
+      [Access Metrics Using the Firehose PLugin](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/5.0/tas-for-vms/cli-plugin.html)
         - You can use the `hammer` login command instead of `cf login`
         - Example metric filter command:
         ```cf nozzle -no-filter | grep -i mem | grep -i percent```

--- a/deployments/cloudfoundry/tile/README.md
+++ b/deployments/cloudfoundry/tile/README.md
@@ -1,7 +1,7 @@
 # Splunk OpenTelemetry Collector Tanzu Tile
 
 This directory is used to generate a Tanzu tile of the [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector).
-The Tanzu tile uses the BOSH release to deploy the collector as a [loggregator firehose nozzle](https://docs.pivotal.io/tiledev/2-2/nozzle.html).
+The Tanzu tile uses the BOSH release to deploy the collector as a [loggregator firehose nozzle](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/nozzle.html).
 
 ## Dependencies
 
@@ -10,7 +10,7 @@ The `release` script requires:
 - `jq`
 - `wget`
 - [Bosh CLI](https://bosh.io/docs/cli-v2-install/)
-- [Tile Generator](https://docs.pivotal.io/tiledev/2-10/tile-generator.html)
+- [Tile Generator](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/tile-generator.html)
 
 ## Releasing
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`docs.pivotal.io` used to redirect to `docs.vmware.com`, but has been fully taken down. This PR updates references to point to the same documents that are hosted on docs.vmware.com instead.