### PR TITLE
Use centos:stream8 image for puppet and salt tests

### DIFF
--- a/internal/buildscripts/packaging/tests/deployments/puppet/images/rpm/Dockerfile.centos-8
+++ b/internal/buildscripts/packaging/tests/deployments/puppet/images/rpm/Dockerfile.centos-8
@@ -1,10 +1,8 @@
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
 ENV container docker
 
-RUN sed -i 's|\$releasever|8-stream|g' /etc/yum.repos.d/CentOS*.repo
-RUN dnf install -y --allowerasing centos-stream-release
-
+RUN echo 'fastestmirror=1' >> /etc/yum.conf
 RUN dnf install -y systemd procps initscripts
 
 ARG PUPPET_RELEASE="6"

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.centos-8
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.centos-8
@@ -1,10 +1,8 @@
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
 ENV container docker
 
-RUN sed -i 's|\$releasever|8-stream|g' /etc/yum.repos.d/CentOS*.repo
-RUN yum install -y --allowerasing centos-stream-release
-
+RUN echo 'fastestmirror=1' >> /etc/yum.conf
 RUN yum install -y systemd procps initscripts python3-pip python3-devel gcc
 
 RUN rpm --import https://repo.saltproject.io/py3/redhat/8/x86_64/latest/SALTSTACK-GPG-KEY.pub


### PR DESCRIPTION
The `centos:8` image is deprecated. Use `quay.io/centos/centos:stream8` instead.