### PR TITLE
MSI: delete config files from install dir

### DIFF
--- a/.github/workflows/scripts/win-test-services.ps1
+++ b/.github/workflows/scripts/win-test-services.ps1
@@ -78,13 +78,24 @@ if ("$with_fluentd" -eq "true") {
     }
 }
 
+$uninstallProperties = Get-ChildItem -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall" |
+    ForEach-Object { Get-ItemProperty $_.PSPath } |
+    Where-Object { $_.DisplayName -eq "Splunk OpenTelemetry Collector" }
 if ($with_msi_uninstall_comments -ne "") {
-    $uninstallProperties = Get-ChildItem -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall" |
-        ForEach-Object { Get-ItemProperty $_.PSPath } |
-        Where-Object { $_.DisplayName -eq "Splunk OpenTelemetry Collector" }
     if ($with_msi_uninstall_comments -ne $uninstallProperties.Comments) {
         throw "Uninstall Comments in registry are not properly set. Found: '$uninstallProperties.Comments', Expected '$with_msi_uninstall_comments'"
     } else {
         write-host "Uninstall Comments in registry are properly set."
     }
+}
+
+$installed_version = [Version]$uninstallProperties.DisplayVersion
+if ($installed_version -gt [Version]"0.97.0.0") {
+    if (Test-Path -Path "${Env:ProgramFiles}\Splunk\OpenTelemetry Collector\*_config.yaml") {
+        throw "Found config files in '${Env:ProgramFiles}\Splunk\OpenTelemetry Collector' these files should not be present"
+    }
+}
+
+If (!(Test-Path -Path "${Env:ProgramData}\Splunk\OpenTelemetry Collector\*_config.yaml")) {
+    throw "No config files found in ${Env:ProgramData}\Splunk\OpenTelemetry Collector these files are expected after the install"
 }

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -256,7 +256,10 @@ jobs:
           $msi_path = Resolve-Path .\dist\splunk-otel-collector*.msi
           Test-Path $msi_path
           Write-Host "Installing $msi_path ..."
-          Start-Process -FilePath "msiexec" -ArgumentList "/i `"$msi_path`" /qn /l* msi-install.log ${{ matrix.install-properties.install }}" -Wait 
+          $process = Start-Process -Wait -PassThru msiexec "/i `"$msi_path`" /qn /l*v msi-install.log ${{ matrix.install-properties.install }}"
+          if ($process.ExitCode -ne 0) {
+            throw "MSI installation failed with exit code $($process.ExitCode)"
+          }
 
       - name: "In case of failure: display the install logs"
         if: ${{ failure() }}
@@ -281,7 +284,13 @@ jobs:
 
       - name: Uninstall the collector
         run: |
-          Start-Process -FilePath "msiexec" -ArgumentList "/x {24E519F6-7F01-43DB-9E72-3B8AD8F065F4} /qn /l* msi-uninstall.log" -Wait
+          $ErrorActionPreference = 'Stop'
+          $uninstall_info = Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\uninstall\* | Where { $_.DisplayName -eq "Splunk OpenTelemetry Collector" }
+          Write-Host "Uninstalling $($uninstall_info.PSChildName) ..."
+          $process = Start-Process -Wait -PassThru msiexec "/x $($uninstall_info.PSChildName) /qn /l*v msi-uninstall.log"
+          if ($process.ExitCode -ne 0) {
+            throw "MSI installation failed with exit code $($process.ExitCode)"
+          }
 
       - name: Check no leftover on the registry
         run: |

--- a/internal/buildscripts/packaging/msi/splunk-otel-collector.wxs
+++ b/internal/buildscripts/packaging/msi/splunk-otel-collector.wxs
@@ -137,8 +137,10 @@
 
       <!-- Copy the default agent config file to ProgramData if it does not already exist -->
       <CustomAction Id="CopyConfig" ExeCommand="xcopy /y &quot;[INSTALLDIR]*_config.yaml&quot; &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\&quot;" Directory="INSTALLDIR" Impersonate="no" Execute="deferred" Return="check" />
+      <CustomAction Id="DeleteProgramFilesConfig" ExeCommand="cmd /c del /q &quot;[INSTALLDIR]*config.yaml&quot;" Directory="INSTALLDIR" Impersonate="no" Execute="deferred" Return="check" />
       <InstallExecuteSequence>
          <Custom Action="CopyConfig" After="InstallFiles">NOT CONFIG_FILE_EXISTS AND NOT Installed</Custom>
+         <Custom Action="DeleteProgramFilesConfig" After="CopyConfig">NOT Installed</Custom>
       </InstallExecuteSequence>
 
    </Product>


### PR DESCRIPTION
**Description:**
This was reported as confusing during Office hours and makes sense: the user sees the files there and thinks that those are the ones being used by the collector. Now the install only leaves the ProgramData ones.

**Testing:**
Manual validation.

**Documentation:**
N/A
