### PR TITLE
Enable Cumulative to Delta Processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🚀 New components 🚀
+
+- (Splunk) Add the `cumulativetodelta` processor ([#4401](https://github.com/signalfx/splunk-otel-collector/pull/4401))
+
 ## v0.95.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.95.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.95.0) and the [opentelemetry-collector-contrib v0.95.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.95.0) releases where appropriate.

--- a/docs/components.md
+++ b/docs/components.md
@@ -67,6 +67,7 @@ The distribution offers support for the following components.
 |:--------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------|
 | [attributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor)                     | [alpha]                     |
 | [batch](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor)                                       | [beta]                      |
+| [cumulativetodelta](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor)       | [beta]                      |
 | [filter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor)                             | [alpha]                     |
 | [groupbyattrs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/groupbyattrsprocessor)                 | [beta]                      |
 | [k8sattributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor)               | [beta]                      |

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.95.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.95.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.95.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.95.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.95.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.95.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.95.0

--- a/go.sum
+++ b/go.sum
@@ -1284,6 +1284,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0.95.0/go.mod h1:XLvarGz+jYEG4eHJxkabKC3J7mU+l0/Yyef8jX6CN/U=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.95.0 h1:u1C/RzSqLz9pgXpzjeguhdttysMXpfZuZCyCtYXS3XM=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.95.0/go.mod h1:FIbrRX2BGpY9+FXdgSZNg7WH3Yk4CuCNP5OLYfM+Oj4=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.95.0 h1:348XhLVfFdlHRXiwRqH1Bd7tIw2PWe8NeRECFtKsznE=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.95.0/go.mod h1:5jgNZX79RDJFDwwYg9JJJVUdgbNIEJ+6FHXpSgI2MeY=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.95.0 h1:G1MrHQ8c1hNT/KzNS/cv3RU9GUicUztuLE9LE2U++Xw=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.95.0/go.mod h1:KO835nLbHPhzzDtPphCjnuT2EkKxVpUBDNG34F26oJs=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.95.0 h1:PtaffrOccEvzt4D66oQJoiLgYTV1DFS0xisUK4QbD2g=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -38,6 +38,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor"
@@ -216,6 +217,7 @@ func Get() (otelcol.Factories, error) {
 	processors, err := processor.MakeFactoryMap(
 		attributesprocessor.NewFactory(),
 		batchprocessor.NewFactory(),
+		cumulativetodeltaprocessor.NewFactory(),
 		filterprocessor.NewFactory(),
 		groupbyattrsprocessor.NewFactory(),
 		k8sattributesprocessor.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -92,6 +92,7 @@ func TestDefaultComponents(t *testing.T) {
 	expectedProcessors := []component.Type{
 		"attributes",
 		"batch",
+		"cumulativetodelta",
 		"filter",
 		"groupbyattrs",
 		"k8sattributes",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Enabling Cumulative to Delta processor which would allow for converting cumulative monotonic metrics to delta metrics.

**Link to Splunk idea:**  https://ideas.splunk.com/ideas/SFXIMMID-I-599

**Testing:** <Describe what testing was performed and which tests were added.>

- Has been tested with a splunk-otel-collector helm chart (w/ a custom-built image) deployed in an EKS cluster, with the "cumulativetodelta" processor enabled in the processors config, and the processor added to the "metrics" pipeline like so: 
```
metrics:
  processors:
  - memory_limiter
  - cumulativetodelta
  - k8sattributes/metrics
  - batch
  - resourcedetection
  - resource
``` 
 We have confirmed that the metrics values that used to be ever-increasing monotonic numbers have become deltas as a result.
- Unit tests pass

**Documentation:** I've updated the list of components doc to include the `cumulativetodelta` processor (as part of this PR).
