### PR TITLE
[receiver/discovery] Do not allow empty `receivers` config value

### DIFF
--- a/internal/receiver/discoveryreceiver/config.go
+++ b/internal/receiver/discoveryreceiver/config.go
@@ -95,6 +95,9 @@ type LogRecord struct {
 }
 
 func (cfg *Config) Validate() error {
+	if len(cfg.Receivers) == 0 {
+		return fmt.Errorf("`receivers` must be defined and include at least one receiver entry")
+	}
 	var err error
 	for rName, rEntry := range cfg.Receivers {
 		name := rName.String()

--- a/internal/receiver/discoveryreceiver/config_test.go
+++ b/internal/receiver/discoveryreceiver/config_test.go
@@ -122,9 +122,9 @@ func TestValidConfig(t *testing.T) {
 }
 
 func TestInvalidConfigs(t *testing.T) {
-
 	tests := []struct{ name, expectedError string }{
 		{name: "no_watch_observers", expectedError: "`watch_observers` must be defined and include at least one configured observer extension"},
+		{name: "no_receivers", expectedError: "`receivers` must be defined and include at least one receiver entry"},
 		{name: "missing_status", expectedError: "receiver \"a_receiver\" validation failure: `status` must be defined and contain at least one `metrics` or `statements` mapping"},
 		{name: "missing_status_metrics_and_statements", expectedError: "receiver \"a_receiver\" validation failure: `status` must be defined and contain at least one `metrics` or `statements` mapping"},
 		{name: "invalid_status_types", expectedError: `receiver "a_receiver" validation failure: invalid status "unsupported". must be one of [successful partial failed]; invalid status "another_unsupported". must be one of [successful partial failed]`},

--- a/internal/receiver/discoveryreceiver/factory_test.go
+++ b/internal/receiver/discoveryreceiver/factory_test.go
@@ -45,7 +45,7 @@ func TestCreateLogsReceiver(t *testing.T) {
 	params := otelcolreceiver.CreateSettings{}
 	receiver, err := factory.CreateLogsReceiver(context.Background(), params, cfg, consumertest.NewNop())
 	assert.Error(t, err)
-	assert.EqualError(t, err, "`watch_observers` must be defined and include at least one configured observer extension")
+	assert.EqualError(t, err, "`receivers` must be defined and include at least one receiver entry")
 	assert.Nil(t, receiver)
 }
 

--- a/internal/receiver/discoveryreceiver/testdata/no_receivers.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/no_receivers.yaml
@@ -1,0 +1,3 @@
+discovery:
+  watch_observers:
+    - an_observer

--- a/internal/receiver/discoveryreceiver/testdata/no_watch_observers.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/no_watch_observers.yaml
@@ -1,3 +1,32 @@
 discovery:
   watch_observers:
+  receivers:
+    receiver_a:
+      rule: type == "container"
+      config: {}
+      status:
+        metrics:
+          successful:
+            - regexp: '.*'
+              first_only: true
+              log_record:
+                severity_text: info
+                body: successful status
+                attributes:
+                  attr_one: attr_one_val
+                  attr_two: attr_two_val
+        statements:
+          failed:
+            - regexp: ConnectionRefusedError
+              first_only: true
+              log_record:
+                attributes: {}
+                severity_text: info
+                body: container appears to not be accepting redis connections
+          partial:
+            - regexp: (WRONGPASS|NOAUTH|ERR AUTH)
+              first_only: false
+              log_record:
+                severity_text: warn
+                body: desired log invalid auth log body
 


### PR DESCRIPTION
The empty receivers field makes the discovery receiver useless except for seeing observed entities with `log_endpoints=true`, which is a debug feature that likely needs to be removed later. It should fail to start instead. The discovery mode automatically fills this value. This change is only applicable if users configure the discovery receiver manually.
