### PR TITLE
use port 8001 to match running prometheus instance

### DIFF
--- a/tests/receivers/lightprometheus/testdata/resource_metrics/basic_auth_metrics.yaml
+++ b/tests/receivers/lightprometheus/testdata/resource_metrics/basic_auth_metrics.yaml
@@ -1,6 +1,6 @@
 resource_metrics:
   - attributes:
-      service.instance.id: localhost:8000
+      service.instance.id: localhost:8001
       service.name: myjob
     scope_metrics:
       - instrumentation_scope:


### PR DESCRIPTION
We had to change to port 8001 to fix a conflict, but I forgot to change the fixtures to match.