### PR TITLE
Remove the need to build and run cassandra as container

### DIFF
--- a/tests/receivers/jmxreceiver/jmxreceiver_test.go
+++ b/tests/receivers/jmxreceiver/jmxreceiver_test.go
@@ -17,7 +17,6 @@
 package tests
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/signalfx/splunk-otel-collector/tests/testutils"
@@ -29,14 +28,8 @@ func TestJMXReceiverProvidesAllJVMMetrics(t *testing.T) {
 		t.Skip("apparent metric gathering issue on qemu")
 	}
 
-	containers := []testutils.Container{
-		testutils.NewContainer().WithContext(
-			filepath.Join("..", "smartagent", "collectd-cassandra", "testdata", "server"),
-		).WithExposedPorts("7199:7199").WithName("jmx").WillWaitForPorts("7199"),
-	}
-
 	testutils.AssertAllMetricsReceived(
-		t, expectedMetrics, "all_metrics_config.yaml", containers,
+		t, expectedMetrics, "all_metrics_config.yaml", nil,
 		[]testutils.CollectorBuilder{
 			func(collector testutils.Collector) testutils.Collector {
 				return collector.WithEnv(map[string]string{


### PR DESCRIPTION
**Description:**
This container was moved to github actions services and there is no need to build it directly.