### PR TITLE
Don't test unsupported Ansible versions

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -77,6 +77,10 @@ jobs:
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
+        exclude:
+          # ansible-core used by ansible 9.2.0 requires a minimum of Python2 version 2.7 or Python3 version 3.6. Current version: 3.5.2
+          - distro: ubuntu1604
+            ansible: ansible~=9.2.0
 
     steps:
       - name: Check out the codebase.

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -59,9 +59,9 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - ansible~=2.10.0
-          - ansible~=6.0
-          - ansible~=7.0
+          # Testing only the versions currently supported per https://endoflife.date/ansible
+          - ansible~=9.2.0
+          - ansible~=8.7.0
         distro:
           - amazonlinux2
           - amazonlinux2023
@@ -77,10 +77,6 @@ jobs:
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
-        exclude:
-          # ansible<6 unsupported on Amazon Linux 2023
-          - distro: amazonlinux2023
-            ansible: ansible~=2.10.0
 
     steps:
       - name: Check out the codebase.
@@ -130,9 +126,9 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - ansible~=2.10.0
-          - ansible~=6.0
-          - ansible~=7.0
+          # Testing only the versions currently supported per https://endoflife.date/ansible
+          - ansible~=9.2.0
+          - ansible~=8.7.0
         distro:
           - "2016"
           - "2019"


### PR DESCRIPTION
**Description:** 
Only test Ansible versions that didn't reach EOL per https://endoflife.date/ansible

**Link to Splunk idea:**
https://splunk.atlassian.net/browse/OTL-2462

**Testing:**
N/A

**Documentation:**
N/A
