### PR TITLE
use latest tags as amended tags for the windows multi-arch latest manifest

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -793,7 +793,7 @@ build-push-windows-multiarch-image:
       if ($env:CI_COMMIT_BRANCH -eq "main" -or $env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$') {
         # only push latest tag for main and stable releases.
         echo "Tagging and pushing ${IMAGE_NAME}:latest"
-        docker manifest create ${IMAGE_NAME}:latest --amend ${IMAGE_NAME}:${IMAGE_TAG}-2019 --amend ${IMAGE_NAME}:${IMAGE_TAG}-2022
+        docker manifest create ${IMAGE_NAME}:latest --amend ${IMAGE_NAME}:latest-2019 --amend ${IMAGE_NAME}:latest-2022
         docker manifest push ${IMAGE_NAME}:latest
       }
       docker pull ${IMAGE_NAME}:${IMAGE_TAG}


### PR DESCRIPTION
This avoids amending successive individual tags to the latest image, which will otherwise add more and more tags over time.