### PR TITLE
[receiver/discovery] Simplify config reporting

### DIFF
--- a/internal/receiver/discoveryreceiver/evaluator.go
+++ b/internal/receiver/discoveryreceiver/evaluator.go
@@ -116,79 +116,30 @@ func (e *evaluator) evaluateMatch(match Match, pattern string, status discovery.
 	return shouldLog, nil
 }
 
-// correlateResourceAttributes will copy all `from` attributes to `to` in addition to
-// updating embedded base64 config content, if configured, to include the correlated observer ID
-// that is otherwise unavailable to status sources.
-func (e *evaluator) correlateResourceAttributes(from, to pcommon.Map, corr correlation) {
-	receiverType := corr.receiverID.Type().String()
-	receiverName := corr.receiverID.Name()
-
+// correlateResourceAttributes sets correlation attributes including embedded base64 config content, if configured.
+func (e *evaluator) correlateResourceAttributes(cfg *Config, to pcommon.Map, corr correlation) {
 	observerID := corr.observerID.String()
 	if observerID != "" && observerID != discovery.NoType.String() {
 		to.PutStr(discovery.ObserverIDAttr, observerID)
 	}
 
-	var receiverAttrs map[string]string
-	hasTemporaryReceiverConfigAttr := false
-	receiverAttrs = e.correlations.Attrs(corr.receiverID)
-
 	if e.config.EmbedReceiverConfig {
-		if _, ok := from.Get(discovery.ReceiverConfigAttr); !ok {
-			// statements don't inherit embedded configs in their resource attributes
-			// from the receiver creator, so we should temporarily include it in `from`
-			// so as not to mutate the original while providing the desired receiver config
-			// value set by the initial receiver config parser.
-			from.PutStr(discovery.ReceiverConfigAttr, receiverAttrs[discovery.ReceiverConfigAttr])
-			hasTemporaryReceiverConfigAttr = true
+		embeddedConfig := map[string]any{}
+		rEntry := cfg.Receivers[corr.receiverID] // it's safe to assume this exists.
+		embeddedReceiversConfig := map[string]any{}
+		receiverConfig := map[string]any{}
+		receiverConfig["rule"] = rEntry.Rule
+		receiverConfig["config"] = rEntry.Config
+		receiverConfig["resource_attributes"] = rEntry.ResourceAttributes
+		embeddedReceiversConfig[corr.receiverID.String()] = receiverConfig
+		embeddedConfig["receivers"] = embeddedReceiversConfig
+		if observerID != "" && observerID != discovery.NoType.String() {
+			embeddedConfig["watch_observers"] = []string{observerID}
 		}
-	}
-
-	from.Range(func(k string, v pcommon.Value) bool {
-		if k == discovery.ReceiverConfigAttr && e.config.EmbedReceiverConfig {
-			configVal := v.AsString()
-			updatedWithObserverAttr := fmt.Sprintf("%s.%s", receiverUpdatedConfigAttr, observerID)
-			if updatedConfig, ok := receiverAttrs[updatedWithObserverAttr]; ok {
-				configVal = updatedConfig
-			} else if observerID != "" {
-				var err error
-				if updatedConfig, err = addObserverToEncodedConfig(configVal, observerID); err != nil {
-					// log failure and continue with existing config sans observer
-					e.logger.Debug(fmt.Sprintf("failed adding %q to %s", observerID, discovery.ReceiverConfigAttr), zap.String("receiver.type", receiverType), zap.String("receiver.name", receiverName), zap.Error(err))
-				} else {
-					e.logger.Debug("Adding watch_observer to embedded receiver config receiver attrs", zap.String("observer", corr.observerID.String()), zap.String("receiver.type", receiverType), zap.String("receiver.name", receiverName))
-					e.correlations.UpdateAttrs(corr.receiverID, map[string]string{
-						updatedWithObserverAttr: updatedConfig,
-					})
-					configVal = updatedConfig
-				}
-			}
-			v = pcommon.NewValueStr(configVal)
+		cfgYaml, err := yaml.Marshal(embeddedConfig)
+		if err != nil {
+			e.logger.Error("failed embedding receiver config", zap.String("observer", observerID), zap.Error(err))
 		}
-		if _, ok := to.Get(k); !ok {
-			v.CopyTo(to.PutEmpty(k))
-		}
-		return true
-	})
-	if hasTemporaryReceiverConfigAttr {
-		from.Remove(discovery.ReceiverConfigAttr)
+		to.PutStr(discovery.ReceiverConfigAttr, base64.StdEncoding.EncodeToString(cfgYaml))
 	}
-}
-
-func addObserverToEncodedConfig(encoded, observerID string) (string, error) {
-	cfg := map[string]any{}
-	dBytes, err := base64.StdEncoding.DecodeString(encoded)
-	if err != nil {
-		return "", err
-	}
-	if err = yaml.Unmarshal(dBytes, &cfg); err != nil {
-		return "", err
-	}
-
-	cfg["watch_observers"] = []string{observerID}
-
-	var cfgYaml []byte
-	if cfgYaml, err = yaml.Marshal(cfg); err != nil {
-		return "", fmt.Errorf("failed embedding receiver config to include %q: %w", observerID, err)
-	}
-	return base64.StdEncoding.EncodeToString(cfgYaml), nil
 }

--- a/internal/receiver/discoveryreceiver/metric_evaluator.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator.go
@@ -127,10 +127,10 @@ func (m *metricEvaluator) evaluateMetrics(md pmetric.Metrics) plog.Logs {
 				entityEvent.ID().PutStr(discovery.EndpointIDAttr, string(endpointID))
 				entityState := entityEvent.SetEntityState()
 
-				m.correlateResourceAttributes(
-					md.ResourceMetrics().At(0).Resource().Attributes(), entityState.Attributes(),
-					m.correlations.GetOrCreate(receiverID, endpointID),
-				)
+				md.ResourceMetrics().At(0).Resource().Attributes().CopyTo(entityState.Attributes())
+				corr := m.correlations.GetOrCreate(receiverID, endpointID)
+				m.correlateResourceAttributes(m.config, entityState.Attributes(), corr)
+
 				// Remove the endpoint ID from the attributes as it's set in the entity ID.
 				entityState.Attributes().Remove(discovery.EndpointIDAttr)
 

--- a/internal/receiver/discoveryreceiver/receiver.go
+++ b/internal/receiver/discoveryreceiver/receiver.go
@@ -171,7 +171,7 @@ func (d *discoveryReceiver) consumerLoop(loopStarted *sync.WaitGroup) {
 }
 
 func (d *discoveryReceiver) createAndSetReceiverCreator() error {
-	receiverCreatorFactory, receiverCreatorConfig, err := d.config.receiverCreatorFactoryAndConfig(d.endpointTracker.correlations)
+	receiverCreatorFactory, receiverCreatorConfig, err := d.config.receiverCreatorFactoryAndConfig()
 	if err != nil {
 		return err
 	}

--- a/internal/receiver/discoveryreceiver/statement_evaluator.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator.go
@@ -187,15 +187,15 @@ func (se *statementEvaluator) evaluateStatement(statement *statussources.Stateme
 		entityEvent := entityEvents.AppendEmpty()
 		entityEvent.ID().PutStr(discovery.EndpointIDAttr, string(endpointID))
 		entityState := entityEvent.SetEntityState()
-		_ = entityState.Attributes().FromRaw(statement.Fields)
-		entityState.Attributes().PutStr(discovery.MessageAttr, statement.Message)
-
-		fromAttrs := pcommon.NewMap()
-		fromAttrs.PutStr(discovery.ReceiverTypeAttr, receiverID.Type().String())
-		fromAttrs.PutStr(discovery.ReceiverNameAttr, receiverID.Name())
-		se.correlateResourceAttributes(fromAttrs, entityState.Attributes(), se.correlations.GetOrCreate(receiverID, endpointID))
-		entityState.Attributes().PutStr(eventTypeAttr, statementMatch)
-		entityState.Attributes().PutStr(receiverRuleAttr, rEntry.Rule.String())
+		attrs := entityState.Attributes()
+		_ = attrs.FromRaw(statement.Fields)
+		corr := se.correlations.GetOrCreate(receiverID, endpointID)
+		se.correlateResourceAttributes(se.config, attrs, corr)
+		attrs.PutStr(discovery.ReceiverTypeAttr, receiverID.Type().String())
+		attrs.PutStr(discovery.ReceiverNameAttr, receiverID.Name())
+		attrs.PutStr(discovery.MessageAttr, statement.Message)
+		attrs.PutStr(eventTypeAttr, statementMatch)
+		attrs.PutStr(receiverRuleAttr, rEntry.Rule.String())
 
 		var desiredRecord LogRecord
 		if match.Record != nil {


### PR DESCRIPTION
This change removes the complicated logic of passing the encoded config by metrics receivers as part of a resource attribute and intercepting it in the discovery receiver. Instead, we compute the embedded config on the fly for every emitted entity. In the short run, this hits the performance of the discovery receiver, but once we move the `metric.match` and `statement.match` discovery events to entity states in the following PRs, it won't be an issue.

Except for the performance implications, there are no functional changes in this PR.
