### PR TITLE
Stop sending metrics reported by batch processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - (Splunk) On Windows the `SPLUNK_*` environment variables were moved from the machine scope to the collector service scope. This avoids collisions with other agents and instrumentation. If any of these environment variables are required by your apps, please adopt them directly. ([#3930](https://github.com/signalfx/splunk-otel-collector/pull/3930))
 - `mysql` discovery now uses the OpenTelemetry Collector Contrib receiver by default instead of the smartagent receiver.
+- (Splunk) Stop sending internal Collector metrics from the batch processor. Drop them at the prometheus receiver level. ([#4273](https://github.com/signalfx/splunk-otel-collector/pull/4273))
 
 ## v0.92.0
 

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -85,6 +85,9 @@ receivers:
           - source_labels: [ __name__ ]
             regex: 'otelcol_http_.*'
             action: drop
+          - source_labels: [ __name__ ]
+            regex: 'otelcol_processor_batch_.*'
+            action: drop
   smartagent/signalfx-forwarder:
     type: signalfx-forwarder
     listenAddress: "${SPLUNK_LISTEN_INTERFACE}:9080"

--- a/cmd/otelcol/config/collector/ecs_ec2_config.yaml
+++ b/cmd/otelcol/config/collector/ecs_ec2_config.yaml
@@ -72,6 +72,9 @@ receivers:
             - source_labels: [ __name__ ]
               regex: 'otelcol_http_.*'
               action: drop
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_processor_batch_.*'
+              action: drop
   signalfx:
     endpoint: 0.0.0.0:9943
     # Whether to preserve incoming access token and use instead of exporter token

--- a/cmd/otelcol/config/collector/fargate_config.yaml
+++ b/cmd/otelcol/config/collector/fargate_config.yaml
@@ -51,6 +51,9 @@ receivers:
             - source_labels: [ __name__ ]
               regex: 'otelcol_http_.*'
               action: drop
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_processor_batch_.*'
+              action: drop
   signalfx:
     endpoint: 0.0.0.0:9943
     # Whether to preserve incoming access token and use instead of exporter token

--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -145,6 +145,9 @@ receivers:
           - source_labels: [ __name__ ]
             regex: 'otelcol_http_.*'
             action: drop
+          - source_labels: [ __name__ ]
+            regex: 'otelcol_processor_batch_.*'
+            action: drop
   # Enables the prometheus simple receiver with default settings
   #  - grpc (default endpoint = 0.0.0.0:9090)
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/simpleprometheusreceiver

--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -50,6 +50,9 @@ receivers:
           - source_labels: [ __name__ ]
             regex: 'otelcol_http_.*'
             action: drop
+          - source_labels: [ __name__ ]
+            regex: 'otelcol_processor_batch_.*'
+            action: drop
   sapm:
     endpoint: "${SPLUNK_LISTEN_INTERFACE}:7276"
     # Whether to preserve incoming access token and use instead of exporter token

--- a/cmd/otelcol/config/collector/otlp_config_linux.yaml
+++ b/cmd/otelcol/config/collector/otlp_config_linux.yaml
@@ -34,6 +34,9 @@ receivers:
           - source_labels: [ __name__ ]
             regex: 'otelcol_http_.*'
             action: drop
+          - source_labels: [ __name__ ]
+            regex: 'otelcol_processor_batch_.*'
+            action: drop
   sapm:
     endpoint: 0.0.0.0:7276
     # Whether to preserve incoming access token and use instead of exporter token

--- a/cmd/otelcol/config/collector/upstream_agent_config.yaml
+++ b/cmd/otelcol/config/collector/upstream_agent_config.yaml
@@ -83,6 +83,9 @@ receivers:
           - source_labels: [ __name__ ]
             regex: 'otelcol_http_.*'
             action: drop
+          - source_labels: [ __name__ ]
+            regex: 'otelcol_processor_batch_.*'
+            action: drop
   signalfx:
     endpoint: 0.0.0.0:9943
   zipkin:

--- a/tests/installation/testdata/systemd/prometheus-internal.yaml
+++ b/tests/installation/testdata/systemd/prometheus-internal.yaml
@@ -12,3 +12,6 @@ prometheus/internal:
           - source_labels: [ __name__ ]
             regex: 'otelcol_http_.*'
             action: drop
+          - source_labels: [ __name__ ]
+            regex: 'otelcol_processor_batch_.*'
+            action: drop

--- a/tests/receivers/prometheus/testdata/internal_metrics_config.yaml
+++ b/tests/receivers/prometheus/testdata/internal_metrics_config.yaml
@@ -14,6 +14,9 @@ receivers:
           - source_labels: [ __name__ ]
             regex: 'otelcol_http_.*'
             action: drop
+          - source_labels: [ __name__ ]
+            regex: 'otelcol_processor_batch_.*'
+            action: drop
 exporters:
   otlp:
     endpoint: "${OTLP_ENDPOINT}"


### PR DESCRIPTION
The batch processor metrics are not being used in any default dashboards but signicantly contribute towards metric timeseries created on the backend.
