### PR TITLE
[receiver/discovery] Add service attributes

### DIFF
--- a/tests/receivers/discovery/testdata/resource_logs/host_observer_endpoints.yaml
+++ b/tests/receivers/discovery/testdata/resource_logs/host_observer_endpoints.yaml
@@ -15,6 +15,8 @@ resource_logs:
                 process_name: otelcol
                 transport: TCP
                 type: hostport
+                service.type: unknown
+                service.name: otelcol
           - attributes:
               otel.entity.id:
                 source.port: 8888
@@ -29,6 +31,8 @@ resource_logs:
                 process_name: otelcol
                 transport: TCP
                 type: hostport
+                service.type: unknown
+                service.name: otelcol
   - scope_logs:
       - logs:
           - attributes:
@@ -45,6 +49,8 @@ resource_logs:
                 process_name: otelcol
                 transport: TCP
                 type: hostport
+                service.type: unknown
+                service.name: otelcol
           - attributes:
               otel.entity.id:
                 source.port: 8888
@@ -59,6 +65,8 @@ resource_logs:
                 process_name: otelcol
                 transport: TCP
                 type: hostport
+                service.type: unknown
+                service.name: otelcol
   - scope_logs:
       - logs:
           - attributes:
@@ -75,6 +83,8 @@ resource_logs:
                 process_name: otelcol
                 transport: TCP
                 type: hostport
+                service.type: unknown
+                service.name: otelcol
           - attributes:
               otel.entity.id:
                 source.port: 8888
@@ -89,3 +99,5 @@ resource_logs:
                 process_name: otelcol
                 transport: TCP
                 type: hostport
+                service.type: unknown
+                service.name: otelcol

--- a/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
+++ b/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
@@ -32,6 +32,7 @@ resource_logs:
                 process_name: otelcol
                 transport: TCP
                 type: hostport
+                service.type: prometheus_simple
   - scope_logs:
       - logs:
           - attributes:
@@ -60,3 +61,5 @@ resource_logs:
                 process_name: otelcol
                 transport: TCP
                 type: hostport
+                service.type: prometheus_simple
+                service.name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer)[::]-4318-TCP-1


### PR DESCRIPTION
`service.name` and `service.type` attributes are required according to the contract with the inventory service. We deduct `service.name` from several inputs and use receiver type for `service.type`
