### PR TITLE
Update some actions to versions using node20

### DIFF
--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -45,7 +45,7 @@ jobs:
           make ${{ matrix.SYS_BINARIES }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.SYS_BINARIES }}
           path: |
@@ -76,7 +76,7 @@ jobs:
         run: make -C instrumentation/ ${{ matrix.SYS_PACKAGE }}-package ARCH="${{ matrix.ARCH }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: splunk-otel-auto-instrumentation-${{ matrix.ARCH }}-${{ matrix.SYS_PACKAGE }}
           path: ./instrumentation/dist/*.${{ matrix.SYS_PACKAGE }}
@@ -128,12 +128,12 @@ jobs:
           echo "Unknown distro '${{ matrix.DISTRO }}'!"
           exit 1
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: binaries-linux_${{ matrix.ARCH }}
           path: ./bin
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: splunk-otel-auto-instrumentation-${{ matrix.ARCH }}-${{ env.SYS_PACKAGE }}
           path: ./instrumentation/dist

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -135,7 +135,7 @@ jobs:
 
       - run: echo "GOLANGCI_LINT_CACHE=${HOME}/.cache/golangci-lint" >> $GITHUB_ENV
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ env.GOLANGCI_LINT_CACHE }}
           key: golangci-lint-${{ hashFiles('**/.golangci.yml', '**/*.go', '**/go.sum') }}
@@ -169,7 +169,7 @@ jobs:
           make for-all CMD="make test" | tee unit-test-results/go-unit-tests.out
 
       - name: Uploading artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unit-test-results
           path: ./unit-test-results
@@ -203,7 +203,7 @@ jobs:
           make test-with-cover
 
       - name: Uploading artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-results
           path: ./coverage.html
@@ -231,7 +231,7 @@ jobs:
           make ${{ matrix.SYS_BINARIES }}
 
       - name: Uploading binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.SYS_BINARIES }}
           path: |

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -93,7 +93,7 @@ jobs:
 
       - run: kitchen test ${{ matrix.DISTRO }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{ matrix.DISTRO }}
@@ -128,7 +128,7 @@ jobs:
         env:
           KITCHEN_YAML: kitchen.windows.yml
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{ matrix.SUITE }}-${{ matrix.DISTRO }}

--- a/.github/workflows/darwin-test.yml
+++ b/.github/workflows/darwin-test.yml
@@ -49,7 +49,7 @@ jobs:
         run: make test-with-cover
 
       - name: Uploading artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-results-${{ matrix.OS }}
           path: ./coverage.html

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: bundle-cache
         with:
           path: .cache/buildx/agent-bundle-${{ matrix.ARCH }}
@@ -60,7 +60,7 @@ jobs:
           DOCKER_BUILDKIT: '1'
           BUNDLE_CACHE_HIT: "${{ steps.bundle-cache.outputs.cache-hit }}"
       - run: docker save -o ./bin/image.tar otelcol:latest
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: otelcol-${{ matrix.ARCH }}
           path: ./bin
@@ -82,7 +82,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: otelcol-${{ matrix.ARCH }}
           path: ./bin
@@ -115,7 +115,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: otelcol-${{ matrix.ARCH }}
           path: ./bin

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -71,7 +71,7 @@ jobs:
           make ${{ matrix.SYS_BINARIES }}
 
       - name: Uploading binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.SYS_BINARIES }}
           path: |
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: bundle-cache
         with:
           path: .cache/buildx/agent-bundle-${{ matrix.ARCH }}
@@ -104,7 +104,7 @@ jobs:
         env:
           BUNDLE_CACHE_HIT: "${{ steps.bundle-cache.outputs.cache-hit }}"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: agent-bundle-linux-${{ matrix.ARCH }}
           path: ./dist/agent-bundle_linux_${{ matrix.ARCH }}.tar.gz
@@ -131,12 +131,12 @@ jobs:
           cache-dependency-path: '**/go.sum'
 
       - name: Downloading binaries-linux_${{ matrix.ARCH }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binaries-linux_${{ matrix.ARCH }}
           path: ./bin
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: agent-bundle-linux-${{ matrix.ARCH }}
           path: ./dist
@@ -145,7 +145,7 @@ jobs:
         run: make ${{ matrix.SYS_PACKAGE }}-package SKIP_COMPILE=true SKIP_BUNDLE=true VERSION="" ARCH="${{ matrix.ARCH }}"
 
       - name: Uploading ${{ matrix.SYS_PACKAGE }} ${{ matrix.ARCH }} package artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.SYS_PACKAGE }}-${{ matrix.ARCH }}-package
           path: ./dist/splunk-otel-collector*
@@ -196,7 +196,7 @@ jobs:
           echo "Unknown distro '${{ matrix.DISTRO }}'!"
           exit 1
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ env.SYS_PACKAGE }}-${{ matrix.ARCH }}-package
           path: ./dist
@@ -276,12 +276,12 @@ jobs:
           image: tonistiigi/binfmt:qemu-v7.0.0
 
       - name: Downloading binaries-linux_${{ matrix.ARCH }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binaries-linux_${{ matrix.ARCH }}
           path: ./bin
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         if: ${{ matrix.ARCH != 'ppc64le' }}
         with:
           name: agent-bundle-linux-${{ matrix.ARCH }}

--- a/.github/workflows/tanzu-tile.yml
+++ b/.github/workflows/tanzu-tile.yml
@@ -52,7 +52,7 @@ jobs:
           echo "tanzu_tile_path=$tanzu_tile_path" >> $GITHUB_ENV
 
       - name: Uploading artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tanzu-tile-latest.pivotal
           path: ${{ env.tanzu_tile_path }}

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: bundle-cache
         with:
           path: .cache/buildx/agent-bundle-${{ matrix.ARCH }}
@@ -76,7 +76,7 @@ jobs:
           DOCKER_BUILDKIT: '1'
           BUNDLE_CACHE_HIT: "${{ steps.bundle-cache.outputs.cache-hit }}"
       - run: mkdir -p dist && docker save -o dist/image.tar otelcol:latest
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: otelcol-${{ matrix.ARCH }}
           path: ./dist
@@ -96,7 +96,7 @@ jobs:
         with:
           platforms: ${{ matrix.ARCH }}
           image: tonistiigi/binfmt:qemu-v7.0.0
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: otelcol-${{ matrix.ARCH }}
           path: ./dist
@@ -127,7 +127,7 @@ jobs:
         with:
           platforms: ${{ matrix.ARCH }}
           image: tonistiigi/binfmt:qemu-v7.0.0
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: otelcol-${{ matrix.ARCH }}
           path: ./dist
@@ -166,7 +166,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: otelcol-${{ matrix.ARCH }}
           path: ./dist

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -66,7 +66,7 @@ jobs:
           make ${{ matrix.SYS_BINARIES }}
 
       - name: Uploading binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.SYS_BINARIES }}
           path: |
@@ -79,14 +79,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ env.PIP_CACHE_DIR }}
           key: agent-bundle-windows-pip-${{ hashFiles('internal/signalfx-agent/bundle/collectd-plugins.yaml', 'internal/signalfx-agent/bundle/scripts/requirements.txt') }}
 
       - run: ./internal/signalfx-agent/bundle/scripts/windows/make.ps1 bundle
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: agent-bundle-windows
           path: ./dist/agent-bundle_windows_amd64.zip
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
 
       - name: Downloading binaries-windows_amd64
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binaries-windows_amd64
           path: ./bin
@@ -113,7 +113,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: agent-bundle-windows
           path: ./dist
@@ -124,7 +124,7 @@ jobs:
           make msi SKIP_COMPILE=true VERSION=""
 
       - name: Uploading msi build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: msi-build
           path: ./dist/*.msi
@@ -146,7 +146,7 @@ jobs:
         uses: nuget/setup-nuget@v2.0.0
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3
+        uses: microsoft/setup-msbuild@v2
 
       - uses: actions/setup-dotnet@v4.0.0
         with:
@@ -154,7 +154,7 @@ jobs:
             6.0.407
 
       - name: Download Splunk OTel Collector msi
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: msi-build
           path: ./tests/zeroconfig/windows/testdata/docker-setup/
@@ -193,7 +193,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Downloading msi build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: msi-build
           path: ./dist
@@ -236,7 +236,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Downloading msi build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: msi-build
           path: ./dist
@@ -267,7 +267,7 @@ jobs:
           }
 
       - name: Uploading choco build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: choco-build
           path: ./dist/*.nupkg
@@ -287,7 +287,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Downloading choco build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: choco-build
           path: ./dist
@@ -356,12 +356,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Downloading binaries-windows_amd64
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binaries-windows_amd64
           path: ./bin
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: agent-bundle-windows
           path: ./dist

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -161,6 +161,8 @@ jobs:
 
       - name: Get splunk-otel-dotnet latest release name
         id: dotnet-instrumentation
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           $release = gh release view --repo signalfx/splunk-otel-dotnet --json name | ConvertFrom-Json | select name
           "release=$($release.name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -159,14 +159,11 @@ jobs:
           name: msi-build
           path: ./tests/zeroconfig/windows/testdata/docker-setup/
 
-      - name: Get latest splunk-otel-dotnet release
+      - name: Get splunk-otel-dotnet latest release name
         id: dotnet-instrumentation
-        uses: pozetroninc/github-action-get-latest-release@v0.7.0
-        with:
-          owner: signalfx
-          repo: splunk-otel-dotnet
-          excludes: prerelease, draft
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $release = gh release view --repo signalfx/splunk-otel-dotnet --json name | ConvertFrom-Json | select name
+          "release=$($release.name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Set SPLUNK_OTEL_DOTNET_VERSION
         run: |


### PR DESCRIPTION
**Description:**
Get rid of GH action warnings about actions using node 16, see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

The CLA assistant still doesn't have a node20 version and it is the last one remaining with this warning.

**Link to Splunk idea:**
N/A

**Testing:**
N/A

**Documentation:**
N/A
