### PR TITLE
Remove windows-2019 from test matrix

### DIFF
--- a/.github/workflows/puppet-test.yml
+++ b/.github/workflows/puppet-test.yml
@@ -154,7 +154,7 @@ jobs:
       - puppet-rake-spec
     strategy:
       matrix:
-        OS: [ "windows-2019", "windows-2022" ]
+        OS: [ "windows-2022" ]
         PUPPET_RELEASE: [ "6.0.2", "7.21.0" ]
         TEST_CASE: [ "default", "custom_vars" ]
       fail-fast: false

--- a/.github/workflows/win-installer-script-test.yml
+++ b/.github/workflows/win-installer-script-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
-        OS: [ "windows-2019", "windows-2022" ]
+        OS: [ "windows-2022" ]
         MODE: [ "agent", "gateway" ]
         WITH_FLUENTD: [ "true", "false" ]
       fail-fast: false

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -73,7 +73,7 @@ jobs:
             ./bin/*
 
   agent-bundle-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       PIP_CACHE_DIR: ${{ github.workspace }}/.cache/pip
     steps:
@@ -229,7 +229,7 @@ jobs:
         run: Get-Content -Path "${env:SYSTEMDRIVE}\opt\td-agent\td-agent.log"
 
   choco-build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [msi-build]
     steps:
       - name: Check out the codebase.
@@ -371,11 +371,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           Copy-Item .\bin\otelcol_windows_amd64.exe .\cmd\otelcol\otelcol.exe
           Copy-Item .\dist\agent-bundle_windows_amd64.zip .\cmd\otelcol\agent-bundle_windows_amd64.zip
-          if ("${{ matrix.OS }}" -eq "windows-2019") {
-            docker build -t otelcol-windows --build-arg BASE_IMAGE=mcr.microsoft.com/windows/servercore:1809 --build-arg JMX_METRIC_GATHERER_RELEASE=$(Get-Content internal\buildscripts\packaging\jmx-metric-gatherer-release.txt) -f .\cmd\otelcol\Dockerfile.windows .\cmd\otelcol\
-          } else {
-            docker build -t otelcol-windows --build-arg BASE_IMAGE=mcr.microsoft.com/windows/servercore:ltsc2022 --build-arg JMX_METRIC_GATHERER_RELEASE=$(Get-Content internal\buildscripts\packaging\jmx-metric-gatherer-release.txt) -f .\cmd\otelcol\Dockerfile.windows .\cmd\otelcol\
-          }
+          docker build -t otelcol-windows --build-arg BASE_IMAGE=mcr.microsoft.com/windows/servercore:ltsc2022 --build-arg JMX_METRIC_GATHERER_RELEASE=$(Get-Content internal\buildscripts\packaging\jmx-metric-gatherer-release.txt) -f .\cmd\otelcol\Dockerfile.windows .\cmd\otelcol\
           Remove-Item .\cmd\otelcol\otelcol.exe
           Remove-Item .\cmd\otelcol\agent-bundle_windows_amd64.zip
 

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -185,7 +185,7 @@ jobs:
     needs: [msi-build]
     strategy:
       matrix:
-        OS: [ "windows-2019", "windows-2022" ]
+        OS: [ "windows-2022" ]
         MODE: [ "agent", "gateway" ]
         WITH_FLUENTD: [ "true", "false" ]
     steps:
@@ -277,7 +277,7 @@ jobs:
     needs: [choco-build]
     strategy:
       matrix:
-        OS: [ "windows-2019", "windows-2022" ]
+        OS: [ "windows-2022" ]
         MODE: [ "agent", "gateway" ]
         WITH_FLUENTD: [ "true", "false" ]
         SCENARIO: [ "install", "upgrade" ]
@@ -350,7 +350,7 @@ jobs:
     needs: [cross-compile, agent-bundle-windows]
     strategy:
       matrix:
-        OS: [ "windows-2019", "windows-2022" ]
+        OS: [ "windows-2022" ]
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v4

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
-        OS: [ "windows-2019", "windows-2022" ]
+        OS: [ "windows-2022" ]
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v4


### PR DESCRIPTION
**Description:**
Windows 2022 and 2019 are similar enough, at the level of the artifacts for this repo, that running on Windows 2019 tests doesn't provide much, if any, value and expose CI runs to [known issues with golang on Windows 2019](https://github.com/golang/go/issues/25965#issuecomment-1623741828), the common `go: CreateFile C:\Users\RUNNER~1\AppData\Local\Temp\go-build1611004282\b2864\settings.test.exe: Access is denied.`

Notice that both OTel collector core and contrib also don't run tests on Windows 2019, both use `windows-latest` only.

I'm opting to keep the GH action matrices so when a new Windows is released we can for a short of period of time run tests on both versions.

**Link to Jira:**
https://splunk.atlassian.net/browse/OTL-2618

**Testing:**
N/A

**Documentation:**
N/A
