### PR TITLE
Add Ack extension to Splunk distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   - Emit entity events only for matching receivers ([#4691](https://github.com/signalfx/splunk-otel-collector/pull/4691))
   - Remove `log_endpoints` config option ([#4692](https://github.com/signalfx/splunk-otel-collector/pull/4692))
 
+### 🚀 New components 🚀
+
+- (Splunk) Add Ack extension
+
 ### 💡 Enhancements 💡
 
 - (Splunk) Include [`splunk-otel-dotnet`](https://github.com/signalfx/splunk-otel-dotnet) in the `splunk-otel-auto-instrumentation` deb/rpm packages (x86_64/amd64 only) ([#4679](https://github.com/signalfx/splunk-otel-collector/pull/4679))

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.99.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.99.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.99.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.99.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.99.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.99.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension v0.99.0
@@ -240,7 +241,6 @@ require (
 	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/mrunalp/fileutils v0.5.1 // indirect
 	github.com/okta/okta-sdk-golang/v2 v2.20.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.99.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.99.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight v0.99.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s v0.99.0 // indirect

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -27,6 +27,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension"
@@ -126,6 +127,7 @@ import (
 func Get() (otelcol.Factories, error) {
 	var errs []error
 	extensions, err := extension.MakeFactoryMap(
+		ackextension.NewFactory(),
 		ballastextension.NewFactory(),
 		basicauthextension.NewFactory(),
 		ecsobserver.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestDefaultComponents(t *testing.T) {
 	expectedExtensions := []string{
+		"ack",
 		"basicauth",
 		"ecs_observer",
 		"ecs_task_observer",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This allows the Splunk distribution of the OpenTelemetry Collector to use the [ack extension.](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/ackextension)