### PR TITLE
Log a deprecation notice as warning for asptnet and dotnet monitors

### DIFF
--- a/internal/signalfx-agent/pkg/monitors/aspdotnet/aspdotnet_windows.go
+++ b/internal/signalfx-agent/pkg/monitors/aspdotnet/aspdotnet_windows.go
@@ -21,6 +21,7 @@ var logger = logrus.WithField("monitorType", monitorType)
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) error {
 	m.logger = logger.WithField("monitorID", conf.MonitorID)
+	m.logger.Warn("[NOTICE] The " + monitorType + " monitor is deprecated and will be removed in a future release. For more information visit https://docs.splunk.com/observability/en/gdi/monitors-languages/asp-dot-net.html")
 	perfcounterConf := &winperfcounters.Config{
 		CountersRefreshInterval: conf.CountersRefreshInterval,
 		PrintValid:              conf.PrintValid,

--- a/internal/signalfx-agent/pkg/monitors/dotnet/dotnet_windows.go
+++ b/internal/signalfx-agent/pkg/monitors/dotnet/dotnet_windows.go
@@ -21,6 +21,7 @@ var logger = logrus.WithField("monitorType", monitorType)
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) error {
 	m.logger = logger.WithField("monitorID", conf.MonitorID)
+	m.logger.Warn("[NOTICE] The " + monitorType + " monitor is deprecated and will be removed in a future release. For more information visit https://docs.splunk.com/observability/en/gdi/monitors-languages/microsoft-dotnet.html")
 	perfcounterConf := &winperfcounters.Config{
 		CountersRefreshInterval: conf.CountersRefreshInterval,
 		PrintValid:              conf.PrintValid,


### PR DESCRIPTION
**Description:**
Log a deprecation notice to .NET related SmartAgent monitors. The instrumentation for .NET provides the same metrics with names matching the OTel conventions and also work on platforms other than Windows.

**Link to Splunk idea:**
https://splunk.atlassian.net/browse/OTL-2452

**Testing:**
N/A

**Documentation:**

#4226
https://github.com/splunk/private-o11y-docs/pull/1699

Follow-up ticket https://splunk.atlassian.net/browse/OTL-2453
