### PR TITLE
Remove deprecated config fields

### DIFF
--- a/internal/signalfx-agent/pkg/core/config/config.go
+++ b/internal/signalfx-agent/pkg/core/config/config.go
@@ -39,24 +39,8 @@ type Config struct {
 	SysPath string `yaml:"sysPath" default:"/sys"`
 }
 
-// Deprecated: this setting has no effect and will be removed.
-// LogConfig contains configuration related to logging
-type LogConfig struct {
-	// Valid levels include `debug`, `info`, `warn`, `error`.  Note that
-	// `debug` logging may leak sensitive configuration (e.g. passwords) to the
-	// agent output.
-	Level string `yaml:"level"`
-	// The log output format to use.  Valid values are: `text`, `json`.
-	Format string `yaml:"format" validate:"oneof=text json"`
-	// TODO: Support log file output and other log targets
-}
-
 // CollectdConfig high-level configurations
 type CollectdConfig struct {
-	// Deprecated: this setting has no effect and will be removed.
-	// If you won't be using any collectd monitors, this can be set to true to
-	// prevent collectd from pre-initializing
-	DisableCollectd bool `yaml:"disableCollectd" default:"false"`
 	// How many read intervals before abandoning a metric. Doesn't affect much
 	// in normal usage.
 	// See [Timeout](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#timeout_iterations).


### PR DESCRIPTION
**Description:**
Remove configuration section that have no need to exist anymore as part of the smart agent receiver.