### PR TITLE
Remove integration-test from collectd-ectd

### DIFF
--- a/internal/signalfx-agent/bundle/collectd-plugins.yaml
+++ b/internal/signalfx-agent/bundle/collectd-plugins.yaml
@@ -10,6 +10,8 @@
 - name: etcd
   version: v2.0.0
   repo: signalfx/collectd-etcd
+  can_remove:
+    - integration-test
 
 - name: hadoop
   version: v1.1.0


### PR DESCRIPTION
Remove the `integration-test` directory included in the `collectd-etcd` pip package.