### PR TITLE
Update triggers for msi-custom gitlab jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -433,6 +433,7 @@ build-msi:
       - dist/*.msi
 
 msi-custom-actions-package:
+  extends: .trigger-filter
   stage: package
   needs:
     - job: msi-custom-actions-assemblies
@@ -455,6 +456,7 @@ msi-custom-actions-package:
       - internal/buildscripts/packaging/msi/SplunkCustomActions/bin/Release/SplunkCustomActions.CA.dll
 
 msi-custom-actions-assemblies:
+  extends: .trigger-filter
   image: 'mcr.microsoft.com/dotnet/sdk:8.0'
   stage: package
   needs: []


### PR DESCRIPTION
Only trigger the `msi-custom-actions-package` and `msi-custom-actions-assemblies` gitlab jobs for main and releases.