### PR TITLE
Remove cve-scan job, commented out in the build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,6 @@ stages:
   - build
   - sign-binaries
   - package
- # - cve-scan
   - sign-packages
   - release
   - docker-manifest-release
@@ -1074,38 +1073,6 @@ puppet-release:
   artifacts:
     paths:
       - deployments/puppet/pkg/*.tar.gz
-
-#cve-scan:
-#  extends: .go-cache
-#  stage: cve-scan
-#  retry: 2
-#  only:
-#    - main
-#    - schedules
-#  before_script:
-#    - apt-get update
-#    - apt-get install -y ca-certificates curl gnupg lsb-release
-#    - curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-#    - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-#    - apt-get update
-#    - apt-get install -y docker-ce-cli docker-scan-plugin
-#  script:
-#    - *docker-reader-role
-#    - |
-#      if [ -f dist/otelcol-amd64.tar ]; then
-#        docker load -i dist/otelcol-amd64.tar
-#        docker tag otelcol:amd64 otelcol:latest
-#      else
-#        make docker-otelcol DOCKER_REPO=${DOCKER_HUB_REPO}
-#      fi
-#    - docker scan --accept-license --login --token ${SNYK_AUTH_TOKEN}
-#    - docker scan --severity high otelcol
-#  after_script:
-#    - |
-#      if [ "$CI_JOB_STATUS" != "success" ]; then
-#        curl -X POST ${SLACK_WEBHOOK_URL} -H 'Content-Type: application/json' \
-#          --data "{\"blocks\": [{\"type\": \"section\",\"text\": {\"type\": \"mrkdwn\",\"text\": \"*@here Gitlab Job #${CI_JOB_ID}*\"}},{\"type\": \"section\",\"text\": {\"type\": \"mrkdwn\",\"text\": \"*:ghost: Vulnerability scan failed on splunk-otel-collector*\"},\"accessory\": {\"type\": \"button\",\"text\": {\"type\": \"plain_text\",\"text\": \"More Info\",\"emoji\": true},\"style\": \"danger\",\"url\": \"${CI_JOB_URL}\",\"action_id\": \"button-action\"}}]}"
-#      fi
 
 chef-release:
   image: '${DOCKER_HUB_REPO}/ruby:2.7-buster'


### PR DESCRIPTION
**Description:**
This code was commented out as we moved Snyk outside of gitlab and are using it with GitHub now. This PR removes the code entirely.