### PR TITLE
Test mass deployment on a scheduled basis

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -17,6 +17,8 @@ on:
       - '.github/workflows/ansible.yml'
       - 'deployments/ansible/**'
       - '!**.md'
+  schedule:
+    - cron: '0 0 * * 1,4' # Every Monday and Thrusday at midnight UTC
 
 concurrency:
   group: ansible-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -14,6 +14,8 @@ on:
       - '.github/workflows/chef-test.yml'
       - 'deployments/chef/**'
       - '!**.md'
+  schedule:
+    - cron: '0 0 * * 2,5' # Every Tuesday and Friday at midnight UTC
 
 concurrency:
   group: chef-test-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/puppet-test.yml
+++ b/.github/workflows/puppet-test.yml
@@ -20,6 +20,8 @@ on:
       - 'internal/buildscripts/packaging/tests/helpers/**'
       - 'internal/buildscripts/packaging/tests/requirements.txt'
       - '!**.md'
+  schedule:
+      - cron: '0 0 * * 3,6' # Every Wednesday and Saturday at midnight UTC
 
 concurrency:
   group: puppet-test-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
**Description:** 
Run the mass deployments workflows on a regular schedule. Avoid CI getting broke silently and requiring work only when we need to merge or release something.

**Link to Splunk idea:**
https://splunk.atlassian.net/browse/OTL-2485

**Testing:**
N/A

**Documentation:**
N/A
