### PR TITLE
chef: fix config file for win installs

### DIFF
--- a/deployments/chef/CHANGELOG.md
+++ b/deployments/chef/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## chef-v0.13.0
+
+- Only copy the collector configuration file to `ProgramData` if the source exists.
+
 ## chef-v0.12.0
 
 - `splunk_ballast_size_mib` is deprecated and removed. For Splunk Otel Collector version `0.97.0` or greater, `GOMEMLIMIT` env var is introduced. The default is set to 90% of the `SPLUNK_TOTAL_MEM_MIB`. For more information regarding the usage, please follow the instructions ([here](https://github.com/signalfx/splunk-otel-collector?tab=readme-ov-file#from-0961-to-0970)).

--- a/deployments/chef/metadata.rb
+++ b/deployments/chef/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Splunk, Inc.'
 maintainer_email 'signalfx-support@splunk.com'
 license 'Apache-2.0'
 description 'Install/Configure the Splunk OpenTelemetry Collector'
-version '0.12.0'
+version '0.13.0'
 chef_version '>= 16.0'
 
 supports 'amazon'

--- a/deployments/chef/recipes/default.rb
+++ b/deployments/chef/recipes/default.rb
@@ -24,7 +24,7 @@ if platform_family?('windows')
 
   remote_file node['splunk_otel_collector']['collector_config_dest'] do
     source "#{node['splunk_otel_collector']['collector_config_source']}"
-    only_if { node['splunk_otel_collector']['collector_config'] == {} }
+    only_if { ::File.exist?(node['splunk_otel_collector']['collector_config_source']) && node['splunk_otel_collector']['collector_config'] == {} }
     notifies :restart, 'windows_service[splunk-otel-collector]', :delayed
   end
 


### PR DESCRIPTION
Only copy the collector configuration file to `ProgramData` if the source exists.