### PR TITLE
Add `apt-get update` to all containers deriving from `base`

### DIFF
--- a/internal/signalfx-agent/bundle/Dockerfile
+++ b/internal/signalfx-agent/bundle/Dockerfile
@@ -38,7 +38,7 @@ FROM base as java
 ARG JDK_VERSION
 ARG MAVEN_VERSION
 
-RUN apt-get install -qq -y wget
+RUN apt-get update && apt-get install -qq -y wget
 
 ENV OPENJDK_BASE_URL="https://github.com/adoptium/temurin11-binaries/releases/download"
 
@@ -331,7 +331,7 @@ RUN find /usr/local/lib/python3.11 -wholename "*test*.key" -delete -or -wholenam
 ######## Extra packages that don't make sense to pull down in any other stage ########
 FROM base as extra-packages
 
-RUN apt-get install -qq -y \
+RUN apt-get update && apt-get install -qq -y \
         host \
         iproute2 \
         libtirpc3


### PR DESCRIPTION
I have build issues on my laptop when running `make docker-otelcol` with the version of `internal/signalfx-agent/bundle/Dockerfile` currently in main.

We currently do this for [the python build](https://github.com/signalfx/splunk-otel-collector/blob/main/internal/signalfx-agent/bundle/Dockerfile#L89).  I tried removing `apt-get` from the python build to see what happens.  It did not improve the situation.

# Logs
## off main
### wget fails sometimes
```
 => ERROR [java 1/8] RUN apt-get install -qq -y wget                                          0.6s
 => CANCELED [extra-packages  1/14] RUN apt-get install -qq -y         host         iproute2  0.7s
------
 > [java 1/8] RUN apt-get install -qq -y wget:
0.429 E: Unable to locate package wget
------
Dockerfile:42
--------------------
  40 |     ARG MAVEN_VERSION
  41 |
  42 | >>> RUN apt-get install -qq -y wget
  43 |
  44 |     ENV OPENJDK_BASE_URL="https://github.com/adoptium/temurin11-binaries/releases/download"
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get install -qq -y wget" did not complete successfully: exit code: 100
make[1]: *** [Makefile:6: agent-bundle-linux] Error 1
make[1]: Leaving directory '/home/jameshughes/workspace/otel-github/splunk-otel-collector/internal/signalfx-agent/bundle'
make: *** [Makefile:153: docker-otelcol] Error 2
```

### sometimes extra-packages fails
```
 => ERROR [extra-packages  1/14] RUN apt-get install -qq -y         host         iproute2     0.6s
 => CANCELED [java 1/8] RUN apt-get install -qq -y wget                                       0.8s
------
 > [extra-packages  1/14] RUN apt-get install -qq -y         host         iproute2         libtirpc3:
0.372 E: Unable to locate package host
0.372 E: Unable to locate package iproute2
------
Dockerfile:334
--------------------
 333 |
 334 | >>> RUN apt-get install -qq -y \
 335 | >>>         host \
 336 | >>>         iproute2 \
 337 | >>>         libtirpc3
 338 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get install -qq -y         host         iproute2         libtirpc3" did not complete successfully: exit code: 100
make[1]: *** [Makefile:6: agent-bundle-linux] Error 1
make[1]: Leaving directory '/home/jameshughes/workspace/otel-github/splunk-otel-collector/internal/signalfx-agent/bundle'
make: *** [Makefile:153: docker-otelcol] Error 2
```

## If I remove apt-update from python, I get this additional failure
```
 => ERROR [python 1/4] RUN apt-get install -qq -y       curl       dpkg       net-tools       0.6s
 => CANCELED [java 1/8] RUN apt-get install -qq -y wget                                       0.8s
 => CANCELED [extra-packages  1/14] RUN apt-get install -qq -y         host         iproute2  0.9s
------
 > [python 1/4] RUN apt-get install -qq -y       curl       dpkg       net-tools       software-properties-common       wget       autoconf       automake       autotools-dev       bison       build-essential       debhelper       debian-archive-keyring       debootstrap       devscripts       dh-make       dpatch       fakeroot       flex       gcc       git-core       libatasmart-dev       libcurl4-openssl-dev       libdbi0-dev       libdbus-1-dev       libdbus-glib-1-dev       libdistro-info-perl       libesmtp-dev       libexpat1-dev       libffi-dev       libganglia1-dev       libgcrypt20-dev       libglib2.0-dev       libiptc-dev       libldap2-dev       libltdl-dev       libmemcached-dev       libmicrohttpd-dev       libmnl-dev       libmodbus-dev       libnotify-dev       liboping-dev       libow-dev       libpcap-dev       libperl-dev       libpq-dev       libprotobuf-c-dev       librabbitmq-dev       librdkafka-dev       librrd-dev       libsnmp-dev       libssl-dev       libtool       libudev-dev       libvarnishapi-dev       libvirt-dev       libxml2-dev       libyajl-dev       lsb-release       pbuilder       pkg-config       po-debconf       protobuf-c-compiler       quilt       zlib1g-dev:
0.424 E: Unable to locate package curl
0.424 E: Unable to locate package net-tools
0.424 E: Unable to locate package software-properties-common
0.424 E: Unable to locate package wget
0.424 E: Unable to locate package autoconf
0.424 E: Unable to locate package automake
0.424 E: Unable to locate package autotools-dev
0.424 E: Unable to locate package bison
0.424 E: Unable to locate package build-essential
0.424 E: Unable to locate package debhelper
0.424 E: Unable to locate package debian-archive-keyring
0.424 E: Unable to locate package debootstrap
0.424 E: Unable to locate package devscripts
0.424 E: Unable to locate package dh-make
0.424 E: Unable to locate package dpatch
0.424 E: Package 'fakeroot' has no installation candidate
0.424 E: Unable to locate package flex
0.424 E: Unable to locate package gcc
0.424 E: Unable to locate package git-core
0.424 E: Unable to locate package libatasmart-dev
0.424 E: Unable to locate package libcurl4-openssl-dev
0.424 E: Unable to locate package libdbi0-dev
0.424 E: Unable to locate package libdbus-1-dev
0.424 E: Unable to locate package libdbus-glib-1-dev
0.424 E: Unable to locate package libdistro-info-perl
0.424 E: Unable to locate package libesmtp-dev
0.424 E: Unable to locate package libexpat1-dev
0.424 E: Unable to locate package libffi-dev
0.424 E: Unable to locate package libganglia1-dev
0.424 E: Unable to locate package libgcrypt20-dev
0.424 E: Unable to locate package libglib2.0-dev
0.424 E: Couldn't find any package by glob 'libglib2.0-dev'
0.424 E: Couldn't find any package by regex 'libglib2.0-dev'
0.424 E: Unable to locate package libiptc-dev
0.424 E: Unable to locate package libldap2-dev
0.424 E: Unable to locate package libltdl-dev
0.424 E: Unable to locate package libmemcached-dev
0.424 E: Unable to locate package libmicrohttpd-dev
0.424 E: Unable to locate package libmnl-dev
0.424 E: Unable to locate package libmodbus-dev
0.424 E: Unable to locate package libnotify-dev
0.424 E: Unable to locate package liboping-dev
0.424 E: Unable to locate package libow-dev
0.424 E: Unable to locate package libpcap-dev
0.424 E: Unable to locate package libperl-dev
0.424 E: Unable to locate package libpq-dev
0.424 E: Unable to locate package libprotobuf-c-dev
0.424 E: Unable to locate package librabbitmq-dev
0.424 E: Unable to locate package librdkafka-dev
0.424 E: Unable to locate package librrd-dev
0.424 E: Unable to locate package libsnmp-dev
0.424 E: Unable to locate package libssl-dev
0.424 E: Unable to locate package libtool
0.424 E: Unable to locate package libudev-dev
0.424 E: Unable to locate package libvarnishapi-dev
0.424 E: Unable to locate package libvirt-dev
0.424 E: Unable to locate package libxml2-dev
0.424 E: Unable to locate package libyajl-dev
0.424 E: Unable to locate package lsb-release
0.424 E: Unable to locate package pbuilder
0.424 E: Unable to locate package pkg-config
0.424 E: Unable to locate package po-debconf
0.424 E: Unable to locate package protobuf-c-compiler
0.424 E: Unable to locate package quilt
0.424 E: Unable to locate package zlib1g-dev
------
Dockerfile:89
--------------------
  88 |
  89 | >>> RUN apt-get install -qq -y \
  90 | >>>       curl \
  91 | >>>       dpkg \
  92 | >>>       net-tools \
  93 | >>>       software-properties-common \
  94 | >>>       wget \
  95 | >>>       autoconf \
  96 | >>>       automake \
  97 | >>>       autotools-dev \
  98 | >>>       bison \
  99 | >>>       build-essential \
 100 | >>>       debhelper \
 101 | >>>       debian-archive-keyring \
 102 | >>>       debootstrap \
 103 | >>>       devscripts \
 104 | >>>       dh-make \
 105 | >>>       dpatch \
 106 | >>>       fakeroot \
 107 | >>>       flex \
 108 | >>>       gcc \
 109 | >>>       git-core \
 110 | >>>       libatasmart-dev \
 111 | >>>       libcurl4-openssl-dev \
 112 | >>>       libdbi0-dev \
 113 | >>>       libdbus-1-dev \
 114 | >>>       libdbus-glib-1-dev \
 115 | >>>       libdistro-info-perl \
 116 | >>>       libesmtp-dev \
 117 | >>>       libexpat1-dev \
 118 | >>>       libffi-dev \
 119 | >>>       libganglia1-dev \
 120 | >>>       libgcrypt20-dev \
 121 | >>>       libglib2.0-dev \
 122 | >>>       libiptc-dev \
 123 | >>>       libldap2-dev \
 124 | >>>       libltdl-dev \
 125 | >>>       libmemcached-dev \
 126 | >>>       libmicrohttpd-dev \
 127 | >>>       libmnl-dev \
 128 | >>>       libmodbus-dev \
 129 | >>>       libnotify-dev \
 130 | >>>       liboping-dev \
 131 | >>>       libow-dev \
 132 | >>>       libpcap-dev \
 133 | >>>       libperl-dev \
 134 | >>>       libpq-dev \
 135 | >>>       libprotobuf-c-dev \
 136 | >>>       librabbitmq-dev \
 137 | >>>       librdkafka-dev \
 138 | >>>       librrd-dev \
 139 | >>>       libsnmp-dev \
 140 | >>>       libssl-dev \
 141 | >>>       libtool \
 142 | >>>       libudev-dev \
 143 | >>>       libvarnishapi-dev \
 144 | >>>       libvirt-dev \
 145 | >>>       libxml2-dev \
 146 | >>>       libyajl-dev \
 147 | >>>       lsb-release \
 148 | >>>       pbuilder \
 149 | >>>       pkg-config \
 150 | >>>       po-debconf \
 151 | >>>       protobuf-c-compiler \
 152 | >>>       quilt \
 153 | >>>       zlib1g-dev
 154 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get install -qq -y       curl       dpkg       net-tools       software-properties-common       wget       autoconf       automake       autotools-dev       bison       build-essential       debhelper       debian-archive-keyring       debootstrap       devscripts       dh-make       dpatch       fakeroot       flex       gcc       git-core       libatasmart-dev       libcurl4-openssl-dev       libdbi0-dev       libdbus-1-dev       libdbus-glib-1-dev       libdistro-info-perl       libesmtp-dev       libexpat1-dev       libffi-dev       libganglia1-dev       libgcrypt20-dev       libglib2.0-dev       libiptc-dev       libldap2-dev       libltdl-dev       libmemcached-dev       libmicrohttpd-dev       libmnl-dev       libmodbus-dev       libnotify-dev       liboping-dev       libow-dev       libpcap-dev       libperl-dev       libpq-dev       libprotobuf-c-dev       librabbitmq-dev       librdkafka-dev       librrd-dev       libsnmp-dev       libssl-dev       libtool       libudev-dev       libvarnishapi-dev       libvirt-dev       libxml2-dev       libyajl-dev       lsb-release       pbuilder       pkg-config       po-debconf       protobuf-c-compiler       quilt       zlib1g-dev" did not complete successfully: exit code: 100
make[1]: *** [Makefile:6: agent-bundle-linux] Error 1
make[1]: Leaving directory '/home/jameshughes/workspace/otel-github/splunk-otel-collector/internal/signalfx-agent/bundle'
make: *** [Makefile:153: docker-otelcol] Error 2
    ~/works/ote/splunk-otel-collector    make_d
```