### PR TITLE
Use latest MSI capabilities instead of custom code in Ansible

### DIFF
--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -27,7 +27,7 @@ splunk_config_override_list_merge: replace
 splunk_service_user: splunk-otel-collector
 splunk_service_group: splunk-otel-collector
 
-splunk_memory_total_mib: 512
+splunk_memory_total_mib: "512"
 
 gomemlimit: ""
 

--- a/deployments/ansible/roles/collector/tasks/otel_win_install.yml
+++ b/deployments/ansible/roles/collector/tasks/otel_win_install.yml
@@ -22,6 +22,11 @@
     splunk_otel_collector_version: "{{version.content | b64decode }}"
   when: splunk_otel_collector_version == "latest"
 
+- name: Use MSI capabilities to install the collector if possible
+  set_fact:
+    splunk_collector_msi_is_configurable: true
+  when: splunk_otel_collector_version is version('0.98.0', '>=')
+
 - name: Get splunk-otel-collector for windows
   ansible.windows.win_get_url:
     url: "{{win_base_url}}/splunk-otel-collector/msi/{{package_stage}}/splunk-otel-collector-\
@@ -33,23 +38,61 @@
     use_proxy: "{{ win_use_proxy }}"
   register: otel_msi_package
 
+- name: Build the arguments for the MSI installer
+  when: splunk_collector_msi_is_configurable is defined
+  set_fact:
+    msi_unfiltered_arguments:
+      - SPLUNK_ACCESS_TOKEN={{ splunk_access_token }}
+      - "{{ 'SPLUNK_API_URL=' + splunk_api_url if splunk_api_url != '' else '' }}"
+      - "{{ 'GOMEMLIMIT=' + (gomemlimit | string) if (gomemlimit | string) != '' else '' }}"
+      - "{{ 'SPLUNK_BUNDLE_DIR='+ splunk_bundle_dir if splunk_bundle_dir != '' else '' }}"
+      - "{{ 'SPLUNK_COLLECTD_DIR=' + splunk_collectd_dir if splunk_collectd_dir != '' else '' }}"
+      - "{{ 'SPLUNK_CONFIG=' + splunk_otel_collector_config if splunk_otel_collector_config != '' else '' }}"
+      - "{{ 'SPLUNK_INGEST_URL=' + splunk_ingest_url if splunk_ingest_url != '' else '' }}"
+      - "{{ 'SPLUNK_HEC_TOKEN=' + splunk_hec_token if splunk_hec_token != '' else '' }}"
+      - "{{ 'SPLUNK_HEC_URL=' + splunk_hec_url if splunk_hec_url != '' else '' }}"
+      - "{{ 'SPLUNK_LISTEN_INTERFACE=' + splunk_listen_interface if splunk_listen_interface != '' else '' }}"
+      - "{{ 'SPLUNK_MEMORY_TOTAL_MIB=' + (splunk_memory_total_mib | string)
+               if (splunk_memory_total_mib | string) != '' else '' }}"
+      - "{{ 'SPLUNK_REALM=' + splunk_realm if splunk_realm != '' else '' }}"
+      - "{{ 'SPLUNK_TRACE_URL=' + splunk_trace_url if splunk_trace_url != '' else '' }}"
+
+- name: Filter out undefined arguments
+  when: splunk_collector_msi_is_configurable is defined
+  set_fact:
+    msi_arguments: "{{ msi_unfiltered_arguments | reject('eq', '') | list }}"
+
 - name: Install splunk-otel-collector-msi
+  when: splunk_collector_msi_is_configurable is defined
+  ansible.windows.win_package:
+    path: "{{otel_msi_package.dest}}"
+    state: present
+    arguments: "{{ msi_arguments }}"
+
+- name: Install splunk-otel-collector-msi-legacy
+  when: splunk_collector_msi_is_configurable is undefined
   ansible.windows.win_package:
     path: "{{otel_msi_package.dest}}"
     state: present
 
 - name: Merge custom config into the default config
   ansible.builtin.import_tasks: config_override.yml
-  when: splunk_config_override != ''
+  when:
+    - splunk_collector_msi_is_configurable is undefined
+    - splunk_config_override != ''
 
 - name: Copy the custom config
   ansible.windows.win_copy:
     content: '{{ updated_config | to_nice_yaml (indent=2) }}'
     dest: "{{ splunk_otel_collector_config }}"
-  when: splunk_config_override != ''
+  when:
+    - splunk_collector_msi_is_configurable is undefined
+    - splunk_config_override != ''
 
 - name: Push Custom Config file for splunk-otel-collector, If provided
   ansible.windows.win_template:
     src: "{{splunk_otel_collector_config_source}}"
     dest: "{{splunk_otel_collector_config}}"
-  when: splunk_otel_collector_config_source != ""
+  when:
+    - splunk_collector_msi_is_configurable is undefined
+    - splunk_otel_collector_config_source != ""

--- a/deployments/ansible/roles/collector/tasks/win_install.yml
+++ b/deployments/ansible/roles/collector/tasks/win_install.yml
@@ -2,11 +2,10 @@
 
 - name: Install Splunk OpenTelemetry Collector with msi package manager
   ansible.builtin.import_tasks: otel_win_install.yml
-  when: ansible_os_family == "Windows"
 
 - name: Set Windows Registry values
   ansible.builtin.import_tasks: otel_win_reg.yml
-  when: ansible_os_family == "Windows"
+  when: splunk_collector_msi_is_configurable is undefined
 
 - name: Install Fluentd with msi package manager
   ansible.builtin.import_tasks: win_fluentd_install.yml


### PR DESCRIPTION
**Description:**
Leverage the latest MSI capabilities so we don't rely on custom Ansible code to install the collector on Windows. At this point if the user wants to install only the collector on Windows they can directly use https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_package_module.html

**Testing:** CI

**Documentation:**
This change is not noticeable to end users, they can keep using the same settings that they used before.