### PR TITLE
Move integration test image to a service container

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -102,6 +102,14 @@ jobs:
     # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
     runs-on: ubuntu-20.04
     needs: [docker-otelcol]
+    services:
+      # Tomcat image for collectd-tomcat test:
+      tomcat:
+        image: tomcat
+        env:
+          JAVA_TOOL_OPTIONS: "-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5000 -Dcom.sun.management.jmxremote.rmi.port=5000 -Dcom.sun.management.jmxremote.host=0.0.0.0 -Djava.rmi.server.hostname=0.0.0.0"
+        ports:
+          - "5000:5000"
     strategy:
       matrix:
         GOTESPLIT_INDEX: [ "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" ]

--- a/tests/receivers/smartagent/collectd-tomcat/tomcat_test.go
+++ b/tests/receivers/smartagent/collectd-tomcat/tomcat_test.go
@@ -16,20 +16,13 @@
 package tests
 
 import (
-	"path"
 	"testing"
 
 	"github.com/signalfx/splunk-otel-collector/tests/testutils"
 )
 
-var apache = []testutils.Container{
-	testutils.NewContainer().WithContext(
-		path.Join(".", "testdata", "server"),
-	).WithName("tomcat").WithExposedPorts("5000:5000").WillWaitForLogs("Server startup in").WillWaitForPorts("5000"),
-}
-
 func TestCollectdTomcatReceiverProvidesDefaultMetrics(t *testing.T) {
 	testutils.AssertAllMetricsReceived(
-		t, "default.yaml", "default_metrics_config.yaml", apache, nil,
+		t, "default.yaml", "default_metrics_config.yaml", nil, nil,
 	)
 }


### PR DESCRIPTION
Attempt to use Github to run docker containers for us rather than having us run it every time.