### PR TITLE
[receiver/discovery] Refactor the endpoint tracker to remove states

### DIFF
--- a/internal/receiver/discoveryreceiver/evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/evaluator_test.go
@@ -105,7 +105,7 @@ func TestCorrelateResourceAttrs(t *testing.T) {
 			endpoint := observer.Endpoint{ID: endpointID}
 			observerID := component.MustNewIDWithName("type", "name")
 			receiverID := component.MustNewIDWithName("receiver", "name")
-			eval.correlations.UpdateEndpoint(endpoint, receiverID, addedState, observerID)
+			eval.correlations.UpdateEndpoint(endpoint, receiverID, observerID)
 
 			corr := eval.correlations.GetOrCreate(receiverID, endpointID)
 
@@ -155,7 +155,7 @@ func TestCorrelateResourceAttrsWithExistingConfig(t *testing.T) {
 			endpoint := observer.Endpoint{ID: endpointID}
 			observerID := component.MustNewIDWithName("type", "name")
 			receiverID := component.MustNewIDWithName("receiver", "name")
-			eval.correlations.UpdateEndpoint(endpoint, receiverID, addedState, observerID)
+			eval.correlations.UpdateEndpoint(endpoint, receiverID, observerID)
 
 			corr := eval.correlations.GetOrCreate(receiverID, endpointID)
 

--- a/internal/receiver/discoveryreceiver/metric_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator_test.go
@@ -83,7 +83,7 @@ func TestMetricEvaluation(t *testing.T) {
 
 					plogs := make(chan plog.Logs)
 					cStore := newCorrelationStore(logger, time.Hour)
-					cStore.UpdateEndpoint(observer.Endpoint{ID: "endpoint.id"}, receiverID, addedState, observerID)
+					cStore.UpdateEndpoint(observer.Endpoint{ID: "endpoint.id"}, receiverID, observerID)
 
 					me := newMetricEvaluator(logger, cfg, plogs, cStore)
 

--- a/internal/receiver/discoveryreceiver/statement_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator_test.go
@@ -74,7 +74,7 @@ func TestStatementEvaluation(t *testing.T) {
 							logger := zap.NewNop()
 							cStore := newCorrelationStore(logger, time.Hour)
 							receiverID := component.MustNewIDWithName("a_receiver", "receiver.name")
-							cStore.UpdateEndpoint(observer.Endpoint{ID: "endpoint.id"}, receiverID, addedState, observerID)
+							cStore.UpdateEndpoint(observer.Endpoint{ID: "endpoint.id"}, receiverID, observerID)
 
 							se, err := newStatementEvaluator(logger, component.MustNewID("some_type"), cfg, plogs, cStore)
 							require.NoError(t, err)


### PR DESCRIPTION
Clearly separate state and delete entities. There is no need to keep the changed/added state from the observer. This will later help to enhance the endpoint storage to maintain more data about discovery states.

No functional changes.
