### PR TITLE
add splunk_otlp_histograms resource attr

### DIFF
--- a/internal/configconverter/otlp_histogram_attr.go
+++ b/internal/configconverter/otlp_histogram_attr.go
@@ -1,0 +1,82 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configconverter
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"go.opentelemetry.io/collector/confmap"
+)
+
+type AddOTLPHistogramAttr struct{}
+
+// Convert updates the service::telemetry::resource to add the attribute splunk.otlp.histograms=true.
+// This additional resource attr is only added if we see any signalfx exporter in use with the config
+// send_otlp_histograms set to true.
+func (AddOTLPHistogramAttr) Convert(_ context.Context, cfgMap *confmap.Conf) error {
+	if cfgMap == nil {
+		return nil
+	}
+
+	sfxExporters := map[string]bool{}
+	metricsPlRe := regexp.MustCompile(`^metrics($|/.*$)`)
+	signalfxExpRe := regexp.MustCompile(`^signalfx($|/.*$)`)
+
+	exp, err := cfgMap.Sub("exporters")
+	if err != nil {
+		return nil // Ignore invalid config. Rely on the config validation to catch this.
+	}
+
+	// get signalfx exporter names which have send_otlp_histograms enabled
+	for expName := range exp.ToStringMap() {
+		if signalfxExpRe.MatchString(expName) {
+			otlpHistoEnabled := cfgMap.Get(fmt.Sprintf("exporters::%s::send_otlp_histograms", expName))
+			if otlpHistoEnabled != nil && otlpHistoEnabled.(bool) {
+				sfxExporters[expName] = true
+			}
+		}
+	}
+
+	// no sfx exporters with send_otlp_histograms enabled
+	if len(sfxExporters) == 0 {
+		return nil
+	}
+
+	pl, err := cfgMap.Sub("service::pipelines")
+	if err != nil {
+		return nil
+	}
+
+	// check if metrics pipelines use any of the signalfx exporters which have send_otlp_histograms enabled
+	for pipelineName := range pl.ToStringMap() {
+		if metricsPlRe.MatchString(pipelineName) {
+			mExps := cfgMap.Get(fmt.Sprintf("service::pipelines::%s::exporters", pipelineName))
+			if metricsExps, ok := mExps.([]any); ok {
+				for _, expName := range metricsExps {
+					if _, ok := sfxExporters[expName.(string)]; ok {
+						resAttrKey := "service::telemetry::resource::splunk_otlp_histograms"
+						if err = cfgMap.Merge(confmap.NewFromStringMap(map[string]any{resAttrKey: "true"})); err != nil {
+							return err
+						}
+						return nil
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/internal/configconverter/otlp_histogram_attr.go
+++ b/internal/configconverter/otlp_histogram_attr.go
@@ -73,9 +73,7 @@ func (AddOTLPHistogramAttr) Convert(_ context.Context, cfgMap *confmap.Conf) err
 					if expNameStr, ok := expName.(string); ok {
 						if _, ok := sfxExporters[expNameStr]; ok {
 							resAttrKey := "service::telemetry::resource::splunk_otlp_histograms"
-							if err = cfgMap.Merge(confmap.NewFromStringMap(map[string]any{resAttrKey: "true"})); err != nil {
-								return err
-							}
+							return cfgMap.Merge(confmap.NewFromStringMap(map[string]any{resAttrKey: "true"}))
 						}
 					}
 				}

--- a/internal/configconverter/otlp_histogram_attr.go
+++ b/internal/configconverter/otlp_histogram_attr.go
@@ -39,7 +39,7 @@ func (AddOTLPHistogramAttr) Convert(_ context.Context, cfgMap *confmap.Conf) err
 
 	exp, err := cfgMap.Sub("exporters")
 	if err != nil {
-		return nil // Ignore invalid config. Rely on the config validation to catch this.
+		return err // In practice this should never happen: config parsing should have caught the error prior to here.
 	}
 
 	// get signalfx exporter names which have send_otlp_histograms enabled
@@ -61,7 +61,7 @@ func (AddOTLPHistogramAttr) Convert(_ context.Context, cfgMap *confmap.Conf) err
 
 	pl, err := cfgMap.Sub("service::pipelines")
 	if err != nil {
-		return nil
+		return err
 	}
 
 	// check if metrics pipelines use any of the signalfx exporters which have send_otlp_histograms enabled

--- a/internal/configconverter/otlp_histogram_attr_test.go
+++ b/internal/configconverter/otlp_histogram_attr_test.go
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Taken from https://github.com/open-telemetry/opentelemetry-collector/blob/v0.66.0/confmap/converter/overwritepropertiesconverter/properties_test.go
+// to prevent breaking changes.
+package configconverter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+)
+
+func TestOTLPHistograms_Enabled(t *testing.T) {
+	cfgMap, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_enabled.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, cfgMap)
+	pmp := AddOTLPHistogramAttr{}
+	assert.NoError(t, pmp.Convert(context.Background(), cfgMap))
+	cfgMapExpected, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_expected.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, cfgMapExpected.ToStringMap(), cfgMap.ToStringMap())
+}
+
+func TestOTLPHistograms_EnabledNoTelemetry(t *testing.T) {
+	cfgMap, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_no_telemetry.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, cfgMap)
+	pmp := AddOTLPHistogramAttr{}
+	assert.NoError(t, pmp.Convert(context.Background(), cfgMap))
+	cfgMapExpected, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_no_telemetry_expected.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, cfgMapExpected.ToStringMap(), cfgMap.ToStringMap())
+}
+
+func TestOTLPHistograms_Disabled(t *testing.T) {
+	cfgMap, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_disabled.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, cfgMap)
+	pmp := AddOTLPHistogramAttr{}
+	assert.NoError(t, pmp.Convert(context.Background(), cfgMap))
+	cfgMapExpected, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_expected.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, cfgMapExpected.ToStringMap(), cfgMap.ToStringMap())
+}
+
+func TestOTLPHistograms_DisabledExporterNotInUse(t *testing.T) {
+	cfgMap, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_no_exp.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, cfgMap)
+	pmp := AddOTLPHistogramAttr{}
+	assert.NoError(t, pmp.Convert(context.Background(), cfgMap))
+	cfgMapExpected, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_no_exp_expected.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, cfgMapExpected.ToStringMap(), cfgMap.ToStringMap())
+}

--- a/internal/configconverter/otlp_histogram_attr_test.go
+++ b/internal/configconverter/otlp_histogram_attr_test.go
@@ -25,46 +25,47 @@ import (
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
 
-func TestOTLPHistograms_Enabled(t *testing.T) {
-	cfgMap, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_enabled.yaml")
-	require.NoError(t, err)
-	require.NotNil(t, cfgMap)
-	pmp := AddOTLPHistogramAttr{}
-	assert.NoError(t, pmp.Convert(context.Background(), cfgMap))
-	cfgMapExpected, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_expected.yaml")
-	require.NoError(t, err)
-	assert.Equal(t, cfgMapExpected.ToStringMap(), cfgMap.ToStringMap())
-}
+func TestOTLPHistogramsAttrs(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantOutput string
+	}{
+		{
+			name:       "enabled",
+			input:      "testdata/otlp_histograms_attr/send_otlp_histrograms_enabled.yaml",
+			wantOutput: "testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_expected.yaml",
+		},
+		{
+			name:       "enabled_no_telemetry",
+			input:      "testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_no_telemetry.yaml",
+			wantOutput: "testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_no_telemetry_expected.yaml",
+		},
+		{
+			name:       "disabled",
+			input:      "testdata/otlp_histograms_attr/send_otlp_histrograms_disabled.yaml",
+			wantOutput: "testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_expected.yaml",
+		},
+		{
+			name:       "disabled_not_in_use_exporter",
+			input:      "testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_no_exp.yaml",
+			wantOutput: "testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_no_exp_expected.yaml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectedCfgMap, err := confmaptest.LoadConf(tt.wantOutput)
+			require.NoError(t, err)
+			require.NotNil(t, expectedCfgMap)
 
-func TestOTLPHistograms_EnabledNoTelemetry(t *testing.T) {
-	cfgMap, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_no_telemetry.yaml")
-	require.NoError(t, err)
-	require.NotNil(t, cfgMap)
-	pmp := AddOTLPHistogramAttr{}
-	assert.NoError(t, pmp.Convert(context.Background(), cfgMap))
-	cfgMapExpected, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_no_telemetry_expected.yaml")
-	require.NoError(t, err)
-	assert.Equal(t, cfgMapExpected.ToStringMap(), cfgMap.ToStringMap())
-}
+			cfgMap, err := confmaptest.LoadConf(tt.input)
+			require.NoError(t, err)
+			require.NotNil(t, cfgMap)
 
-func TestOTLPHistograms_Disabled(t *testing.T) {
-	cfgMap, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_disabled.yaml")
-	require.NoError(t, err)
-	require.NotNil(t, cfgMap)
-	pmp := AddOTLPHistogramAttr{}
-	assert.NoError(t, pmp.Convert(context.Background(), cfgMap))
-	cfgMapExpected, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_expected.yaml")
-	require.NoError(t, err)
-	assert.Equal(t, cfgMapExpected.ToStringMap(), cfgMap.ToStringMap())
-}
+			err = AddOTLPHistogramAttr{}.Convert(context.Background(), cfgMap)
+			require.NoError(t, err)
 
-func TestOTLPHistograms_DisabledExporterNotInUse(t *testing.T) {
-	cfgMap, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_no_exp.yaml")
-	require.NoError(t, err)
-	require.NotNil(t, cfgMap)
-	pmp := AddOTLPHistogramAttr{}
-	assert.NoError(t, pmp.Convert(context.Background(), cfgMap))
-	cfgMapExpected, err := confmaptest.LoadConf("testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_no_exp_expected.yaml")
-	require.NoError(t, err)
-	assert.Equal(t, cfgMapExpected.ToStringMap(), cfgMap.ToStringMap())
+			assert.Equal(t, expectedCfgMap.ToStringMap(), cfgMap.ToStringMap())
+		})
+	}
 }

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled.yaml
@@ -1,0 +1,33 @@
+receivers:
+  hostmetrics:
+exporters:
+  otlp:
+    endpoint: "https://ingest.signalfx.com:443"
+    headers:
+      "X-SF-Token": TOKEN
+    sending_queue:
+      num_consumers: 32
+  signalfx:
+    access_token: TOKEN
+    realm: REALM
+    sending_queue:
+      num_consumers: 32
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - hostmetrics
+      exporters:
+        - otlp
+        - signalfx
+    traces/signalfx:
+      receivers:
+        - otlp
+      exporters:
+        - signalfx
+  telemetry:
+    resource:
+      resattr1: val1
+      resattr2: val2
+    logs:
+      level: debug

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled.yaml
@@ -1,5 +1,7 @@
 receivers:
   hostmetrics:
+    scrapers:
+      cpu:
 exporters:
   otlp:
     endpoint: "https://ingest.signalfx.com:443"

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_expected.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_expected.yaml
@@ -1,0 +1,33 @@
+receivers:
+  hostmetrics:
+exporters:
+  otlp:
+    endpoint: "https://ingest.signalfx.com:443"
+    headers:
+      "X-SF-Token": TOKEN
+    sending_queue:
+      num_consumers: 32
+  signalfx:
+    access_token: TOKEN
+    realm: REALM
+    sending_queue:
+      num_consumers: 32
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - hostmetrics
+      exporters:
+        - otlp
+        - signalfx
+    traces/signalfx:
+      receivers:
+        - otlp
+      exporters:
+        - signalfx
+  telemetry:
+    resource:
+      resattr1: val1
+      resattr2: val2
+    logs:
+      level: debug

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_expected.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_expected.yaml
@@ -1,5 +1,7 @@
 receivers:
   hostmetrics:
+    scrapers:
+      cpu:
 exporters:
   otlp:
     endpoint: "https://ingest.signalfx.com:443"

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_no_exp.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_no_exp.yaml
@@ -1,5 +1,7 @@
 receivers:
   hostmetrics:
+    scrapers:
+      cpu:
 exporters:
   otlp:
     endpoint: "https://ingest.signalfx.com:443"

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_no_exp.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_no_exp.yaml
@@ -1,0 +1,39 @@
+receivers:
+  hostmetrics:
+exporters:
+  otlp:
+    endpoint: "https://ingest.signalfx.com:443"
+    headers:
+      "X-SF-Token": TOKEN
+    sending_queue:
+      num_consumers: 32
+  signalfx:
+    access_token: TOKEN
+    realm: REALM
+    sending_queue:
+      num_consumers: 32
+  signalfx/histograms:
+    access_token: TOKEN
+    realm: REALM
+    sending_queue:
+      num_consumers: 32
+    send_otlp_histograms: true
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - hostmetrics
+      exporters:
+        - otlp
+        - signalfx
+    traces/signalfx:
+      receivers:
+        - otlp
+      exporters:
+        - signalfx
+  telemetry:
+    resource:
+      resattr1: val1
+      resattr2: val2
+    logs:
+      level: debug

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_no_exp_expected.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_no_exp_expected.yaml
@@ -1,5 +1,7 @@
 receivers:
   hostmetrics:
+    scrapers:
+      cpu:
 exporters:
   otlp:
     endpoint: "https://ingest.signalfx.com:443"

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_no_exp_expected.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_disabled_no_exp_expected.yaml
@@ -1,0 +1,39 @@
+receivers:
+  hostmetrics:
+exporters:
+  otlp:
+    endpoint: "https://ingest.signalfx.com:443"
+    headers:
+      "X-SF-Token": TOKEN
+    sending_queue:
+      num_consumers: 32
+  signalfx:
+    access_token: TOKEN
+    realm: REALM
+    sending_queue:
+      num_consumers: 32
+  signalfx/histograms:
+    access_token: TOKEN
+    realm: REALM
+    sending_queue:
+      num_consumers: 32
+    send_otlp_histograms: true
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - hostmetrics
+      exporters:
+        - otlp
+        - signalfx
+    traces/signalfx:
+      receivers:
+        - otlp
+      exporters:
+        - signalfx
+  telemetry:
+    resource:
+      resattr1: val1
+      resattr2: val2
+    logs:
+      level: debug

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled.yaml
@@ -1,5 +1,7 @@
 receivers:
   hostmetrics:
+    scrapers:
+      cpu:
 exporters:
   otlp:
     endpoint: "https://ingest.signalfx.com:443"

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled.yaml
@@ -1,0 +1,44 @@
+receivers:
+  hostmetrics:
+exporters:
+  otlp:
+    endpoint: "https://ingest.signalfx.com:443"
+    headers:
+      "X-SF-Token": TOKEN
+    sending_queue:
+      num_consumers: 32
+  signalfx:
+    access_token: TOKEN
+    realm: REALM
+    sending_queue:
+      num_consumers: 32
+  signalfx/histograms:
+    access_token: TOKEN
+    realm: REALM
+    sending_queue:
+      num_consumers: 32
+    send_otlp_histograms: true
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - hostmetrics
+      exporters:
+        - otlp
+        - signalfx
+    metrics/signalfx:
+      receivers:
+        - hostmetrics
+      exporters:
+        - signalfx
+    metrics/signalfx/histograms:
+      receivers:
+        - hostmetrics
+      exporters:
+        - signalfx/histograms
+  telemetry:
+    resource:
+      resattr1: val1
+      resattr2: val2
+    logs:
+      level: debug

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_expected.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_expected.yaml
@@ -1,5 +1,7 @@
 receivers:
   hostmetrics:
+    scrapers:
+      cpu:
 exporters:
   otlp:
     endpoint: "https://ingest.signalfx.com:443"

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_expected.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_expected.yaml
@@ -1,0 +1,45 @@
+receivers:
+  hostmetrics:
+exporters:
+  otlp:
+    endpoint: "https://ingest.signalfx.com:443"
+    headers:
+      "X-SF-Token": TOKEN
+    sending_queue:
+      num_consumers: 32
+  signalfx:
+    access_token: TOKEN
+    realm: REALM
+    sending_queue:
+      num_consumers: 32
+  signalfx/histograms:
+    access_token: TOKEN
+    realm: REALM
+    sending_queue:
+      num_consumers: 32
+    send_otlp_histograms: true
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - hostmetrics
+      exporters:
+        - otlp
+        - signalfx
+    metrics/signalfx:
+      receivers:
+        - hostmetrics
+      exporters:
+        - signalfx
+    metrics/signalfx/histograms:
+      receivers:
+        - hostmetrics
+      exporters:
+        - signalfx/histograms
+  telemetry:
+    resource:
+      splunk_otlp_histograms: "true"
+      resattr1: val1
+      resattr2: val2
+    logs:
+      level: debug

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_no_telemetry.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_no_telemetry.yaml
@@ -1,5 +1,7 @@
 receivers:
   hostmetrics:
+    scrapers:
+      cpu:
 exporters:
   otlp:
     endpoint: "https://ingest.signalfx.com:443"

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_no_telemetry.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_no_telemetry.yaml
@@ -1,0 +1,41 @@
+receivers:
+  hostmetrics:
+exporters:
+  otlp:
+    endpoint: "https://ingest.signalfx.com:443"
+    headers:
+      "X-SF-Token": TOKEN
+    sending_queue:
+      num_consumers: 32
+  signalfx:
+    access_token: TOKEN
+    realm: REALM
+    sending_queue:
+      num_consumers: 32
+  signalfx/histograms:
+    access_token: TOKEN
+    realm: REALM
+    sending_queue:
+      num_consumers: 32
+    send_otlp_histograms: true
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - hostmetrics
+      exporters:
+        - otlp
+        - signalfx
+    metrics/signalfx:
+      receivers:
+        - hostmetrics
+      exporters:
+        - signalfx
+    metrics/histograms:
+      receivers:
+        - hostmetrics
+      processors:
+        - batch
+      exporters:
+        - otlp
+        - signalfx/histograms

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_no_telemetry_expected.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_no_telemetry_expected.yaml
@@ -1,5 +1,7 @@
 receivers:
   hostmetrics:
+    scrapers:
+      cpu:
 exporters:
   otlp:
     endpoint: "https://ingest.signalfx.com:443"

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_no_telemetry_expected.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histrograms_enabled_no_telemetry_expected.yaml
@@ -1,0 +1,44 @@
+receivers:
+  hostmetrics:
+exporters:
+  otlp:
+    endpoint: "https://ingest.signalfx.com:443"
+    headers:
+      "X-SF-Token": TOKEN
+    sending_queue:
+      num_consumers: 32
+  signalfx:
+    access_token: TOKEN
+    realm: REALM
+    sending_queue:
+      num_consumers: 32
+  signalfx/histograms:
+    access_token: TOKEN
+    realm: REALM
+    sending_queue:
+      num_consumers: 32
+    send_otlp_histograms: true
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - hostmetrics
+      exporters:
+        - otlp
+        - signalfx
+    metrics/signalfx:
+      receivers:
+        - hostmetrics
+      exporters:
+        - signalfx
+    metrics/histograms:
+      receivers:
+        - hostmetrics
+      processors:
+        - batch
+      exporters:
+        - otlp
+        - signalfx/histograms
+  telemetry:
+    resource:
+      splunk_otlp_histograms: "true"

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -222,6 +222,7 @@ func (s *Settings) ConfMapConverters() []confmap.Converter {
 			configconverter.LogLevelToVerbosity{},
 			configconverter.DisableKubeletUtilizationMetrics{},
 			configconverter.DisableExcessiveInternalMetrics{},
+			configconverter.AddOTLPHistogramAttr{},
 		)
 	}
 	return confMapConverters

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -173,6 +173,7 @@ func TestNewSettingsConvertConfig(t *testing.T) {
 		configconverter.LogLevelToVerbosity{},
 		configconverter.DisableKubeletUtilizationMetrics{},
 		configconverter.DisableExcessiveInternalMetrics{},
+		configconverter.AddOTLPHistogramAttr{},
 	}, settings.ConfMapConverters())
 	require.Equal(t, []string{"--feature-gates", "foo", "--feature-gates", "-bar"}, settings.ColCoreArgs())
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Adds the resource attribute `splunk_otlp_histograms: true` to the `service::telemetry::resource` if the collector detects any in use signalfx metrics exporter with the flag `send_otlp_histograms` enabled.

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>
Added tests

**Documentation:** <Describe the documentation added.>
