### PR TITLE
[ktlo] Fix Ansible tests on Windows

### DIFF
--- a/deployments/ansible/molecule/custom_vars/windows-verify.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-verify.yml
@@ -120,7 +120,7 @@
 
     - name: Verify IIS env vars
       assert:
-        that: (item.key + '=' + item.value) in iis_env.value
+        that: (item.key + '=' + (item.value | string)) in iis_env.value
       loop: "{{ iis_reg_values | dict2items }}"
 
     - name: Get splunk-otel-collector service env vars
@@ -131,7 +131,7 @@
 
     - name: Verify splunk-otel-collector service env vars
       assert:
-        that: (item.key + '=' + item.value) in collector_env.value
+        that: (item.key + '=' + (item.value | string)) in collector_env.value
       loop: "{{ collector_reg_values | dict2items }}"
 
     - name: Verify env vars

--- a/deployments/ansible/molecule/default/windows-verify.yml
+++ b/deployments/ansible/molecule/default/windows-verify.yml
@@ -40,5 +40,5 @@
 
     - name: Verify splunk-otel-collector service env vars
       assert:
-        that: (item.key + '=' + item.value) in collector_env.value
+        that: (item.key + '=' + (item.value | string)) in collector_env.value
       loop: "{{ collector_reg_values | dict2items }}"

--- a/deployments/ansible/molecule/with_instrumentation/windows-verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation/windows-verify.yml
@@ -55,7 +55,7 @@
 
     - name: Verify IIS env vars
       assert:
-        that: (item.key + '=' + item.value) in iis_env.value
+        that: (item.key + '=' + (item.value | string)) in iis_env.value
       loop: "{{ iis_reg_values | dict2items }}"
 
     - name: Get splunk-otel-collector service env vars
@@ -66,7 +66,7 @@
 
     - name: Verify splunk-otel-collector service env vars
       assert:
-        that: (item.key + '=' + item.value) in collector_env.value
+        that: (item.key + '=' + (item.value | string)) in collector_env.value
       loop: "{{ collector_reg_values | dict2items }}"
 
     - name: Verify .NET tracing env vars were not added to the system


### PR DESCRIPTION
The addition of environment variable `SPLUNK_MEMORY_TOTAL_MIB=256` exposed a bug on the test code: 256 is converted to an integer and the string concatenation fails.

This came from the scheduled run of Ansible tests:
https://github.com/signalfx/splunk-otel-collector/actions/runs/8639527708/job/23686002963#step:8:1585
```
  TASK [Verify splunk-otel-collector service env vars] ***************************
  fatal: [2016]: FAILED! => {"msg": "The conditional check '(item.key + '=' + item.value) in collector_env.value' failed. The error was: Unexpected templating type error occurred on ({% if (item.key + '=' + item.value) in collector_env.value %} True {% else %} False {% endif %}): can only concatenate str (not \"int\") to str. can only concatenate str (not \"int\") to str"}
```
