### PR TITLE
[receiver/discovery] Combine matching conditions with different statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### 🛑 Breaking changes 🛑
 
-- (Splunk) `receiver/discovery`: Remove `severity_text` field from log evaluation statements. ([#4583](https://github.com/signalfx/splunk-otel-collector/pull/4583))
+- (Splunk) `receiver/discovery`: Update metrics and logs evaluation statements schema:
+  - Remove `severity_text` field from log evaluation statements ([#4583](https://github.com/signalfx/splunk-otel-collector/pull/4583))
+  - Combine matching conditions with different statuses in one list ([#4588](https://github.com/signalfx/splunk-otel-collector/pull/4588))
 
 ## v0.97.0
 

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/mysql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/mysql.discovery.yaml
@@ -18,26 +18,26 @@
 #       password: splunk.discovery.default
 #   status:
 #     metrics:
-#       successful:
-#         - strict: mysql.locks
-#           first_only: true
-#           log_record:
-#             body: Mysql receiver is working!
+#       - status: successful
+#         strict: mysql.locks
+#         first_only: true
+#         log_record:
+#           body: Mysql receiver is working!
 #     statements:
-#       failed:
-#         - regexp: "Can't connect to MySQL server on .* [(]111[)]"
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
-#       partial:
-#         - regexp: 'Access denied for user'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Make sure your user credentials are correctly specified using the
-#               `--set splunk.discovery.receivers.mysql.config.username="<username>"` and
-#               `--set splunk.discovery.receivers.mysql.config.password="<password>"` command or the
-#               `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_username="<username>"` and
-#               `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_password="<password>"` environment variables.
+#       - status: failed
+#         regexp: "Can't connect to MySQL server on .* [(]111[)]"
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
+#       - status: partial
+#         regexp: 'Access denied for user'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Make sure your user credentials are correctly specified using the
+#             `--set splunk.discovery.receivers.mysql.config.username="<username>"` and
+#             `--set splunk.discovery.receivers.mysql.config.password="<password>"` command or the
+#             `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_username="<username>"` and
+#             `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_password="<password>"` environment variables.

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/oracledb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/oracledb.discovery.yaml
@@ -19,50 +19,53 @@
 #       service: splunk.discovery.default
 #   status:
 #     metrics:
-#       successful:
-#         - strict: oracledb.cpu_time
-#           first_only: true
-#           log_record:
-#             body: oracledb receiver is working!
+#       - status: successful
+#         strict: oracledb.cpu_time
+#         first_only: true
+#         log_record:
+#           body: oracledb receiver is working!
 #     statements:
-#       failed:
-#         - regexp: "connection refused"
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: The container is not serving http connections.
-#         - regexp: "received goaway and there are no active streams"
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: Unable to connect and scrape metrics.
-#         - regexp: "dial tcp: lookup"
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: Unable to resolve oracledb tcp endpoint
-#         - regexp: 'error executing select .*: EOF'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: Unable to execute select from oracledb. Verify endpoint and user permissions. 
-#       partial:
-#         - regexp: "listener does not currently know of service requested"
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Make sure your oracledb service is correctly specified using the
-#               `--set splunk.discovery.receivers.oracledb.config.service="<service>"` command or the
-#               `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_service="<service>"` environment variable. 
-#         - regexp: 'invalid username/password'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Make sure your user credentials are correctly specified using the
-#               `--set splunk.discovery.receivers.oracledb.config.username="<username>"` and
-#               `--set splunk.discovery.receivers.oracledb.config.password="<password>"` command or the
-#               `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_username="<username>"` and
-#               `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_password="<password>"` environment variables.
-#               
+#       - status: failed
+#         regexp: "connection refused"
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: The container is not serving http connections.
+#       - status: failed
+#         regexp: "received goaway and there are no active streams"
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: Unable to connect and scrape metrics.
+#       - status: failed
+#         regexp: "dial tcp: lookup"
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: Unable to resolve oracledb tcp endpoint
+#       - status: failed
+#         regexp: 'error executing select .*: EOF'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: Unable to execute select from oracledb. Verify endpoint and user permissions.
+#       - status: partial
+#         regexp: "listener does not currently know of service requested"
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Make sure your oracledb service is correctly specified using the
+#             `--set splunk.discovery.receivers.oracledb.config.service="<service>"` command or the
+#             `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_service="<service>"` environment variable.
+#       - status: partial
+#         regexp: 'invalid username/password'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Make sure your user credentials are correctly specified using the
+#             `--set splunk.discovery.receivers.oracledb.config.username="<username>"` and
+#             `--set splunk.discovery.receivers.oracledb.config.password="<password>"` command or the
+#             `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_username="<username>"` and
+#             `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_password="<password>"` environment variables.

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/postgresql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/postgresql.discovery.yaml
@@ -18,59 +18,63 @@
 #         password: splunk.discovery.default
 #   status:
 #     metrics:
-#       successful:
-#         - strict: postgresql.commits
-#           first_only: true
-#           log_record:
-#             body: PostgreSQL receiver is working!
+#       - status: successful
+#         strict: postgresql.commits
+#         first_only: true
+#         log_record:
+#           body: PostgreSQL receiver is working!
 #     statements:
-#       failed:
-#         - regexp: 'connect: network is unreachable'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: The container cannot be reached by the Collector. Make sure they're in the same network.
-#         - regexp: 'connect: connection refused'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: The container is refusing PostgreSQL connections.
-#       partial:
-#         - regexp: 'pq: password authentication failed for user'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Please ensure your user credentials are correctly specified with
-#               `--set splunk.discovery.receivers.postgresql.config.username="<username>"` and
-#               `--set splunk.discovery.receivers.postgresql.config.password="<password>"` or
-#               `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_username="<username>"` and
-#               `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_password="<password>"` environment variables.
-#         - regexp: 'pq: database .* does not exist'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Make sure the target database is correctly specified using the
-#               `--set splunk.discovery.receivers.postgresql.config.databases="[<db>]"` command or the
-#               `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_databases="[<db>]"` environment variable.
-#         - regexp: 'pq: SSL is not enabled on the server'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Make sure the target database has SSL enabled or set insecure using the
-#               `--set splunk.discovery.receivers.postgresql.config.tls::insecure="<boolean>"` command or the
-#               `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_tls_x3a__x3a_insecure="<boolean>"` environment variable.
-#         - regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Make sure your PostgreSQL database has
-#               `shared_preload_libraries = 'pg_stat_statements'`
-#               in the postgresql.conf file and that
-#               `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-#               has been run for each database you would like to monitor.
-#               For example:
-#               `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`
+#       - status: failed
+#         regexp: 'connect: network is unreachable'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: The container cannot be reached by the Collector. Make sure they're in the same network.
+#       - status: failed
+#         regexp: 'connect: connection refused'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: The container is refusing PostgreSQL connections.
+#       - status: partial
+#         regexp: 'pq: password authentication failed for user'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Please ensure your user credentials are correctly specified with
+#             `--set splunk.discovery.receivers.postgresql.config.username="<username>"` and
+#             `--set splunk.discovery.receivers.postgresql.config.password="<password>"` or
+#             `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_username="<username>"` and
+#             `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_password="<password>"` environment variables.
+#       - status: partial
+#         regexp: 'pq: database .* does not exist'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Make sure the target database is correctly specified using the
+#             `--set splunk.discovery.receivers.postgresql.config.databases="[<db>]"` command or the
+#             `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_databases="[<db>]"` environment variable.
+#       - status: partial
+#         regexp: 'pq: SSL is not enabled on the server'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Make sure the target database has SSL enabled or set insecure using the
+#             `--set splunk.discovery.receivers.postgresql.config.tls::insecure="<boolean>"` command or the
+#             `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_tls_x3a__x3a_insecure="<boolean>"` environment variable.
+#       - status: partial
+#         regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Make sure your PostgreSQL database has
+#             `shared_preload_libraries = 'pg_stat_statements'`
+#             in the postgresql.conf file and that
+#             `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+#             has been run for each database you would like to monitor.
+#             For example:
+#             `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/redis.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/redis.discovery.yaml
@@ -16,54 +16,58 @@
 #     default: {}
 #   status:
 #     metrics:
-#       successful:
-#         - strict: redis.uptime
-#           first_only: true
-#           log_record:
-#             body: redis receiver is working!
+#       - status: successful
+#         strict: redis.uptime
+#         first_only: true
+#         log_record:
+#           body: redis receiver is working!
 #     statements:
-#       failed:
-#         - regexp: "connection refused"
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: The container is not serving http connections.
-#         - regexp: "received goaway and there are no active streams"
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: Unable to connect and scrape metrics.
-#         - regexp: "dial tcp: lookup"
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: Unable to resolve redis tcp endpoint
-#       partial: 
-#         - regexp: 'NOAUTH Authentication required.'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Make sure your user credentials are correctly specified using the
-#               `--set splunk.discovery.receivers.redis.config.password="<password>"` and 
-#               `--set splunk.discovery.receivers.redis.config.username="<username>"` commands or the
-#               `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` and 
-#               `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variables.
-#         - regexp: 'called without any password configured for the default user'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Make sure your user credentials are correctly specified using the
-#               `--set splunk.discovery.receivers.redis.config.password="<password>"` command or the
-#               `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variables.      
-#         - regexp: 'WRONGPASS invalid username-password pair or user is disabled'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Make sure your user credentials are correctly specified using the
-#               `--set splunk.discovery.receivers.redis.config.password="<password>"` and 
-#               `--set splunk.discovery.receivers.redis.config.username="<username>"` commands or the
-#               `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` and 
-#               `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variables.           
+#       - status: failed
+#         regexp: "connection refused"
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: The container is not serving http connections.
+#       - status: failed
+#         regexp: "received goaway and there are no active streams"
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: Unable to connect and scrape metrics.
+#       - status: failed
+#         regexp: "dial tcp: lookup"
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: Unable to resolve redis tcp endpoint
+#       - status: partial
+#         regexp: 'NOAUTH Authentication required.'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Make sure your user credentials are correctly specified using the
+#             `--set splunk.discovery.receivers.redis.config.password="<password>"` and
+#             `--set splunk.discovery.receivers.redis.config.username="<username>"` commands or the
+#             `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` and
+#             `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variables.
+#       - status: partial
+#         regexp: 'called without any password configured for the default user'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Make sure your user credentials are correctly specified using the
+#             `--set splunk.discovery.receivers.redis.config.password="<password>"` command or the
+#             `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variables.
+#       - status: partial
+#         regexp: 'WRONGPASS invalid username-password pair or user is disabled'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Make sure your user credentials are correctly specified using the
+#             `--set splunk.discovery.receivers.redis.config.password="<password>"` and
+#             `--set splunk.discovery.receivers.redis.config.username="<username>"` commands or the
+#             `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` and
+#             `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variables.

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-collectd-mysql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-collectd-mysql.discovery.yaml
@@ -22,42 +22,44 @@
 #       isolatedCollectd: true
 #   status:
 #     metrics:
-#       successful:
-#         - strict: mysql_octets.rx
-#           first_only: true
-#           log_record:
-#             body: smartagent/collectd/mysql receiver is working!
+#       - status: successful
+#         strict: mysql_octets.rx
+#         first_only: true
+#         log_record:
+#           body: smartagent/collectd/mysql receiver is working!
 #     statements:
-#       failed:
-#         - regexp: "mysql plugin: Failed to connect to database .* at server .* Can't connect to MySQL server on .* [(]111[)]"
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: The container is refusing MySQL connections.
-#       partial:
-#         - regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* [(]using password: .*[)]'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Make sure your user credentials are correctly specified using the
-#               `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.username="<username>"` and
-#               `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.password="<password>"` command or the
-#               `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_username="<username>"` and
-#               `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_password="<password>"` environment variables.
-#         - regexp: 'mysql plugin: Failed to connect to database .* at server .* Unknown database'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Make sure your MySQL databases are correctly specified using the
-#               `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` command or the
-#               `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.
-#         - regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* to database'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Make sure your MySQL databases and auth information are correctly specified using the
-#               `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` command or the
-#               `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.
+#       - status: failed
+#         regexp: "mysql plugin: Failed to connect to database .* at server .* Can't connect to MySQL server on .* [(]111[)]"
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: The container is refusing MySQL connections.
+#       - status: partial
+#         regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* [(]using password: .*[)]'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Make sure your user credentials are correctly specified using the
+#             `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.username="<username>"` and
+#             `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.password="<password>"` command or the
+#             `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_username="<username>"` and
+#             `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_password="<password>"` environment variables.
+#       - status: partial
+#         regexp: 'mysql plugin: Failed to connect to database .* at server .* Unknown database'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Make sure your MySQL databases are correctly specified using the
+#             `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` command or the
+#             `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.
+#       - status: partial
+#         regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* to database'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Make sure your MySQL databases and auth information are correctly specified using the
+#             `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` command or the
+#             `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-collectd-nginx.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-collectd-nginx.discovery.yaml
@@ -20,20 +20,21 @@
 #       isolatedCollectd: true
 #   status:
 #     metrics:
-#       successful:
-#         - strict: connections.accepted
-#           first_only: true
-#           log_record:
-#             body: smartagent/collectd/nginx receiver is working!
+#       - status: successful
+#         strict: connections.accepted
+#         first_only: true
+#         log_record:
+#           body: smartagent/collectd/nginx receiver is working!
 #     statements:
-#       failed:
-#         - regexp: "nginx plugin: curl_easy_perform failed: Operation timed out after"
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: The container is not serving http connections.
-#         - regexp: "read-function of plugin .* failed"
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: The integration is unable to read metrics from this endpoint.
+#       - status: failed
+#         regexp: "nginx plugin: curl_easy_perform failed: Operation timed out after"
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: The container is not serving http connections.
+#       - status: failed
+#         regexp: "read-function of plugin .* failed"
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: The integration is unable to read metrics from this endpoint.

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-postgresql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-postgresql.discovery.yaml
@@ -22,61 +22,64 @@
 #       masterDBName: splunk.discovery.default
 #   status:
 #     metrics:
-#       successful:
-#         - strict: postgres_query_count
-#           first_only: true
-#           log_record:
-#             body: PostgreSQL receiver is working!
-#       partial:
-#         - strict: postgres_rows_inserted
-#           first_only: true
-#           log_record:
-#             body: >-
-#               Make sure that
-#               `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-#               has been run for each database you would like to monitor.
-#               For example:
-#               `psql --dbname "<db-name>" -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"`
+#       - status: successful
+#         strict: postgres_query_count
+#         first_only: true
+#         log_record:
+#           body: PostgreSQL receiver is working!
+#       - status: partial
+#         strict: postgres_rows_inserted
+#         first_only: true
+#         log_record:
+#           body: >-
+#             Make sure that
+#             `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+#             has been run for each database you would like to monitor.
+#             For example:
+#             `psql --dbname "<db-name>" -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"`
 #     statements:
-#       failed:
-#         - regexp: 'connect: network is unreachable'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: The container cannot be reached by the Collector. Make sure they're in the same network.
-#         - regexp: 'connect: connection refused'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: The container is refusing PostgreSQL connections.
-#       partial:
-#         - regexp: 'pq: password authentication failed for user'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Please ensure your user credentials are correctly specified with
-#               `--set splunk.discovery.receivers.smartagent/postgresql.config.params::username="<username>"` and
-#               `--set splunk.discovery.receivers.smartagent/postgresql.config.params::password="<password>"` or
-#               `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_username="<username>"` and
-#               `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_password="<password>"` environment variables.
-#         - regexp: 'pq: database .* does not exist'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Make sure the target database is correctly specified using the
-#               `--set splunk.discovery.receivers.smartagent/postgresql.config.masterDBName="<db>"` command or the
-#               `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_masterDBName="<db>"` environment variable.
-#         - regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
-#           first_only: true
-#           log_record:
-#             append_pattern: true
-#             body: >-
-#               Make sure your PostgreSQL database has
-#               `shared_preload_libraries = 'pg_stat_statements'`
-#               in the postgresql.conf file and that
-#               `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-#               has been run for each database you would like to monitor.
-#               For example:
-#               `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`
+#       - status: failed
+#         regexp: 'connect: network is unreachable'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: The container cannot be reached by the Collector. Make sure they're in the same network.
+#       - status: failed
+#         regexp: 'connect: connection refused'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: The container is refusing PostgreSQL connections.
+#       - status: partial
+#         regexp: 'pq: password authentication failed for user'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Please ensure your user credentials are correctly specified with
+#             `--set splunk.discovery.receivers.smartagent/postgresql.config.params::username="<username>"` and
+#             `--set splunk.discovery.receivers.smartagent/postgresql.config.params::password="<password>"` or
+#             `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_username="<username>"` and
+#             `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_password="<password>"` environment variables.
+#       - status: partial
+#         regexp: 'pq: database .* does not exist'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Make sure the target database is correctly specified using the
+#             `--set splunk.discovery.receivers.smartagent/postgresql.config.masterDBName="<db>"` command or the
+#             `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_masterDBName="<db>"` environment variable.
+#       - status: partial
+#         regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
+#         first_only: true
+#         log_record:
+#           append_pattern: true
+#           body: >-
+#             Make sure your PostgreSQL database has
+#             `shared_preload_libraries = 'pg_stat_statements'`
+#             in the postgresql.conf file and that
+#             `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+#             has been run for each database you would like to monitor.
+#             For example:
+#             `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`

--- a/internal/common/discovery/discovery.go
+++ b/internal/common/discovery/discovery.go
@@ -53,6 +53,9 @@ var allowedStatuses = func() map[StatusType]struct{} {
 }()
 
 func IsValidStatus(status StatusType) (bool, error) {
+	if status == "" {
+		return false, fmt.Errorf("status cannot be empty")
+	}
 	if _, ok := allowedStatuses[status]; !ok {
 		return false, fmt.Errorf("invalid status %q. must be one of %v", status, StatusTypes)
 	}

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml
@@ -14,26 +14,26 @@ mysql:
       password: splunk.discovery.default
   status:
     metrics:
-      successful:
-        - strict: mysql.locks
-          first_only: true
-          log_record:
-            body: Mysql receiver is working!
+      - status: successful
+        strict: mysql.locks
+        first_only: true
+        log_record:
+          body: Mysql receiver is working!
     statements:
-      failed:
-        - regexp: "Can't connect to MySQL server on .* [(]111[)]"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
-      partial:
-        - regexp: 'Access denied for user'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your user credentials are correctly specified using the
-              `--set splunk.discovery.receivers.mysql.config.username="<username>"` and
-              `--set splunk.discovery.receivers.mysql.config.password="<password>"` command or the
-              `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_username="<username>"` and
-              `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_password="<password>"` environment variables.
+      - status: failed
+        regexp: "Can't connect to MySQL server on .* [(]111[)]"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
+      - status: partial
+        regexp: 'Access denied for user'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your user credentials are correctly specified using the
+            `--set splunk.discovery.receivers.mysql.config.username="<username>"` and
+            `--set splunk.discovery.receivers.mysql.config.password="<password>"` command or the
+            `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_username="<username>"` and
+            `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_password="<password>"` environment variables.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml.tmpl
@@ -10,26 +10,26 @@
       password: {{ defaultValue }}
   status:
     metrics:
-      successful:
-        - strict: mysql.locks
-          first_only: true
-          log_record:
-            body: Mysql receiver is working!
+      - status: successful
+        strict: mysql.locks
+        first_only: true
+        log_record:
+          body: Mysql receiver is working!
     statements:
-      failed:
-        - regexp: "Can't connect to MySQL server on .* [(]111[)]"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
-      partial:
-        - regexp: 'Access denied for user'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your user credentials are correctly specified using the
-              `--set {{ configProperty "username" "<username>" }}` and
-              `--set {{ configProperty "password" "<password>" }}` command or the
-              `{{ configPropertyEnvVar "username" "<username>" }}` and
-              `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
+      - status: failed
+        regexp: "Can't connect to MySQL server on .* [(]111[)]"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
+      - status: partial
+        regexp: 'Access denied for user'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your user credentials are correctly specified using the
+            `--set {{ configProperty "username" "<username>" }}` and
+            `--set {{ configProperty "password" "<password>" }}` command or the
+            `{{ configPropertyEnvVar "username" "<username>" }}` and
+            `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml
@@ -15,50 +15,53 @@ oracledb:
       service: splunk.discovery.default
   status:
     metrics:
-      successful:
-        - strict: oracledb.cpu_time
-          first_only: true
-          log_record:
-            body: oracledb receiver is working!
+      - status: successful
+        strict: oracledb.cpu_time
+        first_only: true
+        log_record:
+          body: oracledb receiver is working!
     statements:
-      failed:
-        - regexp: "connection refused"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container is not serving http connections.
-        - regexp: "received goaway and there are no active streams"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: Unable to connect and scrape metrics.
-        - regexp: "dial tcp: lookup"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: Unable to resolve oracledb tcp endpoint
-        - regexp: 'error executing select .*: EOF'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: Unable to execute select from oracledb. Verify endpoint and user permissions. 
-      partial:
-        - regexp: "listener does not currently know of service requested"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your oracledb service is correctly specified using the
-              `--set splunk.discovery.receivers.oracledb.config.service="<service>"` command or the
-              `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_service="<service>"` environment variable. 
-        - regexp: 'invalid username/password'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your user credentials are correctly specified using the
-              `--set splunk.discovery.receivers.oracledb.config.username="<username>"` and
-              `--set splunk.discovery.receivers.oracledb.config.password="<password>"` command or the
-              `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_username="<username>"` and
-              `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_password="<password>"` environment variables.
-              
+      - status: failed
+        regexp: "connection refused"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container is not serving http connections.
+      - status: failed
+        regexp: "received goaway and there are no active streams"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: Unable to connect and scrape metrics.
+      - status: failed
+        regexp: "dial tcp: lookup"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: Unable to resolve oracledb tcp endpoint
+      - status: failed
+        regexp: 'error executing select .*: EOF'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: Unable to execute select from oracledb. Verify endpoint and user permissions.
+      - status: partial
+        regexp: "listener does not currently know of service requested"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your oracledb service is correctly specified using the
+            `--set splunk.discovery.receivers.oracledb.config.service="<service>"` command or the
+            `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_service="<service>"` environment variable.
+      - status: partial
+        regexp: 'invalid username/password'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your user credentials are correctly specified using the
+            `--set splunk.discovery.receivers.oracledb.config.username="<username>"` and
+            `--set splunk.discovery.receivers.oracledb.config.password="<password>"` command or the
+            `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_username="<username>"` and
+            `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_password="<password>"` environment variables.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml.tmpl
@@ -11,50 +11,53 @@
       service: {{ defaultValue }}
   status:
     metrics:
-      successful:
-        - strict: oracledb.cpu_time
-          first_only: true
-          log_record:
-            body: oracledb receiver is working!
+      - status: successful
+        strict: oracledb.cpu_time
+        first_only: true
+        log_record:
+          body: oracledb receiver is working!
     statements:
-      failed:
-        - regexp: "connection refused"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container is not serving http connections.
-        - regexp: "received goaway and there are no active streams"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: Unable to connect and scrape metrics.
-        - regexp: "dial tcp: lookup"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: Unable to resolve oracledb tcp endpoint
-        - regexp: 'error executing select .*: EOF'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: Unable to execute select from oracledb. Verify endpoint and user permissions. 
-      partial:
-        - regexp: "listener does not currently know of service requested"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your oracledb service is correctly specified using the
-              `--set {{ configProperty "service" "<service>" }}` command or the
-              `{{ configPropertyEnvVar "service" "<service>" }}` environment variable. 
-        - regexp: 'invalid username/password'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your user credentials are correctly specified using the
-              `--set {{ configProperty "username" "<username>" }}` and
-              `--set {{ configProperty "password" "<password>" }}` command or the
-              `{{ configPropertyEnvVar "username" "<username>" }}` and
-              `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
-              
+      - status: failed
+        regexp: "connection refused"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container is not serving http connections.
+      - status: failed
+        regexp: "received goaway and there are no active streams"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: Unable to connect and scrape metrics.
+      - status: failed
+        regexp: "dial tcp: lookup"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: Unable to resolve oracledb tcp endpoint
+      - status: failed
+        regexp: 'error executing select .*: EOF'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: Unable to execute select from oracledb. Verify endpoint and user permissions.
+      - status: partial
+        regexp: "listener does not currently know of service requested"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your oracledb service is correctly specified using the
+            `--set {{ configProperty "service" "<service>" }}` command or the
+            `{{ configPropertyEnvVar "service" "<service>" }}` environment variable.
+      - status: partial
+        regexp: 'invalid username/password'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your user credentials are correctly specified using the
+            `--set {{ configProperty "username" "<username>" }}` and
+            `--set {{ configProperty "password" "<password>" }}` command or the
+            `{{ configPropertyEnvVar "username" "<username>" }}` and
+            `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml
@@ -14,59 +14,63 @@ postgresql:
         password: splunk.discovery.default
   status:
     metrics:
-      successful:
-        - strict: postgresql.commits
-          first_only: true
-          log_record:
-            body: PostgreSQL receiver is working!
+      - status: successful
+        strict: postgresql.commits
+        first_only: true
+        log_record:
+          body: PostgreSQL receiver is working!
     statements:
-      failed:
-        - regexp: 'connect: network is unreachable'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container cannot be reached by the Collector. Make sure they're in the same network.
-        - regexp: 'connect: connection refused'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container is refusing PostgreSQL connections.
-      partial:
-        - regexp: 'pq: password authentication failed for user'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Please ensure your user credentials are correctly specified with
-              `--set splunk.discovery.receivers.postgresql.config.username="<username>"` and
-              `--set splunk.discovery.receivers.postgresql.config.password="<password>"` or
-              `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_username="<username>"` and
-              `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_password="<password>"` environment variables.
-        - regexp: 'pq: database .* does not exist'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure the target database is correctly specified using the
-              `--set splunk.discovery.receivers.postgresql.config.databases="[<db>]"` command or the
-              `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_databases="[<db>]"` environment variable.
-        - regexp: 'pq: SSL is not enabled on the server'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure the target database has SSL enabled or set insecure using the
-              `--set splunk.discovery.receivers.postgresql.config.tls::insecure="<boolean>"` command or the
-              `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_tls_x3a__x3a_insecure="<boolean>"` environment variable.
-        - regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your PostgreSQL database has
-              `shared_preload_libraries = 'pg_stat_statements'`
-              in the postgresql.conf file and that
-              `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-              has been run for each database you would like to monitor.
-              For example:
-              `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`
+      - status: failed
+        regexp: 'connect: network is unreachable'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container cannot be reached by the Collector. Make sure they're in the same network.
+      - status: failed
+        regexp: 'connect: connection refused'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container is refusing PostgreSQL connections.
+      - status: partial
+        regexp: 'pq: password authentication failed for user'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Please ensure your user credentials are correctly specified with
+            `--set splunk.discovery.receivers.postgresql.config.username="<username>"` and
+            `--set splunk.discovery.receivers.postgresql.config.password="<password>"` or
+            `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_username="<username>"` and
+            `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_password="<password>"` environment variables.
+      - status: partial
+        regexp: 'pq: database .* does not exist'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure the target database is correctly specified using the
+            `--set splunk.discovery.receivers.postgresql.config.databases="[<db>]"` command or the
+            `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_databases="[<db>]"` environment variable.
+      - status: partial
+        regexp: 'pq: SSL is not enabled on the server'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure the target database has SSL enabled or set insecure using the
+            `--set splunk.discovery.receivers.postgresql.config.tls::insecure="<boolean>"` command or the
+            `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_tls_x3a__x3a_insecure="<boolean>"` environment variable.
+      - status: partial
+        regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your PostgreSQL database has
+            `shared_preload_libraries = 'pg_stat_statements'`
+            in the postgresql.conf file and that
+            `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+            has been run for each database you would like to monitor.
+            For example:
+            `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml.tmpl
@@ -10,59 +10,63 @@
         password: {{ defaultValue }}
   status:
     metrics:
-      successful:
-        - strict: postgresql.commits
-          first_only: true
-          log_record:
-            body: PostgreSQL receiver is working!
+      - status: successful
+        strict: postgresql.commits
+        first_only: true
+        log_record:
+          body: PostgreSQL receiver is working!
     statements:
-      failed:
-        - regexp: 'connect: network is unreachable'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container cannot be reached by the Collector. Make sure they're in the same network.
-        - regexp: 'connect: connection refused'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container is refusing PostgreSQL connections.
-      partial:
-        - regexp: 'pq: password authentication failed for user'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Please ensure your user credentials are correctly specified with
-              `--set {{ configProperty "username" "<username>" }}` and
-              `--set {{ configProperty "password" "<password>" }}` or
-              `{{ configPropertyEnvVar "username" "<username>" }}` and
-              `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
-        - regexp: 'pq: database .* does not exist'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure the target database is correctly specified using the
-              `--set {{ configProperty "databases" "[<db>]" }}` command or the
-              `{{ configPropertyEnvVar "databases" "[<db>]" }}` environment variable.
-        - regexp: 'pq: SSL is not enabled on the server'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure the target database has SSL enabled or set insecure using the
-              `--set {{ configProperty "tls::insecure" "<boolean>" }}` command or the
-              `{{ configPropertyEnvVar "tls::insecure" "<boolean>" }}` environment variable.
-        - regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your PostgreSQL database has
-              `shared_preload_libraries = 'pg_stat_statements'`
-              in the postgresql.conf file and that
-              `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-              has been run for each database you would like to monitor.
-              For example:
-              `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`
+      - status: failed
+        regexp: 'connect: network is unreachable'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container cannot be reached by the Collector. Make sure they're in the same network.
+      - status: failed
+        regexp: 'connect: connection refused'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container is refusing PostgreSQL connections.
+      - status: partial
+        regexp: 'pq: password authentication failed for user'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Please ensure your user credentials are correctly specified with
+            `--set {{ configProperty "username" "<username>" }}` and
+            `--set {{ configProperty "password" "<password>" }}` or
+            `{{ configPropertyEnvVar "username" "<username>" }}` and
+            `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
+      - status: partial
+        regexp: 'pq: database .* does not exist'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure the target database is correctly specified using the
+            `--set {{ configProperty "databases" "[<db>]" }}` command or the
+            `{{ configPropertyEnvVar "databases" "[<db>]" }}` environment variable.
+      - status: partial
+        regexp: 'pq: SSL is not enabled on the server'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure the target database has SSL enabled or set insecure using the
+            `--set {{ configProperty "tls::insecure" "<boolean>" }}` command or the
+            `{{ configPropertyEnvVar "tls::insecure" "<boolean>" }}` environment variable.
+      - status: partial
+        regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your PostgreSQL database has
+            `shared_preload_libraries = 'pg_stat_statements'`
+            in the postgresql.conf file and that
+            `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+            has been run for each database you would like to monitor.
+            For example:
+            `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml
@@ -12,54 +12,58 @@ redis:
     default: {}
   status:
     metrics:
-      successful:
-        - strict: redis.uptime
-          first_only: true
-          log_record:
-            body: redis receiver is working!
+      - status: successful
+        strict: redis.uptime
+        first_only: true
+        log_record:
+          body: redis receiver is working!
     statements:
-      failed:
-        - regexp: "connection refused"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container is not serving http connections.
-        - regexp: "received goaway and there are no active streams"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: Unable to connect and scrape metrics.
-        - regexp: "dial tcp: lookup"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: Unable to resolve redis tcp endpoint
-      partial: 
-        - regexp: 'NOAUTH Authentication required.'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your user credentials are correctly specified using the
-              `--set splunk.discovery.receivers.redis.config.password="<password>"` and 
-              `--set splunk.discovery.receivers.redis.config.username="<username>"` commands or the
-              `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` and 
-              `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variables.
-        - regexp: 'called without any password configured for the default user'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your user credentials are correctly specified using the
-              `--set splunk.discovery.receivers.redis.config.password="<password>"` command or the
-              `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variables.      
-        - regexp: 'WRONGPASS invalid username-password pair or user is disabled'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your user credentials are correctly specified using the
-              `--set splunk.discovery.receivers.redis.config.password="<password>"` and 
-              `--set splunk.discovery.receivers.redis.config.username="<username>"` commands or the
-              `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` and 
-              `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variables.           
+      - status: failed
+        regexp: "connection refused"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container is not serving http connections.
+      - status: failed
+        regexp: "received goaway and there are no active streams"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: Unable to connect and scrape metrics.
+      - status: failed
+        regexp: "dial tcp: lookup"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: Unable to resolve redis tcp endpoint
+      - status: partial
+        regexp: 'NOAUTH Authentication required.'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your user credentials are correctly specified using the
+            `--set splunk.discovery.receivers.redis.config.password="<password>"` and
+            `--set splunk.discovery.receivers.redis.config.username="<username>"` commands or the
+            `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` and
+            `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variables.
+      - status: partial
+        regexp: 'called without any password configured for the default user'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your user credentials are correctly specified using the
+            `--set splunk.discovery.receivers.redis.config.password="<password>"` command or the
+            `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variables.
+      - status: partial
+        regexp: 'WRONGPASS invalid username-password pair or user is disabled'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your user credentials are correctly specified using the
+            `--set splunk.discovery.receivers.redis.config.password="<password>"` and
+            `--set splunk.discovery.receivers.redis.config.username="<username>"` commands or the
+            `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` and
+            `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variables.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml.tmpl
@@ -8,54 +8,58 @@
     default: {}
   status:
     metrics:
-      successful:
-        - strict: redis.uptime
-          first_only: true
-          log_record:
-            body: redis receiver is working!
+      - status: successful
+        strict: redis.uptime
+        first_only: true
+        log_record:
+          body: redis receiver is working!
     statements:
-      failed:
-        - regexp: "connection refused"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container is not serving http connections.
-        - regexp: "received goaway and there are no active streams"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: Unable to connect and scrape metrics.
-        - regexp: "dial tcp: lookup"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: Unable to resolve redis tcp endpoint
-      partial: 
-        - regexp: 'NOAUTH Authentication required.'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your user credentials are correctly specified using the
-              `--set {{ configProperty "password" "<password>" }}` and 
-              `--set {{ configProperty "username" "<username>" }}` commands or the
-              `{{ configPropertyEnvVar "password" "<password>" }}` and 
-              `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
-        - regexp: 'called without any password configured for the default user'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your user credentials are correctly specified using the
-              `--set {{ configProperty "password" "<password>" }}` command or the
-              `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.      
-        - regexp: 'WRONGPASS invalid username-password pair or user is disabled'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your user credentials are correctly specified using the
-              `--set {{ configProperty "password" "<password>" }}` and 
-              `--set {{ configProperty "username" "<username>" }}` commands or the
-              `{{ configPropertyEnvVar "password" "<password>" }}` and 
-              `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.           
+      - status: failed
+        regexp: "connection refused"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container is not serving http connections.
+      - status: failed
+        regexp: "received goaway and there are no active streams"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: Unable to connect and scrape metrics.
+      - status: failed
+        regexp: "dial tcp: lookup"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: Unable to resolve redis tcp endpoint
+      - status: partial
+        regexp: 'NOAUTH Authentication required.'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your user credentials are correctly specified using the
+            `--set {{ configProperty "password" "<password>" }}` and
+            `--set {{ configProperty "username" "<username>" }}` commands or the
+            `{{ configPropertyEnvVar "password" "<password>" }}` and
+            `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
+      - status: partial
+        regexp: 'called without any password configured for the default user'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your user credentials are correctly specified using the
+            `--set {{ configProperty "password" "<password>" }}` command or the
+            `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
+      - status: partial
+        regexp: 'WRONGPASS invalid username-password pair or user is disabled'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your user credentials are correctly specified using the
+            `--set {{ configProperty "password" "<password>" }}` and
+            `--set {{ configProperty "username" "<username>" }}` commands or the
+            `{{ configPropertyEnvVar "password" "<password>" }}` and
+            `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml
@@ -18,42 +18,44 @@ smartagent/collectd/mysql:
       isolatedCollectd: true
   status:
     metrics:
-      successful:
-        - strict: mysql_octets.rx
-          first_only: true
-          log_record:
-            body: smartagent/collectd/mysql receiver is working!
+      - status: successful
+        strict: mysql_octets.rx
+        first_only: true
+        log_record:
+          body: smartagent/collectd/mysql receiver is working!
     statements:
-      failed:
-        - regexp: "mysql plugin: Failed to connect to database .* at server .* Can't connect to MySQL server on .* [(]111[)]"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container is refusing MySQL connections.
-      partial:
-        - regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* [(]using password: .*[)]'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your user credentials are correctly specified using the
-              `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.username="<username>"` and
-              `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.password="<password>"` command or the
-              `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_username="<username>"` and
-              `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_password="<password>"` environment variables.
-        - regexp: 'mysql plugin: Failed to connect to database .* at server .* Unknown database'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your MySQL databases are correctly specified using the
-              `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` command or the
-              `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.
-        - regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* to database'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your MySQL databases and auth information are correctly specified using the
-              `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` command or the
-              `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.
+      - status: failed
+        regexp: "mysql plugin: Failed to connect to database .* at server .* Can't connect to MySQL server on .* [(]111[)]"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container is refusing MySQL connections.
+      - status: partial
+        regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* [(]using password: .*[)]'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your user credentials are correctly specified using the
+            `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.username="<username>"` and
+            `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.password="<password>"` command or the
+            `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_username="<username>"` and
+            `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_password="<password>"` environment variables.
+      - status: partial
+        regexp: 'mysql plugin: Failed to connect to database .* at server .* Unknown database'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your MySQL databases are correctly specified using the
+            `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` command or the
+            `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.
+      - status: partial
+        regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* to database'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your MySQL databases and auth information are correctly specified using the
+            `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` command or the
+            `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml.tmpl
@@ -14,42 +14,44 @@
       isolatedCollectd: true
   status:
     metrics:
-      successful:
-        - strict: mysql_octets.rx
-          first_only: true
-          log_record:
-            body: smartagent/collectd/mysql receiver is working!
+      - status: successful
+        strict: mysql_octets.rx
+        first_only: true
+        log_record:
+          body: smartagent/collectd/mysql receiver is working!
     statements:
-      failed:
-        - regexp: "mysql plugin: Failed to connect to database .* at server .* Can't connect to MySQL server on .* [(]111[)]"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container is refusing MySQL connections.
-      partial:
-        - regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* [(]using password: .*[)]'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your user credentials are correctly specified using the
-              `--set {{ configProperty "username" "<username>" }}` and
-              `--set {{ configProperty "password" "<password>" }}` command or the
-              `{{ configPropertyEnvVar "username" "<username>" }}` and
-              `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
-        - regexp: 'mysql plugin: Failed to connect to database .* at server .* Unknown database'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your MySQL databases are correctly specified using the
-              `--set {{ configProperty "databases" "[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]" }}` command or the
-              `{{ configPropertyEnvVar "databases" "[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]" }}` environment variable.
-        - regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* to database'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your MySQL databases and auth information are correctly specified using the
-              `--set {{ configProperty "databases" "[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]" }}` command or the
-              `{{ configPropertyEnvVar "databases" "[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]" }}` environment variable.
+      - status: failed
+        regexp: "mysql plugin: Failed to connect to database .* at server .* Can't connect to MySQL server on .* [(]111[)]"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container is refusing MySQL connections.
+      - status: partial
+        regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* [(]using password: .*[)]'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your user credentials are correctly specified using the
+            `--set {{ configProperty "username" "<username>" }}` and
+            `--set {{ configProperty "password" "<password>" }}` command or the
+            `{{ configPropertyEnvVar "username" "<username>" }}` and
+            `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
+      - status: partial
+        regexp: 'mysql plugin: Failed to connect to database .* at server .* Unknown database'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your MySQL databases are correctly specified using the
+            `--set {{ configProperty "databases" "[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]" }}` command or the
+            `{{ configPropertyEnvVar "databases" "[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]" }}` environment variable.
+      - status: partial
+        regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* to database'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your MySQL databases and auth information are correctly specified using the
+            `--set {{ configProperty "databases" "[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]" }}` command or the
+            `{{ configPropertyEnvVar "databases" "[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]" }}` environment variable.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-nginx.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-nginx.discovery.yaml
@@ -16,20 +16,21 @@ smartagent/collectd/nginx:
       isolatedCollectd: true
   status:
     metrics:
-      successful:
-        - strict: connections.accepted
-          first_only: true
-          log_record:
-            body: smartagent/collectd/nginx receiver is working!
+      - status: successful
+        strict: connections.accepted
+        first_only: true
+        log_record:
+          body: smartagent/collectd/nginx receiver is working!
     statements:
-      failed:
-        - regexp: "nginx plugin: curl_easy_perform failed: Operation timed out after"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container is not serving http connections.
-        - regexp: "read-function of plugin .* failed"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The integration is unable to read metrics from this endpoint.
+      - status: failed
+        regexp: "nginx plugin: curl_easy_perform failed: Operation timed out after"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container is not serving http connections.
+      - status: failed
+        regexp: "read-function of plugin .* failed"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The integration is unable to read metrics from this endpoint.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-nginx.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-nginx.discovery.yaml.tmpl
@@ -12,20 +12,21 @@
       isolatedCollectd: true
   status:
     metrics:
-      successful:
-        - strict: connections.accepted
-          first_only: true
-          log_record:
-            body: smartagent/collectd/nginx receiver is working!
+      - status: successful
+        strict: connections.accepted
+        first_only: true
+        log_record:
+          body: smartagent/collectd/nginx receiver is working!
     statements:
-      failed:
-        - regexp: "nginx plugin: curl_easy_perform failed: Operation timed out after"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container is not serving http connections.
-        - regexp: "read-function of plugin .* failed"
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The integration is unable to read metrics from this endpoint.
+      - status: failed
+        regexp: "nginx plugin: curl_easy_perform failed: Operation timed out after"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container is not serving http connections.
+      - status: failed
+        regexp: "read-function of plugin .* failed"
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The integration is unable to read metrics from this endpoint.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml
@@ -18,61 +18,64 @@ smartagent/postgresql:
       masterDBName: splunk.discovery.default
   status:
     metrics:
-      successful:
-        - strict: postgres_query_count
-          first_only: true
-          log_record:
-            body: PostgreSQL receiver is working!
-      partial:
-        - strict: postgres_rows_inserted
-          first_only: true
-          log_record:
-            body: >-
-              Make sure that
-              `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-              has been run for each database you would like to monitor.
-              For example:
-              `psql --dbname "<db-name>" -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"`
+      - status: successful
+        strict: postgres_query_count
+        first_only: true
+        log_record:
+          body: PostgreSQL receiver is working!
+      - status: partial
+        strict: postgres_rows_inserted
+        first_only: true
+        log_record:
+          body: >-
+            Make sure that
+            `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+            has been run for each database you would like to monitor.
+            For example:
+            `psql --dbname "<db-name>" -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"`
     statements:
-      failed:
-        - regexp: 'connect: network is unreachable'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container cannot be reached by the Collector. Make sure they're in the same network.
-        - regexp: 'connect: connection refused'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container is refusing PostgreSQL connections.
-      partial:
-        - regexp: 'pq: password authentication failed for user'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Please ensure your user credentials are correctly specified with
-              `--set splunk.discovery.receivers.smartagent/postgresql.config.params::username="<username>"` and
-              `--set splunk.discovery.receivers.smartagent/postgresql.config.params::password="<password>"` or
-              `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_username="<username>"` and
-              `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_password="<password>"` environment variables.
-        - regexp: 'pq: database .* does not exist'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure the target database is correctly specified using the
-              `--set splunk.discovery.receivers.smartagent/postgresql.config.masterDBName="<db>"` command or the
-              `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_masterDBName="<db>"` environment variable.
-        - regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your PostgreSQL database has
-              `shared_preload_libraries = 'pg_stat_statements'`
-              in the postgresql.conf file and that
-              `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-              has been run for each database you would like to monitor.
-              For example:
-              `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`
+      - status: failed
+        regexp: 'connect: network is unreachable'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container cannot be reached by the Collector. Make sure they're in the same network.
+      - status: failed
+        regexp: 'connect: connection refused'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container is refusing PostgreSQL connections.
+      - status: partial
+        regexp: 'pq: password authentication failed for user'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Please ensure your user credentials are correctly specified with
+            `--set splunk.discovery.receivers.smartagent/postgresql.config.params::username="<username>"` and
+            `--set splunk.discovery.receivers.smartagent/postgresql.config.params::password="<password>"` or
+            `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_username="<username>"` and
+            `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_password="<password>"` environment variables.
+      - status: partial
+        regexp: 'pq: database .* does not exist'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure the target database is correctly specified using the
+            `--set splunk.discovery.receivers.smartagent/postgresql.config.masterDBName="<db>"` command or the
+            `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_masterDBName="<db>"` environment variable.
+      - status: partial
+        regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your PostgreSQL database has
+            `shared_preload_libraries = 'pg_stat_statements'`
+            in the postgresql.conf file and that
+            `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+            has been run for each database you would like to monitor.
+            For example:
+            `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml.tmpl
@@ -14,61 +14,64 @@
       masterDBName: {{ defaultValue }}
   status:
     metrics:
-      successful:
-        - strict: postgres_query_count
-          first_only: true
-          log_record:
-            body: PostgreSQL receiver is working!
-      partial:
-        - strict: postgres_rows_inserted
-          first_only: true
-          log_record:
-            body: >-
-              Make sure that
-              `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-              has been run for each database you would like to monitor.
-              For example:
-              `psql --dbname "<db-name>" -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"`
+      - status: successful
+        strict: postgres_query_count
+        first_only: true
+        log_record:
+          body: PostgreSQL receiver is working!
+      - status: partial
+        strict: postgres_rows_inserted
+        first_only: true
+        log_record:
+          body: >-
+            Make sure that
+            `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+            has been run for each database you would like to monitor.
+            For example:
+            `psql --dbname "<db-name>" -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"`
     statements:
-      failed:
-        - regexp: 'connect: network is unreachable'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container cannot be reached by the Collector. Make sure they're in the same network.
-        - regexp: 'connect: connection refused'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: The container is refusing PostgreSQL connections.
-      partial:
-        - regexp: 'pq: password authentication failed for user'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Please ensure your user credentials are correctly specified with
-              `--set {{ configProperty "params" "username" "<username>" }}` and
-              `--set {{ configProperty "params" "password" "<password>" }}` or
-              `{{ configPropertyEnvVar "params" "username" "<username>" }}` and
-              `{{ configPropertyEnvVar "params" "password" "<password>" }}` environment variables.
-        - regexp: 'pq: database .* does not exist'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure the target database is correctly specified using the
-              `--set {{ configProperty "masterDBName" "<db>" }}` command or the
-              `{{ configPropertyEnvVar "masterDBName" "<db>" }}` environment variable.
-        - regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
-          first_only: true
-          log_record:
-            append_pattern: true
-            body: >-
-              Make sure your PostgreSQL database has
-              `shared_preload_libraries = 'pg_stat_statements'`
-              in the postgresql.conf file and that
-              `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-              has been run for each database you would like to monitor.
-              For example:
-              `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`
+      - status: failed
+        regexp: 'connect: network is unreachable'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container cannot be reached by the Collector. Make sure they're in the same network.
+      - status: failed
+        regexp: 'connect: connection refused'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: The container is refusing PostgreSQL connections.
+      - status: partial
+        regexp: 'pq: password authentication failed for user'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Please ensure your user credentials are correctly specified with
+            `--set {{ configProperty "params" "username" "<username>" }}` and
+            `--set {{ configProperty "params" "password" "<password>" }}` or
+            `{{ configPropertyEnvVar "params" "username" "<username>" }}` and
+            `{{ configPropertyEnvVar "params" "password" "<password>" }}` environment variables.
+      - status: partial
+        regexp: 'pq: database .* does not exist'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure the target database is correctly specified using the
+            `--set {{ configProperty "masterDBName" "<db>" }}` command or the
+            `{{ configPropertyEnvVar "masterDBName" "<db>" }}` environment variable.
+      - status: partial
+        regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
+        first_only: true
+        log_record:
+          append_pattern: true
+          body: >-
+            Make sure your PostgreSQL database has
+            `shared_preload_libraries = 'pg_stat_statements'`
+            in the postgresql.conf file and that
+            `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+            has been run for each database you would like to monitor.
+            For example:
+            `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`

--- a/internal/receiver/discoveryreceiver/README.md
+++ b/internal/receiver/discoveryreceiver/README.md
@@ -151,23 +151,23 @@ receivers:
            // the metric or log statement
          status:
            metrics:
-             successful:
-               - regexp: '.*'
-                 // Only emit a single log record for this status entry instead of one for each matching received metric (`false`, the default)
-                 first_only: true
-                 log_record:
-                   body: Successfully able to connect to Redis container.
+             - status: successful
+               regexp: '.*'
+               // Only emit a single log record for this status entry instead of one for each matching received metric (`false`, the default)
+               first_only: true
+               log_record:
+                 body: Successfully able to connect to Redis container.
            statements:
-             partial:
-               - regexp: (WRONGPASS|NOAUTH|ERR AUTH)
-                 first_only: true
-                 log_record:
-                   body: Container appears to be accepting redis connections but the default auth setting is incorrect.
-             failed:
-               - regexp: ConnectionRefusedError
-                 first_only: true
-                 log_record:
-                   body: Container appears to not be accepting redis connections.
+             - status: partial
+               regexp: (WRONGPASS|NOAUTH|ERR AUTH)
+               first_only: true
+               log_record:
+                 body: Container appears to be accepting redis connections but the default auth setting is incorrect.
+             - status: failed
+               regexp: ConnectionRefusedError
+               first_only: true
+               log_record:
+                 body: Container appears to not be accepting redis connections.
 exporters:
   debug:
     verbosity: detailed

--- a/internal/receiver/discoveryreceiver/config.go
+++ b/internal/receiver/discoveryreceiver/config.go
@@ -70,20 +70,22 @@ type ReceiverEntry struct {
 }
 
 // Status defines the Match rules for applicable app and telemetry sources.
+// The first matching rule determines status of the endpoint.
 // At this time only Metrics and zap logger Statements status source types are supported.
 type Status struct {
-	Metrics    map[discovery.StatusType][]Match `mapstructure:"metrics"`
-	Statements map[discovery.StatusType][]Match `mapstructure:"statements"`
+	Metrics    []Match `mapstructure:"metrics"`
+	Statements []Match `mapstructure:"statements"`
 }
 
 // Match defines the rules for the desired match type and resulting log record
 // content emitted by the Discovery receiver
 type Match struct {
-	Record    *LogRecord `mapstructure:"log_record"`
-	Strict    string     `mapstructure:"strict"`
-	Regexp    string     `mapstructure:"regexp"`
-	Expr      string     `mapstructure:"expr"`
-	FirstOnly bool       `mapstructure:"first_only"`
+	Status    discovery.StatusType `mapstructure:"status"`
+	Record    *LogRecord           `mapstructure:"log_record"`
+	Strict    string               `mapstructure:"strict"`
+	Regexp    string               `mapstructure:"regexp"`
+	Expr      string               `mapstructure:"expr"`
+	FirstOnly bool                 `mapstructure:"first_only"`
 }
 
 // LogRecord is a definition of the desired plog.LogRecord content to emit for a match.
@@ -131,36 +133,34 @@ func (s *Status) validate() error {
 	}
 
 	if len(s.Metrics) == 0 && len(s.Statements) == 0 {
-		return fmt.Errorf("`status` must contain at least one `metrics` or `statements` mapping with at least one of %v", discovery.StatusTypes)
+		return fmt.Errorf("`status` must contain at least one `metrics` or `statements` list")
 	}
 
 	var err error
 	statusSources := []struct {
-		matches    map[discovery.StatusType][]Match
 		sourceType string
-	}{{s.Metrics, "metrics"}, {s.Statements, "statements"}}
+		matches    []Match
+	}{{"metrics", s.Metrics}, {"statements", s.Statements}}
 	for _, statusSource := range statusSources {
-		for statusType, statements := range statusSource.matches {
-			if ok, e := discovery.IsValidStatus(statusType); !ok {
-				err = multierr.Combine(err, e)
+		for _, statement := range statusSource.matches {
+			if ok, e := discovery.IsValidStatus(statement.Status); !ok {
+				err = multierr.Combine(err, fmt.Errorf(`"%s" status match validation failed: %w`, statusSource.sourceType, e))
 				continue
 			}
-			for _, logMatch := range statements {
-				var matchTypes []string
-				if logMatch.Strict != "" {
-					matchTypes = append(matchTypes, "strict")
-				}
-				if logMatch.Regexp != "" {
-					matchTypes = append(matchTypes, "regexp")
-				}
-				if logMatch.Expr != "" {
-					matchTypes = append(matchTypes, "expr")
-				}
-				if len(matchTypes) != 1 {
-					err = multierr.Combine(err, fmt.Errorf(
-						"`%s` status source type `%s` match type validation failed. Must provide one of %v but received %v", statusSource.sourceType, statusType, allowedMatchTypes, matchTypes,
-					))
-				}
+			var matchTypes []string
+			if statement.Strict != "" {
+				matchTypes = append(matchTypes, "strict")
+			}
+			if statement.Regexp != "" {
+				matchTypes = append(matchTypes, "regexp")
+			}
+			if statement.Expr != "" {
+				matchTypes = append(matchTypes, "expr")
+			}
+			if len(matchTypes) != 1 {
+				err = multierr.Combine(err, fmt.Errorf(
+					`"%s" status match validation failed. Must provide one of %v but received %v`, statusSource.sourceType, allowedMatchTypes, matchTypes,
+				))
 			}
 		}
 	}

--- a/internal/receiver/discoveryreceiver/config_test.go
+++ b/internal/receiver/discoveryreceiver/config_test.go
@@ -56,46 +56,43 @@ func TestValidConfig(t *testing.T) {
 					"type": "collectd/redis",
 				},
 				Status: &Status{
-					Metrics: map[discovery.StatusType][]Match{
-						discovery.Successful: {
-							Match{
-								Record: &LogRecord{
-									Attributes: map[string]string{
-										"attr_one": "attr_one_val",
-										"attr_two": "attr_two_val",
-									},
-									Body: "smartagent/redis receiver successful status",
+					Metrics: []Match{
+						{
+							Status: discovery.Successful,
+							Record: &LogRecord{
+								Attributes: map[string]string{
+									"attr_one": "attr_one_val",
+									"attr_two": "attr_two_val",
 								},
-								Strict:    "",
-								Regexp:    ".*",
-								Expr:      "",
-								FirstOnly: true,
+								Body: "smartagent/redis receiver successful status",
 							},
+							Strict:    "",
+							Regexp:    ".*",
+							Expr:      "",
+							FirstOnly: true,
 						},
 					},
-					Statements: map[discovery.StatusType][]Match{
-						discovery.Failed: {
-							{
-								Strict:    "",
-								Regexp:    "ConnectionRefusedError",
-								Expr:      "",
-								FirstOnly: true,
-								Record: &LogRecord{
-									Attributes: map[string]string{},
-									Body:       "container appears to not be accepting redis connections",
-								},
+					Statements: []Match{
+						{
+							Status:    discovery.Failed,
+							Strict:    "",
+							Regexp:    "ConnectionRefusedError",
+							Expr:      "",
+							FirstOnly: true,
+							Record: &LogRecord{
+								Attributes: map[string]string{},
+								Body:       "container appears to not be accepting redis connections",
 							},
 						},
-						discovery.Partial: {
-							{
-								Strict:    "",
-								Regexp:    "(WRONGPASS|NOAUTH|ERR AUTH)",
-								Expr:      "",
-								FirstOnly: false,
-								Record: &LogRecord{
-									Attributes: nil,
-									Body:       "desired log invalid auth log body",
-								},
+						{
+							Status:    discovery.Partial,
+							Strict:    "",
+							Regexp:    "(WRONGPASS|NOAUTH|ERR AUTH)",
+							Expr:      "",
+							FirstOnly: false,
+							Record: &LogRecord{
+								Attributes: nil,
+								Body:       "desired log invalid auth log body",
 							},
 						},
 					},
@@ -119,13 +116,13 @@ func TestValidConfig(t *testing.T) {
 }
 
 func TestInvalidConfigs(t *testing.T) {
-
 	tests := []struct{ name, expectedError string }{
 		{name: "no_watch_observers", expectedError: "`watch_observers` must be defined and include at least one configured observer extension"},
 		{name: "missing_status", expectedError: "receiver \"a_receiver\" validation failure: `status` must be defined and contain at least one `metrics` or `statements` mapping"},
+		{name: "missing_match_status", expectedError: "receiver \"a_receiver\" validation failure: \"metrics\" status match validation failed: status cannot be empty; \"statements\" status match validation failed: status cannot be empty"},
 		{name: "missing_status_metrics_and_statements", expectedError: "receiver \"a_receiver\" validation failure: `status` must be defined and contain at least one `metrics` or `statements` mapping"},
-		{name: "invalid_status_types", expectedError: `receiver "a_receiver" validation failure: invalid status "unsupported". must be one of [successful partial failed]; invalid status "another_unsupported". must be one of [successful partial failed]`},
-		{name: "multiple_status_match_types", expectedError: "receiver \"a_receiver\" validation failure: `metrics` status source type `successful` match type validation failed. Must provide one of [regexp strict expr] but received [strict regexp]; `statements` status source type `failed` match type validation failed. Must provide one of [regexp strict expr] but received [strict expr]"},
+		{name: "invalid_status_types", expectedError: `receiver "a_receiver" validation failure: "metrics" status match validation failed: invalid status "unsupported". must be one of [successful partial failed]; "statements" status match validation failed: invalid status "another_unsupported". must be one of [successful partial failed]`},
+		{name: "multiple_status_match_types", expectedError: "receiver \"a_receiver\" validation failure: \"metrics\" status match validation failed. Must provide one of [regexp strict expr] but received [strict regexp]; \"statements\" status match validation failed. Must provide one of [regexp strict expr] but received [strict expr]"},
 		{name: "reserved_receiver_creator", expectedError: `receiver "receiver_creator/with-name" validation failure: receiver cannot be a receiver_creator`},
 		{name: "reserved_receiver_name", expectedError: `receiver "a_receiver/with-receiver_creator/in-name" validation failure: receiver name cannot contain "receiver_creator/"`},
 		{name: "reserved_receiver_name_with_endpoint", expectedError: `receiver "receiver/with{endpoint=}/" validation failure: receiver name cannot contain "{endpoint=[^}]*}/"`},

--- a/internal/receiver/discoveryreceiver/metric_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator_test.go
@@ -67,6 +67,7 @@ func TestMetricEvaluation(t *testing.T) {
 				},
 			}
 			for _, status := range discovery.StatusTypes {
+				match.Status = status
 				t.Run(string(status), func(t *testing.T) {
 					for _, firstOnly := range []bool{true, false} {
 						match.FirstOnly = firstOnly
@@ -76,7 +77,7 @@ func TestMetricEvaluation(t *testing.T) {
 								Receivers: map[component.ID]ReceiverEntry{
 									component.MustNewIDWithName("a_receiver", "receiver.name"): {
 										Rule:   "a.rule",
-										Status: &Status{Metrics: map[discovery.StatusType][]Match{status: {match}}},
+										Status: &Status{Metrics: []Match{match}},
 									},
 								},
 								WatchObservers: []component.ID{observerID},

--- a/internal/receiver/discoveryreceiver/statement_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator_test.go
@@ -52,6 +52,7 @@ func TestStatementEvaluation(t *testing.T) {
 						},
 					}
 					for _, status := range discovery.StatusTypes {
+						match.Status = status
 						t.Run(string(status), func(t *testing.T) {
 							for _, firstOnly := range []bool{true, false} {
 								match.FirstOnly = firstOnly
@@ -61,7 +62,7 @@ func TestStatementEvaluation(t *testing.T) {
 										Receivers: map[component.ID]ReceiverEntry{
 											component.MustNewIDWithName("a_receiver", "receiver.name"): {
 												Rule:   "a.rule",
-												Status: &Status{Statements: map[discovery.StatusType][]Match{status: {match}}},
+												Status: &Status{Statements: []Match{match}},
 											},
 										},
 										WatchObservers: []component.ID{observerID},

--- a/internal/receiver/discoveryreceiver/testdata/config.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/config.yaml
@@ -17,23 +17,23 @@ discovery/discovery-name:
         receiver_attribute: receiver_attribute_value
       status:
         metrics:
-          successful:
-            - regexp: '.*'
-              first_only: true
-              log_record:
-                body: smartagent/redis receiver successful status
-                attributes:
-                  attr_one: attr_one_val
-                  attr_two: attr_two_val
+          - status: successful
+            regexp: '.*'
+            first_only: true
+            log_record:
+              body: smartagent/redis receiver successful status
+              attributes:
+                attr_one: attr_one_val
+                attr_two: attr_two_val
         statements:
-          failed:
-            - regexp: ConnectionRefusedError
-              first_only: true
-              log_record:
-                attributes: {}
-                body: container appears to not be accepting redis connections
-          partial:
-            - regexp: (WRONGPASS|NOAUTH|ERR AUTH)
-              first_only: false
-              log_record:
-                body: desired log invalid auth log body
+          - status: failed
+            regexp: ConnectionRefusedError
+            first_only: true
+            log_record:
+              attributes: {}
+              body: container appears to not be accepting redis connections
+          - status: partial
+            regexp: (WRONGPASS|NOAUTH|ERR AUTH)
+            first_only: false
+            log_record:
+              body: desired log invalid auth log body

--- a/internal/receiver/discoveryreceiver/testdata/invalid_status_types.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/invalid_status_types.yaml
@@ -6,8 +6,8 @@ discovery:
       rule: a rule
       status:
         metrics:
-          unsupported:
-            - regexp: '.*'
+          - status: unsupported
+            regexp: '.*'
         statements:
-          another_unsupported:
-            - regexp: '.*'
+          - status: another_unsupported
+            regexp: '.*'

--- a/internal/receiver/discoveryreceiver/testdata/missing_match_status.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/missing_match_status.yaml
@@ -2,9 +2,10 @@ discovery:
   watch_observers:
     - an_observer
   receivers:
-    receiver_creator/with-name:
+    a_receiver:
       rule: a rule
       status:
         metrics:
-          - status: successful
-            regexp: '.*'
+          - regexp: '.*'
+        statements:
+          - regexp: '.*'

--- a/internal/receiver/discoveryreceiver/testdata/multiple_status_match_types.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/multiple_status_match_types.yaml
@@ -6,10 +6,10 @@ discovery:
       rule: a rule
       status:
         metrics:
-          successful:
-            - regexp: 'a regex'
-              strict: 'a strict'
+          - status: successful
+            regexp: 'a regex'
+            strict: 'a strict'
         statements:
-          failed:
-            - strict: 'another strict'
-              expr: 'an expr'
+          - status: failed
+            strict: 'another strict'
+            expr: 'an expr'

--- a/internal/receiver/discoveryreceiver/testdata/reserved_receiver_name.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/reserved_receiver_name.yaml
@@ -6,5 +6,5 @@ discovery:
       rule: a rule
       status:
         metrics:
-          successful:
-            - regexp: '.*'
+          - status: successful
+            regexp: '.*'

--- a/internal/receiver/discoveryreceiver/testdata/reserved_receiver_name_with_endpoint.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/reserved_receiver_name_with_endpoint.yaml
@@ -6,5 +6,5 @@ discovery:
       rule: a rule
       status:
         metrics:
-          successful:
-            - regexp: '.*'
+          - status: successful
+            regexp: '.*'

--- a/tests/general/discoverymode/testdata/docker-observer-config.d/receivers/internal-prometheus.discovery.yaml
+++ b/tests/general/discoverymode/testdata/docker-observer-config.d/receivers/internal-prometheus.discovery.yaml
@@ -15,8 +15,8 @@ prometheus_simple:
         label_four: overwritten by env var property
   status:
     metrics:
-      successful:
-        - strict: prometheus_tsdb_time_retentions_total
-          first_only: true
-          log_record:
-            body: prometheus detected
+      - status: successful
+        strict: prometheus_tsdb_time_retentions_total
+        first_only: true
+        log_record:
+          body: prometheus detected

--- a/tests/general/discoverymode/testdata/host-observer-config.d/receivers/internal-prometheus.discovery.yaml
+++ b/tests/general/discoverymode/testdata/host-observer-config.d/receivers/internal-prometheus.discovery.yaml
@@ -18,8 +18,8 @@ prometheus_simple:
         label_two: ${LABEL_TWO_VALUE}
   status:
     metrics:
-      successful:
-        - strict: otelcol_process_uptime
-          first_only: true
-          log_record:
-            body: internal collector prometheus exporter detected
+      - status: successful
+        strict: otelcol_process_uptime
+        first_only: true
+        log_record:
+          body: internal collector prometheus exporter detected

--- a/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
+++ b/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
@@ -19,26 +19,28 @@ receivers:
           two.key: two.value
         status:
           metrics:
-            successful:
-                - regexp: ^otelcol_process_uptime$
-                  first_only: true
-                  log_record:
-                    body: Successfully connected to prometheus server
+            - status: successful
+              regexp: ^otelcol_process_uptime$
+              first_only: true
+              log_record:
+                body: Successfully connected to prometheus server
           statements:
-            failed:
-              # Only the first matching statement match will be logged
-              - strict: Failed to scrape Prometheus endpoint
-                first_only: true
-                log_record:
-                  body: (strict) Port appears to not be serving prometheus metrics
-              - regexp: '"message":"Failed to scrape Prometheus endpoint"'
-                first_only: true
-                log_record:
-                  body: (regexp) Port appears to not be serving prometheus metrics
-              - expr: message == 'Failed to scrape Prometheus endpoint' && target_labels contains 'up'
-                first_only: true
-                log_record:
-                  body: (expr) Port appears to not be serving prometheus metrics
+            # Only the first matching statement match will be applied
+            - status: failed
+              strict: Failed to scrape Prometheus endpoint
+              first_only: true
+              log_record:
+                body: (strict) Port appears to not be serving prometheus metrics
+            - status: failed
+              regexp: '"message":"Failed to scrape Prometheus endpoint"'
+              first_only: true
+              log_record:
+                body: (regexp) Port appears to not be serving prometheus metrics
+            - status: failed
+              expr: message == 'Failed to scrape Prometheus endpoint' && target_labels contains 'up'
+              first_only: true
+              log_record:
+                body: (expr) Port appears to not be serving prometheus metrics
 
     watch_observers:
       - host_observer


### PR DESCRIPTION
Define the status of match conditions as a field instead of a map key. This way, we make the status evaluation deterministic. The first matching rule defines the status of the discovery endpoint. Without this reorganization, it's unclear which status wins if matching rules with different statuses overlap.

For example the following configuration:
```
    receivers:
      prometheus_simple:
        rule: type == "hostport" and command contains "otelcol"
        resource_attributes:
          one.key: one.value
          two.key: two.value
        status:
          metrics:
            successful:
            - regexp: ^otelcol_process_uptime$
              first_only: true
              log_record:
                body: Successfully connected to prometheus server
```
must be changed to
```
    receivers:
      prometheus_simple:
        rule: type == "hostport" and command contains "otelcol"
        resource_attributes:
          one.key: one.value
          two.key: two.value
        status:
          metrics:
            - status: successful
              regexp: ^otelcol_process_uptime$
              first_only: true
              log_record:
                body: Successfully connected to prometheus server
```
