### PR TITLE
Fix Chef lint workflow

### DIFF
--- a/deployments/chef/Gemfile
+++ b/deployments/chef/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'rspec', '= 3.9'
 gem 'rake'
 gem 'chefspec'
 gem 'berkshelf'


### PR DESCRIPTION
**Description:** 
The scheduled Chef job reported a consistent failure running `make rake-spec`. This is due to a change in the rspec gem published on 02/04/24, see https://rubygems.org/gems/rspec/versions/3.13.0. Errors:

https://github.com/pjanotti/splunk-otel-collector/actions/runs/7792487517/job/21250575903#step:4:1
```terminal
docker run \
	--rm \
	splunk-otel-collector-chef-dev \
	rake spec

An error occurred while loading ./spec/unit/recipes/default_spec.rb. - Did you mean?
                    rspec ./spec/shared_examples.rb

Failure/Error: require 'chefspec'

LoadError:
  cannot load such file -- rspec/matchers/expecteds_for_multiple_diffs
# /usr/local/bundle/gems/chefspec-9.3.6/lib/chefspec/matchers/resource_matcher.rb:1:in `<top (required)>'
# /usr/local/bundle/gems/chefspec-9.3.6/lib/chefspec/matchers.rb:9:in `require_relative'
# /usr/local/bundle/gems/chefspec-9.3.6/lib/chefspec/matchers.rb:9:in `<module:Matchers>'
# /usr/local/bundle/gems/chefspec-9.3.6/lib/chefspec/matchers.rb:2:in `<module:ChefSpec>'
# /usr/local/bundle/gems/chefspec-9.3.6/lib/chefspec/matchers.rb:1:in `<top (required)>'
# /usr/local/bundle/gems/chefspec-9.3.6/lib/chefspec.rb:66:in `require_relative'
# /usr/local/bundle/gems/chefspec-9.3.6/lib/chefspec.rb:66:in `<top (required)>'
# ./spec/spec_helper.rb:2:in `<top (required)>'
# ./spec/unit/recipes/default_spec.rb:7:in `<top (required)>'
# ------------------
# --- Caused by: ---
# LoadError:
#   cannot load such file -- chefspec
#   ./spec/spec_helper.rb:2:in `<top (required)>'
No examples found.


Finished in 0.00006 seconds (files took 0.[60](https://github.com/pjanotti/splunk-otel-collector/actions/runs/7792487517/job/21250575903#step:4:61)03 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```

I'm not familiar with the dependencies and packages via gem/ruby but after some trial and error I was able to get the following info:

```terminal
Gem::MissingSpecVersionError:
  Could not find 'rspec' (>= 3.9, <= 3.13) - did find: [rspec-3.0.0]
  Checked in 'GEM_PATH=/root/.gem/ruby/2.7.0:/usr/local/lib/ruby/gems/2.7.0:/usr/local/bundle', execute `gem env` for more information
```
Based on this I pinned the rspec to version 3.9 and it fixed the issue. If you have more experience with gem/ruby and have a suggestion please let me know.

**Link to Splunk idea:**

**Testing:**
Local run of `make rake-spec`.

**Documentation:**
N/A
