### PR TITLE
sanitize docs

### DIFF
--- a/docs/getting-started/linux-installer.md
+++ b/docs/getting-started/linux-installer.md
@@ -6,7 +6,7 @@ For non-containerized Linux environments, an installer script is available. The
 script deploys and configures:
 
 - Splunk OpenTelemetry Collector for Linux (**x86_64/amd64 and aarch64/arm64 platforms only**)
-- [SignalFx Smart Agent and collectd bundle](https://github.com/signalfx/signalfx-agent/releases) (**x86_64/amd64 platforms only**)
+- [collectd bundle](https://github.com/signalfx/splunk-otel-collector/blob/main/internal/signalfx-agent/bundle/README.md)
 - Log Collection with [Fluentd (via the TD Agent)](https://www.fluentd.org/)
   - Optional, **disabled** by default
   - See the [Fluentd Configuration](#fluentd-configuration) section for additional information, including how to enable installation for [supported platforms](#supported-platforms).

--- a/internal/signalfx-agent/bundle/python/sfxmonitor/__main__.py
+++ b/internal/signalfx-agent/bundle/python/sfxmonitor/__main__.py
@@ -28,7 +28,7 @@ def run():
     logger.addHandler(PipeLogHandler(output_writer))
 
     runner = Runner(input_reader, output_writer)
-    logger.info("Starting up SignalFx Python monitor runner (python: %s)", sys.executable)
+    logger.info("Starting up Python monitor runner (python: %s)", sys.executable)
     runner.process()
 
 

--- a/pkg/extension/smartagentextension/README.md
+++ b/pkg/extension/smartagentextension/README.md
@@ -1,7 +1,4 @@
-# SignalFx Smart Agent Extension
-
-> **Note:** The SignalFx Smart Agent extension is only supported on x86_64/amd64 platforms.  Support for arm64
-> platforms is currently **experimental**.
+# Smart Agent Extension
 
 The `smartagent` extension provides a mechanism to specify config options that are not
 just specific to a single instance of the [Smart Agent Receiver](../../receiver/smartagentreceiver/README.md) but are applicable to
@@ -10,7 +7,7 @@ all instances.  This component provides a means of migrating your existing
 to the Splunk Distribution of OpenTelemetry Collector.
 
 As the Smart Agent Receiver doesn't provide 1:1 functional parity with the SignalFx Smart Agent in itself,
-only a subset of existing configuration fields are supported by the Smart Agent Extension at this time:
+only a subset of existing configuration fields are supported by the Smart Agent Extension:
 
 1. The `bundleDir` field refers to the path of a supported Smart Agent release bundle.  The
 x86_64/amd64 Splunk Distribution of OpenTelemetry Collector packages include the agent bundle, and their installers

--- a/pkg/receiver/smartagentreceiver/README.md
+++ b/pkg/receiver/smartagentreceiver/README.md
@@ -1,15 +1,17 @@
-# SignalFx Smart Agent Receiver
+# Smart Agent Receiver
 
-> **Note:** The SignalFx Smart Agent receiver is fully supported only on x86_64/amd64 platforms. Support for arm64
-> platforms is currently **experimental**.
+This receiver allows to use monitors.
 
-The Smart Agent Receiver lets you use [SignalFx Smart Agent monitors](https://github.com/signalfx/signalfx-agent#monitors)
-in the [Splunk Distribution of OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector). Many
-monitors also require a [Smart Agent release bundle](https://github.com/signalfx/signalfx-agent/releases/latest),
-which is installed by the Splunk Distribution of OpenTelemetry Collector on supported x86_64/amd64 platforms.
+Monitors collect metrics from the host system and services. They are configured under the monitors list in the agent config. For application-specific monitors, you can define discovery rules in your monitor configuration. A separate monitor instance is created for each discovered instance of applications that match a discovery rule. See [Auto Discovery](https://github.com/signalfx/signalfx-agent/blob/main/docs/auto-discovery.md) for more information.
+
+Many of the monitors are built around [collectd](https://collectd.org/), an open source third-party monitor, and use it to collect metrics. Some other monitors do not use collectd. However, either type is configured in the same way.
+
+For a list of supported monitors and their configurations, see [Monitor Config](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md).
+
+The agent is primarily intended to monitor services/applications running on the same host as the agent. This is in keeping with the collectd model. The main issue with monitoring services on other hosts is that the host dimension that collectd sets on all metrics will currently get set to the hostname of the machine that the agent is running on. This allows everything to have a consistent host dimension so that metrics can be matched to a specific machine during metric analysis.
 
 See the
-[migration guide](../../../docs/signalfx-smart-agent-migration.md)
+[migration guide](https://docs.splunk.com/observability/en/gdi/opentelemetry/smart-agent/smart-agent-migration-to-otel-collector.html)
 for more information about migrating from the Smart Agent to the Splunk Distribution of the OpenTelemetry Collector.
 
 **Beta: All Smart Agent monitors are supported by Splunk. Configuration and behavior may change without notice.**


### PR DESCRIPTION
Remove mention of SignalFx when possible, inline docs from the signalfx agent repository, link to docs rather than an empty repository docs page.