### PR TITLE
Skip cve scan in release for now

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ stages:
   - build
   - sign-binaries
   - package
-  - cve-scan
+ # - cve-scan
   - sign-packages
   - release
   - docker-manifest-release


### PR DESCRIPTION
CVE Scan is succeeding in GitHub, but there seems to be a `snyk` issue we're running into in GitLab. Working on resolving in the background.