### PR TITLE
Create manifest separately for latest as well

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,7 @@ stages:
   - cve-scan
   - sign-packages
   - release
+  - docker-manifest-release
   - github-release
   - sign-image
 
@@ -768,7 +769,7 @@ sign-windows2022-image:
 
 build-push-windows-multiarch-image:
   extends: .trigger-filter
-  stage: release
+  stage: docker-manifest-release
   dependencies:
     - build-push-windows2019-image
     - build-push-windows2022-image
@@ -788,8 +789,6 @@ build-push-windows-multiarch-image:
         $IMAGE_TAG = "${env:CI_COMMIT_SHA}"
       }
       echo "Building ${IMAGE_NAME}:${IMAGE_TAG}"
-      docker pull ${IMAGE_NAME}:${IMAGE_TAG}-2019
-      docker pull ${IMAGE_NAME}:${IMAGE_TAG}-2022
       docker manifest create ${IMAGE_NAME}:${IMAGE_TAG} --amend ${IMAGE_NAME}:${IMAGE_TAG}-2019 --amend ${IMAGE_NAME}:${IMAGE_TAG}-2022
       echo "Pushing ${IMAGE_NAME}:${IMAGE_TAG}"
       docker manifest push ${IMAGE_NAME}:${IMAGE_TAG}
@@ -797,7 +796,8 @@ build-push-windows-multiarch-image:
       if ($env:CI_COMMIT_BRANCH -eq "main" -or $env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$') {
         # only push latest tag for main and stable releases.
         echo "Tagging and pushing ${IMAGE_NAME}:latest"
-        docker buildx imagetools create --tag ${IMAGE_NAME}:latest ${IMAGE_NAME}:${IMAGE_TAG}
+        docker manifest create ${IMAGE_NAME}:latest --amend ${IMAGE_NAME}:${IMAGE_TAG}-2019 --amend ${IMAGE_NAME}:${IMAGE_TAG}-2022
+        docker manifest push ${IMAGE_NAME}:latest
       }
     - docker inspect --format='{{.RepoDigests}}' ${IMAGE_NAME}:${IMAGE_TAG} | Tee-Object -FilePath dist/windows_multiarch_digest.txt
     - (Get-Content -Raw -Path tags) -replace "`r`n", "`n"| Set-Content -NoNewline tags_to_sign


### PR DESCRIPTION
* Make sure the multiarch release runs after both docker images are built and pushed
* No need to pull images, we can create manifests by downloading the sha256 signatures from the registry (tested on a Windows machine)
* Remove the use of a docker buildx command as the gitlab worker doesn't have the right version. Build the manifest for each tag and push separately.