### PR TITLE
Hec-docs

### DIFF
--- a/internal/buildscripts/packaging/fpm/etc/otel/collector/splunk-otel-collector.conf.example
+++ b/internal/buildscripts/packaging/fpm/etc/otel/collector/splunk-otel-collector.conf.example
@@ -38,7 +38,7 @@ SPLUNK_INGEST_URL=https://ingest.us0.signalfx.com
 # Splunk trace endpoint URL.
 SPLUNK_TRACE_URL=https://ingest.us0.signalfx.com/v2/trace
 
-# Splunk HEC endpoint URL.
+# Splunk HEC endpoint URL, if forwarding to Observability cloud
 SPLUNK_HEC_URL=https://ingest.us0.signalfx.com/v1/log
 # If you're forwarding to a Splunk Enterprise instance running on example.com, with HEC at port 8088:
 # SPLUNK_HEC_URL=https://example.com:8088/services/collector

--- a/internal/buildscripts/packaging/fpm/etc/otel/collector/splunk-otel-collector.conf.example
+++ b/internal/buildscripts/packaging/fpm/etc/otel/collector/splunk-otel-collector.conf.example
@@ -40,6 +40,8 @@ SPLUNK_TRACE_URL=https://ingest.us0.signalfx.com/v2/trace
 
 # Splunk HEC endpoint URL.
 SPLUNK_HEC_URL=https://ingest.us0.signalfx.com/v1/log
+# If you're forwarding to a Splunk Enterprise instance running on example.com, with HEC at port 8088:
+# SPLUNK_HEC_URL=https://example.com:8088/services/collector
 
 # Splunk HEC token.
 SPLUNK_HEC_TOKEN=12345

--- a/internal/buildscripts/packaging/fpm/etc/otel/collector/splunk-otel-collector.conf.example
+++ b/internal/buildscripts/packaging/fpm/etc/otel/collector/splunk-otel-collector.conf.example
@@ -38,7 +38,7 @@ SPLUNK_INGEST_URL=https://ingest.us0.signalfx.com
 # Splunk trace endpoint URL.
 SPLUNK_TRACE_URL=https://ingest.us0.signalfx.com/v2/trace
 
-# Splunk HEC endpoint URL, if forwarding to Observability cloud
+# Splunk HEC endpoint URL, if forwarding to Splunk Observability Cloud
 SPLUNK_HEC_URL=https://ingest.us0.signalfx.com/v1/log
 # If you're forwarding to a Splunk Enterprise instance running on example.com, with HEC at port 8088:
 # SPLUNK_HEC_URL=https://example.com:8088/services/collector


### PR DESCRIPTION
**Description:** Documenting the HEC URLs depending on your use case in the splunk-otel-collector.conf.example file, as it's currently confusing.
