### PR TITLE
Add service environment helpers to the Windows support bundle

### DIFF
--- a/.github/workflows/scripts/win-test-support-bundle.ps1
+++ b/.github/workflows/scripts/win-test-support-bundle.ps1
@@ -19,6 +19,7 @@ Test-Path -Path "\tmp\splunk-support-bundle\metrics\free.txt"
 Test-Path -Path "\tmp\splunk-support-bundle\metrics\top.txt"
 Test-Path -Path "\tmp\splunk-support-bundle\zpages\tracez.html"
 Test-Path -Path "\tmp\splunk-support-bundle\config\${mode}_config.yaml"
+Test-Path -Path "\tmp\splunk-support-bundle\config\service_environment.txt"
 
 if ( "$with_fluentd" -eq "true" ) {
     Test-Path -Path "\tmp\splunk-support-bundle\logs\td-agent.log"

--- a/docker/kong/Dockerfile
+++ b/docker/kong/Dockerfile
@@ -1,4 +1,4 @@
-FROM kong/kong-gateway:3.5.0.2
+FROM kong/kong-gateway:3.6.1.2
 
 COPY kong.yml /kong/declarative/kong.yml
 

--- a/internal/buildscripts/packaging/msi/splunk-support-bundle.ps1
+++ b/internal/buildscripts/packaging/msi/splunk-support-bundle.ps1
@@ -125,12 +125,15 @@ function setServiceEnvironmentVariable($key, $value) {
 #######################################
 function getServiceEnvironment($output_file = $null) {
     Write-Output "INFO: Getting splunk-otel-collector service environment variables..."
-    $service_env = Get-ItemPropertyValue -Path $SVC_REGISTRY_KEY -Name "Environment" -ErrorAction SilentlyContinue
-    if (-NOT $service_env) {
-        Write-Output "ERROR: Could not find environment variables for splunk-otel-collector service."
-        return
+    $service_env = @()
+    try {
+        $service_env = Get-ItemPropertyValue -Path $SVC_REGISTRY_KEY -Name "Environment"
     }
-
+    catch {
+        Write-Output "ERROR: Could not find environment variables for splunk-otel-collector service: $($Error[0])"
+        $service_env = @()
+    }
+    
     foreach ($entry in $service_env) {
         $key, $value = $entry.Split("=", 2)
         if ($key.Contains("TOKEN", [System.StringComparison]::InvariantCultureIgnoreCase) -AND $value.Length -gt 0) {

--- a/internal/buildscripts/packaging/msi/splunk-support-bundle.ps1
+++ b/internal/buildscripts/packaging/msi/splunk-support-bundle.ps1
@@ -125,7 +125,12 @@ function setServiceEnvironmentVariable($key, $value) {
 #######################################
 function getServiceEnvironment($output_file = $null) {
     Write-Output "INFO: Getting splunk-otel-collector service environment variables..."
-    $service_env = Get-ItemPropertyValue -Path $SVC_REGISTRY_KEY -Name "Environment"
+    $service_env = Get-ItemPropertyValue -Path $SVC_REGISTRY_KEY -Name "Environment" -ErrorAction SilentlyContinue
+    if (-NOT $service_env) {
+        Write-Output "ERROR: Could not find environment variables for splunk-otel-collector service."
+        return
+    }
+
     foreach ($entry in $service_env) {
         $key, $value = $entry.Split("=", 2)
         if ($key.Contains("TOKEN", [System.StringComparison]::InvariantCultureIgnoreCase) -AND $value.Length -gt 0) {
@@ -369,6 +374,6 @@ $(getLogs) 2>&1 | Tee-Object -FilePath "$TMPDIR/stdout.log" -Append
 $(getMetrics) 2>&1 | Tee-Object -FilePath "$TMPDIR/stdout.log" -Append
 $(getZpages) 2>&1 | Tee-Object -FilePath "$TMPDIR/stdout.log" -Append
 $(getHostInfo) 2>&1 | Tee-Object -FilePath "$TMPDIR/stdout.log" -Append
-$(getServiceEnvironment("$TMPDIR/config/service_environment.txt")) 2>&1
+$(getServiceEnvironment("$TMPDIR/config/service_environment.txt")) 2>&1 `
     | Tee-Object -FilePath "$TMPDIR/stdout.log" -Append
 $(zipResults) 2>&1 | Tee-Object -FilePath "$TMPDIR/stdout.log" -Append

--- a/internal/buildscripts/packaging/msi/splunk-support-bundle.ps1
+++ b/internal/buildscripts/packaging/msi/splunk-support-bundle.ps1
@@ -136,7 +136,7 @@ function getServiceEnvironment($output_file = $null) {
     
     foreach ($entry in $service_env) {
         $key, $value = $entry.Split("=", 2)
-        if ($key.Contains("TOKEN", [System.StringComparison]::InvariantCultureIgnoreCase) -AND $value.Length -gt 0) {
+        if ($key.ToUpper().Contains("TOKEN") -AND $value.Length -gt 0) {
             $entry = "$key=********"
         }
 


### PR DESCRIPTION
**Description:**
Although the information itself is reported via the effective configuration this change adds a dedicated file showing what is set on the registry. It also adds a helper to set/modify a single environment variable at the service scope.

**Testing:**
Manual local testing.

**Documentation:**
Internal to the script.