### PR TITLE
[receiver/discovery] Emit entity events only for matching receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - (Splunk) `receiver/discovery`: Update the component to emit entity events 
   - Emit entity events for discovered endpoints with log_endpoints: true ([#4684](https://github.com/signalfx/splunk-otel-collector/pull/4684))
   - Ensure active endpoints emitted as entity events periodically ([#4684](https://github.com/signalfx/splunk-otel-collector/pull/4684))
+  - Emit entity events only for matching receivers ([#4691](https://github.com/signalfx/splunk-otel-collector/pull/4691))
 
 ### 💡 Enhancements 💡
 

--- a/internal/receiver/discoveryreceiver/config_test.go
+++ b/internal/receiver/discoveryreceiver/config_test.go
@@ -100,7 +100,7 @@ func TestValidConfig(t *testing.T) {
 				Rule: mustNewRule(`type == "container" && name matches "(?i)redis"`),
 			},
 		},
-		LogEndpoints:        true,
+		LogEndpoints:        false,
 		EmbedReceiverConfig: true,
 		CorrelationTTL:      25 * time.Second,
 		WatchObservers: []component.ID{

--- a/internal/receiver/discoveryreceiver/testdata/config.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/config.yaml
@@ -2,7 +2,7 @@ discovery:
   watch_observers:
     - an_observer
     - another_observer/with_name
-  log_endpoints: true
+  log_endpoints: false
   embed_receiver_config: true
   correlation_ttl: 25s
   receivers:

--- a/tests/receivers/discovery/testdata/host_observer_endpoints_config.yaml
+++ b/tests/receivers/discovery/testdata/host_observer_endpoints_config.yaml
@@ -6,6 +6,13 @@ extensions:
 receivers:
   discovery:
     log_endpoints: true
+    receivers:
+      hostmetrics:
+        rule: type == "hostport"
+        status:
+          metrics:
+            - status: successful
+              regexp: .*
     watch_observers:
       - host_observer
       - host_observer/with_name


### PR DESCRIPTION
Only the entity tracker will be responsible for emitting entity events. So we want to avoid sending entity state events for any observed endpoints. We need to send events only for those that we have defined discovery rules.
