### PR TITLE
[receiver/discovery] Track only endpoints matching a receiver rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/participle/v2 v2.1.1
 	github.com/antonmedv/expr v1.15.5
 	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/expr-lang/expr v1.16.3
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-zookeeper/zk v1.0.3
 	github.com/gogo/protobuf v1.3.2
@@ -193,7 +194,6 @@ require (
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/duosecurity/duo_api_golang v0.0.0-20240205144049-bb361ad4ae1c // indirect
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
-	github.com/expr-lang/expr v1.16.3 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
 	github.com/go-openapi/validate v0.23.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 // indirect

--- a/internal/receiver/discoveryreceiver/README.md
+++ b/internal/receiver/discoveryreceiver/README.md
@@ -277,12 +277,12 @@ Flags: 0
 
 ### ReceiverConfig
 
-| Name                  | Type              | Default    | Docs                                                                                                                                            |
-|-----------------------|-------------------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| `rule` (required)     | string            | <no value> | The Receiver Creator compatible discover rule                                                                                                   |
-| `config`              | map[string]any    | <no value> | The receiver instance configuration, including any Receiver Creator endpoint env value expr program value expansion                             |
-| `resource_attributes` | map[string]string | <no value> | A mapping of string resource attributes and their (expr program compatible) values to include in reported metrics for status log record matches |
-| `status`              | map[string]Match  | <no value> | A mapping of `metrics` and/or `statements` to Match items for status evaluation                                                                 |
+| Name                  | Type              | Default    | Docs                                                                                                                                                                                              |
+|-----------------------|-------------------|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `rule` (required)     | string            | <no value> | The Receiver Creator compatible discover rule. Ensure that rules defined in different receivers cannot match the same endpoint. Endpoints matching rules from multiple receivers will be ignored. |
+| `config`              | map[string]any    | <no value> | The receiver instance configuration, including any Receiver Creator endpoint env value expr program value expansion                                                                               |
+| `resource_attributes` | map[string]string | <no value> | A mapping of string resource attributes and their (expr program compatible) values to include in reported metrics for status log record matches                                                   |
+| `status`              | map[string]Match  | <no value> | A mapping of `metrics` and/or `statements` to Match items for status evaluation                                                                                                                   |
 
 ### Match
 

--- a/internal/receiver/discoveryreceiver/config.go
+++ b/internal/receiver/discoveryreceiver/config.go
@@ -66,7 +66,7 @@ type ReceiverEntry struct {
 	Config             map[string]any    `mapstructure:"config"`
 	Status             *Status           `mapstructure:"status"`
 	ResourceAttributes map[string]string `mapstructure:"resource_attributes"`
-	Rule               string            `mapstructure:"rule"`
+	Rule               Rule              `mapstructure:"rule"`
 }
 
 // Status defines the Match rules for applicable app and telemetry sources.
@@ -200,7 +200,7 @@ func (cfg *Config) receiverCreatorReceiversConfig(correlations correlationStore)
 		}
 		resourceAttributes[discovery.ReceiverNameAttr] = receiverID.Name()
 		resourceAttributes[discovery.ReceiverTypeAttr] = receiverID.Type().String()
-		resourceAttributes[receiverRuleAttr] = rEntry.Rule
+		resourceAttributes[receiverRuleAttr] = rEntry.Rule.String()
 		resourceAttributes[discovery.EndpointIDAttr] = "`id`"
 
 		if cfg.EmbedReceiverConfig {
@@ -227,7 +227,7 @@ func (cfg *Config) receiverCreatorReceiversConfig(correlations correlationStore)
 		}
 
 		rEntryMap := map[string]any{}
-		rEntryMap["rule"] = rEntry.Rule
+		rEntryMap["rule"] = rEntry.Rule.String()
 		rEntryMap["config"] = rEntry.Config
 		rEntryMap["resource_attributes"] = resourceAttributes
 		receiversConfig[receiverID.String()] = rEntryMap

--- a/internal/receiver/discoveryreceiver/config_test.go
+++ b/internal/receiver/discoveryreceiver/config_test.go
@@ -40,7 +40,7 @@ func TestValidConfig(t *testing.T) {
 
 	assert.Equal(t, 1, len(configs.ToStringMap()))
 
-	cm, err := configs.Sub("discovery/discovery-name")
+	cm, err := configs.Sub("discovery")
 	require.NoError(t, err)
 	cfg := createDefaultConfig().(*Config)
 	err = component.UnmarshalConfig(cm, cfg)
@@ -97,7 +97,7 @@ func TestValidConfig(t *testing.T) {
 				ResourceAttributes: map[string]string{
 					"receiver_attribute": "receiver_attribute_value",
 				},
-				Rule: "type == \"container\"",
+				Rule: mustNewRule(`type == "container" && name matches "(?i)redis"`),
 			},
 		},
 		LogEndpoints:        true,
@@ -146,7 +146,7 @@ func TestInvalidConfigs(t *testing.T) {
 func TestReceiverCreatorFactoryAndConfig(t *testing.T) {
 	conf, err := confmaptest.LoadConf(path.Join(".", "testdata", "config.yaml"))
 	require.NoError(t, err)
-	conf, err = conf.Sub("discovery/discovery-name")
+	conf, err = conf.Sub("discovery")
 	require.NoError(t, err)
 	require.NotEmpty(t, conf.ToStringMap())
 	dCfg := Config{}
@@ -171,7 +171,7 @@ func TestReceiverCreatorFactoryAndConfig(t *testing.T) {
 
 	receiverTemplate, err := dCfg.receiverCreatorReceiversConfig(correlations)
 	require.NoError(t, err)
-	expectedConfigHash := "cmVjZWl2ZXJzOgogIHNtYXJ0YWdlbnQvcmVkaXM6CiAgICBjb25maWc6CiAgICAgIGF1dGg6IHBhc3N3b3JkCiAgICAgIGhvc3Q6ICdgaG9zdGAnCiAgICAgIHBvcnQ6ICdgcG9ydGAnCiAgICAgIHR5cGU6IGNvbGxlY3RkL3JlZGlzCiAgICByZXNvdXJjZV9hdHRyaWJ1dGVzOgogICAgICByZWNlaXZlcl9hdHRyaWJ1dGU6IHJlY2VpdmVyX2F0dHJpYnV0ZV92YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiY29udGFpbmVyIgo="
+	expectedConfigHash := "cmVjZWl2ZXJzOgogIHNtYXJ0YWdlbnQvcmVkaXM6CiAgICBjb25maWc6CiAgICAgIGF1dGg6IHBhc3N3b3JkCiAgICAgIGhvc3Q6ICdgaG9zdGAnCiAgICAgIHBvcnQ6ICdgcG9ydGAnCiAgICAgIHR5cGU6IGNvbGxlY3RkL3JlZGlzCiAgICByZXNvdXJjZV9hdHRyaWJ1dGVzOgogICAgICByZWNlaXZlcl9hdHRyaWJ1dGU6IHJlY2VpdmVyX2F0dHJpYnV0ZV92YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiY29udGFpbmVyIiAmJiBuYW1lIG1hdGNoZXMgIig/aSlyZWRpcyIK"
 	expectedTemplate := map[string]any{
 		"smartagent/redis": map[string]any{
 			"config": map[string]any{
@@ -184,11 +184,11 @@ func TestReceiverCreatorFactoryAndConfig(t *testing.T) {
 				"discovery.endpoint.id":     "`id`",
 				"discovery.receiver.config": expectedConfigHash,
 				"discovery.receiver.name":   "redis",
-				"discovery.receiver.rule":   `type == "container"`,
+				"discovery.receiver.rule":   `type == "container" && name matches "(?i)redis"`,
 				"discovery.receiver.type":   "smartagent",
 				"receiver_attribute":        "receiver_attribute_value",
 			},
-			"rule": `type == "container"`,
+			"rule": `type == "container" && name matches "(?i)redis"`,
 		},
 	}
 	require.Equal(t, expectedTemplate, receiverTemplate)
@@ -209,7 +209,7 @@ func TestReceiverCreatorFactoryAndConfig(t *testing.T) {
 				"resource_attributes": map[any]any{
 					"receiver_attribute": "receiver_attribute_value",
 				},
-				"rule": `type == "container"`,
+				"rule": `type == "container" && name matches "(?i)redis"`,
 			},
 		},
 	}, embedded)

--- a/internal/receiver/discoveryreceiver/evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/evaluator_test.go
@@ -97,7 +97,6 @@ func TestEvaluateInvalidMatch(t *testing.T) {
 }
 
 func TestCorrelateResourceAttrs(t *testing.T) {
-	sampleType := component.MustNewID("SPLUNK_unit_test_receiver")
 	for _, embed := range []bool{false, true} {
 		t.Run(fmt.Sprintf("embed-%v", embed), func(t *testing.T) {
 			eval, _, endpointID := setup(t)
@@ -105,9 +104,10 @@ func TestCorrelateResourceAttrs(t *testing.T) {
 
 			endpoint := observer.Endpoint{ID: endpointID}
 			observerID := component.MustNewIDWithName("type", "name")
-			eval.correlations.UpdateEndpoint(endpoint, addedState, observerID)
+			receiverID := component.MustNewIDWithName("receiver", "name")
+			eval.correlations.UpdateEndpoint(endpoint, receiverID, addedState, observerID)
 
-			corr := eval.correlations.GetOrCreate(sampleType, endpointID)
+			corr := eval.correlations.GetOrCreate(receiverID, endpointID)
 
 			from := pcommon.NewMap()
 			from.FromRaw(
@@ -118,7 +118,7 @@ func TestCorrelateResourceAttrs(t *testing.T) {
 
 			to := pcommon.NewMap()
 
-			require.Empty(t, eval.correlations.Attrs(sampleType))
+			require.Empty(t, eval.correlations.Attrs(receiverID))
 			eval.correlateResourceAttributes(from, to, corr)
 
 			expectedResourceAttrs := map[string]any{
@@ -134,7 +134,7 @@ func TestCorrelateResourceAttrs(t *testing.T) {
 
 			require.Equal(t, expectedResourceAttrs, to.AsRaw())
 
-			attrs := eval.correlations.Attrs(sampleType)
+			attrs := eval.correlations.Attrs(receiverID)
 
 			expectedAttrs := map[string]string{}
 			if embed {
@@ -147,7 +147,6 @@ func TestCorrelateResourceAttrs(t *testing.T) {
 }
 
 func TestCorrelateResourceAttrsWithExistingConfig(t *testing.T) {
-	sampleType := component.MustNewID("SPLUNK_unit_test_receiver")
 	for _, embed := range []bool{false, true} {
 		t.Run(fmt.Sprintf("embed-%v", embed), func(t *testing.T) {
 			eval, _, endpointID := setup(t)
@@ -155,9 +154,10 @@ func TestCorrelateResourceAttrsWithExistingConfig(t *testing.T) {
 
 			endpoint := observer.Endpoint{ID: endpointID}
 			observerID := component.MustNewIDWithName("type", "name")
-			eval.correlations.UpdateEndpoint(endpoint, addedState, observerID)
+			receiverID := component.MustNewIDWithName("receiver", "name")
+			eval.correlations.UpdateEndpoint(endpoint, receiverID, addedState, observerID)
 
-			corr := eval.correlations.GetOrCreate(sampleType, endpointID)
+			corr := eval.correlations.GetOrCreate(receiverID, endpointID)
 
 			encodedConfig := base64.StdEncoding.EncodeToString([]byte("config: some config\nrule: some rule\n"))
 
@@ -171,7 +171,7 @@ func TestCorrelateResourceAttrsWithExistingConfig(t *testing.T) {
 
 			to := pcommon.NewMap()
 
-			require.Empty(t, eval.correlations.Attrs(sampleType))
+			require.Empty(t, eval.correlations.Attrs(receiverID))
 			eval.correlateResourceAttributes(from, to, corr)
 
 			var receiverConfig string
@@ -190,7 +190,7 @@ func TestCorrelateResourceAttrsWithExistingConfig(t *testing.T) {
 
 			require.Equal(t, expectedResourceAttrs, to.AsRaw())
 
-			attrs := eval.correlations.Attrs(sampleType)
+			attrs := eval.correlations.Attrs(receiverID)
 			expectedAttrs := map[string]string{}
 
 			if embed {

--- a/internal/receiver/discoveryreceiver/metric_evaluator.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator.go
@@ -135,7 +135,7 @@ func (m *metricEvaluator) evaluateMetrics(md pmetric.Metrics) plog.Logs {
 				entityState.Attributes().Remove(discovery.EndpointIDAttr)
 
 				entityState.Attributes().PutStr(eventTypeAttr, metricMatch)
-				entityState.Attributes().PutStr(receiverRuleAttr, rEntry.Rule)
+				entityState.Attributes().PutStr(receiverRuleAttr, rEntry.Rule.String())
 
 				desiredRecord := match.Record
 				if desiredRecord == nil {

--- a/internal/receiver/discoveryreceiver/metric_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator_test.go
@@ -69,10 +69,11 @@ func TestMetricEvaluation(t *testing.T) {
 				match.Status = status
 				t.Run(string(status), func(t *testing.T) {
 					observerID := component.MustNewIDWithName("an_observer", "observer.name")
+					receiverID := component.MustNewIDWithName("a_receiver", "receiver.name")
 					cfg := &Config{
 						Receivers: map[component.ID]ReceiverEntry{
-							component.MustNewIDWithName("a_receiver", "receiver.name"): {
-								Rule:   "a.rule",
+							receiverID: {
+								Rule:   Rule{text: "a.rule", program: nil},
 								Status: &Status{Metrics: []Match{match}},
 							},
 						},
@@ -82,10 +83,7 @@ func TestMetricEvaluation(t *testing.T) {
 
 					plogs := make(chan plog.Logs)
 					cStore := newCorrelationStore(logger, time.Hour)
-					cStore.UpdateEndpoint(
-						observer.Endpoint{ID: "endpoint.id"},
-						addedState, observerID,
-					)
+					cStore.UpdateEndpoint(observer.Endpoint{ID: "endpoint.id"}, receiverID, addedState, observerID)
 
 					me := newMetricEvaluator(logger, cfg, plogs, cStore)
 

--- a/internal/receiver/discoveryreceiver/rule.go
+++ b/internal/receiver/discoveryreceiver/rule.go
@@ -1,0 +1,107 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The code is copied from
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/c07d1e622c59ed013e6a02f96a5cc556513263da/receiver/receivercreator/rules.go
+// with minimal changes. Once the discovery receiver upstreamed, this code can be reused.
+
+package discoveryreceiver
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/builtin"
+	"github.com/expr-lang/expr/vm"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+)
+
+// Rule wraps expr rule for later evaluation.
+type Rule struct {
+	program *vm.Program
+	text    string
+}
+
+// UnmarshalText will unmarshal a field from text
+func (r *Rule) UnmarshalText(text []byte) error {
+	rule, err := newRule(string(text))
+	if err != nil {
+		return fmt.Errorf(`invalid rule "%s": %w`, text, err)
+	}
+	*r = rule
+	return err
+}
+
+// MarshalText marshals the rule to text
+func (r Rule) MarshalText() (text []byte, err error) {
+	return []byte(r.String()), nil
+}
+
+// ruleRe is used to verify the rule starts type check.
+var ruleRe = regexp.MustCompile(
+	fmt.Sprintf(`^type\s*==\s*(%q|%q|%q|%q|%q|%q)`, observer.PodType, observer.K8sServiceType, observer.PortType, observer.HostPortType, observer.ContainerType, observer.K8sNodeType),
+)
+
+// newRule creates a new rule instance.
+func newRule(ruleStr string) (Rule, error) {
+	if ruleStr == "" {
+		return Rule{}, errors.New("rule cannot be empty")
+	}
+	if !ruleRe.MatchString(ruleStr) {
+		// TODO: Try validating against bytecode instead.
+		return Rule{}, errors.New("rule must specify type")
+	}
+
+	// TODO: Maybe use https://godoc.org/github.com/expr-lang/expr#Env in type checking
+	// depending on type == specified.
+	v, err := expr.Compile(
+		ruleStr,
+		// expr v1.14.1 introduced a `type` builtin whose implementation we relocate to `typeOf`
+		// to avoid collision
+		expr.DisableBuiltin("type"),
+		expr.Function("typeOf", func(params ...any) (any, error) {
+			return builtin.Type(params[0]), nil
+		}, new(func(any) string)),
+	)
+	if err != nil {
+		return Rule{}, err
+	}
+	return Rule{text: ruleStr, program: v}, nil
+}
+
+func mustNewRule(ruleStr string) Rule {
+	rule, err := newRule(ruleStr)
+	if err != nil {
+		panic(err)
+	}
+	return rule
+}
+
+func (r *Rule) String() string {
+	return r.text
+}
+
+// eval the rule against the given endpoint.
+func (r *Rule) eval(env observer.EndpointEnv) (bool, error) {
+	res, err := expr.Run(r.program, env)
+	if err != nil {
+		return false, err
+	}
+	if ret, ok := res.(bool); ok {
+		return ret, nil
+	}
+	return false, errors.New("rule did not return a boolean")
+}

--- a/internal/receiver/discoveryreceiver/rule_test.go
+++ b/internal/receiver/discoveryreceiver/rule_test.go
@@ -1,0 +1,133 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The code is copied from
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/c07d1e622c59ed013e6a02f96a5cc556513263da/receiver/receivercreator/rules.go
+// with minimal changes. Once the discovery receiver upstreamed, this code can be reused.
+
+package discoveryreceiver
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuleEval(t *testing.T) {
+	type args struct {
+		endpoint observer.Endpoint
+		ruleStr  string
+	}
+	tests := []struct {
+		args    args
+		name    string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "basic port",
+			args:    args{portEndpoint, `type == "port" && name == "port.name" && pod.labels["label.one"] == "value.one"`},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "basic hostport",
+			args:    args{hostportEndpoint, `type == "hostport" && port == 1 && process_name == "process.name"`},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "basic pod",
+			args:    args{podEndpoint, `type == "pod" && labels["label.one"] == "value.one"`},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "annotations",
+			args:    args{podEndpoint, `type == "pod" && annotations["annotation.one"] == "value.one"`},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "basic container",
+			args:    args{containerEndpoint, `type == "container" && labels["label.one"] == "value.one"`},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "basic k8s.node",
+			args:    args{k8sNodeEndpoint, `type == "k8s.node" && kubelet_endpoint_port == 1`},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "relocated type builtin",
+			args:    args{k8sNodeEndpoint, `type == "k8s.node" && typeOf("some string") == "string"`},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newRule(tt.args.ruleStr)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+
+			env, err := tt.args.endpoint.Env()
+			require.NoError(t, err)
+
+			match, err := got.eval(env)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("eval() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			assert.Equal(t, tt.want, match, "expected eval to return %v but returned %v", tt.want, match)
+		})
+	}
+}
+
+func TestNewRule(t *testing.T) {
+	type args struct {
+		ruleStr string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"empty rule", args{""}, true},
+		{"does not startMetrics with type", args{"port == 1234"}, true},
+		{"invalid syntax", args{"port =="}, true},
+		{"valid port", args{`type == "port" && port_name == "http"`}, false},
+		{"valid pod", args{`type=="pod" && port_name == "http"`}, false},
+		{"valid hostport", args{`type == "hostport" && port_name == "http"`}, false},
+		{"valid container", args{`type == "container" && port == 8080`}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newRule(tt.args.ruleStr)
+			if err == nil {
+				assert.NotNil(t, got, "expected rule to be created when there was no error")
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newRule() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/internal/receiver/discoveryreceiver/statement_evaluator.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator.go
@@ -195,7 +195,7 @@ func (se *statementEvaluator) evaluateStatement(statement *statussources.Stateme
 		fromAttrs.PutStr(discovery.ReceiverNameAttr, receiverID.Name())
 		se.correlateResourceAttributes(fromAttrs, entityState.Attributes(), se.correlations.GetOrCreate(receiverID, endpointID))
 		entityState.Attributes().PutStr(eventTypeAttr, statementMatch)
-		entityState.Attributes().PutStr(receiverRuleAttr, rEntry.Rule)
+		entityState.Attributes().PutStr(receiverRuleAttr, rEntry.Rule.String())
 
 		var desiredRecord LogRecord
 		if match.Record != nil {

--- a/internal/receiver/discoveryreceiver/statement_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator_test.go
@@ -58,7 +58,7 @@ func TestStatementEvaluation(t *testing.T) {
 							cfg := &Config{
 								Receivers: map[component.ID]ReceiverEntry{
 									component.MustNewIDWithName("a_receiver", "receiver.name"): {
-										Rule:   "a.rule",
+										Rule:   mustNewRule(`type == "container"`),
 										Status: &Status{Statements: []Match{match}},
 									},
 								},
@@ -73,10 +73,8 @@ func TestStatementEvaluation(t *testing.T) {
 							// logger := zaptest.NewLogger(t)
 							logger := zap.NewNop()
 							cStore := newCorrelationStore(logger, time.Hour)
-							cStore.UpdateEndpoint(
-								observer.Endpoint{ID: "endpoint.id"},
-								addedState, observerID,
-							)
+							receiverID := component.MustNewIDWithName("a_receiver", "receiver.name")
+							cStore.UpdateEndpoint(observer.Endpoint{ID: "endpoint.id"}, receiverID, addedState, observerID)
 
 							se, err := newStatementEvaluator(logger, component.MustNewID("some_type"), cfg, plogs, cStore)
 							require.NoError(t, err)
@@ -153,7 +151,7 @@ func TestStatementEvaluation(t *testing.T) {
 									"discovery.event.type":    "statement.match",
 									"discovery.observer.id":   "an_observer/observer.name",
 									"discovery.receiver.name": "receiver.name",
-									"discovery.receiver.rule": "a.rule",
+									"discovery.receiver.rule": `type == "container"`,
 									"discovery.receiver.type": "a_receiver",
 									"discovery.status":        string(status),
 									"discovery.message":       expectedMsg,

--- a/internal/receiver/discoveryreceiver/testdata/config.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/config.yaml
@@ -1,4 +1,4 @@
-discovery/discovery-name:
+discovery:
   watch_observers:
     - an_observer
     - another_observer/with_name
@@ -7,7 +7,7 @@ discovery/discovery-name:
   correlation_ttl: 25s
   receivers:
     smartagent/redis:
-      rule: type == "container"
+      rule: type == "container" && name matches "(?i)redis"
       config:
         type: collectd/redis
         auth: password

--- a/internal/receiver/discoveryreceiver/testdata/conflicting_rules.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/conflicting_rules.yaml
@@ -1,0 +1,16 @@
+discovery:
+  watch_observers:
+    - an_observer
+  receivers:
+    receiver_1:
+      rule: type == "container" && name == "app"
+      status:
+        metrics:
+          - status: successful
+            regexp: '.*'
+    receiver_2:
+      rule: type == "container" && name == "app"
+      status:
+        statements:
+          - status: failed
+            regexp: '.*'

--- a/internal/receiver/discoveryreceiver/testdata/invalid_status_types.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/invalid_status_types.yaml
@@ -3,7 +3,7 @@ discovery:
     - an_observer
   receivers:
     a_receiver:
-      rule: a rule
+      rule: type == "container"
       status:
         metrics:
           - status: unsupported

--- a/internal/receiver/discoveryreceiver/testdata/missing_match_status.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/missing_match_status.yaml
@@ -3,7 +3,7 @@ discovery:
     - an_observer
   receivers:
     a_receiver:
-      rule: a rule
+      rule: type == "container"
       status:
         metrics:
           - regexp: '.*'

--- a/internal/receiver/discoveryreceiver/testdata/missing_status.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/missing_status.yaml
@@ -3,4 +3,4 @@ discovery:
     - an_observer
   receivers:
     a_receiver:
-      rule: a rule
+      rule: type == "container"

--- a/internal/receiver/discoveryreceiver/testdata/missing_status_metrics_and_statements.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/missing_status_metrics_and_statements.yaml
@@ -3,5 +3,5 @@ discovery:
     - an_observer
   receivers:
     a_receiver:
-      rule: a rule
+      rule: type == "container"
       status:

--- a/internal/receiver/discoveryreceiver/testdata/multiple_status_match_types.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/multiple_status_match_types.yaml
@@ -3,7 +3,7 @@ discovery:
     - an_observer
   receivers:
     a_receiver:
-      rule: a rule
+      rule: type == "container"
       status:
         metrics:
           - status: successful

--- a/internal/receiver/discoveryreceiver/testdata/reserved_receiver_creator.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/reserved_receiver_creator.yaml
@@ -3,7 +3,7 @@ discovery:
     - an_observer
   receivers:
     receiver_creator/with-name:
-      rule: a rule
+      rule: type == "container"
       status:
         metrics:
           - status: successful

--- a/internal/receiver/discoveryreceiver/testdata/reserved_receiver_name.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/reserved_receiver_name.yaml
@@ -3,7 +3,7 @@ discovery:
     - an_observer
   receivers:
     a_receiver/with-receiver_creator/in-name:
-      rule: a rule
+      rule: type == "container"
       status:
         metrics:
           - status: successful

--- a/internal/receiver/discoveryreceiver/testdata/reserved_receiver_name_with_endpoint.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/reserved_receiver_name_with_endpoint.yaml
@@ -3,7 +3,7 @@ discovery:
     - an_observer
   receivers:
     receiver/with{endpoint=}/:
-      rule: a rule
+      rule: type == "container"
       status:
         metrics:
           - status: successful


### PR DESCRIPTION
This way, we can start tracking target endpoints in the correlation store and emit entity events on regular basis.

Also, this requires limiting discovered endpoint to only one receiver. If an overlapping rule is found in multiple receivers, that endpoint will be ignored with a warning. If we keep allowing multiple receivers per endpoint, it'll be unclear how to track successful discovery of endpoint/service because different receivers may provide conflicting results.

This change required pulling code from the receivercreator, which will be reused once the discovery receiver is upstreamed.
