### PR TITLE
Add deprecation notice to dotnet monitors

### DIFF
--- a/internal/signalfx-agent/pkg/monitors/aspdotnet/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/aspdotnet/metadata.yaml
@@ -1,6 +1,12 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated in favor of metrics collected by the
+    [Splunk Distribution of OpenTelemetry .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/otel-dotnet/configuration/dotnet-metrics-attributes.html)
+    and the [SignalFx Instrumentation for .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/dotnet/configuration/dotnet-metrics-attributes.html).
+    Please, update any monitoring configuration to use the metrics provided by the
+    instrumentation as this monitor will be removed in a future release.**
+
     (Windows Only) This monitor reports metrics about requests, errors, sessions,
     worker processes for ASP.NET applications.
 

--- a/internal/signalfx-agent/pkg/monitors/aspdotnet/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/aspdotnet/metadata.yaml
@@ -5,7 +5,7 @@ monitors:
     [Splunk Distribution of OpenTelemetry .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/otel-dotnet/configuration/dotnet-metrics-attributes.html)
     and the [SignalFx Instrumentation for .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/dotnet/configuration/dotnet-metrics-attributes.html).
     Please, update any monitoring configuration to use the metrics provided by the
-    instrumentation as this monitor will be removed in a future release.**
+    instrumentation as this monitor will be removed in February 2025.**
 
     (Windows Only) This monitor reports metrics about requests, errors, sessions,
     worker processes for ASP.NET applications.

--- a/internal/signalfx-agent/pkg/monitors/dotnet/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/dotnet/metadata.yaml
@@ -1,6 +1,12 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated in favor of metrics collected by the
+    [Splunk Distribution of OpenTelemetry .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/otel-dotnet/configuration/dotnet-metrics-attributes.html)
+    and the [SignalFx Instrumentation for .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/dotnet/configuration/dotnet-metrics-attributes.html).
+    Please, update any monitoring configuration to use the metrics provided by the
+    instrumentation as this monitor will be removed in a future release.**
+
     (Windows Only) This monitor reports metrics for .NET applications.
 
     The most critical .NET performance counters

--- a/internal/signalfx-agent/pkg/monitors/dotnet/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/dotnet/metadata.yaml
@@ -5,7 +5,7 @@ monitors:
     [Splunk Distribution of OpenTelemetry .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/otel-dotnet/configuration/dotnet-metrics-attributes.html)
     and the [SignalFx Instrumentation for .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/dotnet/configuration/dotnet-metrics-attributes.html).
     Please, update any monitoring configuration to use the metrics provided by the
-    instrumentation as this monitor will be removed in a future release.**
+    instrumentation as this monitor will be removed in February 2025.**
 
     (Windows Only) This monitor reports metrics for .NET applications.
 


### PR DESCRIPTION
**Description:**
Add deprecation notice to .NET related SmartAgent monitors. The instrumentation for .NET provides the same metrics with names matching the OTel conventions and also work on platforms other than Windows.

**Link to Splunk idea:**
https://splunk.atlassian.net/browse/OTL-2452

**Testing:**
N/A

**Documentation:**
Follow-up ticket https://splunk.atlassian.net/browse/OTL-2453
