### PR TITLE
[receiver/discovery] Refactor correlation store to be endpoint-centric

### DIFF
--- a/internal/receiver/discoveryreceiver/evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/evaluator_test.go
@@ -107,7 +107,7 @@ func TestCorrelateResourceAttrs(t *testing.T) {
 			receiverID := component.MustNewIDWithName("receiver", "name")
 			eval.correlations.UpdateEndpoint(endpoint, receiverID, observerID)
 
-			corr := eval.correlations.GetOrCreate(receiverID, endpointID)
+			corr := eval.correlations.GetOrCreate(endpointID, receiverID)
 
 			cfg := &Config{
 				Receivers: map[component.ID]ReceiverEntry{
@@ -126,7 +126,7 @@ func TestCorrelateResourceAttrs(t *testing.T) {
 
 			to := pcommon.NewMap()
 
-			require.Empty(t, eval.correlations.Attrs(receiverID))
+			require.Empty(t, eval.correlations.Attrs(endpointID))
 			eval.correlateResourceAttributes(cfg, to, corr)
 
 			expectedResourceAttrs := map[string]any{

--- a/internal/receiver/discoveryreceiver/metric_evaluator.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator.go
@@ -128,7 +128,7 @@ func (m *metricEvaluator) evaluateMetrics(md pmetric.Metrics) plog.Logs {
 				entityState := entityEvent.SetEntityState()
 
 				md.ResourceMetrics().At(0).Resource().Attributes().CopyTo(entityState.Attributes())
-				corr := m.correlations.GetOrCreate(receiverID, endpointID)
+				corr := m.correlations.GetOrCreate(endpointID, receiverID)
 				m.correlateResourceAttributes(m.config, entityState.Attributes(), corr)
 
 				// Remove the endpoint ID from the attributes as it's set in the entity ID.

--- a/internal/receiver/discoveryreceiver/statement_evaluator.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator.go
@@ -189,7 +189,7 @@ func (se *statementEvaluator) evaluateStatement(statement *statussources.Stateme
 		entityState := entityEvent.SetEntityState()
 		attrs := entityState.Attributes()
 		_ = attrs.FromRaw(statement.Fields)
-		corr := se.correlations.GetOrCreate(receiverID, endpointID)
+		corr := se.correlations.GetOrCreate(endpointID, receiverID)
 		se.correlateResourceAttributes(se.config, attrs, corr)
 		attrs.PutStr(discovery.ReceiverTypeAttr, receiverID.Type().String())
 		attrs.PutStr(discovery.ReceiverNameAttr, receiverID.Name())


### PR DESCRIPTION
Update the `correlationStore` methods to take `endpointID` as the first argument.

The most important change is repurposing of the attributes store. After https://github.com/signalfx/splunk-otel-collector/pull/4717, it's not being used anymore, but this will be used to store endpoint-specific attributes. So this change migrates the field from storing receiver's attributes to storing endpoint/correlation attributes.

There are no functional changes in this PR.