### PR TITLE
Go 1.21.5 setup on Windows is taking too long, use default

### DIFF
--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -172,12 +172,6 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-
       - name: Setup NuGet
         uses: nuget/setup-nuget@v2.0.0
 


### PR DESCRIPTION
Setting up 1.21.5 is taking about 9 to 15 minutes, let's try to use the default, currently 1.21.8, since this only runs an integration test. 

Update: @atoulme just upgraded go version to 1.21.9, but, it seems reasonable to live this one with whatever is the default version on the runner.