### PR TITLE
Add new component: SQL Server receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🚀 New components 🚀
+
+- (Splunk) Add SQL Server receiver
+
 ### 🛑 Breaking changes 🛑
 
 - (Splunk) `receiver/discovery`: Update metrics and logs evaluation statements schema:

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver v0.97.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver v0.97.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.97.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.97.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver v0.97.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.97.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.97.0

--- a/go.sum
+++ b/go.sum
@@ -1425,6 +1425,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecrece
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver v0.97.0/go.mod h1:xXX6qz7R9GKQy3OU/tO9it7ja4V8TvoYTiUN7UMm6VE=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.97.0 h1:/o+xhyntk1VbRBcR5KRsz6PBLIH8l8CG2mbfdUL+doA=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.97.0/go.mod h1:RO3V203iKCCS753WgwEdGEYK8GvU1rTUmbwL/9AmpaA=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.97.0 h1:2Qt85hoLKn4XbkDkdhxHHYyvPm5ngdUWoyo0TjQzYs8=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.97.0/go.mod h1:oF10K9+sACOJBt+w8s4hr1nvFipBMo4wZcB8bW69tk8=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver v0.97.0 h1:B0kiCYfzBSOLHXJQzYeakBcycpDJVirCkU8XQjUcdzo=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver v0.97.0/go.mod h1:KK7u7CWQd0Bgt5SL9pu1EnzC+aMv+4FZkQwqFKLfcU4=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.97.0 h1:6ed4O0uInCS7WxfpwFt4ZJ8cytVqno2bckGIzNe+qZ0=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -84,6 +84,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver"
@@ -183,6 +184,7 @@ func Get() (otelcol.Factories, error) {
 		solacereceiver.NewFactory(),
 		splunkhecreceiver.NewFactory(),
 		sqlqueryreceiver.NewFactory(),
+		sqlserverreceiver.NewFactory(),
 		sshcheckreceiver.NewFactory(),
 		statsdreceiver.NewFactory(),
 		syslogreceiver.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -80,6 +80,7 @@ func TestDefaultComponents(t *testing.T) {
 		"solace",
 		"splunk_hec",
 		"sqlquery",
+		"sqlserver",
 		"sshcheck",
 		"statsd",
 		"syslog",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This adds the SQL Server receiver to the Splunk distribution of the OpenTelemetry Collector.