### PR TITLE
Update default config to have only one otlp exporter

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -131,7 +131,7 @@ exporters:
     endpoint: "${SPLUNK_TRACE_URL}"
     headers:
       "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"
-    # Use instead when sending to gateway
+    # When sending to gateway use
     #endpoint: "${SPLUNK_GATEWAY_URL}:4317"
     #tls:
     #  insecure: true

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -131,6 +131,10 @@ exporters:
     endpoint: "${SPLUNK_TRACE_URL}"
     headers:
       "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"
+    # Use instead when sending to gateway
+    #endpoint: "${SPLUNK_GATEWAY_URL}:4317"
+    #tls:
+    #  insecure: true
   # Metrics + Events
   signalfx:
     access_token: "${SPLUNK_ACCESS_TOKEN}"
@@ -153,11 +157,6 @@ exporters:
     token: "${SPLUNK_ACCESS_TOKEN}"
     endpoint: "${SPLUNK_INGEST_URL}/v1/log"
     log_data_enabled: false
-  # Send to gateway
-  otlp/gateway:
-    endpoint: "${SPLUNK_GATEWAY_URL}:4317"
-    tls:
-      insecure: true
   # Debug
   debug:
     verbosity: detailed
@@ -176,14 +175,10 @@ service:
       - resourcedetection
       #- resource/add_environment
       exporters: [otlp, signalfx]
-      # Use instead when sending to gateway
-      #exporters: [otlp/gateway, signalfx]
     metrics:
       receivers: [hostmetrics, otlp, signalfx, smartagent/signalfx-forwarder]
       processors: [memory_limiter, batch, resourcedetection]
       exporters: [signalfx]
-      # Use instead when sending to gateway
-      #exporters: [otlp/gateway]
     metrics/internal:
       receivers: [prometheus/internal]
       processors: [memory_limiter, batch, resourcedetection]
@@ -202,5 +197,3 @@ service:
       - resourcedetection
       #- resource/add_environment
       exporters: [splunk_hec, splunk_hec/profiling]
-      # Use instead when sending to gateway
-      #exporters: [otlp/gateway]

--- a/tests/general/default_config_test.go
+++ b/tests/general/default_config_test.go
@@ -247,12 +247,6 @@ func TestDefaultAgentConfig(t *testing.T) {
 					"debug": map[string]any{
 						"verbosity": "detailed",
 					},
-					"otlp/gateway": map[string]any{
-						"endpoint": ":4317",
-						"tls": map[string]any{
-							"insecure": true,
-						},
-					},
 					"otlp": map[string]any{
 						"headers": map[string]any{
 							"X-SF-Token": "<redacted>",


### PR DESCRIPTION
Remove an exporter that is not being used. Having one point for switching to gateway seems more convenient.
