### PR TITLE
Bump minimum version of idna to >= 3.7

### DIFF
--- a/internal/signalfx-agent/bundle/scripts/security-requirements.txt
+++ b/internal/signalfx-agent/bundle/scripts/security-requirements.txt
@@ -1,3 +1,4 @@
 certifi>=2023.07.22
 requests>=2.31.0
 urllib3>=1.26.18,<2
+idna>=3.7,<4


### PR DESCRIPTION
Tested locally on a docker image, the proper version of `idna` was installed.