### PR TITLE
[discovery] Apply entity events schema the discovery receiver logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Remove `severity_text` field from log evaluation statements ([#4583](https://github.com/signalfx/splunk-otel-collector/pull/4583))
   - Remove `first_only`  field from match struct. Events are always emitted only once for first matching metric or log statement ([#4593](https://github.com/signalfx/splunk-otel-collector/pull/4593))
   - Combine matching conditions with different statuses in one list ([#4588](https://github.com/signalfx/splunk-otel-collector/pull/4588))
+  - Apply entity events schema to the logs emitted by the receiver ([#4638](https://github.com/signalfx/splunk-otel-collector/pull/4638))
 
 ## v0.97.0
 

--- a/go.mod
+++ b/go.mod
@@ -530,7 +530,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr v0.97.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.97.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.97.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0.97.0 // indirect

--- a/internal/common/discovery/discovery.go
+++ b/internal/common/discovery/discovery.go
@@ -27,6 +27,12 @@ const (
 	ReceiverNameAttr   = "discovery.receiver.name"
 	ReceiverTypeAttr   = "discovery.receiver.type"
 	StatusAttr         = "discovery.status"
+	MessageAttr        = "discovery.message"
+
+	OtelEntityAttributesAttr = "otel.entity.attributes"
+	OtelEntityIDAttr         = "otel.entity.id"
+	OtelEntityEventTypeAttr  = "otel.entity.event.type"
+	OtelEntityEventTypeState = "entity_state"
 
 	DiscoExtensionsKey = "extensions/splunk.discovery"
 	DiscoReceiversKey  = "receivers/splunk.discovery"

--- a/internal/receiver/discoveryreceiver/metric_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator_test.go
@@ -110,15 +110,7 @@ func TestMetricEvaluation(t *testing.T) {
 					require.Equal(t, 1, emitted.LogRecordCount())
 
 					rl := emitted.ResourceLogs().At(0)
-					rAttrs = rl.Resource().Attributes()
-					require.Equal(t, map[string]any{
-						"discovery.endpoint.id":   "endpoint.id",
-						"discovery.event.type":    "metric.match",
-						"discovery.observer.id":   "an_observer/observer.name",
-						"discovery.receiver.name": "receiver.name",
-						"discovery.receiver.rule": "a.rule",
-						"discovery.receiver.type": "a_receiver",
-					}, rAttrs.AsRaw())
+					require.Equal(t, 0, rl.Resource().Attributes().Len())
 
 					sLogs := rl.ScopeLogs()
 					require.Equal(t, 1, sLogs.Len())
@@ -129,13 +121,23 @@ func TestMetricEvaluation(t *testing.T) {
 
 					lrAttrs := lr.Attributes()
 					require.Equal(t, map[string]any{
-						"discovery.status": string(status),
-						"metric.name":      "desired.name",
-						"one":              "one.value",
-						"two":              "two.value",
+						discovery.OtelEntityIDAttr: map[string]any{
+							"discovery.endpoint.id": "endpoint.id",
+						},
+						discovery.OtelEntityEventTypeAttr: discovery.OtelEntityEventTypeState,
+						discovery.OtelEntityAttributesAttr: map[string]any{
+							"discovery.event.type":    "metric.match",
+							"discovery.observer.id":   "an_observer/observer.name",
+							"discovery.receiver.name": "receiver.name",
+							"discovery.receiver.rule": "a.rule",
+							"discovery.receiver.type": "a_receiver",
+							"discovery.status":        string(status),
+							"discovery.message":       "desired body content",
+							"metric.name":             "desired.name",
+							"one":                     "one.value",
+							"two":                     "two.value",
+						},
 					}, lrAttrs.AsRaw())
-
-					require.Equal(t, "desired body content", lr.Body().AsString())
 				})
 			}
 		})

--- a/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
+++ b/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
@@ -1,5 +1,7 @@
 extensions:
   host_observer:
+  host_observer/with_name:
+  host_observer/with/another/name:
 
 receivers:
   # set up otlp receiver to use its endpoints as assertion material
@@ -38,6 +40,8 @@ receivers:
 
     watch_observers:
       - host_observer
+      - host_observer/with_name
+      - host_observer/with/another/name
 
 # drop scrape_timestamp attributes until we can accept arbitrary values
 processors:
@@ -60,6 +64,8 @@ service:
       level: debug
   extensions:
     - host_observer
+    - host_observer/with_name
+    - host_observer/with/another/name
   pipelines:
     metrics:
       receivers: [otlp]

--- a/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
+++ b/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
@@ -1,7 +1,5 @@
 extensions:
   host_observer:
-  host_observer/with_name:
-  host_observer/with/another/name:
 
 receivers:
   # set up otlp receiver to use its endpoints as assertion material
@@ -40,19 +38,15 @@ receivers:
 
     watch_observers:
       - host_observer
-      - host_observer/with_name
-      - host_observer/with/another/name
 
 # drop scrape_timestamp attributes until we can accept arbitrary values
 processors:
-  attributes:
-    actions:
-      - action: delete
-        key: scrape_timestamp
-      - action: delete
-        key: observed_timestamp
-      - action: delete
-        key: timestamp
+  transform:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        statements:
+          - delete_key(attributes["otel.entity.attributes"], "scrape_timestamp")
 
 exporters:
   otlp:
@@ -66,13 +60,11 @@ service:
       level: debug
   extensions:
     - host_observer
-    - host_observer/with_name
-    - host_observer/with/another/name
   pipelines:
     metrics:
       receivers: [otlp]
       exporters: [otlp]
     logs:
       receivers: [discovery]
-      processors: [attributes]
+      processors: [transform]
       exporters: [otlp]

--- a/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
+++ b/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
@@ -1,41 +1,44 @@
 resource_logs:
-  - attributes:
-      discovery.endpoint.id: (host_observer)[::]-8888-TCP-1
-      discovery.event.type: metric.match
-      discovery.observer.id: host_observer
-      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiIGFuZCBjb21tYW5kIGNvbnRhaW5zICJvdGVsY29sIgp3YXRjaF9vYnNlcnZlcnM6Ci0gaG9zdF9vYnNlcnZlcgo=
-      discovery.receiver.rule: type == "hostport" and command contains "otelcol"
-      discovery.receiver.type: prometheus_simple
-      http.scheme: http
-      net.host.port: "8888"
-      one.key: one.value
-      service.instance.id: '[::]:8888'
-      service.name: prometheus_simple/[::]:8888
-      two.key: two.value
-      service_instance_id: <ANY>
-      service_name: otelcol
-      service_version: <VERSION_FROM_BUILD>
-    scope_logs:
+  - scope_logs:
       - logs:
-          - body: Successfully connected to prometheus server
-            attributes:
-              discovery.status: successful
-              metric.name: otelcol_process_uptime
-
-  - attributes:
-      discovery.endpoint.id: (host_observer)[::]-4318-TCP-1
-      discovery.event.type: statement.match
-      discovery.observer.id: host_observer
-      discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiIGFuZCBjb21tYW5kIGNvbnRhaW5zICJvdGVsY29sIgp3YXRjaF9vYnNlcnZlcnM6Ci0gaG9zdF9vYnNlcnZlcgo=
-      discovery.receiver.name: ""
-      discovery.receiver.rule: type == "hostport" and command contains "otelcol"
-      discovery.receiver.type: prometheus_simple
-    scope_logs:
+          - attributes:
+              otel.entity.id:
+                discovery.endpoint.id: (host_observer)[::]-8888-TCP-1
+              otel.entity.event.type: entity_state
+              otel.entity.attributes:
+                discovery.event.type: metric.match
+                discovery.observer.id: host_observer
+                discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiIGFuZCBjb21tYW5kIGNvbnRhaW5zICJvdGVsY29sIgp3YXRjaF9vYnNlcnZlcnM6Ci0gaG9zdF9vYnNlcnZlcgo=
+                discovery.receiver.rule: type == "hostport" and command contains "otelcol"
+                discovery.receiver.type: prometheus_simple
+                http.scheme: http
+                net.host.port: "8888"
+                one.key: one.value
+                service.instance.id: '[::]:8888'
+                service.name: prometheus_simple/[::]:8888
+                two.key: two.value
+                service_instance_id: <ANY>
+                service_name: otelcol
+                service_version: <VERSION_FROM_BUILD>
+                discovery.status: successful
+                discovery.message: Successfully connected to prometheus server
+                metric.name: otelcol_process_uptime
+  - scope_logs:
       - logs:
-          - body: (strict) Port appears to not be serving prometheus metrics
-            attributes:
-              caller: <ANY>
-              discovery.status: failed
-              kind: receiver
-              name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer)[::]-4318-TCP-1
-              target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
+          - attributes:
+              otel.entity.id:
+                discovery.endpoint.id: (host_observer)[::]-4318-TCP-1
+              otel.entity.event.type: entity_state
+              otel.entity.attributes:
+                discovery.event.type: statement.match
+                discovery.observer.id: host_observer
+                discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiIGFuZCBjb21tYW5kIGNvbnRhaW5zICJvdGVsY29sIgp3YXRjaF9vYnNlcnZlcnM6Ci0gaG9zdF9vYnNlcnZlcgo=
+                discovery.receiver.name: ""
+                discovery.receiver.rule: type == "hostport" and command contains "otelcol"
+                discovery.receiver.type: prometheus_simple
+                caller: <ANY>
+                discovery.status: failed
+                discovery.message: (strict) Port appears to not be serving prometheus metrics
+                kind: receiver
+                name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer)[::]-4318-TCP-1
+                target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'


### PR DESCRIPTION
This change updates the schema of the logs emitted by the discovery receiver to represent entity events. No information is dropped, but it was reshuffled to adopt for the new schema:
- Entity ID is made of one key/value pair moved from `discovery.endpoint.id` resource attribute
- All other resource attributes are moved to the entity state event attributes
- Log body was moved to the `discovery.event.message` entity state attribute

The Discovery config provider is updated to use the entity events.

The keys used in the entity ID and entity attributes are not finalized and are expected to be changed in the following PRs.
