### PR TITLE
Update Ansible test tools

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -93,10 +93,10 @@ jobs:
           path: "${{ github.workspace }}/requirements.txt"
           contents: |
             ${{ matrix.ansible }}
-            molecule==3.3.0
-            molecule-docker==0.2.4
-            docker==5.0.0
-            ansible-lint==5.4.0
+            ansible-lint==6.22.2
+            molecule==6.0.3
+            molecule-plugins[docker]==23.5.0
+            docker==7.0.0
             urllib3<2
 
       - name: Set up Python 3.
@@ -152,10 +152,10 @@ jobs:
           path: "${{ github.workspace }}/requirements.txt"
           contents: |
             ${{ matrix.ansible }}
-            ansible-compat==2.2.7
-            ansible-lint==5.4.0
-            molecule==4.0.4
-            molecule-vagrant==2.0.0
+            ansible-compat==4.1.11
+            ansible-lint==6.22.2
+            molecule==6.0.3
+            molecule-plugins[vagrant]==23.5.0
             pywinrm==0.4.3
 
       - name: Set up Python 3.

--- a/deployments/ansible/molecule/config/docker.yml
+++ b/deployments/ansible/molecule/config/docker.yml
@@ -19,5 +19,7 @@ platforms:
 
 provisioner:
   name: ansible
+  env:
+    ANSIBLE_ROLES_PATH: ../../roles
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}

--- a/deployments/ansible/molecule/config/vagrant.yml
+++ b/deployments/ansible/molecule/config/vagrant.yml
@@ -18,4 +18,6 @@ platforms:
   - name: amazonlinux
     box: bento/amazonlinux-2
 provisioner:
+  env:
+    ANSIBLE_ROLES_PATH: ../../roles
   name: ansible

--- a/deployments/ansible/molecule/config/windows.yml
+++ b/deployments/ansible/molecule/config/windows.yml
@@ -37,7 +37,7 @@ platforms:
     instance_raw_config_args: *vagrant_args
   - name: "2022"
     box: gusztavvargadr/iis-windows-server
-    box_version: 10.2102.2312
+    box_version: 10.2102.2310
     cpus: 2
     memory: 4096
     instance_raw_config_args: *vagrant_args

--- a/deployments/ansible/molecule/config/windows.yml
+++ b/deployments/ansible/molecule/config/windows.yml
@@ -31,7 +31,7 @@ platforms:
     instance_raw_config_args: *vagrant_args
   - name: "2019"
     box: gusztavvargadr/windows-server-2019-standard
-    box_version: 1809.0.2305
+    box_version: 1809.0.2310
     cpus: 2
     memory: 4096
     instance_raw_config_args: *vagrant_args

--- a/deployments/ansible/molecule/config/windows.yml
+++ b/deployments/ansible/molecule/config/windows.yml
@@ -37,7 +37,7 @@ platforms:
     instance_raw_config_args: *vagrant_args
   - name: "2022"
     box: gusztavvargadr/iis-windows-server
-    box_version: 10.2102.2306
+    box_version: 10.2102.2312
     cpus: 2
     memory: 4096
     instance_raw_config_args: *vagrant_args

--- a/deployments/ansible/molecule/custom_vars/converge.yml
+++ b/deployments/ansible/molecule/custom_vars/converge.yml
@@ -23,4 +23,4 @@
   tasks:
     - name: "Include signalfx.splunk_otel_collector.collector role"
       include_role:
-        name: "collector"
+        name: "signalfx.splunk_otel_collector.collector"

--- a/deployments/ansible/molecule/custom_vars/windows-converge.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-converge.yml
@@ -34,4 +34,4 @@
   tasks:
     - name: "Include signalfx.splunk_otel_collector.collector role"
       include_role:
-        name: "collector"
+        name: "signalfx.splunk_otel_collector.collector"

--- a/deployments/ansible/molecule/default/converge.yml
+++ b/deployments/ansible/molecule/default/converge.yml
@@ -9,4 +9,4 @@
   tasks:
     - name: "Include signalfx.splunk_otel_collector.collector role"
       include_role:
-        name: "collector"
+        name: "signalfx.splunk_otel_collector.collector"

--- a/deployments/ansible/molecule/default/windows-converge.yml
+++ b/deployments/ansible/molecule/default/windows-converge.yml
@@ -8,4 +8,4 @@
   tasks:
     - name: "Include signalfx.splunk_otel_collector.collector role"
       include_role:
-        name: "collector"
+        name: "signalfx.splunk_otel_collector.collector"

--- a/deployments/ansible/molecule/with_instrumentation/converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation/converge.yml
@@ -17,4 +17,4 @@
   tasks:
     - name: "Include signalfx.splunk_otel_collector.collector role"
       include_role:
-        name: "collector"
+        name: "signalfx.splunk_otel_collector.collector"

--- a/deployments/ansible/molecule/with_instrumentation/windows-converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation/windows-converge.yml
@@ -11,4 +11,4 @@
   tasks:
     - name: "Include signalfx.splunk_otel_collector.collector role"
       include_role:
-        name: "collector"
+        name: "signalfx.splunk_otel_collector.collector"

--- a/deployments/ansible/molecule/with_instrumentation_preload_custom/converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_custom/converge.yml
@@ -16,4 +16,4 @@
   tasks:
     - name: "Include signalfx.splunk_otel_collector.collector role"
       include_role:
-        name: "collector"
+        name: "signalfx.splunk_otel_collector.collector"

--- a/deployments/ansible/molecule/with_instrumentation_preload_default/converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_default/converge.yml
@@ -9,4 +9,4 @@
   tasks:
     - name: "Include signalfx.splunk_otel_collector.collector role"
       include_role:
-        name: "collector"
+        name: "signalfx.splunk_otel_collector.collector"

--- a/deployments/ansible/molecule/with_instrumentation_systemd_custom/converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_custom/converge.yml
@@ -16,4 +16,4 @@
   tasks:
     - name: "Include signalfx.splunk_otel_collector.collector role"
       include_role:
-        name: "collector"
+        name: "signalfx.splunk_otel_collector.collector"

--- a/deployments/ansible/molecule/with_instrumentation_systemd_default/converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_default/converge.yml
@@ -10,4 +10,4 @@
   tasks:
     - name: "Include signalfx.splunk_otel_collector.collector role"
       include_role:
-        name: "collector"
+        name: "signalfx.splunk_otel_collector.collector"


### PR DESCRIPTION
**Description:**
Update tools used in Ansible tests, the main target being `molecule-vagrant` that was archived one year ago.

The new tools complained about the role "collector" not being found, [error message](https://github.com/pjanotti/splunk-otel-collector/actions/runs/7746705618/job/21125532013#step:6:119):
```terminal
  ERROR! the role 'collector' was not found in /home/runner/work/splunk-otel-collector/splunk-otel-collector/deployments/ansible/molecule/custom_vars/roles:/home/runner/.cache/molecule/ansible/custom_vars/roles:/home/runner/work/splunk-otel-collector/splunk-otel-collector/deployments:/home/runner/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/home/runner/work/splunk-otel-collector/splunk-otel-collector/deployments/ansible/molecule/custom_vars
  
  The error appears to be in '/home/runner/work/splunk-otel-collector/splunk-otel-collector/deployments/ansible/molecule/custom_vars/converge.yml': line 26, column 15, but may
  be elsewhere in the file depending on the exact syntax problem.
  
  The offending line appears to be:
  
        include_role:
          name: "collector"
                ^ here

```
Reading our docs it seems that we need to use a full-qualified name. I considered if `ANSIBLE_ROLES_PATH` should be used, but, since the full-qualified name resolved and matches what is defined on the `galaxy.yml` I opted to use it.
 
There are also more warnings, which seems related to the docker package, being logged during the tests.

On the positive side it seems that is makes slightly less like for the Windows test to hit the `gurumeditation` state: it still does that for the majority of the tests but I got 4 passing on Windows.

**Link to Splunk idea:**
https://splunk.atlassian.net/browse/OTL-2555

**Testing:**
Windows tested locally on mac Intel.

**Documentation:**
N/A
