### PR TITLE
[receiver/discovery] Emit evaluation entities by the endpoint tracker

### DIFF
--- a/internal/receiver/discoveryreceiver/endpoint_tracker_test.go
+++ b/internal/receiver/discoveryreceiver/endpoint_tracker_test.go
@@ -164,7 +164,7 @@ func TestEndpointToPLogsHappyPath(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			events, failed, err := entityStateEvents(
 				component.MustNewIDWithName("observer_type", "observer.name"),
-				[]observer.Endpoint{test.endpoint}, t0,
+				[]observer.Endpoint{test.endpoint}, newCorrelationStore(zap.NewNop(), time.Hour), t0,
 			)
 			require.NoError(t, err)
 			require.Zero(t, failed)
@@ -276,7 +276,7 @@ func TestEndpointToPLogsInvalidEndpoints(t *testing.T) {
 			// Validate entity_state event
 			events, failed, err := entityStateEvents(
 				component.MustNewIDWithName("observer_type", "observer.name"),
-				[]observer.Endpoint{test.endpoint}, t0,
+				[]observer.Endpoint{test.endpoint}, newCorrelationStore(zap.NewNop(), time.Hour), t0,
 			)
 			if test.expectedError != "" {
 				require.Error(t, err)
@@ -343,7 +343,7 @@ func FuzzEndpointToPlogs(f *testing.F) {
 							Transport: observer.Transport(transport),
 						},
 					},
-				}, t0,
+				}, newCorrelationStore(zap.NewNop(), time.Hour), t0,
 			)
 
 			expectedLogs := expectedPLogs(endpointID)
@@ -661,6 +661,7 @@ func TestEntityEmittingLifecycle(t *testing.T) {
 	require.Equal(t, 1, gotLogs.LogRecordCount())
 	// TODO: Use plogtest.IgnoreTimestamp once available
 	expectedEvents, failed, err := entityStateEvents(obsID, []observer.Endpoint{portEndpoint},
+		newCorrelationStore(zap.NewNop(), time.Hour),
 		gotLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Timestamp().AsTime())
 	require.NoError(t, err)
 	require.Zero(t, failed)

--- a/internal/receiver/discoveryreceiver/evaluator.go
+++ b/internal/receiver/discoveryreceiver/evaluator.go
@@ -24,7 +24,6 @@ import (
 	"github.com/antonmedv/expr/vm"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 
@@ -117,10 +116,10 @@ func (e *evaluator) evaluateMatch(match Match, pattern string, status discovery.
 }
 
 // correlateResourceAttributes sets correlation attributes including embedded base64 config content, if configured.
-func (e *evaluator) correlateResourceAttributes(cfg *Config, to pcommon.Map, corr correlation) {
+func (e *evaluator) correlateResourceAttributes(cfg *Config, to map[string]string, corr correlation) {
 	observerID := corr.observerID.String()
 	if observerID != "" && observerID != discovery.NoType.String() {
-		to.PutStr(discovery.ObserverIDAttr, observerID)
+		to[discovery.ObserverIDAttr] = observerID
 	}
 
 	if e.config.EmbedReceiverConfig {
@@ -140,6 +139,6 @@ func (e *evaluator) correlateResourceAttributes(cfg *Config, to pcommon.Map, cor
 		if err != nil {
 			e.logger.Error("failed embedding receiver config", zap.String("observer", observerID), zap.Error(err))
 		}
-		to.PutStr(discovery.ReceiverConfigAttr, base64.StdEncoding.EncodeToString(cfgYaml))
+		to[discovery.ReceiverConfigAttr] = base64.StdEncoding.EncodeToString(cfgYaml)
 	}
 }

--- a/internal/receiver/discoveryreceiver/evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/evaluator_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
 )
 
@@ -124,12 +123,11 @@ func TestCorrelateResourceAttrs(t *testing.T) {
 				},
 			}
 
-			to := pcommon.NewMap()
-
+			to := map[string]string{}
 			require.Empty(t, eval.correlations.Attrs(endpointID))
 			eval.correlateResourceAttributes(cfg, to, corr)
 
-			expectedResourceAttrs := map[string]any{
+			expectedResourceAttrs := map[string]string{
 				"discovery.observer.id": "type/name",
 			}
 
@@ -147,7 +145,7 @@ watch_observers:
 `))
 			}
 
-			require.Equal(t, expectedResourceAttrs, to.AsRaw())
+			require.Equal(t, expectedResourceAttrs, to)
 		})
 	}
 }

--- a/internal/receiver/discoveryreceiver/receiver.go
+++ b/internal/receiver/discoveryreceiver/receiver.go
@@ -99,9 +99,9 @@ func (d *discoveryReceiver) Start(ctx context.Context, host component.Host) (err
 	d.endpointTracker = newEndpointTracker(d.observables, d.config, d.logger, d.pLogs, correlations)
 	d.endpointTracker.start()
 
-	d.metricEvaluator = newMetricEvaluator(d.logger, d.config, d.pLogs, correlations)
+	d.metricEvaluator = newMetricEvaluator(d.logger, d.config, correlations)
 
-	if d.statementEvaluator, err = newStatementEvaluator(d.logger, d.settings.ID, d.config, d.pLogs, correlations); err != nil {
+	if d.statementEvaluator, err = newStatementEvaluator(d.logger, d.settings.ID, d.config, correlations); err != nil {
 		return fmt.Errorf("failed creating statement evaluator: %w", err)
 	}
 

--- a/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
+++ b/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
@@ -23,6 +23,15 @@ resource_logs:
                 discovery.status: successful
                 discovery.message: Successfully connected to prometheus server
                 metric.name: otelcol_process_uptime
+                discovery.observer.type: host_observer
+                discovery.observer.name: ""
+                command: /otelcol --config /etc/config.yaml
+                endpoint: '[::]:8888'
+                is_ipv6: true
+                port: 8888
+                process_name: otelcol
+                transport: TCP
+                type: hostport
   - scope_logs:
       - logs:
           - attributes:
@@ -42,3 +51,12 @@ resource_logs:
                 kind: receiver
                 name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer)[::]-4318-TCP-1
                 target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
+                discovery.observer.name: ""
+                discovery.observer.type: host_observer
+                command: /otelcol --config /etc/config.yaml
+                endpoint: '[::]:4318'
+                is_ipv6: true
+                port: 4318
+                process_name: otelcol
+                transport: TCP
+                type: hostport


### PR DESCRIPTION
This change consolidates the entity emitting in one place: the endpoint tracker. Once the evaluation succeeds, the endpoint attributes are updated in the correlation store, and the new entity state is emitted immediately. Every subsequent state is emitted with all the added attributes.

Currently, we emit a superset of all the attributes that were previously emitted on a regular basis or during evaluation. Later, we will reduce the set and remove redundant attributes.

The tests are kept with minimal changes to ensure no attributes are lost in the emitted entities.
