### PR TITLE
Remove spanmetrics processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- (Splunk) `spanmetricsprocessor`: Remove `spanmetricsprocessor`. Please use `spanmetrics` connector instead.
+
 ## v0.96.1
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.96.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.96.0) and the [opentelemetry-collector-contrib v0.96.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.96.0) releases where appropriate.

--- a/docs/components.md
+++ b/docs/components.md
@@ -77,7 +77,6 @@ The distribution offers support for the following components.
 | [resourcedetection](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)       | [beta]                      |
 | [resource](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor)                         | [beta]                      |
 | [routing](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/routingprocessor)                           | [beta]                      |
-| [span_metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.95.0/processor/spanmetricsprocessor)                  | [in development]            |
 | [span](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/spanprocessor)                                 | [alpha]                     |
 | [tail_sampling](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor)                | [beta]                      |
 | [timestamp](../pkg/processor/timestampprocessor)                                                                                                     | [in development]            |

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.96.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor v0.95.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.96.0

--- a/go.sum
+++ b/go.sum
@@ -1397,8 +1397,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceproc
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.96.0/go.mod h1:JWwuTmaCCAIg+578JoA3h49KKduGyzGQtd8Mr9AKzX8=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.96.0 h1:QYZ1oyCeEgXI2blgwocD4e5R6in3wXFTYl2imZT/Yj8=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.96.0/go.mod h1:RKsOkor8OroKRP48b5IMHeAR0i8WsRuUEvLqxqwqq+E=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor v0.95.0 h1:zL6QvBvBvP4SqC/fBwH73wYIGzrs6p/pI8oIB8MsjLk=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor v0.95.0/go.mod h1:hlgS5QXAk0Yq07Hqho+YzfHnmVnNapbuYiWIOg8bo8k=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.96.0 h1:xk76zUw+de12cTub55C8dFFX7LrHit6+gn7DFSXfbUA=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.96.0/go.mod h1:zo7zFs2ouCcWZFTm8e+rB7cKoBPMczQc4UxINpCGVtk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.96.0 h1:I7pyP5UMHf+Xc7WnO/PN4ff15IbTmrNlcJn/LEngzWU=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -48,7 +48,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
@@ -226,7 +225,6 @@ func Get() (otelcol.Factories, error) {
 		resourcedetectionprocessor.NewFactory(),
 		resourceprocessor.NewFactory(),
 		routingprocessor.NewFactory(),
-		spanmetricsprocessor.NewFactory(),
 		spanprocessor.NewFactory(),
 		tailsamplingprocessor.NewFactory(),
 		timestampprocessor.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -103,7 +103,6 @@ func TestDefaultComponents(t *testing.T) {
 		"resourcedetection",
 		"routing",
 		"span",
-		"spanmetrics",
 		"tail_sampling",
 		"timestamp",
 		"transform",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The `spanmetrics` processor was deleted from upstream, we should delete as well.