### PR TITLE
make logs easier to read

### DIFF
--- a/tests/testutils/collector_container.go
+++ b/tests/testutils/collector_container.go
@@ -257,7 +257,7 @@ func newCollectorLogConsumer(logger *zap.Logger) collectorLogConsumer {
 }
 
 func (l collectorLogConsumer) Accept(log testcontainers.Log) {
-	msg := string(log.Content)
+	msg := strings.TrimSpace(string(log.Content))
 	if log.LogType == testcontainers.StderrLog {
 		l.logger.Info(msg)
 	} else {


### PR DESCRIPTION
Make container logs easier to read by chomping the extra newline at the end:

```
2024-05-06T07:30:31.257Z	INFO	testutils/collector_container.go:262	2024-05-06T07:30:31.256Z	info	zapgrpc/zapgrpc.go:176	[core] [Channel #1 SubChannel #2]Subchannel created	{"grpc_log": true}

2024-05-06T07:30:31.257Z	INFO	testutils/collector_container.go:262	2024-05-06T07:30:31.256Z	info	zapgrpc/zapgrpc.go:176	[core] [Channel #1]Channel Connectivity change to CONNECTING	{"grpc_log": true}

2024-05-06T07:30:31.257Z	INFO	testutils/collector_container.go:262	2024-05-06T07:30:31.256Z	info	zapgrpc/zapgrpc.go:176	[core] [Channel #1]Channel exiting idle mode	{"grpc_log": true}

2024-05-06T07:30:31.257Z	INFO	testutils/collector_container.go:262	2024-05-06T07:30:31.256Z	info	zapgrpc/zapgrpc.go:176	[core] [Channel #1 SubChannel #2]Subchannel Connectivity change to CONNECTING	{"grpc_log": true}
```

After:
```
2024-05-06T07:30:31.257Z	INFO	testutils/collector_container.go:262	2024-05-06T07:30:31.256Z	info	zapgrpc/zapgrpc.go:176	[core] [Channel #1 SubChannel #2]Subchannel created	{"grpc_log": true}
2024-05-06T07:30:31.257Z	INFO	testutils/collector_container.go:262	2024-05-06T07:30:31.256Z	info	zapgrpc/zapgrpc.go:176	[core] [Channel #1]Channel Connectivity change to CONNECTING	{"grpc_log": true}
2024-05-06T07:30:31.257Z	INFO	testutils/collector_container.go:262	2024-05-06T07:30:31.256Z	info	zapgrpc/zapgrpc.go:176	[core] [Channel #1]Channel exiting idle mode	{"grpc_log": true}
2024-05-06T07:30:31.257Z	INFO	testutils/collector_container.go:262	2024-05-06T07:30:31.256Z	info	zapgrpc/zapgrpc.go:176	[core] [Channel #1 SubChannel #2]Subchannel Connectivity change to CONNECTING	{"grpc_log": true}
```
