### PR TITLE
Windows script to install Splunk distro for .NET instead of SFx.NET

### DIFF
--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -159,20 +159,20 @@ jobs:
           name: msi-build
           path: ./tests/zeroconfig/windows/testdata/docker-setup/
 
-      - name: Get latest signalfx-dotnet-tracing release
-        id: dotnet-tracing
+      - name: Get latest splunk-otel-dotnet release
+        id: dotnet-instrumentation
         uses: pozetroninc/github-action-get-latest-release@v0.7.0
         with:
           owner: signalfx
-          repo: signalfx-dotnet-tracing
+          repo: splunk-otel-dotnet
           excludes: prerelease, draft
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set SIGNALFX_DOTNET_TRACING_VERSION
+      - name: Set SPLUNK_OTEL_DOTNET_VERSION
         run: |
-          version="${{ steps.dotnet-tracing.outputs.release }}"
-          sed -i "s|SIGNALFX_DOTNET_TRACING_VERSION|${version#v}|" tests/zeroconfig/windows/testdata/resource_traces/aspnetcore.yaml
-          sed -i "s|SIGNALFX_DOTNET_TRACING_VERSION|${version#v}|" tests/zeroconfig/windows/testdata/resource_traces/aspnetfx.yaml
+          version="${{ steps.dotnet-instrumentation.outputs.release }}"
+          sed -i "s|SPLUNK_OTEL_DOTNET_VERSION|${version#v}|" tests/zeroconfig/windows/testdata/resource_traces/aspnetcore.yaml
+          sed -i "s|SPLUNK_OTEL_DOTNET_VERSION|${version#v}|" tests/zeroconfig/windows/testdata/resource_traces/aspnetfx.yaml
         shell: bash
 
       - name: Run the test script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- (Splunk) The Splunk OpenTelemetry Collector [Windows install script](https://docs.splunk.com/observability/en/gdi/opentelemetry/collector-windows/install-windows.html#install-the-collector-using-the-script)
+  now installs the [Splunk Distribution of OpenTelemetry .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/otel-dotnet/get-started.html#instrument-net-applications-for-splunk-observability-cloud-opentelemetry)
+  instead of the [SignalFx Instrumentation for .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/otel-dotnet/sfx/sfx-instrumentation.html#signalfx-instrumentation-for-net-deprecated)
+  when the parameter `-with_dotnet_instrumentation` is set to `$true` ([#4343](https://github.com/signalfx/splunk-otel-collector/pull/4343))
+
 ### 💡 Enhancements 💡
 
 - (Splunk) Add a resource attribute to internal metrics to track discovery usage ([#4323](https://github.com/signalfx/splunk-otel-collector/pull/4323))

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -69,7 +69,8 @@
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -with_fluentd $true
 .PARAMETER with_dotnet_instrumentation
-    (OPTIONAL) Whether to install and configure .NET tracing to forward .NET application traces to the local collector (default: $false)
+    (OPTIONAL) Whether to install and configure the Splunk Distribution of OpenTelemetry .NET to forward .NET application telemetry to the local collector (default: $false).
+    If the instrumentation is already installed the script will update it to the latest version - stop all instrumented applications before attempting to update the instrumentation.
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -with_dotnet_instrumentation $true
 .PARAMETER deployment_env
@@ -703,7 +704,14 @@ if ($with_dotnet_instrumentation) {
     if (-not $currentInstallVersion) {
         Install-OpenTelemetryCore
     } else {
-        Update-OpenTelemetryCore
+        Write-Warning "Splunk Distribution of OpenTelemetry .NET is already installed. Updating to the latest version..."
+        try {
+            Update-OpenTelemetryCore
+        }
+        catch {
+            Write-Error "Failed to update Splunk Distribution of OpenTelemetry .NET. Stop all instrumented applications and then try again."
+            throw $_
+        }
     }
 
     $installed_version = Get-OpenTelemetryInstallVersion

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -492,7 +492,7 @@ $tempdir = create_temp_dir -tempdir $tempdir
 
 if ($with_dotnet_instrumentation) {
     if ((msi_installed -name "SignalFx .NET Tracing 64-bit") -Or (msi_installed -name "SignalFx .NET Tracing 32-bit")) {
-        throw "SignalFx .NET Instrumentation is already installed. Uninstall SignalFx Instrumentation for .NET and rerun this script."
+        throw "SignalFx .NET Instrumentation is already installed. Stop all instrumented applications and uninstall SignalFx Instrumentation for .NET before running this script again."
     }
     echo "Downloading Splunk Distribution of OpenTelemetry .NET ..."
     $module_name = "Splunk.OTel.DotNet.psm1"
@@ -719,6 +719,7 @@ if ($otel_resource_attributes -ne "") {
     try {
         update_registry -path "$regkey" -name "OTEL_RESOURCE_ATTRIBUTES" -value "$otel_resource_attributes"
     } catch {
+        Write-Warning "Failed to set OTEL_RESOURCE_ATTRIBUTES environment variable."
         continue
     }
 }

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -73,7 +73,7 @@
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -with_dotnet_instrumentation $true
 .PARAMETER deployment_env
-    (OPTIONAL) A system-wide SignalFx "environment" used by .NET instrumentation. Sets the SIGNALFX_ENV environment variable. Ignored if -with_dotnet_instrumentation is false.
+    (OPTIONAL) A system-wide "deployment.environment" set via the environment variable 'OTEL_RESOURCE_ATTRIBUTES' for the whole machine. Ignored if -with_dotnet_instrumentation is false.
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -with_dotnet_instrumentation $true -deployment_env staging
 .PARAMETER bundle_dir
@@ -414,7 +414,7 @@ function download_collector_package([string]$collector_version=$collector_versio
 }
 
 # check registry for the agent msi package
-function msi_installed([string]$name="Splunk OpenTelemetry Collector") {
+function msi_installed([string]$name) {
     return (Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where { $_.DisplayName -eq $name }) -ne $null
 }
 
@@ -471,7 +471,7 @@ if (!(check_if_admin)) {
 echo 'Checking execution policy'
 check_policy
 
-if (msi_installed) {
+if (msi_installed -name "Splunk OpenTelemetry Collector") {
     throw "The Splunk OpenTelemetry Collector is already installed. Remove or uninstall the Collector and rerun this script."
 }
 
@@ -491,16 +491,16 @@ if ($with_fluentd -And (Test-Path -Path "$fluentd_base_dir\bin\fluentd")) {
 $tempdir = create_temp_dir -tempdir $tempdir
 
 if ($with_dotnet_instrumentation) {
-    echo "Installing SignalFx Instrumentation for .NET ..."
-    $module_name = "Splunk.SignalFx.DotNet.psm1"
-    $download = "https://github.com/signalfx/signalfx-dotnet-tracing/releases/latest/download/Splunk.SignalFx.DotNet.psm1"
+    if ((msi_installed -name "SignalFx .NET Tracing 64-bit") -Or (msi_installed -name "SignalFx .NET Tracing 32-bit")) {
+        throw "SignalFx .NET Instrumentation is already installed. Uninstall SignalFx Instrumentation for .NET and rerun this script."
+    }
+    echo "Downloading Splunk Distribution of OpenTelemetry .NET ..."
+    $module_name = "Splunk.OTel.DotNet.psm1"
+    $download = "https://github.com/signalfx/splunk-otel-dotnet/releases/latest/download/$module_name"
     $dotnet_autoinstr_path = Join-Path $tempdir $module_name
     echo "Downloading .NET Instrumentation installer ..."
     Invoke-WebRequest -Uri $download -OutFile $dotnet_autoinstr_path -UseBasicParsing
     Import-Module $dotnet_autoinstr_path
-    if (Get-IsSignalFxInstalled) {
-        throw "SignalFx Instrumentation for .NET is already installed. Remove or uninstall SignalFx Instrumentation for .NET and rerun this script."
-    }
 }
 
 if ($ingest_url -eq "") {
@@ -689,28 +689,49 @@ restarted to apply the changes by restarting the system or running the following
     echo "$message"
 }
 
-if ($with_dotnet_instrumentation) {
-    echo "Installing SignalFx Dotnet Auto Instrumentation..."
-    Install-SignalFxDotnet
+$otel_resource_attributes = ""
+if ($deployment_env -ne "") {
+    echo "Setting deployment environment to $deployment_env"
+    $otel_resource_attributes = "deployment.environment=$deployment_env"
+} else {
+    echo "Deployment environment was not specified. Unless otherwise defined, will appear as 'unknown' in the UI."
+}
 
-    $regkey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
-    if ($deployment_env -ne "") {
-        echo "Setting SIGNALFX_ENV environment variable to $deployment_env ..."
-        update_registry -path "$regkey" -name "SIGNALFX_ENV" -value "$deployment_env"
+if ($with_dotnet_instrumentation) {
+    echo "Installing Splunk Distribution of OpenTelemetry .NET..."
+    $currentInstallVersion = Get-OpenTelemetryInstallVersion
+    if (-not $currentInstallVersion) {
+        Install-OpenTelemetryCore
     } else {
-        echo "SIGNALFX_ENV environment variable not set. Unless otherwise defined, will appear as 'unknown' in the UI."
+        Update-OpenTelemetryCore
     }
 
+    $installed_version = Get-OpenTelemetryInstallVersion
+    if ($otel_resource_attributes -ne "") {
+        $otel_resource_attributes += ","
+    }
+    $otel_resource_attributes += "splunk.zc.method=splunk-otel-dotnet-$installed_version"
+}
+
+if ($otel_resource_attributes -ne "") {
+    # The OTEL_RESOURCE_ATTRIBUTES environment variable must be set before restarting IIS.
+    $regkey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
     try {
-        $dotnet_version = (Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where { $_.DisplayName -eq "SignalFx .NET Tracing 64-bit" }).DisplayVersion
-        update_registry -path "$regkey" -name "SIGNALFX_GLOBAL_TAGS" "splunk.zc.method:signalfx-dotnet-tracing-${dotnet_version}"
+        update_registry -path "$regkey" -name "OTEL_RESOURCE_ATTRIBUTES" -value "$otel_resource_attributes"
     } catch {
         continue
     }
+}
+
+if ($with_dotnet_instrumentation) {
+    if (service_installed -name "W3SVC") {
+        echo "Registering OpenTelemetry for IIS..."
+        Register-OpenTelemetryForIIS
+    }
 
     $message = "
-SignalFx .NET Instrumentation has been installed and configured to forward traces to the Splunk OpenTelemetry Collector.
-By default, .NET Instrumentation will automatically generate traces for applications running on IIS.
+Splunk Distribution of OpenTelemetry for .NET has been installed and configured to forward traces to the Splunk OpenTelemetry Collector.
+By default, the .NET instrumentation will automatically generate telemetry only for .NET applications running on IIS.
 "
     echo "$message"
 }

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -70,7 +70,6 @@
     .\install.ps1 -access_token "ACCESSTOKEN" -with_fluentd $true
 .PARAMETER with_dotnet_instrumentation
     (OPTIONAL) Whether to install and configure the Splunk Distribution of OpenTelemetry .NET to forward .NET application telemetry to the local collector (default: $false).
-    If the instrumentation is already installed the script will update it to the latest version - stop all instrumented applications before attempting to update the instrumentation.
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -with_dotnet_instrumentation $true
 .PARAMETER deployment_env
@@ -701,18 +700,11 @@ if ($deployment_env -ne "") {
 if ($with_dotnet_instrumentation) {
     echo "Installing Splunk Distribution of OpenTelemetry .NET..."
     $currentInstallVersion = Get-OpenTelemetryInstallVersion
-    if (-not $currentInstallVersion) {
-        Install-OpenTelemetryCore
-    } else {
-        Write-Warning "Splunk Distribution of OpenTelemetry .NET is already installed. Updating to the latest version..."
-        try {
-            Update-OpenTelemetryCore
-        }
-        catch {
-            Write-Error "Failed to update Splunk Distribution of OpenTelemetry .NET. Stop all instrumented applications and then try again."
-            throw $_
-        }
+    if ($currentInstallVersion) {
+        throw "The Splunk Distribution of OpenTelemetry .NET is already installed. Stop all instrumented applications and uninstall it and then rerun this script."
     }
+
+    Install-OpenTelemetryCore
 
     $installed_version = Get-OpenTelemetryInstallVersion
     if ($otel_resource_attributes -ne "") {

--- a/tests/zeroconfig/windows/README.md
+++ b/tests/zeroconfig/windows/README.md
@@ -6,7 +6,7 @@ a deployment following the Zero Configuration procedures.
 
 ## Requirements to run the tests locally
 
-The GitHub job `windows-zeroconfig-e2e-test` in the [`build-and-test`](../../../.github/workflows/build-and-test.yml)
+The GitHub job `dotnet-zeroconfig-e2e-test` in the [`build-and-test`](../../../.github/workflows/build-and-test.yml)
 has the actual requirements to run the tests locally, overall one needs:
 
 - Set up the [`./testdata/docker-setup`](./testdata/docker-setup) folder by adding:

--- a/tests/zeroconfig/windows/testdata/resource_traces/aspnetcore.yaml
+++ b/tests/zeroconfig/windows/testdata/resource_traces/aspnetcore.yaml
@@ -3,22 +3,32 @@ resource_spans:
     deployment.environment: zc-iis-test
     host.name: <ANY>
     os.type: windows
+    process.pid: <ANY>
+    process.runtime.description: .NET 6.0.27
+    process.runtime.name: .NET
+    process.runtime.version: 6.0.27
     service.name: AspNetCore.WebApi.Net
+    splunk.distro.version: SPLUNK_OTEL_DOTNET_VERSION
+    splunk.zc.method: splunk-otel-dotnet-vSPLUNK_OTEL_DOTNET_VERSION
+    telemetry.distro.name: splunk-otel-dotnet
+    telemetry.distro.version: SPLUNK_OTEL_DOTNET_VERSION
+    telemetry.sdk.language: dotnet
+    telemetry.sdk.name: opentelemetry
+    telemetry.sdk.version: <ANY>
   scope_spans:
-  - instrumentation_scope:
-      attributes: {}
-    spans:
-    - name: GET /aspnetcoreapp/api/values/{id}
-      attributes:
-        aspnet_core.endpoint: 'HTTP: GET /api/values/{id}'
-        aspnet_core.route: /api/values/{id}
-        component: aspnet_core
-        http.host: localhost:8000
-        http.method: GET
-        http.status_code: "200"
-        http.url: http://localhost:8000/aspnetcoreapp/api/values/6
-        http.user_agent: Go-http-client/1.1
-        net.peer.ip: <ANY>
-        signalfx.tracing.library: dotnet-tracing
-        signalfx.tracing.version: <ANY>
-        splunk.zc.method: signalfx-dotnet-tracing-SIGNALFX_DOTNET_TRACING_VERSION
+    - instrumentation_scope:
+        attributes: {}
+        name: OpenTelemetry.Instrumentation.AspNetCore
+        version: <ANY>
+      spans:
+        - attributes:
+            http.request.method: GET
+            http.response.status_code: 200
+            http.route: /api/values/{id}
+            network.protocol.version: "1.1"
+            server.address: localhost
+            server.port: 8000
+            url.path: /aspnetcoreapp/api/values/6
+            url.scheme: http
+            user_agent.original: Go-http-client/1.1
+          name: GET /api/values/{id}

--- a/tests/zeroconfig/windows/testdata/resource_traces/aspnetfx.yaml
+++ b/tests/zeroconfig/windows/testdata/resource_traces/aspnetfx.yaml
@@ -3,30 +3,30 @@ resource_spans:
     deployment.environment: zc-iis-test
     host.name: <ANY>
     os.type: windows
+    process.pid: <ANY>
+    process.runtime.description: .NET Framework 4.8.4645.0
+    process.runtime.name: .NET Framework
+    process.runtime.version: "4.8"
     service.name: Default Web Site/aspnetfxapp
+    splunk.distro.version: SPLUNK_OTEL_DOTNET_VERSION
+    splunk.zc.method: splunk-otel-dotnet-vSPLUNK_OTEL_DOTNET_VERSION
+    telemetry.distro.name: splunk-otel-dotnet
+    telemetry.distro.version: SPLUNK_OTEL_DOTNET_VERSION
+    telemetry.sdk.language: dotnet
+    telemetry.sdk.name: opentelemetry
+    telemetry.sdk.version: <ANY>
   scope_spans:
-  - instrumentation_scope:
-      attributes: {}
-    spans:
-    - name: GET /api/values/{id}
-      attributes:
-        http.host: localhost:8000
-        http.method: GET
-        http.status_code: "200"
-        http.url: http://localhost/aspnetfxapp/api/values/4
-        http.user_agent: Go-http-client/1.1
-        net.peer.ip: <ANY>
-        signalfx.tracing.library: dotnet-tracing
-        signalfx.tracing.version: <ANY>
-        splunk.zc.method: signalfx-dotnet-tracing-SIGNALFX_DOTNET_TRACING_VERSION
-    - name: GET /api/values/{id}
-      attributes:
-        aspnet.controller: values
-        aspnet.route: api/{controller}/{id}
-        http.host: localhost:8000
-        http.method: GET
-        http.status_code: "200"
-        http.url: http://localhost/aspnetfxapp/api/values/4
-        http.user_agent: Go-http-client/1.1
-        net.peer.ip: <ANY>
-        splunk.zc.method: signalfx-dotnet-tracing-SIGNALFX_DOTNET_TRACING_VERSION
+    - instrumentation_scope:
+        attributes: {}
+        name: OpenTelemetry.Instrumentation.AspNet.Telemetry
+        version: <ANY>
+      spans:
+        - attributes:
+            http.host: localhost
+            http.method: GET
+            http.route: api/{controller}/{id}
+            http.status_code: 200
+            http.target: /aspnetfxapp/api/values/4
+            http.url: http://localhost/aspnetfxapp/api/values/4
+            http.user_agent: Go-http-client/1.1
+          name: api/{controller}/{id}


### PR DESCRIPTION
**Description:**
Change the Windows install script to install the [Splunk Distribution of OpenTelemetry .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/otel-dotnet/get-started.html#instrument-net-applications-for-splunk-observability-cloud-opentelemetry)
  instead of the [SignalFx Instrumentation for .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/otel-dotnet/sfx/sfx-instrumentation.html#signalfx-instrumentation-for-net-deprecated)
  when the parameter `-with_dotnet_instrumentation` is set to `$true`

**Link to Splunk idea:**
N/A

**Testing:**
Local and CI validation on fork.

**Documentation:**
Pending: update install script documentation.
