### PR TITLE
Windows Installer Script - Add support for offline installs

### DIFF
--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -730,6 +730,7 @@ if ($with_dotnet_instrumentation) {
         throw "The Splunk Distribution of OpenTelemetry .NET is already installed. Stop all instrumented applications and uninstall it and then rerun this script."
     }
 
+    # If the variable dotnet_auto_zip_path is an empty string, then the Installer will download the .NET Instrumentation from the default repository.
     Install-OpenTelemetryCore -LocalPath $dotnet_auto_zip_path
 
     $installed_version = Get-OpenTelemetryInstallVersion

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -549,7 +549,7 @@ if ($bundle_dir -eq "") {
     $bundle_dir = "$installation_path\agent-bundle"
 }
 
-if ("$force_skip_verify_access_token") {
+if ($force_skip_verify_access_token) {
     echo 'Skipping Access Token verification'
 } else {   
     if ("$env:VERIFY_ACCESS_TOKEN" -ne "false") {

--- a/internal/buildscripts/packaging/installer/install.ps1
+++ b/internal/buildscripts/packaging/installer/install.ps1
@@ -107,7 +107,7 @@
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -msi_path "C:\SOME_FOLDER\splunk-otel-collector-1.2.3-amd64.msi"
 .PARAMETER dotnet_psm1_path
-    (OPTIONAL) Specify a local path to a Splunk OpenTelemetry .NET Auto Instrumentation Powershell Module file (.psm1) instead of downloading the package.  This module will be used to install the .NET auto instrumentation files.  The most current PSM1 file can be downloaded at https://github.com/signalfx/splunk-otel-dotnet/releases
+    (OPTIONAL) Specify a local path to a Splunk OpenTelemetry .NET Auto Instrumentation Powershell Module file (.psm1) instead of downloading the package. This module will be used to install the .NET auto instrumentation files. The most current PSM1 file can be downloaded at https://github.com/signalfx/splunk-otel-dotnet/releases
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -dotnet_psm1_path "C:\SOME_FOLDER\Splunk.OTel.DotNet.psm1"
 .PARAMETER dotnet_auto_zip_path


### PR DESCRIPTION
**Description:** Added support for offline installs to the Windows Installer Script.  Its common for windows servers in the DMZ to have outbound access blocked which prevents the current script from working.  The current script does support an offline MSI but it does NOT support an offline .net auto instrumentation file.  This change adds that capability.

**Link to Splunk idea:** There is no idea for this, but this is something we see in field sales all the time.  Support tosses this issue back to the SAs/SEs so I lets just fix the root cause.

**Testing:** Ran the script multiple times with various options in my Home Lab using Win Server 2012R2 with powershell 5.1.  I believe it needs more testing, but my home lab resources are limited.  Hopefully the QA team can put it through the paces.

**Documentation:** Added Param documentation to the script file to support the Get-Help command.  Other comments are in line.

### How To Use This Script
The original collector installer script allows you to use a local downloaded file for the Otel Collector MSI by using the parameter **msi_path**.  However, if you enable the **with_dotnet_instrumentation** to install the .net auto instrumentation, that part of the installer script does not support manually downloading files and for many server environments this section will fail.  You then end up with a partially installed set of collector and instrumentation.  The script changes are designed to support fully offline installs of both the collector and the .net auto instrumentation when using the combination of these new params and the previously existing msi_path.

**New Params:**

- **dotnet_psm1_path:**  (OPTIONAL) Specify a local path to a Splunk OpenTelemetry .NET Auto Instrumentation Powershell Module file (.psm1) instead of downloading the package.  This module will be used to install the .NET auto instrumentation files.  The most current PSM1 file can be downloaded at https://github.com/signalfx/splunk-otel-dotnet/releases
- **dotnet_auto_zip_path:**  (OPTIONAL) Specify a local path to a Splunk OpenTelemetry .NET Auto Instrumentation zip package that will be installed by the dotnet psm1 module instead of downloading the package.  The most current zip file can be downloaded at https://github.com/signalfx/splunk-otel-dotnet/releases
- **force_skip_verify_access_token:** (OPTIONAL) Forces the skipping the verification check of the Splunk Observability Access Token regardless of what is in the env variable VERIFY_ACCESS_TOKEN.  This is helpful on new installs where access might be an issue or the token isn't created yet.

**Example Command Line:**

Please note my example has the ".\" to call the script and depending on your setup you may need to use a different setup.  This command also requires Administrator permissions to be sure to open a powershell window as administrator.  For ease of use, I also copy all the binaries and this new script into the same folder.  In the example below I also using the option force_skip_verify_access_token as its common for new servers in a DMZ to all outbound traffic blocked.  Blocked traffic result in the access_token verification process failing and then the installer will error out and stop.  This options allows you to skip that check and continue with the install.  However data will not flow into Splunk Observability until the proper ports are open.

- .\splunk-otel-collector.ps1 -access_token "x-MyFakeToken" -msi_path "C:\myOtel\splunk-otel-collector-0.96.1-amd64.msi" -dotnet_psm1_path "C:\myOtel\Splunk.OTel.DotNet.psm1" -dotnet_auto_zip_path "C:\myOtel\splunk-opentelemetry-dotnet-windows.zip" -with_dotnet_instrumentation $true -force_skip_verify_access_token $true -realm ="US1"

**Known Issues:**

- Powershell version 5.1 is required due to a Extract-Archive call that is used in the PSM1 script to deploy the .net instrumentation.  Older Windows servers might have Powershell 4.0 installed.  If you see an error related to the extract-archive command then try to update powershell.  the update to 5.1 can be found here:
  - https://www.microsoft.com/en-us/download/details.aspx?id=54616&ranMID=24542&ranEAID=TnL5HPStwNw&ranSiteID=TnL5HPStwNw-PY0rN6sxCyF8hlhQhRlodA&epi=TnL5HPStwNw-PY0rN6sxCyF8hlhQhRlodA&irgwc=1&OCID=AID2000142_aff_7593_1243925&tduid=(ir__biyzqumvw9kfrgvj0jd6oxxa1e2xjal2pedo1uo900)(7593)(1243925)(TnL5HPStwNw-PY0rN6sxCyF8hlhQhRlodA)()&irclickid=_biyzqumvw9kfrgvj0jd6oxxa1e2xjal2pedo1uo900
