### PR TITLE
Exclude 1 link from lychee validation

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -19,4 +19,5 @@ exclude = [
     "https://github.com/signalfx/splunk-otel-collector/tree/main/internal/exporter/pulsarexporter",  # exporter was deleted
     "https://github.com/signalfx/splunk-otel-collector/tree/main/cmd/translatesfx", # translatesfx was deleted
     "https://www.microsoft.com/en-us/evalcenter/download-windows-server-2022"
+    "https://superuser.com/a/980821", # failing with 403 Forbidden
 ]

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -18,6 +18,6 @@ exclude = [
     "ideas.splunk.com",
     "https://github.com/signalfx/splunk-otel-collector/tree/main/internal/exporter/pulsarexporter",  # exporter was deleted
     "https://github.com/signalfx/splunk-otel-collector/tree/main/cmd/translatesfx", # translatesfx was deleted
-    "https://www.microsoft.com/en-us/evalcenter/download-windows-server-2022"
+    "https://www.microsoft.com/en-us/evalcenter/download-windows-server-2022",
     "https://superuser.com/a/980821", # failing with 403 Forbidden
 ]


### PR DESCRIPTION
Lychee workflow `[.github/workflows/lychee.yml](https://github.com/signalfx/splunk-otel-collector/actions/workflows/lychee.yml)` is broken https://github.com/signalfx/splunk-otel-collector/actions/runs/8056560876#summary-22005858584