### PR TITLE
[discovery] Don't use component.MustNewIDWithName

### DIFF
--- a/internal/confmapprovider/discovery/properties/property.go
+++ b/internal/confmapprovider/discovery/properties/property.go
@@ -95,9 +95,13 @@ func NewProperty(property, val string) (*Property, error) {
 		}
 		subStringMap = map[string]any{"config": confmap.NewFromStringMap(dst).ToStringMap()}
 	}
+	receiverType, err := component.NewType(p.Component.Type)
+	if err != nil {
+		return nil, fmt.Errorf("invalid receiver type %q: %w", p.Component.Type, err)
+	}
 	p.stringMap = map[string]any{
 		p.ComponentType: map[string]any{
-			component.MustNewIDWithName(p.Component.Type, p.Component.Name).String(): subStringMap,
+			component.NewIDWithName(receiverType, p.Component.Name).String(): subStringMap,
 		},
 	}
 	p.Input = property

--- a/internal/confmapprovider/discovery/properties/property_test.go
+++ b/internal/confmapprovider/discovery/properties/property_test.go
@@ -221,21 +221,13 @@ func TestInvalidProperties(t *testing.T) {
 		{property: "splunk.discovery.invalid", expectedError: "invalid property \"splunk.discovery.invalid\" (parsing error): splunk.discovery:1:18: unexpected token \"invalid\" (expected (\"receivers\" | \"extensions\") <dot> ComponentID <dot> ((\"config\" <dot>) | \"enabled\") (<string> | <dot> | <forwardslash>)*)"},
 		{property: "splunk.discovery.extensions.config.one.two", expectedError: "invalid property \"splunk.discovery.extensions.config.one.two\" (parsing error): splunk.discovery:1:43: unexpected token \"<EOF>\" (expected <dot> ((\"config\" <dot>) | \"enabled\") (<string> | <dot> | <forwardslash>)*)"},
 		{property: "splunk.discovery.receivers.type/name.config", expectedError: "invalid property \"splunk.discovery.receivers.type/name.config\" (parsing error): splunk.discovery:1:44: unexpected token \"<EOF>\" (expected <dot>)"},
+		{property: "splunk.discovery.extensions.extension--0-1-with-config-in-type-_x64__x86_🙈🙉🙊4:000x0;;0;;0;;-___-----type/e/x/t/e%ns<i>o<=n=>nam/e-with-config.config.o::n::e.config", expectedError: "invalid receiver type \"extension--0-1-with-config-in-type-_x64__x86_🙈🙉🙊4:000x0;;0;;0;;-___-----type\": invalid character(s) in type \"extension--0-1-with-config-in-type-_x64__x86_🙈🙉🙊4:000x0;;0;;0;;-___-----type\""},
 	} {
 		t.Run(tt.property, func(t *testing.T) {
 			p, err := NewProperty(tt.property, "val")
 			require.Error(t, err)
 			require.EqualError(t, err, tt.expectedError)
 			require.Nil(t, p)
-		})
-	}
-	for _, tt := range []struct {
-		property, expectedError string
-	}{
-		{property: "splunk.discovery.extensions.extension--0-1-with-config-in-type-_x64__x86_🙈🙉🙊4:000x0;;0;;0;;-___-----type/e/x/t/e%ns<i>o<=n=>nam/e-with-config.config.o::n::e.config", expectedError: `invalid character(s) in type "extension--0-1-with-config-in-type-_x64__x86_🙈🙉🙊4:000x0;;0;;0;;-___-----type"`},
-	} {
-		t.Run(tt.property, func(t *testing.T) {
-			require.PanicsWithError(t, tt.expectedError, func() { NewProperty(tt.property, "val") })
 		})
 	}
 }


### PR DESCRIPTION
To avoid collector crashes. We don't control the input in most of the cases