### PR TITLE
Remove fieldalignment tool and check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,6 @@ install-tools:
 	cd ./internal/tools && go install github.com/pavius/impi/cmd/impi
 	cd ./internal/tools && go install github.com/tcnksm/ghr
 	cd ./internal/tools && go install golang.org/x/tools/cmd/goimports
-	cd ./internal/tools && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment
-
 
 .PHONY: generate-metrics
 generate-metrics:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -104,7 +104,6 @@ checklinks:
 fmt: addlicense misspell-correction
 	gofmt -w -s .
 	goimports -w  -local github.com/signalfx/splunk-otel-collector ./
-	fieldalignment -fix ./... || true
 
 .PHONY: lint
 lint: checklicense misspell impi

--- a/internal/receiver/databricksreceiver/internal/metadata/generated_metrics.go
+++ b/internal/receiver/databricksreceiver/internal/metadata/generated_metrics.go
@@ -7673,8 +7673,11 @@ func newMetricDatabricksTasksScheduleStatus(cfg MetricConfig) metricDatabricksTa
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
-	metricsBuffer                                                                                                            pmetric.Metrics
-	buildInfo                                                                                                                component.BuildInfo
+	config                                                                                                                   MetricsBuilderConfig // config of the metrics builder.
+	startTime                                                                                                                pcommon.Timestamp    // start time that will be applied to all recorded data points.
+	metricsCapacity                                                                                                          int                  // maximum observed number of metrics per resource.
+	metricsBuffer                                                                                                            pmetric.Metrics      // accumulates metrics data before emitting.
+	buildInfo                                                                                                                component.BuildInfo  // contains version information.
 	metricDatabricksJobsActiveTotal                                                                                          metricDatabricksJobsActiveTotal
 	metricDatabricksJobsRunDuration                                                                                          metricDatabricksJobsRunDuration
 	metricDatabricksJobsScheduleStatus                                                                                       metricDatabricksJobsScheduleStatus
@@ -7815,9 +7818,6 @@ type MetricsBuilder struct {
 	metricDatabricksSparkTimerLiveListenerBusQueueStreamsListenerProcessingTime                                              metricDatabricksSparkTimerLiveListenerBusQueueStreamsListenerProcessingTime
 	metricDatabricksTasksRunDuration                                                                                         metricDatabricksTasksRunDuration
 	metricDatabricksTasksScheduleStatus                                                                                      metricDatabricksTasksScheduleStatus
-	startTime                                                                                                                pcommon.Timestamp
-	metricsCapacity                                                                                                          int
-	config                                                                                                                   MetricsBuilderConfig
 }
 
 // metricBuilderOption applies changes to default metrics builder.

--- a/internal/receiver/databricksreceiver/internal/metadata/generated_resource.go
+++ b/internal/receiver/databricksreceiver/internal/metadata/generated_resource.go
@@ -9,8 +9,8 @@ import (
 // ResourceBuilder is a helper struct to build resources predefined in metadata.yaml.
 // The ResourceBuilder is not thread-safe and must not to be used in multiple goroutines.
 type ResourceBuilder struct {
-	res    pcommon.Resource
 	config ResourceAttributesConfig
+	res    pcommon.Resource
 }
 
 // NewResourceBuilder creates a new ResourceBuilder. This method should be called on the start of the application.

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -28,5 +28,4 @@ import (
 	_ "github.com/tcnksm/ghr"
 	_ "go.opentelemetry.io/collector/cmd/mdatagen"
 	_ "golang.org/x/tools/cmd/goimports"
-	_ "golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment"
 )


### PR DESCRIPTION
**Description:** 
Noticed while checking the status of GH actions: this was being flagged as error on the "Checks" tab, but, the make file ignores the actual result. After digging the history my understanding is that the fieldalignment is disabled both in core and contrib:

* Tool seems to have been introduced via https://github.com/signalfx/splunk-otel-collector/commit/b392b5b734a7c8ef68f3896c58a4aee52f1226de
* https://github.com/open-telemetry/opentelemetry-collector/issues/2789#issuecomment-1867105194

Noise to be removed by this PR: the "2" issues for build-and-test https://github.com/signalfx/splunk-otel-collector/pull/4392/checks


