### PR TITLE
[receiver/discovery] Remove discovery.event.type and metric.name attrs

### DIFF
--- a/internal/receiver/discoveryreceiver/metric_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator_test.go
@@ -127,14 +127,12 @@ func TestMetricEvaluation(t *testing.T) {
 					emitWG.Wait()
 
 					require.Equal(t, map[string]string{
-						"discovery.event.type":    "metric.match",
 						"discovery.observer.id":   "an_observer/observer.name",
 						"discovery.receiver.name": "receiver.name",
 						"discovery.receiver.rule": "a.rule",
 						"discovery.receiver.type": "a_receiver",
 						"discovery.status":        string(status),
 						"discovery.message":       "desired body content",
-						"metric.name":             "desired.name",
 						"one":                     "one.value",
 						"two":                     "two.value",
 						"extra_attr":              "target_resource",

--- a/internal/receiver/discoveryreceiver/receiver.go
+++ b/internal/receiver/discoveryreceiver/receiver.go
@@ -32,12 +32,9 @@ import (
 )
 
 const (
-	eventTypeAttr             = "discovery.event.type"
-	metricNameAttr            = "metric.name"
-	observerNameAttr          = "discovery.observer.name"
-	observerTypeAttr          = "discovery.observer.type"
-	receiverRuleAttr          = "discovery.receiver.rule"
-	receiverUpdatedConfigAttr = "discovery.receiver.updated.config"
+	observerNameAttr = "discovery.observer.name"
+	observerTypeAttr = "discovery.observer.type"
+	receiverRuleAttr = "discovery.receiver.rule"
 )
 
 var (

--- a/internal/receiver/discoveryreceiver/statement_evaluator.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator.go
@@ -29,8 +29,6 @@ import (
 
 var _ zapcore.Core = (*statementEvaluator)(nil)
 
-const statementMatch = "statement.match"
-
 // statementEvaluator conforms to a zapcore.Core to intercept component log statements and
 // determine if they match any configured Status match rules. If so, they emit log records
 // for the matching statement.
@@ -190,7 +188,6 @@ func (se *statementEvaluator) evaluateStatement(statement *statussources.Stateme
 		attrs[discovery.ReceiverTypeAttr] = receiverID.Type().String()
 		attrs[discovery.ReceiverNameAttr] = receiverID.Name()
 		attrs[discovery.MessageAttr] = statement.Message
-		attrs[eventTypeAttr] = statementMatch
 		attrs[receiverRuleAttr] = rEntry.Rule.String()
 
 		var desiredRecord LogRecord

--- a/internal/receiver/discoveryreceiver/statement_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator_test.go
@@ -129,7 +129,6 @@ func TestStatementEvaluation(t *testing.T) {
 								}
 							}
 							require.Equal(t, map[string]string{
-								"discovery.event.type":    "statement.match",
 								"discovery.observer.id":   "an_observer/observer.name",
 								"discovery.receiver.name": "receiver.name",
 								"discovery.receiver.rule": `type == "container"`,

--- a/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
+++ b/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
@@ -8,7 +8,6 @@ resource_logs:
               otel.entity.event.type: entity_state
               otel.entity.attributes:
                 discovery.endpoint.id: (host_observer)[::]-8888-TCP-1
-                discovery.event.type: metric.match
                 discovery.observer.id: host_observer
                 discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiIGFuZCBjb21tYW5kIGNvbnRhaW5zICJvdGVsY29sIgp3YXRjaF9vYnNlcnZlcnM6Ci0gaG9zdF9vYnNlcnZlcgo=
                 discovery.receiver.rule: type == "hostport" and command contains "otelcol"
@@ -24,7 +23,6 @@ resource_logs:
                 service_version: <VERSION_FROM_BUILD>
                 discovery.status: successful
                 discovery.message: Successfully connected to prometheus server
-                metric.name: otelcol_process_uptime
                 discovery.observer.type: host_observer
                 discovery.observer.name: ""
                 command: /otelcol --config /etc/config.yaml
@@ -43,7 +41,6 @@ resource_logs:
               otel.entity.event.type: entity_state
               otel.entity.attributes:
                 discovery.endpoint.id: (host_observer)[::]-4318-TCP-1
-                discovery.event.type: statement.match
                 discovery.observer.id: host_observer
                 discovery.receiver.config: cmVjZWl2ZXJzOgogIHByb21ldGhldXNfc2ltcGxlOgogICAgY29uZmlnOiB7fQogICAgcmVzb3VyY2VfYXR0cmlidXRlczoKICAgICAgb25lLmtleTogb25lLnZhbHVlCiAgICAgIHR3by5rZXk6IHR3by52YWx1ZQogICAgcnVsZTogdHlwZSA9PSAiaG9zdHBvcnQiIGFuZCBjb21tYW5kIGNvbnRhaW5zICJvdGVsY29sIgp3YXRjaF9vYnNlcnZlcnM6Ci0gaG9zdF9vYnNlcnZlcgo=
                 discovery.receiver.name: ""


### PR DESCRIPTION
Stop emitting `discovery.event.type` and `metric.name` entity attributes. They are not relevant anymore since the entity events are emitted constantly from the latest state
