### PR TITLE
Cleanup configurations to use port 443

### DIFF
--- a/cmd/otelcol/config/collector/ecs_ec2_config.yaml
+++ b/cmd/otelcol/config/collector/ecs_ec2_config.yaml
@@ -123,7 +123,7 @@ processors:
 exporters:
   # Traces
   otlp:
-    endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com"
+    endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com:443"
     headers:
       "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"
   # Metrics + Events

--- a/cmd/otelcol/config/collector/fargate_config.yaml
+++ b/cmd/otelcol/config/collector/fargate_config.yaml
@@ -97,7 +97,7 @@ processors:
 exporters:
   # Traces
   otlp:
-    endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com"
+    endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com:443"
     headers:
       "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"
   # Metrics + Events


### PR DESCRIPTION
**Description:**
Explicitly set port 443 on grpc endpoints to make sure they are considered valid by gRPC framework
