### PR TITLE
salt: support Node.js and .NET zero config on linux

### DIFF
--- a/.github/workflows/salt-test.yml
+++ b/.github/workflows/salt-test.yml
@@ -58,8 +58,8 @@ jobs:
             exit 1
           fi
           distro=$(for d in $dockerfiles; do echo -n "\"$d\","; done)
-          arch="\"amd64\", \"arm64\""
-          matrix="{\"DISTRO\": [${distro%,}]}"
+          config="\"default\", \"custom\""
+          matrix="{\"DISTRO\": [${distro%,}], \"CONFIG\": [${config}]}"
           echo "$matrix" | jq
           echo "matrix=${matrix}" >> $GITHUB_OUTPUT
     outputs:
@@ -97,7 +97,7 @@ jobs:
             # workaround for pytest substring matching
             distro="amazonlinux-2 and not amazonlinux-2023"
           fi
-          python3 -u -m pytest -s --verbose -k "$distro" \
+          python3 -u -m pytest -s --verbose -k "$distro and ${{ matrix.CONFIG }}" \
             internal/buildscripts/packaging/tests/deployments/salt/salt_test.py
 
       # qemu, networking, running systemd in containers, etc., can be flaky
@@ -109,6 +109,6 @@ jobs:
             # workaround for pytest substring matching
             distro="amazonlinux-2 and not amazonlinux-2023"
           fi
-          python3 -u -m pytest -s --verbose -k "$distro" \
+          python3 -u -m pytest -s --verbose -k "$distro and ${{ matrix.CONFIG }}" \
             --last-failed \
             internal/buildscripts/packaging/tests/deployments/salt/salt_test.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### 💡 Enhancements 💡
+
+- (Splunk) [`splunk-otel-collector` Salt formula](https://github.com/signalfx/splunk-otel-collector/tree/main/deployments/salt): Initial support for
+  Splunk OpenTelemetry [Node.js](https://github.com/signalfx/splunk-otel-js) and [.NET](https://github.com/signalfx/splunk-otel-dotnet) Auto Instrumentation on Linux
+  - Both are activated by default if the `install_auto_instrumentation` option is set to `True`.
+  - To skip Node.js auto instrumentation, configure the `auto_instrumentation_sdks` option without `nodejs`.
+  - To skip .NET auto instrumentation, configure the `auto_instrumentation_sdks` option without `dotnet`.
+  - `npm` is required to be pre-installed on the node to install the Node.js SDK. Configure the `auto_instrumentation_npm_path` option to specify the path to `npm`.
+  - .NET auto instrumentation is currently only supported on amd64/x64_64.
+
 ## v0.100.0
 
 ### 🛑 Breaking changes 🛑

--- a/deployments/salt/README.md
+++ b/deployments/salt/README.md
@@ -140,12 +140,11 @@ splunk-otel-collector:
 
 ### Auto Instrumentation (Linux Only)
 
-**Note:** The Java application(s) on the node need to be started/restarted
-separately after installation/configuration in order for any changes to take
-effect.
+**Note:** The application(s) on the node need to be started/restarted separately
+after installation/configuration in order for any changes to take effect.
 
 - `install_auto_instrumentation`: Whether to install/manage [Splunk
-  OpenTelemetry Auto Instrumentation for Java](
+  OpenTelemetry Auto Instrumentation](
   https://github.com/signalfx/splunk-otel-collector/tree/main/instrumentation).
   When set to `True`, the `splunk-otel-auto-instrumentation` deb/rpm package
   will be downloaded and installed from the Collector repository. (**default:**
@@ -153,7 +152,23 @@ effect.
 
 - `auto_instrumentation_version`: Version of the
   `splunk-otel-auto-instrumentation` package to install, e.g. `0.50.0`. The
-  minimum supported version is `0.48.0`. (**default:** `latest`)
+  minimum supported version is `0.48.0`. The minimum supported version for
+  Node.js auto instrumentation is `0.87.0`. The minimum supported version for
+  .NET auto instrumentation is `0.99.0`. (**default:** `latest`)
+
+- `auto_instrumentation_sdks`: List of Splunk OpenTelemetry Auto
+  Instrumentation SDKs to install, configure, and activate. (**default:**
+  `['java', 'nodejs', 'dotnet']`)
+
+  Currently, the following values are supported:
+  - `java`: [Splunk OpenTelemetry for Java](https://github.com/signalfx/splunk-otel-java)
+  - `nodejs`: [Splunk OpenTelemetry for Node.js](https://github.com/signalfx/splunk-otel-js)
+  - `dotnet`: [Splunk OpenTelemetry for .NET](https://github.com/signalfx/splunk-otel-dotnet) (x86_64/amd64 only)
+
+  **Note:** This formula does not manage the installation/configuration of
+  Node.js, `npm`, or Node.js applications. If `nodejs` is included in this
+  option, Node.js and `npm` are required to be pre-installed on the node in
+  order to install and activate the Node.js SDK.
 
 - `auto_instrumentation_systemd`: By default, the `/etc/ld.so.preload` file on
   the node will be configured for the
@@ -179,6 +194,14 @@ effect.
   is provided by the `splunk-otel-auto-instrumentation` package. If the path is
   changed from the default value, the path should be an existing file on the
   node. (**default:** `/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar`)
+
+- `auto_instrumentation_npm_path`: If the `auto_instrumentation_sdks` option
+  includes `nodejs`, the Splunk OpenTelemetry for Node.js SDK will be installed
+  with the `npm` command. Use this option to specify a custom path on the
+  node for `npm`, for example `/my/custom/path/to/npm`. (**default:** `npm`)
+
+  **Note:** This role does not manage the installation/configuration of
+  Node.js or `npm`.
 
 - `auto_instrumentation_resource_attributes`: Configure the OpenTelemetry auto
   instrumentation resource attributes, e.g.

--- a/deployments/salt/splunk-otel-collector/auto_instrumentation.sls
+++ b/deployments/salt/splunk-otel-collector/auto_instrumentation.sls
@@ -1,6 +1,8 @@
 {% set auto_instrumentation_version = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_version', 'latest') %}
 {% set auto_instrumentation_systemd = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_systemd', False) | to_bool %}
+{% set auto_instrumentation_sdks = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_sdks', ['java', 'nodejs', 'dotnet']) %}
 {% set auto_instrumentation_java_agent_path = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_java_agent_path', '/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar') %}
+{% set auto_instrumentation_npm_path = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_npm_path', 'npm') %}
 {% set auto_instrumentation_ld_so_preload = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_ld_so_preload') %}
 {% set auto_instrumentation_resource_attributes = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_resource_attributes') %}
 {% set auto_instrumentation_service_name = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_service_name') %}
@@ -10,6 +12,15 @@
 {% set auto_instrumentation_enable_profiler_memory = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_enable_profiler_memory', False) | to_bool %}
 {% set auto_instrumentation_enable_metrics = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_enable_metrics', False) | to_bool %}
 {% set auto_instrumentation_otlp_endpoint = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_otlp_endpoint', 'http://127.0.0.1:4317') %}
+{% set with_new_instrumentation = auto_instrumentation_version == 'latest' or salt['pkg.version_cmp'](auto_instrumentation_version, '0.87.0') >= 0 %}
+{% set dotnet_supported = (auto_instrumentation_version == 'latest' or salt['pkg.version_cmp'](auto_instrumentation_version, '0.99.0') >= 0) and grains['cpuarch'] in ['amd64', 'x86_64'] %}
+{% set systemd_config_path = '/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf' %}
+{% set old_instrumentation_config_path = '/usr/lib/splunk-instrumentation/instrumentation.conf' %}
+{% set java_config_path = '/etc/splunk/zeroconfig/java.conf' %}
+{% set nodejs_config_path = '/etc/splunk/zeroconfig/node.conf' %}
+{% set dotnet_config_path = '/etc/splunk/zeroconfig/dotnet.conf' %}
+{% set nodejs_prefix = '/usr/lib/splunk-instrumentation/splunk-otel-js' %}
+{% set dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet' %}
 
 Install Splunk OpenTelemetry Auto Instrumentation:
   pkg.installed:
@@ -17,6 +28,21 @@ Install Splunk OpenTelemetry Auto Instrumentation:
     - version: {{ auto_instrumentation_version }}
     - require:
       - pkg: splunk-otel-collector
+
+{% if 'nodejs' in auto_instrumentation_sdks and with_new_instrumentation %}
+{{ nodejs_prefix }}/node_modules:
+  file.directory:
+    - makedirs: True
+    - require:
+      - pkg: splunk-otel-auto-instrumentation
+
+Install splunk-otel-js:
+  cmd.run:
+    - name: {{ auto_instrumentation_npm_path}} install --global=false /usr/lib/splunk-instrumentation/splunk-otel-js.tgz
+    - cwd: {{ nodejs_prefix }}
+    - require:
+      - file: {{ nodejs_prefix }}/node_modules
+{% endif %}
 
 /etc/ld.so.preload:
   file.managed:
@@ -32,11 +58,26 @@ Install Splunk OpenTelemetry Auto Instrumentation:
       - pkg: splunk-otel-auto-instrumentation
 
 {% if auto_instrumentation_systemd %}
-/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf:
+{{ systemd_config_path }}:
   file.managed:
     - contents:
         - "[Manager]"
+        {% if 'java' in auto_instrumentation_sdks %}
         - DefaultEnvironment="JAVA_TOOL_OPTIONS=-javaagent:{{ auto_instrumentation_java_agent_path }}"
+        {% endif %}
+        {% if 'nodejs' in auto_instrumentation_sdks and with_new_instrumentation %}
+        - DefaultEnvironment="NODE_OPTIONS=-r {{ nodejs_prefix }}/node_modules/@splunk/otel/instrument"
+        {% endif %}
+        {% if 'dotnet' in auto_instrumentation_sdks and dotnet_supported %}
+        - DefaultEnvironment="CORECLR_ENABLE_PROFILING=1"
+        - DefaultEnvironment="CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}"
+        - DefaultEnvironment="CORECLR_PROFILER_PATH={{ dotnet_home }}/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so"
+        - DefaultEnvironment="DOTNET_ADDITIONAL_DEPS={{ dotnet_home }}/AdditionalDeps"
+        - DefaultEnvironment="DOTNET_SHARED_STORE={{ dotnet_home }}/store"
+        - DefaultEnvironment="DOTNET_STARTUP_HOOKS={{ dotnet_home }}/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll"
+        - DefaultEnvironment="OTEL_DOTNET_AUTO_HOME={{ dotnet_home }}"
+        - DefaultEnvironment="OTEL_DOTNET_AUTO_PLUGINS=Splunk.OpenTelemetry.AutoInstrumentation.Plugin,Splunk.OpenTelemetry.AutoInstrumentation"
+        {% endif %}
         {% if auto_instrumentation_resource_attributes != "" %}
         - DefaultEnvironment="OTEL_RESOURCE_ATTRIBUTES=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }}-systemd,{{ auto_instrumentation_resource_attributes }}"
         {% else %}
@@ -52,13 +93,22 @@ Install Splunk OpenTelemetry Auto Instrumentation:
     - makedirs: True
     - require:
       - pkg: splunk-otel-auto-instrumentation
+
+{% for config in [java_config_path, nodejs_config_path, dotnet_config_path, old_instrumentation_config_path] %}
+Delete {{ config }}:
+  file.absent:
+    - name: {{ config }}
+    - require:
+      - pkg: splunk-otel-auto-instrumentation
+{% endfor %}
 {% else %}
 Delete auto instrumentation systemd config:
   file.absent:
-    - name: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+    - name: {{ systemd_config_path }}
 
-{% if auto_instrumentation_version == 'latest' or salt['pkg.version_cmp'](auto_instrumentation_version, '0.87.0') >= 0 %}
-/etc/splunk/zeroconfig/java.conf:
+{% if with_new_instrumentation %}
+{% if 'java' in auto_instrumentation_sdks %}
+{{ java_config_path }}:
   file.managed:
     - contents:
         - JAVA_TOOL_OPTIONS=-javaagent:{{ auto_instrumentation_java_agent_path }}
@@ -78,7 +128,75 @@ Delete auto instrumentation systemd config:
     - require:
       - pkg: splunk-otel-auto-instrumentation
 {% else %}
-/usr/lib/splunk-instrumentation/instrumentation.conf:
+Delete {{ java_config_path }}:
+  file.absent:
+    - name:
+    - require:
+      - pkg: splunk-otel-auto-instrumentation
+{% endif %}
+{% if 'nodejs' in auto_instrumentation_sdks and with_new_instrumentation %}
+{{ nodejs_config_path }}:
+  file.managed:
+    - contents:
+        - NODE_OPTIONS=-r {{ nodejs_prefix }}/node_modules/@splunk/otel/instrument
+        {% if auto_instrumentation_resource_attributes != "" %}
+        - OTEL_RESOURCE_ATTRIBUTES=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }},{{ auto_instrumentation_resource_attributes }}
+        {% else %}
+        - OTEL_RESOURCE_ATTRIBUTES=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }}
+        {% endif %}
+        {% if auto_instrumentation_service_name != "" %}
+        - OTEL_SERVICE_NAME={{ auto_instrumentation_service_name }}
+        {% endif %}
+        - SPLUNK_PROFILER_ENABLED={{ auto_instrumentation_enable_profiler | string | lower }}
+        - SPLUNK_PROFILER_MEMORY_ENABLED={{ auto_instrumentation_enable_profiler_memory | string | lower }}
+        - SPLUNK_METRICS_ENABLED={{ auto_instrumentation_enable_metrics | string | lower }}
+        - OTEL_EXPORTER_OTLP_ENDPOINT={{ auto_instrumentation_otlp_endpoint }}
+    - makedirs: True
+    - require:
+      - pkg: splunk-otel-auto-instrumentation
+{% else %}
+Delete {{ nodejs_config_path }}:
+  file.absent:
+    - name: {{ nodejs_config_path }}
+    - require:
+      - pkg: splunk-otel-auto-instrumentation
+{% endif %}
+{% if 'dotnet' in auto_instrumentation_sdks and dotnet_supported %}
+{{ dotnet_config_path }}:
+  file.managed:
+    - contents:
+        - CORECLR_ENABLE_PROFILING=1
+        - CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}
+        - CORECLR_PROFILER_PATH={{ dotnet_home }}/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so
+        - DOTNET_ADDITIONAL_DEPS={{ dotnet_home }}/AdditionalDeps
+        - DOTNET_SHARED_STORE={{ dotnet_home }}/store
+        - DOTNET_STARTUP_HOOKS={{ dotnet_home }}/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll
+        - OTEL_DOTNET_AUTO_HOME={{ dotnet_home }}
+        - OTEL_DOTNET_AUTO_PLUGINS=Splunk.OpenTelemetry.AutoInstrumentation.Plugin,Splunk.OpenTelemetry.AutoInstrumentation
+        {% if auto_instrumentation_resource_attributes != "" %}
+        - OTEL_RESOURCE_ATTRIBUTES=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }},{{ auto_instrumentation_resource_attributes }}
+        {% else %}
+        - OTEL_RESOURCE_ATTRIBUTES=splunk.zc.method=splunk-otel-auto-instrumentation-{{ auto_instrumentation_version }}
+        {% endif %}
+        {% if auto_instrumentation_service_name != "" %}
+        - OTEL_SERVICE_NAME={{ auto_instrumentation_service_name }}
+        {% endif %}
+        - SPLUNK_PROFILER_ENABLED={{ auto_instrumentation_enable_profiler | string | lower }}
+        - SPLUNK_PROFILER_MEMORY_ENABLED={{ auto_instrumentation_enable_profiler_memory | string | lower }}
+        - SPLUNK_METRICS_ENABLED={{ auto_instrumentation_enable_metrics | string | lower }}
+        - OTEL_EXPORTER_OTLP_ENDPOINT={{ auto_instrumentation_otlp_endpoint }}
+    - makedirs: True
+    - require:
+      - pkg: splunk-otel-auto-instrumentation
+{% else %}
+Delete {{ dotnet_config_path }}:
+  file.absent:
+    - name: {{ dotnet_config_path }}
+    - require:
+      - pkg: splunk-otel-auto-instrumentation
+{% endif %}
+{% else %}
+{{ old_instrumentation_config_path }}:
   file.managed:
     - contents:
         - java_agent_jar={{ auto_instrumentation_java_agent_path }}
@@ -105,4 +223,4 @@ Reload systemd:
   cmd.run:
     - name: systemctl daemon-reload
     - onchanges:
-        - file: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        - file: {{ systemd_config_path }}

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.debian-bullseye
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.debian-bullseye
@@ -10,6 +10,12 @@ RUN echo 'deb https://repo.saltproject.io/py3/debian/11/amd64/latest/ bullseye m
     apt-get update && \
     apt-get install -y salt-minion
 
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
 ENV container docker
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.debian-buster
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.debian-buster
@@ -10,6 +10,13 @@ RUN echo 'deb https://repo.saltproject.io/py3/debian/10/amd64/latest/ buster mai
     apt-get update && \
     apt-get install -y salt-minion
 
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
+
 ENV container docker
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.debian-stretch
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.debian-stretch
@@ -13,6 +13,13 @@ RUN echo 'deb https://repo.saltproject.io/py3/debian/9/amd64/latest/ stretch mai
     apt-get update && \
     apt-get install -y salt-minion
 
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
+
 ENV container docker
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.ubuntu-bionic
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.ubuntu-bionic
@@ -10,6 +10,13 @@ RUN echo 'deb https://repo.saltproject.io/py3/ubuntu/18.04/amd64/latest bionic m
     apt-get update && \
     apt-get install -y salt-minion
 
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
+
 ENV container docker
 
 RUN rm -f /lib/systemd/system/multi-user.target.wants/* \

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.ubuntu-focal
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.ubuntu-focal
@@ -10,6 +10,13 @@ RUN echo 'deb https://repo.saltproject.io/py3/ubuntu/20.04/amd64/latest focal ma
     apt-get update && \
     apt-get install -y salt-minion
 
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
+
 ENV container docker
 
 RUN rm -f /lib/systemd/system/multi-user.target.wants/* \

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.ubuntu-jammy
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/deb/Dockerfile.ubuntu-jammy
@@ -12,6 +12,13 @@ RUN apt-get install -y software-properties-common ca-certificates wget curl apt-
 #    apt-get install -y salt-minion
 RUN pip install 'Jinja2<3.1' salt
 
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
+
 ENV container docker
 
 RUN rm -f /lib/systemd/system/multi-user.target.wants/* \

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.amazonlinux-2
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.amazonlinux-2
@@ -2,12 +2,19 @@ FROM amazonlinux:2
 
 ENV container docker
 
-RUN yum install -y systemd procps initscripts python3-pip python3-devel gcc
+RUN yum install -y systemd procps initscripts python3-pip python3-devel gcc wget tar
 
 RUN rpm --import https://repo.saltproject.io/py3/amazon/2/x86_64/latest/SALTSTACK-GPG-KEY.pub
 RUN curl -fsSL https://repo.saltproject.io/py3/amazon/2/x86_64/latest.repo | tee /etc/yum.repos.d/salt-amzn.repo
 
 RUN yum install -y salt-minion
+
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
 	"systemd-tmpfiles-setup.service" ] || rm -f $i; done); \

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.amazonlinux-2023
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.amazonlinux-2023
@@ -2,13 +2,20 @@ FROM amazonlinux:2023
 
 ENV container docker
 
-RUN yum install -y systemd procps initscripts python3-pip python3-devel gcc
+RUN yum install -y systemd procps initscripts python3-pip python3-devel gcc wget tar
 
 # Only the "amazon/2" repo is currently available, but seems to work for 2023
 RUN rpm --import https://repo.saltproject.io/salt/py3/amazon/2/x86_64/SALT-PROJECT-GPG-PUBKEY-2023.pub
 RUN curl -fsSL https://repo.saltproject.io/salt/py3/amazon/2/x86_64/latest.repo | tee /etc/yum.repos.d/salt-amzn.repo
 
 RUN yum install -y salt-minion
+
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
 	"systemd-tmpfiles-setup.service" ] || rm -f $i; done); \

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.centos-7
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.centos-7
@@ -2,12 +2,19 @@ FROM centos:7
 
 ENV container docker
 
-RUN yum install -y systemd procps initscripts python3-pip python3-devel gcc
+RUN yum install -y systemd procps initscripts python3-pip python3-devel gcc wget
 
 RUN rpm --import https://repo.saltproject.io/py3/redhat/7/x86_64/latest/SALTSTACK-GPG-KEY.pub
 RUN curl -fsSL https://repo.saltproject.io/py3/redhat/7/x86_64/latest.repo | tee /etc/yum.repos.d/salt.repo
 
 RUN yum install -y salt-minion
+
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
 	"systemd-tmpfiles-setup.service" ] || rm -f $i; done); \

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.centos-8
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.centos-8
@@ -3,12 +3,19 @@ FROM quay.io/centos/centos:stream8
 ENV container docker
 
 RUN echo 'fastestmirror=1' >> /etc/yum.conf
-RUN yum install -y systemd procps initscripts python3-pip python3-devel gcc
+RUN yum install -y systemd procps initscripts python3-pip python3-devel gcc wget
 
 RUN rpm --import https://repo.saltproject.io/py3/redhat/8/x86_64/latest/SALTSTACK-GPG-KEY.pub
 RUN curl -fsSL https://repo.saltproject.io/py3/redhat/8/x86_64/latest.repo | tee /etc/yum.repos.d/salt.repo
 
 RUN yum install -y salt-minion
+
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
 	"systemd-tmpfiles-setup.service" ] || rm -f $i; done); \

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.centos-9
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.centos-9
@@ -5,12 +5,19 @@ ENV container docker
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 RUN echo 'fastestmirror=1' >> /etc/yum.conf
 
-RUN dnf install -y systemd procps initscripts python3-pip python3-devel gcc
+RUN dnf install -y systemd procps initscripts python3-pip python3-devel gcc wget
 
 RUN rpm --import https://repo.saltproject.io/salt/py3/redhat/9/x86_64/SALT-PROJECT-GPG-PUBKEY-2023.pub
 RUN curl -fsSL https://repo.saltproject.io/salt/py3/redhat/9/x86_64/latest.repo | tee /etc/yum.repos.d/salt.repo
 
 RUN dnf install -y salt-minion
+
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
 	"systemd-tmpfiles-setup.service" ] || rm -f $i; done); \

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.opensuse-12
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.opensuse-12
@@ -8,6 +8,13 @@ RUN zypper -n install -l curl dbus-1 systemd-sysvinit tar wget python3-pip ca-ce
 
 RUN zypper install -y salt salt-minion salt-master 
 
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
+
 RUN (cd /usr/lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
     rm -f /usr/lib/systemd/system/multi-user.target.wants/*;\

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.opensuse-15
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.opensuse-15
@@ -3,9 +3,16 @@ FROM opensuse/leap:15
 ENV container docker
 
 RUN sed -i 's|download.opensuse.org|provo-mirror.opensuse.org|' /etc/zypp/repos.d/*.repo
-RUN zypper -n install -l curl dbus-1 systemd-sysvinit tar wget python3-pip ca-certificates
+RUN zypper -n install -l curl dbus-1 systemd-sysvinit tar wget python3-pip ca-certificates gzip
 
 RUN zypper install -y salt salt-minion salt-master
+
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
 
 RUN (cd /usr/lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
 	"systemd-tmpfiles-setup.service" ] || rm -f $i; done); \

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.oraclelinux-7
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.oraclelinux-7
@@ -2,12 +2,19 @@ FROM oraclelinux:7
 
 ENV container docker
 
-RUN yum install -y systemd procps initscripts python3-pip python3-devel gcc
+RUN yum install -y systemd procps initscripts python3-pip python3-devel gcc wget
 
 RUN rpm --import https://repo.saltproject.io/py3/redhat/7/x86_64/latest/SALTSTACK-GPG-KEY.pub
 RUN curl -fsSL https://repo.saltproject.io/py3/redhat/7/x86_64/latest.repo | tee /etc/yum.repos.d/salt.repo
 
 RUN yum install -y salt-minion
+
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \

--- a/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.oraclelinux-8
+++ b/internal/buildscripts/packaging/tests/deployments/salt/images/rpm/Dockerfile.oraclelinux-8
@@ -2,12 +2,19 @@ FROM oraclelinux:8
 
 ENV container docker
 
-RUN dnf install -y systemd procps initscripts python3-pip python3-devel gcc
+RUN dnf install -y systemd procps initscripts python3-pip python3-devel gcc wget
 
 RUN rpm --import https://repo.saltproject.io/py3/redhat/8/x86_64/latest/SALTSTACK-GPG-KEY.pub
 RUN curl -fsSL https://repo.saltproject.io/py3/redhat/8/x86_64/latest.repo | tee /etc/yum.repos.d/salt.repo
 
 RUN dnf install -y salt-minion
+
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+    mkdir -p /opt/ && \
+    tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
+    mv /opt/node* /opt/node
+
+ENV PATH=/opt/node/bin:$PATH
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
 	"systemd-tmpfiles-setup.service" ] || rm -f $i; done); \


### PR DESCRIPTION
- Activate Node.js and .NET instrumentation by default if `install_auto_instrumentation` is `true` for either preload or systemd.
- Update test to verify env vars for both preload and systemd configs.