### PR TITLE
adopt redaction processor into our distro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🚀 New components 🚀
 
-- (Splunk) Add Redaction processor ([#4766}(https://github.com/signalfx/splunk-otel-collector/pull/4766))
+- (Splunk) Add Redaction processor ([#4766](https://github.com/signalfx/splunk-otel-collector/pull/4766))
 
 ## v0.99.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🚀 New components 🚀
+
+- (Splunk) Add Redaction processor ([#4766}(https://github.com/signalfx/splunk-otel-collector/pull/4766))
+
 ## v0.99.0
 
 ### 🛑 Breaking changes 🛑

--- a/docs/components.md
+++ b/docs/components.md
@@ -77,13 +77,14 @@ The distribution offers support for the following components.
 | [logstransform](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/logstransformprocessor)               | [in development]            |
 | [memorylimiter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor)                       | [beta]                      |
 | [metricstransform](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)         | [beta]                      |
-| [probabilisticsampler](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/probabilisticsamplerprocessor) | [beta] |
+| [probabilisticsampler](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/probabilisticsamplerprocessor) | [beta]                      |
+| [redaction](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor)                       | [beta]                      |
 | [resourcedetection](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)       | [beta]                      |
 | [resource](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor)                         | [beta]                      |
 | [routing](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/routingprocessor)                           | [beta]                      |
 | [span](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/spanprocessor)                                 | [alpha]                     |
 | [tail_sampling](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor)                | [beta]                      |
-| [timestamp](../pkg/processor/timestampprocessor)                                                                                                     | [in development]            |
+| [timestamp](../pkg/processor/timestampprocessor)                                                                                            | [in development]            |
 | [transform](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor)                       | [alpha]                     |
 
 </div>

--- a/docs/components.md
+++ b/docs/components.md
@@ -66,26 +66,26 @@ The distribution offers support for the following components.
 
 <div>
 
-| Processors                                                                                                                                  | Stability                   |
-|:--------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------|
-| [attributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor)                     | [alpha]                     |
-| [batch](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor)                                       | [beta]                      |
-| [cumulativetodelta](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor)       | [beta]                      |
-| [filter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor)                             | [alpha]                     |
-| [groupbyattrs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/groupbyattrsprocessor)                 | [beta]                      |
-| [k8sattributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor)               | [beta]                      |
-| [logstransform](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/logstransformprocessor)               | [in development]            |
-| [memorylimiter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor)                       | [beta]                      |
-| [metricstransform](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)         | [beta]                      |
-| [probabilisticsampler](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/probabilisticsamplerprocessor) | [beta]                      |
-| [redaction](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor)                       | [beta]                      |
-| [resourcedetection](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)       | [beta]                      |
-| [resource](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor)                         | [beta]                      |
-| [routing](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/routingprocessor)                           | [beta]                      |
-| [span](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/spanprocessor)                                 | [alpha]                     |
-| [tail_sampling](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor)                | [beta]                      |
-| [timestamp](../pkg/processor/timestampprocessor)                                                                                            | [in development]            |
-| [transform](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor)                       | [alpha]                     |
+| Processors                                                                                                                                  | Stability        |
+|:--------------------------------------------------------------------------------------------------------------------------------------------|:-----------------|
+| [attributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor)                     | [alpha]          |
+| [batch](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor)                                       | [beta]           |
+| [cumulativetodelta](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor)       | [beta]           |
+| [filter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor)                             | [alpha]          |
+| [groupbyattrs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/groupbyattrsprocessor)                 | [beta]           |
+| [k8sattributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor)               | [beta]           |
+| [logstransform](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/logstransformprocessor)               | [in development] |
+| [memorylimiter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor)                       | [beta]           |
+| [metricstransform](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)         | [beta]           |
+| [probabilisticsampler](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/probabilisticsamplerprocessor) | [beta]           |
+| [redaction](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor)                       | [beta]           |
+| [resourcedetection](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)       | [beta]           |
+| [resource](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor)                         | [beta]           |
+| [routing](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/routingprocessor)                           | [beta]           |
+| [span](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/spanprocessor)                                 | [alpha]          |
+| [tail_sampling](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor)                | [beta]           |
+| [timestamp](../pkg/processor/timestampprocessor)                                                                                            | [in development] |
+| [transform](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor)                       | [alpha]          |
 
 </div>
 

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor v0.99.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.99.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.99.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.99.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.99.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.99.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.99.0

--- a/go.sum
+++ b/go.sum
@@ -1349,6 +1349,7 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstrans
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.99.0/go.mod h1:+Z4a3Yt3PjqtGI5pdNmQ4AyvdB7aFxBoq2sjN1RJNVQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.99.0 h1:HH+sX8uN+JkqCOuoA/4FVqqGdJS93NSicB/PgTLELZM=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.99.0/go.mod h1:BwSpsu4+Xk3+Le4sqjs6eVZd5xJ+dZ0mZqoX9+sBbUc=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.99.0 h1:m3m2WRyyTmfpkydRqWYw5yginEF3dM7Of55zsy8lrXg=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.99.0/go.mod h1:Dw7Gw4gdxwNWHV9aB+DrnyDNWN6ujJsm00+O3jhN9bc=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.99.0 h1:Z9wCwf4PV0RLqYAMhM7AXKmdF7lHEq/yElEgTYV24Ow=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.99.0/go.mod h1:ZEfo92OtOsUC8A85caKlUWP3sXULpAfJphxAJYAmVXA=

--- a/go.sum
+++ b/go.sum
@@ -1349,6 +1349,7 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstrans
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.99.0/go.mod h1:+Z4a3Yt3PjqtGI5pdNmQ4AyvdB7aFxBoq2sjN1RJNVQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.99.0 h1:HH+sX8uN+JkqCOuoA/4FVqqGdJS93NSicB/PgTLELZM=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.99.0/go.mod h1:BwSpsu4+Xk3+Le4sqjs6eVZd5xJ+dZ0mZqoX9+sBbUc=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.99.0/go.mod h1:Dw7Gw4gdxwNWHV9aB+DrnyDNWN6ujJsm00+O3jhN9bc=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.99.0 h1:Z9wCwf4PV0RLqYAMhM7AXKmdF7lHEq/yElEgTYV24Ow=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.99.0/go.mod h1:ZEfo92OtOsUC8A85caKlUWP3sXULpAfJphxAJYAmVXA=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.99.0 h1:MfB6sf60dyDu1x3Zvo+FC95lUa2DXBJ0tnnTTho426Y=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -46,6 +46,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor"
@@ -232,6 +233,7 @@ func Get() (otelcol.Factories, error) {
 		memorylimiterprocessor.NewFactory(),
 		metricstransformprocessor.NewFactory(),
 		probabilisticsamplerprocessor.NewFactory(),
+		redactionprocessor.NewFactory(),
 		resourcedetectionprocessor.NewFactory(),
 		resourceprocessor.NewFactory(),
 		routingprocessor.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -104,6 +104,7 @@ func TestDefaultComponents(t *testing.T) {
 		"memory_limiter",
 		"metricstransform",
 		"probabilistic_sampler",
+		"redaction",
 		"resource",
 		"resourcedetection",
 		"routing",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This adds the Redaction processor to the Splunk distribution of the OpenTelemetry Collector.
