### PR TITLE
Add default deployment.environment resource attribute as part of traces pipeline

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -114,15 +114,14 @@ processors:
     detectors: [gcp, ecs, ec2, azure, system]
     override: true
 
-  # Optional: The following processor can be used to add a default "deployment.environment" attribute to the logs and 
+  # The following processor can be used to add a default "deployment.environment" attribute to the logs and
   # traces when it's not populated by instrumentation libraries.
-  # If enabled, make sure to enable this processor in a pipeline.
   # For more information, see https://docs.splunk.com/Observability/gdi/opentelemetry/components/resource-processor.html
-  #resource/add_environment:
-    #attributes:
-      #- action: insert
-        #value: staging/production/...
-        #key: deployment.environment
+  resource/add_environment:
+    attributes:
+      - action: insert
+        value: default
+        key: deployment.environment
 
 exporters:
   # Traces
@@ -172,7 +171,7 @@ service:
       - memory_limiter
       - batch
       - resourcedetection
-      #- resource/add_environment
+      - resource/add_environment
       exporters: [sapm, signalfx]
       # Use instead when sending to gateway
       #exporters: [otlp, signalfx]

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -114,7 +114,7 @@ processors:
     detectors: [gcp, ecs, ec2, azure, system]
     override: true
 
-  # The following processor can be used to add a default "deployment.environment" attribute to the logs and
+  # The following processor is used to add a default "deployment.environment" attribute to the logs and
   # traces when it's not populated by instrumentation libraries.
   # For more information, see https://docs.splunk.com/Observability/gdi/opentelemetry/components/resource-processor.html
   resource/add_environment:

--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -70,14 +70,13 @@ processors:
     check_interval: 2s
     limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
 
-  # Optional: The following processor can be used to add a default "deployment.environment" attribute to the traces
+  # The following processor can be used to add a default "deployment.environment" attribute to the traces
   # when it's not populated by instrumentation libraries.
-  # If enabled, make sure to enable this processor in the pipeline below.
-  #resource/add_environment:
-    #attributes:
-      #- action: insert
-        #value: staging/production/...
-        #key: deployment.environment
+  resource/add_environment:
+    attributes:
+      - action: insert
+        value: default
+        key: deployment.environment
 
   # Detect if the collector is running on a cloud system. Overrides resource attributes set by receivers.
   # Detector order is important: the `system` detector goes last so it can't preclude cloud detectors from setting host/os info.
@@ -134,7 +133,7 @@ service:
       processors:
       - memory_limiter
       - batch
-      #- resource/add_environment
+      - resource/add_environment
       exporters: [sapm]
     metrics:
       receivers: [otlp, signalfx]

--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -70,7 +70,7 @@ processors:
     check_interval: 2s
     limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
 
-  # The following processor can be used to add a default "deployment.environment" attribute to the traces
+  # The following processor is used to add a default "deployment.environment" attribute to the traces
   # when it's not populated by instrumentation libraries.
   resource/add_environment:
     attributes:

--- a/tests/general/default_config_test.go
+++ b/tests/general/default_config_test.go
@@ -119,6 +119,13 @@ func TestDefaultGatewayConfig(t *testing.T) {
 						"detectors": []any{"gcp", "ecs", "ec2", "azure", "system"},
 						"override":  true,
 					},
+					"resource/add_environment": map[string]any{
+						"attributes": map[string]any{
+							"action": "insert",
+							"key":    "deployment.environment",
+							"value":  "default",
+						},
+					},
 				},
 				"receivers": map[string]any{
 					"jaeger": map[string]any{
@@ -192,7 +199,7 @@ func TestDefaultGatewayConfig(t *testing.T) {
 						},
 						"traces": map[string]any{
 							"exporters":  []any{"sapm"},
-							"processors": []any{"memory_limiter", "batch"},
+							"processors": []any{"memory_limiter", "batch", "resource/add_environment"},
 							"receivers":  []any{"jaeger", "otlp", "sapm", "zipkin"},
 						},
 					},

--- a/tests/general/default_config_test.go
+++ b/tests/general/default_config_test.go
@@ -303,6 +303,13 @@ func TestDefaultAgentConfig(t *testing.T) {
 					"resourcedetection": map[string]any{"detectors": []any{"gcp", "ecs", "ec2", "azure", "system"},
 						"override": true,
 					}},
+				"resource/add_environment": map[string]any{
+					"attributes": map[string]any{
+						"action": "insert",
+						"key":    "deployment.environment",
+						"value":  "default",
+					},
+				},
 				"receivers": map[string]any{"fluentforward": map[string]any{"endpoint": fmt.Sprintf("%s:8006", ip)},
 					"hostmetrics": map[string]any{
 						"collection_interval": "10s",
@@ -380,7 +387,7 @@ func TestDefaultAgentConfig(t *testing.T) {
 							"receivers":  []any{"prometheus/internal"}},
 						"traces": map[string]any{
 							"exporters":  []any{"sapm", "signalfx"},
-							"processors": []any{"memory_limiter", "batch", "resourcedetection"},
+							"processors": []any{"memory_limiter", "batch", "resourcedetection", "resource/add_environment"},
 							"receivers":  []any{"jaeger", "otlp", "smartagent/signalfx-forwarder", "zipkin"},
 						},
 					},


### PR DESCRIPTION
**Description:**
Add default `deployment.environment` resource attribute as part of traces pipeline
