### PR TITLE
Add a converter to disable excessive internal metrics

### DIFF
--- a/internal/configconverter/disable_excessive_internal_metrics.go
+++ b/internal/configconverter/disable_excessive_internal_metrics.go
@@ -1,0 +1,124 @@
+// Copyright  Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configconverter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+const (
+	// promJobNamePrefix is the name prefix of the prometheus jobs that scrapes internal otel-collector metrics.
+	promJobNamePrefix = "otel-"
+
+	// Metric patterns to drop.
+	rpcMetricPattern   = "otelcol_rpc_.*"
+	httpMetricPattern  = "otelcol_http_.*"
+	batchMetricPattern = "otelcol_processor_batch_.*"
+)
+
+// promScrapeConfigsKeys are possible keys to get the config of a prometheus receiver scrapings internal collector metrics.
+var promScrapeConfigsKeys = []string{
+	"receivers::prometheus/internal::config::scrape_configs",
+	"receivers::prometheus/agent::config::scrape_configs",
+	"receivers::prometheus/k8s_cluster_receiver::config::scrape_configs",
+	"receivers::prometheus/collector::config::scrape_configs",
+}
+
+// DisableExcessiveInternalMetrics is a MapConverter that updates config of the prometheus receiver scraping internal
+// collector metrics to drop excessive internal metrics matching the following patterns:
+// - "otelcol_rpc_.*"
+// - "otelcol_http_.*"
+// - "otelcol_processor_batch_.*"
+type DisableExcessiveInternalMetrics struct{}
+
+func (DisableExcessiveInternalMetrics) Convert(_ context.Context, cfgMap *confmap.Conf) error {
+	if cfgMap == nil {
+		return fmt.Errorf("cannot DisableExcessiveInternalMetrics on nil *confmap.Conf")
+	}
+
+	for _, promScrapeConfigsKey := range promScrapeConfigsKeys {
+		scrapeConfMap := cfgMap.Get(promScrapeConfigsKey)
+		if scrapeConfMap == nil {
+			continue
+		}
+
+		scrapeConfigs, ok := scrapeConfMap.([]any)
+		if !ok {
+			continue // Ignore invalid scrape_configs, as they will be caught by the config validation.
+		}
+
+		for _, scrapeConfig := range scrapeConfigs {
+			sc, ok := scrapeConfig.(map[string]any)
+			if !ok {
+				continue // Ignore Ignore invalid metric_relabel_configs, as they will be caught by the config validation.
+			}
+			jobName, ok := sc["job_name"]
+			if !ok || !strings.HasPrefix(jobName.(string), promJobNamePrefix) {
+				continue
+			}
+
+			metricRelabelConfigs := sc["metric_relabel_configs"]
+			if metricRelabelConfigs == nil {
+				metricRelabelConfigs = make([]any, 0, 3)
+			}
+			mrcs, ok := metricRelabelConfigs.([]any)
+			if !ok {
+				continue // Ignore invalid metric_relabel_configs, as they will be caught by the config validation.
+			}
+
+			foundRegexPatterns := make(map[string]bool)
+			for _, metricRelabelConfig := range mrcs {
+				mrc, ok := metricRelabelConfig.(map[string]any)
+				if !ok {
+					continue // Ignore invalid metric_relabel_config, as they will be caught by the config validation.
+				}
+				sourceLabels, ok := mrc["source_labels"].([]any)
+				if !ok || len(sourceLabels) != 1 || sourceLabels[0] != model.MetricNameLabel {
+					continue
+				}
+				regex, ok := mrc["regex"].(string)
+				if !ok {
+					continue
+				}
+				foundRegexPatterns[regex] = true
+			}
+
+			for _, pattern := range []string{rpcMetricPattern, httpMetricPattern, batchMetricPattern} {
+				if !foundRegexPatterns[pattern] {
+					mrcs = append(mrcs, map[string]any{
+						"source_labels": []any{model.MetricNameLabel},
+						"regex":         pattern,
+						"action":        string(relabel.Drop),
+					})
+				}
+			}
+
+			sc["metric_relabel_configs"] = mrcs
+		}
+
+		// Update the config with the new scrape_configs.
+		if err := cfgMap.Merge(confmap.NewFromStringMap(map[string]any{promScrapeConfigsKey: scrapeConfigs})); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/configconverter/disable_excessive_internal_metrics_test.go
+++ b/internal/configconverter/disable_excessive_internal_metrics_test.go
@@ -1,0 +1,84 @@
+// Copyright  Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configconverter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+)
+
+func TestDisableExcessiveInternalMetrics(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantOutput string
+	}{
+		{
+			name:       "no_prom_receiver",
+			input:      "testdata/disable_excessive_internal_metrics/no_prom_receiver.yaml",
+			wantOutput: "testdata/disable_excessive_internal_metrics/no_prom_receiver.yaml",
+		},
+		{
+			name:       "no_scrape_configs_prom_receiver",
+			input:      "testdata/disable_excessive_internal_metrics/no_scrape_configs.yaml",
+			wantOutput: "testdata/disable_excessive_internal_metrics/no_scrape_configs.yaml",
+		},
+		{
+			name:       "different_job",
+			input:      "testdata/disable_excessive_internal_metrics/different_job.yaml",
+			wantOutput: "testdata/disable_excessive_internal_metrics/different_job.yaml",
+		},
+		{
+			name:       "no_metric_relabel_configs_set",
+			input:      "testdata/disable_excessive_internal_metrics/no_metric_relabel_configs_set_input.yaml",
+			wantOutput: "testdata/disable_excessive_internal_metrics/no_metric_relabel_configs_set_output.yaml",
+		},
+		{
+			name:       "metric_relabel_configs_with_other_actions",
+			input:      "testdata/disable_excessive_internal_metrics/metric_relabel_configs_with_other_actions_input.yaml",
+			wantOutput: "testdata/disable_excessive_internal_metrics/metric_relabel_configs_with_other_actions_output.yaml",
+		},
+		{
+			name:       "metric_relabel_configs_with_batch_drop_action",
+			input:      "testdata/disable_excessive_internal_metrics/metric_relabel_configs_with_batch_drop_action_input.yaml",
+			wantOutput: "testdata/disable_excessive_internal_metrics/metric_relabel_configs_with_batch_drop_action_output.yaml",
+		},
+		{
+			name:       "all_metric_relabel_configs_are_present",
+			input:      "testdata/disable_excessive_internal_metrics/all_metric_relabel_configs_are_present.yaml",
+			wantOutput: "testdata/disable_excessive_internal_metrics/all_metric_relabel_configs_are_present.yaml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectedCfgMap, err := confmaptest.LoadConf(tt.wantOutput)
+			require.NoError(t, err)
+			require.NotNil(t, expectedCfgMap)
+
+			cfgMap, err := confmaptest.LoadConf(tt.input)
+			require.NoError(t, err)
+			require.NotNil(t, cfgMap)
+
+			err = DisableExcessiveInternalMetrics{}.Convert(context.Background(), cfgMap)
+			require.NoError(t, err)
+
+			assert.Equal(t, expectedCfgMap, cfgMap)
+		})
+	}
+}

--- a/internal/configconverter/testdata/disable_excessive_internal_metrics/all_metric_relabel_configs_are_present.yaml
+++ b/internal/configconverter/testdata/disable_excessive_internal_metrics/all_metric_relabel_configs_are_present.yaml
@@ -1,0 +1,37 @@
+receivers:
+  prometheus/agent:
+    config:
+      scrape_configs:
+        - job_name: 'otel-agent'
+          scrape_interval: 10s
+          static_configs:
+            - targets: ["${SPLUNK_LISTEN_INTERFACE}:8888"]
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_rpc_.*'
+              action: keep
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_processor_batch_.*'
+              action: drop
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_http_.*'
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    spike_limit_mib: 800
+    ballast_size_mib: 64
+exporters:
+  debug:
+    verbosity: normal
+    sampling_initial: 2
+    sampling_thereafter: 500
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - prometheus/agent
+      processors:
+        - memory_limiter
+      exporters:
+        - logging

--- a/internal/configconverter/testdata/disable_excessive_internal_metrics/different_job.yaml
+++ b/internal/configconverter/testdata/disable_excessive_internal_metrics/different_job.yaml
@@ -1,0 +1,32 @@
+receivers:
+  prometheus/internal:
+    config:
+      scrape_configs:
+        - job_name: 'another-job'
+          scrape_interval: 10s
+          static_configs:
+            - targets: ["${SPLUNK_LISTEN_INTERFACE}:8888"]
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'my-metric-.*'
+              action: drop
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    spike_limit_mib: 800
+    ballast_size_mib: 64
+exporters:
+  debug:
+    verbosity: normal
+    sampling_initial: 2
+    sampling_thereafter: 500
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - prometheus/internal
+      processors:
+        - memory_limiter
+      exporters:
+        - logging

--- a/internal/configconverter/testdata/disable_excessive_internal_metrics/metric_relabel_configs_with_batch_drop_action_input.yaml
+++ b/internal/configconverter/testdata/disable_excessive_internal_metrics/metric_relabel_configs_with_batch_drop_action_input.yaml
@@ -1,0 +1,32 @@
+receivers:
+  prometheus/internal:
+    config:
+      scrape_configs:
+        - job_name: 'otel-collector'
+          scrape_interval: 10s
+          static_configs:
+            - targets: ["${SPLUNK_LISTEN_INTERFACE}:8888"]
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_processor_batch_.*'
+              action: drop
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    spike_limit_mib: 800
+    ballast_size_mib: 64
+exporters:
+  debug:
+    verbosity: normal
+    sampling_initial: 2
+    sampling_thereafter: 500
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - prometheus/internal
+      processors:
+        - memory_limiter
+      exporters:
+        - logging

--- a/internal/configconverter/testdata/disable_excessive_internal_metrics/metric_relabel_configs_with_batch_drop_action_output.yaml
+++ b/internal/configconverter/testdata/disable_excessive_internal_metrics/metric_relabel_configs_with_batch_drop_action_output.yaml
@@ -1,0 +1,38 @@
+receivers:
+  prometheus/internal:
+    config:
+      scrape_configs:
+        - job_name: 'otel-collector'
+          scrape_interval: 10s
+          static_configs:
+            - targets: ["${SPLUNK_LISTEN_INTERFACE}:8888"]
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_processor_batch_.*'
+              action: drop
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_rpc_.*'
+              action: drop
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_http_.*'
+              action: drop
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    spike_limit_mib: 800
+    ballast_size_mib: 64
+exporters:
+  debug:
+    verbosity: normal
+    sampling_initial: 2
+    sampling_thereafter: 500
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - prometheus/internal
+      processors:
+        - memory_limiter
+      exporters:
+        - logging

--- a/internal/configconverter/testdata/disable_excessive_internal_metrics/metric_relabel_configs_with_other_actions_input.yaml
+++ b/internal/configconverter/testdata/disable_excessive_internal_metrics/metric_relabel_configs_with_other_actions_input.yaml
@@ -1,0 +1,39 @@
+receivers:
+  prometheus/internal:
+    config:
+      scrape_configs:
+        - job_name: 'otel-collector'
+          scrape_interval: 10s
+          static_configs:
+            - targets: ["${SPLUNK_LISTEN_INTERFACE}:8888"]
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: '.*grpc_io.*'
+              action: drop
+            - source_labels: [ __name__ ]
+              target_label: 'label1'
+              action: labeldrop
+            - source_labels: [subsystem, server]
+              separator: "@"
+              regex: "(.*)@(.*)"
+              replacement: "${2}/${1}"
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    spike_limit_mib: 800
+    ballast_size_mib: 64
+exporters:
+  debug:
+    verbosity: normal
+    sampling_initial: 2
+    sampling_thereafter: 500
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - prometheus/internal
+      processors:
+        - memory_limiter
+      exporters:
+        - logging

--- a/internal/configconverter/testdata/disable_excessive_internal_metrics/metric_relabel_configs_with_other_actions_output.yaml
+++ b/internal/configconverter/testdata/disable_excessive_internal_metrics/metric_relabel_configs_with_other_actions_output.yaml
@@ -1,0 +1,48 @@
+receivers:
+  prometheus/internal:
+    config:
+      scrape_configs:
+        - job_name: 'otel-collector'
+          scrape_interval: 10s
+          static_configs:
+            - targets: ["${SPLUNK_LISTEN_INTERFACE}:8888"]
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: '.*grpc_io.*'
+              action: drop
+            - source_labels: [ __name__ ]
+              target_label: 'label1'
+              action: labeldrop
+            - source_labels: [subsystem, server]
+              separator: "@"
+              regex: "(.*)@(.*)"
+              replacement: "${2}/${1}"
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_rpc_.*'
+              action: drop
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_http_.*'
+              action: drop
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_processor_batch_.*'
+              action: drop
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    spike_limit_mib: 800
+    ballast_size_mib: 64
+exporters:
+  debug:
+    verbosity: normal
+    sampling_initial: 2
+    sampling_thereafter: 500
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - prometheus/internal
+      processors:
+        - memory_limiter
+      exporters:
+        - logging

--- a/internal/configconverter/testdata/disable_excessive_internal_metrics/new_input.yaml
+++ b/internal/configconverter/testdata/disable_excessive_internal_metrics/new_input.yaml
@@ -1,0 +1,218 @@
+exporters:
+  sapm:
+    access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+    endpoint: https://ingest.us0.signalfx.com/v2/trace
+  signalfx:
+    access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+    api_url: https://api.us0.signalfx.com
+    correlation: null
+    ingest_url: https://ingest.us0.signalfx.com
+    sync_host_metadata: true
+extensions:
+  health_check: null
+  k8s_observer:
+    auth_type: serviceAccount
+    node: ${K8S_NODE_NAME}
+  memory_ballast:
+    size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
+  zpages: null
+processors:
+  batch: null
+  filter/logs:
+    logs:
+      exclude:
+        match_type: strict
+        resource_attributes:
+          - key: splunk.com/exclude
+            value: "true"
+  k8sattributes:
+    extract:
+      annotations:
+        - from: pod
+          key: splunk.com/sourcetype
+        - from: namespace
+          key: splunk.com/exclude
+          tag_name: splunk.com/exclude
+        - from: pod
+          key: splunk.com/exclude
+          tag_name: splunk.com/exclude
+        - from: namespace
+          key: splunk.com/index
+          tag_name: com.splunk.index
+        - from: pod
+          key: splunk.com/index
+          tag_name: com.splunk.index
+      labels:
+        - key: app
+      metadata:
+        - k8s.namespace.name
+        - k8s.node.name
+        - k8s.pod.name
+        - k8s.pod.uid
+        - container.id
+        - container.image.name
+        - container.image.tag
+    filter:
+      node_from_env_var: K8S_NODE_NAME
+    pod_association:
+      - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+      - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+      - sources:
+          - from: resource_attribute
+            name: ip
+      - sources:
+          - from: connection
+      - sources:
+          - from: resource_attribute
+            name: host.name
+  memory_limiter:
+    check_interval: 2s
+    limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+  resource:
+    attributes:
+      - action: insert
+        key: k8s.node.name
+        value: ${K8S_NODE_NAME}
+      - action: upsert
+        key: k8s.cluster.name
+        value: dmitry-gke
+  resource/add_agent_k8s:
+    attributes:
+      - action: insert
+        key: k8s.pod.name
+        value: ${K8S_POD_NAME}
+      - action: insert
+        key: k8s.pod.uid
+        value: ${K8S_POD_UID}
+      - action: insert
+        key: k8s.namespace.name
+        value: ${K8S_NAMESPACE}
+  resource/add_environment:
+    attributes:
+      - action: insert
+        key: deployment.environment
+        value: dmitry-gke
+  resource/logs:
+    attributes:
+      - action: upsert
+        from_attribute: k8s.pod.annotations.splunk.com/sourcetype
+        key: com.splunk.sourcetype
+      - action: delete
+        key: k8s.pod.annotations.splunk.com/sourcetype
+      - action: delete
+        key: splunk.com/exclude
+  resourcedetection:
+    detectors:
+      - env
+      - gcp
+      - system
+    override: true
+    timeout: 15s
+receivers:
+  hostmetrics:
+    collection_interval: 10s
+    scrapers:
+      cpu: null
+      disk: null
+      filesystem: null
+      load: null
+      memory: null
+      network: null
+      paging: null
+      processes: null
+  jaeger:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:14250
+      thrift_http:
+        endpoint: 0.0.0.0:14268
+  kubeletstats:
+    auth_type: serviceAccount
+    collection_interval: 10s
+    endpoint: ${K8S_NODE_IP}:10250
+    extra_metadata_labels:
+      - container.id
+    metric_groups:
+      - container
+      - pod
+      - node
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  prometheus/agent:
+    config:
+      scrape_configs:
+        - job_name: otel-agent
+          scrape_interval: 10s
+          static_configs:
+            - targets:
+                - ${K8S_POD_IP}:8889
+  receiver_creator:
+    receivers: null
+    watch_observers:
+      - k8s_observer
+  signalfx:
+    endpoint: 0.0.0.0:9943
+  smartagent/signalfx-forwarder:
+    listenAddress: 0.0.0.0:9080
+    type: signalfx-forwarder
+  zipkin:
+    endpoint: 0.0.0.0:9411
+service:
+  extensions:
+    - health_check
+    - k8s_observer
+    - memory_ballast
+    - zpages
+  pipelines:
+    metrics:
+      exporters:
+        - signalfx
+      processors:
+        - memory_limiter
+        - batch
+        - resourcedetection
+        - resource
+      receivers:
+        - hostmetrics
+        - kubeletstats
+        - otlp
+        - receiver_creator
+        - signalfx
+    metrics/agent:
+      exporters:
+        - signalfx
+      processors:
+        - memory_limiter
+        - batch
+        - resource/add_agent_k8s
+        - resourcedetection
+        - resource
+      receivers:
+        - prometheus/agent
+    traces:
+      exporters:
+        - sapm
+        - signalfx
+      processors:
+        - memory_limiter
+        - k8sattributes
+        - batch
+        - resourcedetection
+        - resource
+        - resource/add_environment
+      receivers:
+        - otlp
+        - jaeger
+        - smartagent/signalfx-forwarder
+        - zipkin
+  telemetry:
+    metrics:
+      address: 0.0.0.0:8889

--- a/internal/configconverter/testdata/disable_excessive_internal_metrics/no_metric_relabel_configs_set_input.yaml
+++ b/internal/configconverter/testdata/disable_excessive_internal_metrics/no_metric_relabel_configs_set_input.yaml
@@ -1,0 +1,28 @@
+receivers:
+  prometheus/internal:
+    config:
+      scrape_configs:
+        - job_name: 'otel-collector'
+          scrape_interval: 10s
+          static_configs:
+            - targets: ["${SPLUNK_LISTEN_INTERFACE}:8888"]
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    spike_limit_mib: 800
+    ballast_size_mib: 64
+exporters:
+  debug:
+    verbosity: normal
+    sampling_initial: 2
+    sampling_thereafter: 500
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - prometheus/internal
+      processors:
+        - memory_limiter
+      exporters:
+        - logging

--- a/internal/configconverter/testdata/disable_excessive_internal_metrics/no_metric_relabel_configs_set_output.yaml
+++ b/internal/configconverter/testdata/disable_excessive_internal_metrics/no_metric_relabel_configs_set_output.yaml
@@ -1,0 +1,38 @@
+receivers:
+  prometheus/internal:
+    config:
+      scrape_configs:
+        - job_name: 'otel-collector'
+          scrape_interval: 10s
+          static_configs:
+            - targets: ["${SPLUNK_LISTEN_INTERFACE}:8888"]
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_rpc_.*'
+              action: drop
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_http_.*'
+              action: drop
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_processor_batch_.*'
+              action: drop
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    spike_limit_mib: 800
+    ballast_size_mib: 64
+exporters:
+  debug:
+    verbosity: normal
+    sampling_initial: 2
+    sampling_thereafter: 500
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - prometheus/internal
+      processors:
+        - memory_limiter
+      exporters:
+        - logging

--- a/internal/configconverter/testdata/disable_excessive_internal_metrics/no_prom_receiver.yaml
+++ b/internal/configconverter/testdata/disable_excessive_internal_metrics/no_prom_receiver.yaml
@@ -1,0 +1,25 @@
+receivers:
+  hostmetrics:
+    collection_interval: 1s
+    scrapers:
+      cpu:
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    spike_limit_mib: 800
+    ballast_size_mib: 64
+exporters:
+  debug:
+    verbosity: normal
+    sampling_initial: 2
+    sampling_thereafter: 500
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - hostmetrics
+      processors:
+        - memory_limiter
+      exporters:
+        - logging

--- a/internal/configconverter/testdata/disable_excessive_internal_metrics/no_scrape_configs.yaml
+++ b/internal/configconverter/testdata/disable_excessive_internal_metrics/no_scrape_configs.yaml
@@ -1,0 +1,24 @@
+receivers:
+  prometheus/internal:
+    config:
+      scrape_configs: []
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    spike_limit_mib: 800
+    ballast_size_mib: 64
+exporters:
+  debug:
+    verbosity: normal
+    sampling_initial: 2
+    sampling_thereafter: 500
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - prometheus/internal
+      processors:
+        - memory_limiter
+      exporters:
+        - logging

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -219,6 +219,7 @@ func (s *Settings) ConfMapConverters() []confmap.Converter {
 			configconverter.NormalizeGcp{},
 			configconverter.LogLevelToVerbosity{},
 			configconverter.DisableKubeletUtilizationMetrics{},
+			configconverter.DisableExcessiveInternalMetrics{},
 		)
 	}
 	return confMapConverters

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -181,6 +181,7 @@ func TestNewSettingsConvertConfig(t *testing.T) {
 		configconverter.NormalizeGcp{},
 		configconverter.LogLevelToVerbosity{},
 		configconverter.DisableKubeletUtilizationMetrics{},
+		configconverter.DisableExcessiveInternalMetrics{},
 	}, settings.ConfMapConverters())
 	require.Equal(t, []string{"--feature-gates", "foo", "--feature-gates", "-bar"}, settings.ColCoreArgs())
 }


### PR DESCRIPTION
0.93.0 version add a significant amount of internal metrics upstream. We want disable them on the prometheus receiver level until it's handled upstream.
