### PR TITLE
[receiver/discovery] Remove `append_pattern` option from log statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- (Splunk) `receiver/discovery`: Remove `append_pattern` option from log evaluation statements ([#4583](https://github.com/signalfx/splunk-otel-collector/pull/4583))
+  - The matched log message is now set as `discovery.matched_log` entity attributes instead of being appended to 
+    the `discovery.message` attribute.
+  - The matched log fields like `caller` and `stacktrace` are not sent as attributes anymore.
+
 ### 💡 Enhancements 💡
 
 - (Splunk) [`splunk-otel-collector` Salt formula](https://github.com/signalfx/splunk-otel-collector/tree/main/deployments/salt): Initial support for

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
@@ -29,17 +29,14 @@
 #       - status: failed
 #         regexp: 'connect: network is unreachable'
 #         log_record:
-#           append_pattern: true
 #           body: The container cannot be reached by the Collector. Make sure they're in the same network.
 #       - status: failed
 #         regexp: 'connect: connection refused'
 #         log_record:
-#           append_pattern: true
 #           body: The container is refusing mongodb connections.
 #       - status: partial
 #         regexp: '.* unable to authenticate using mechanism .*'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #               Please ensure your user credentials are correctly specified with
 #               `--set splunk.discovery.receivers.mongodb.config.username="<username>"` and
@@ -49,7 +46,6 @@
 #       - status: partial
 #         regexp: '.* failed to fetch index stats metrics: (Unauthorized) not authorized on admin to execute command .*'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure the account used to access Mongodb has been given a clusterMonitor role in order to collect metrics.
 #             `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/mysql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/mysql.discovery.yaml
@@ -26,12 +26,10 @@
 #       - status: failed
 #         regexp: "Can't connect to MySQL server on .* [(]111[)]"
 #         log_record:
-#           append_pattern: true
 #           body:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
 #       - status: partial
 #         regexp: 'Access denied for user'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure your user credentials are correctly specified using the
 #             `--set splunk.discovery.receivers.mysql.config.username="<username>"` and

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/oracledb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/oracledb.discovery.yaml
@@ -27,27 +27,22 @@
 #       - status: failed
 #         regexp: "connection refused"
 #         log_record:
-#           append_pattern: true
 #           body: The container is not serving http connections.
 #       - status: failed
 #         regexp: "received goaway and there are no active streams"
 #         log_record:
-#           append_pattern: true
 #           body: Unable to connect and scrape metrics.
 #       - status: failed
 #         regexp: "dial tcp: lookup"
 #         log_record:
-#           append_pattern: true
 #           body: Unable to resolve oracledb tcp endpoint
 #       - status: failed
 #         regexp: 'error executing select .*: EOF'
 #         log_record:
-#           append_pattern: true
 #           body: Unable to execute select from oracledb. Verify endpoint and user permissions.
 #       - status: partial
 #         regexp: "listener does not currently know of service requested"
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure your oracledb service is correctly specified using the
 #             `--set splunk.discovery.receivers.oracledb.config.service="<service>"` command or the
@@ -55,7 +50,6 @@
 #       - status: partial
 #         regexp: 'invalid username/password'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure your user credentials are correctly specified using the
 #             `--set splunk.discovery.receivers.oracledb.config.username="<username>"` and

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/postgresql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/postgresql.discovery.yaml
@@ -26,17 +26,14 @@
 #       - status: failed
 #         regexp: 'connect: network is unreachable'
 #         log_record:
-#           append_pattern: true
 #           body: The container cannot be reached by the Collector. Make sure they're in the same network.
 #       - status: failed
 #         regexp: 'connect: connection refused'
 #         log_record:
-#           append_pattern: true
 #           body: The container is refusing PostgreSQL connections.
 #       - status: partial
 #         regexp: 'pq: password authentication failed for user'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Please ensure your user credentials are correctly specified with
 #             `--set splunk.discovery.receivers.postgresql.config.username="<username>"` and
@@ -46,7 +43,6 @@
 #       - status: partial
 #         regexp: 'pq: database .* does not exist'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure the target database is correctly specified using the
 #             `--set splunk.discovery.receivers.postgresql.config.databases="[<db>]"` command or the
@@ -54,7 +50,6 @@
 #       - status: partial
 #         regexp: 'pq: SSL is not enabled on the server'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure the target database has SSL enabled or set insecure using the
 #             `--set splunk.discovery.receivers.postgresql.config.tls::insecure="<boolean>"` command or the
@@ -62,7 +57,6 @@
 #       - status: partial
 #         regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure your PostgreSQL database has
 #             `shared_preload_libraries = 'pg_stat_statements'`

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/redis.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/redis.discovery.yaml
@@ -24,22 +24,18 @@
 #       - status: failed
 #         regexp: "connection refused"
 #         log_record:
-#           append_pattern: true
 #           body: The container is not serving http connections.
 #       - status: failed
 #         regexp: "received goaway and there are no active streams"
 #         log_record:
-#           append_pattern: true
 #           body: Unable to connect and scrape metrics.
 #       - status: failed
 #         regexp: "dial tcp: lookup"
 #         log_record:
-#           append_pattern: true
 #           body: Unable to resolve redis tcp endpoint
 #       - status: partial
 #         regexp: 'NOAUTH Authentication required.'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure your user credentials are correctly specified using the
 #             `--set splunk.discovery.receivers.redis.config.password="<password>"` and
@@ -49,7 +45,6 @@
 #       - status: partial
 #         regexp: 'called without any password configured for the default user'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure your user credentials are correctly specified using the
 #             `--set splunk.discovery.receivers.redis.config.password="<password>"` command or the
@@ -57,7 +52,6 @@
 #       - status: partial
 #         regexp: 'WRONGPASS invalid username-password pair or user is disabled'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure your user credentials are correctly specified using the
 #             `--set splunk.discovery.receivers.redis.config.password="<password>"` and

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-collectd-mysql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-collectd-mysql.discovery.yaml
@@ -30,12 +30,10 @@
 #       - status: failed
 #         regexp: "mysql plugin: Failed to connect to database .* at server .* Can't connect to MySQL server on .* [(]111[)]"
 #         log_record:
-#           append_pattern: true
 #           body: The container is refusing MySQL connections.
 #       - status: partial
 #         regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* [(]using password: .*[)]'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure your user credentials are correctly specified using the
 #             `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.username="<username>"` and
@@ -45,7 +43,6 @@
 #       - status: partial
 #         regexp: 'mysql plugin: Failed to connect to database .* at server .* Unknown database'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure your MySQL databases are correctly specified using the
 #             `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` command or the
@@ -53,7 +50,6 @@
 #       - status: partial
 #         regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* to database'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure your MySQL databases and auth information are correctly specified using the
 #             `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` command or the

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-collectd-nginx.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-collectd-nginx.discovery.yaml
@@ -28,10 +28,8 @@
 #       - status: failed
 #         regexp: "nginx plugin: curl_easy_perform failed: Operation timed out after"
 #         log_record:
-#           append_pattern: true
 #           body: The container is not serving http connections.
 #       - status: failed
 #         regexp: "read-function of plugin .* failed"
 #         log_record:
-#           append_pattern: true
 #           body: The integration is unable to read metrics from this endpoint.

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-postgresql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-postgresql.discovery.yaml
@@ -39,17 +39,14 @@
 #       - status: failed
 #         regexp: 'connect: network is unreachable'
 #         log_record:
-#           append_pattern: true
 #           body: The container cannot be reached by the Collector. Make sure they're in the same network.
 #       - status: failed
 #         regexp: 'connect: connection refused'
 #         log_record:
-#           append_pattern: true
 #           body: The container is refusing PostgreSQL connections.
 #       - status: partial
 #         regexp: 'pq: password authentication failed for user'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Please ensure your user credentials are correctly specified with
 #             `--set splunk.discovery.receivers.smartagent/postgresql.config.params::username="<username>"` and
@@ -59,7 +56,6 @@
 #       - status: partial
 #         regexp: 'pq: database .* does not exist'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure the target database is correctly specified using the
 #             `--set splunk.discovery.receivers.smartagent/postgresql.config.masterDBName="<db>"` command or the
@@ -67,7 +63,6 @@
 #       - status: partial
 #         regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
 #         log_record:
-#           append_pattern: true
 #           body: >-
 #             Make sure your PostgreSQL database has
 #             `shared_preload_libraries = 'pg_stat_statements'`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
@@ -25,17 +25,14 @@ mongodb:
       - status: failed
         regexp: 'connect: network is unreachable'
         log_record:
-          append_pattern: true
           body: The container cannot be reached by the Collector. Make sure they're in the same network.
       - status: failed
         regexp: 'connect: connection refused'
         log_record:
-          append_pattern: true
           body: The container is refusing mongodb connections.
       - status: partial
         regexp: '.* unable to authenticate using mechanism .*'
         log_record:
-          append_pattern: true
           body: >-
               Please ensure your user credentials are correctly specified with
               `--set splunk.discovery.receivers.mongodb.config.username="<username>"` and
@@ -45,7 +42,6 @@ mongodb:
       - status: partial
         regexp: '.* failed to fetch index stats metrics: (Unauthorized) not authorized on admin to execute command .*'
         log_record:
-          append_pattern: true
           body: >-
             Make sure the account used to access Mongodb has been given a clusterMonitor role in order to collect metrics.
             `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
@@ -21,17 +21,14 @@
       - status: failed
         regexp: 'connect: network is unreachable'
         log_record:
-          append_pattern: true
           body: The container cannot be reached by the Collector. Make sure they're in the same network.
       - status: failed
         regexp: 'connect: connection refused'
         log_record:
-          append_pattern: true
           body: The container is refusing mongodb connections.
       - status: partial
         regexp: '.* unable to authenticate using mechanism .*'
         log_record:
-          append_pattern: true
           body: >-
               Please ensure your user credentials are correctly specified with
               `--set {{ configProperty "username" "<username>" }}` and
@@ -41,7 +38,6 @@
       - status: partial
         regexp: '.* failed to fetch index stats metrics: (Unauthorized) not authorized on admin to execute command .*'
         log_record:
-          append_pattern: true
           body: >-
             Make sure the account used to access Mongodb has been given a clusterMonitor role in order to collect metrics.
             `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml
@@ -22,12 +22,10 @@ mysql:
       - status: failed
         regexp: "Can't connect to MySQL server on .* [(]111[)]"
         log_record:
-          append_pattern: true
           body:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
       - status: partial
         regexp: 'Access denied for user'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your user credentials are correctly specified using the
             `--set splunk.discovery.receivers.mysql.config.username="<username>"` and

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml.tmpl
@@ -18,12 +18,10 @@
       - status: failed
         regexp: "Can't connect to MySQL server on .* [(]111[)]"
         log_record:
-          append_pattern: true
           body:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
       - status: partial
         regexp: 'Access denied for user'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your user credentials are correctly specified using the
             `--set {{ configProperty "username" "<username>" }}` and

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml
@@ -23,27 +23,22 @@ oracledb:
       - status: failed
         regexp: "connection refused"
         log_record:
-          append_pattern: true
           body: The container is not serving http connections.
       - status: failed
         regexp: "received goaway and there are no active streams"
         log_record:
-          append_pattern: true
           body: Unable to connect and scrape metrics.
       - status: failed
         regexp: "dial tcp: lookup"
         log_record:
-          append_pattern: true
           body: Unable to resolve oracledb tcp endpoint
       - status: failed
         regexp: 'error executing select .*: EOF'
         log_record:
-          append_pattern: true
           body: Unable to execute select from oracledb. Verify endpoint and user permissions.
       - status: partial
         regexp: "listener does not currently know of service requested"
         log_record:
-          append_pattern: true
           body: >-
             Make sure your oracledb service is correctly specified using the
             `--set splunk.discovery.receivers.oracledb.config.service="<service>"` command or the
@@ -51,7 +46,6 @@ oracledb:
       - status: partial
         regexp: 'invalid username/password'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your user credentials are correctly specified using the
             `--set splunk.discovery.receivers.oracledb.config.username="<username>"` and

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml.tmpl
@@ -19,27 +19,22 @@
       - status: failed
         regexp: "connection refused"
         log_record:
-          append_pattern: true
           body: The container is not serving http connections.
       - status: failed
         regexp: "received goaway and there are no active streams"
         log_record:
-          append_pattern: true
           body: Unable to connect and scrape metrics.
       - status: failed
         regexp: "dial tcp: lookup"
         log_record:
-          append_pattern: true
           body: Unable to resolve oracledb tcp endpoint
       - status: failed
         regexp: 'error executing select .*: EOF'
         log_record:
-          append_pattern: true
           body: Unable to execute select from oracledb. Verify endpoint and user permissions.
       - status: partial
         regexp: "listener does not currently know of service requested"
         log_record:
-          append_pattern: true
           body: >-
             Make sure your oracledb service is correctly specified using the
             `--set {{ configProperty "service" "<service>" }}` command or the
@@ -47,7 +42,6 @@
       - status: partial
         regexp: 'invalid username/password'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your user credentials are correctly specified using the
             `--set {{ configProperty "username" "<username>" }}` and

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml
@@ -22,17 +22,14 @@ postgresql:
       - status: failed
         regexp: 'connect: network is unreachable'
         log_record:
-          append_pattern: true
           body: The container cannot be reached by the Collector. Make sure they're in the same network.
       - status: failed
         regexp: 'connect: connection refused'
         log_record:
-          append_pattern: true
           body: The container is refusing PostgreSQL connections.
       - status: partial
         regexp: 'pq: password authentication failed for user'
         log_record:
-          append_pattern: true
           body: >-
             Please ensure your user credentials are correctly specified with
             `--set splunk.discovery.receivers.postgresql.config.username="<username>"` and
@@ -42,7 +39,6 @@ postgresql:
       - status: partial
         regexp: 'pq: database .* does not exist'
         log_record:
-          append_pattern: true
           body: >-
             Make sure the target database is correctly specified using the
             `--set splunk.discovery.receivers.postgresql.config.databases="[<db>]"` command or the
@@ -50,7 +46,6 @@ postgresql:
       - status: partial
         regexp: 'pq: SSL is not enabled on the server'
         log_record:
-          append_pattern: true
           body: >-
             Make sure the target database has SSL enabled or set insecure using the
             `--set splunk.discovery.receivers.postgresql.config.tls::insecure="<boolean>"` command or the
@@ -58,7 +53,6 @@ postgresql:
       - status: partial
         regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your PostgreSQL database has
             `shared_preload_libraries = 'pg_stat_statements'`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml.tmpl
@@ -18,17 +18,14 @@
       - status: failed
         regexp: 'connect: network is unreachable'
         log_record:
-          append_pattern: true
           body: The container cannot be reached by the Collector. Make sure they're in the same network.
       - status: failed
         regexp: 'connect: connection refused'
         log_record:
-          append_pattern: true
           body: The container is refusing PostgreSQL connections.
       - status: partial
         regexp: 'pq: password authentication failed for user'
         log_record:
-          append_pattern: true
           body: >-
             Please ensure your user credentials are correctly specified with
             `--set {{ configProperty "username" "<username>" }}` and
@@ -38,7 +35,6 @@
       - status: partial
         regexp: 'pq: database .* does not exist'
         log_record:
-          append_pattern: true
           body: >-
             Make sure the target database is correctly specified using the
             `--set {{ configProperty "databases" "[<db>]" }}` command or the
@@ -46,7 +42,6 @@
       - status: partial
         regexp: 'pq: SSL is not enabled on the server'
         log_record:
-          append_pattern: true
           body: >-
             Make sure the target database has SSL enabled or set insecure using the
             `--set {{ configProperty "tls::insecure" "<boolean>" }}` command or the
@@ -54,7 +49,6 @@
       - status: partial
         regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your PostgreSQL database has
             `shared_preload_libraries = 'pg_stat_statements'`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml
@@ -20,22 +20,18 @@ redis:
       - status: failed
         regexp: "connection refused"
         log_record:
-          append_pattern: true
           body: The container is not serving http connections.
       - status: failed
         regexp: "received goaway and there are no active streams"
         log_record:
-          append_pattern: true
           body: Unable to connect and scrape metrics.
       - status: failed
         regexp: "dial tcp: lookup"
         log_record:
-          append_pattern: true
           body: Unable to resolve redis tcp endpoint
       - status: partial
         regexp: 'NOAUTH Authentication required.'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your user credentials are correctly specified using the
             `--set splunk.discovery.receivers.redis.config.password="<password>"` and
@@ -45,7 +41,6 @@ redis:
       - status: partial
         regexp: 'called without any password configured for the default user'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your user credentials are correctly specified using the
             `--set splunk.discovery.receivers.redis.config.password="<password>"` command or the
@@ -53,7 +48,6 @@ redis:
       - status: partial
         regexp: 'WRONGPASS invalid username-password pair or user is disabled'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your user credentials are correctly specified using the
             `--set splunk.discovery.receivers.redis.config.password="<password>"` and

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml.tmpl
@@ -16,22 +16,18 @@
       - status: failed
         regexp: "connection refused"
         log_record:
-          append_pattern: true
           body: The container is not serving http connections.
       - status: failed
         regexp: "received goaway and there are no active streams"
         log_record:
-          append_pattern: true
           body: Unable to connect and scrape metrics.
       - status: failed
         regexp: "dial tcp: lookup"
         log_record:
-          append_pattern: true
           body: Unable to resolve redis tcp endpoint
       - status: partial
         regexp: 'NOAUTH Authentication required.'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your user credentials are correctly specified using the
             `--set {{ configProperty "password" "<password>" }}` and
@@ -41,7 +37,6 @@
       - status: partial
         regexp: 'called without any password configured for the default user'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your user credentials are correctly specified using the
             `--set {{ configProperty "password" "<password>" }}` command or the
@@ -49,7 +44,6 @@
       - status: partial
         regexp: 'WRONGPASS invalid username-password pair or user is disabled'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your user credentials are correctly specified using the
             `--set {{ configProperty "password" "<password>" }}` and

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml
@@ -26,12 +26,10 @@ smartagent/collectd/mysql:
       - status: failed
         regexp: "mysql plugin: Failed to connect to database .* at server .* Can't connect to MySQL server on .* [(]111[)]"
         log_record:
-          append_pattern: true
           body: The container is refusing MySQL connections.
       - status: partial
         regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* [(]using password: .*[)]'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your user credentials are correctly specified using the
             `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.username="<username>"` and
@@ -41,7 +39,6 @@ smartagent/collectd/mysql:
       - status: partial
         regexp: 'mysql plugin: Failed to connect to database .* at server .* Unknown database'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your MySQL databases are correctly specified using the
             `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` command or the
@@ -49,7 +46,6 @@ smartagent/collectd/mysql:
       - status: partial
         regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* to database'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your MySQL databases and auth information are correctly specified using the
             `--set splunk.discovery.receivers.smartagent/collectd/mysql.config.databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` command or the

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml.tmpl
@@ -22,12 +22,10 @@
       - status: failed
         regexp: "mysql plugin: Failed to connect to database .* at server .* Can't connect to MySQL server on .* [(]111[)]"
         log_record:
-          append_pattern: true
           body: The container is refusing MySQL connections.
       - status: partial
         regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* [(]using password: .*[)]'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your user credentials are correctly specified using the
             `--set {{ configProperty "username" "<username>" }}` and
@@ -37,7 +35,6 @@
       - status: partial
         regexp: 'mysql plugin: Failed to connect to database .* at server .* Unknown database'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your MySQL databases are correctly specified using the
             `--set {{ configProperty "databases" "[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]" }}` command or the
@@ -45,7 +42,6 @@
       - status: partial
         regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* to database'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your MySQL databases and auth information are correctly specified using the
             `--set {{ configProperty "databases" "[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]" }}` command or the

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-nginx.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-nginx.discovery.yaml
@@ -24,10 +24,8 @@ smartagent/collectd/nginx:
       - status: failed
         regexp: "nginx plugin: curl_easy_perform failed: Operation timed out after"
         log_record:
-          append_pattern: true
           body: The container is not serving http connections.
       - status: failed
         regexp: "read-function of plugin .* failed"
         log_record:
-          append_pattern: true
           body: The integration is unable to read metrics from this endpoint.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-nginx.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-nginx.discovery.yaml.tmpl
@@ -20,10 +20,8 @@
       - status: failed
         regexp: "nginx plugin: curl_easy_perform failed: Operation timed out after"
         log_record:
-          append_pattern: true
           body: The container is not serving http connections.
       - status: failed
         regexp: "read-function of plugin .* failed"
         log_record:
-          append_pattern: true
           body: The integration is unable to read metrics from this endpoint.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml
@@ -35,17 +35,14 @@ smartagent/postgresql:
       - status: failed
         regexp: 'connect: network is unreachable'
         log_record:
-          append_pattern: true
           body: The container cannot be reached by the Collector. Make sure they're in the same network.
       - status: failed
         regexp: 'connect: connection refused'
         log_record:
-          append_pattern: true
           body: The container is refusing PostgreSQL connections.
       - status: partial
         regexp: 'pq: password authentication failed for user'
         log_record:
-          append_pattern: true
           body: >-
             Please ensure your user credentials are correctly specified with
             `--set splunk.discovery.receivers.smartagent/postgresql.config.params::username="<username>"` and
@@ -55,7 +52,6 @@ smartagent/postgresql:
       - status: partial
         regexp: 'pq: database .* does not exist'
         log_record:
-          append_pattern: true
           body: >-
             Make sure the target database is correctly specified using the
             `--set splunk.discovery.receivers.smartagent/postgresql.config.masterDBName="<db>"` command or the
@@ -63,7 +59,6 @@ smartagent/postgresql:
       - status: partial
         regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your PostgreSQL database has
             `shared_preload_libraries = 'pg_stat_statements'`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml.tmpl
@@ -31,17 +31,14 @@
       - status: failed
         regexp: 'connect: network is unreachable'
         log_record:
-          append_pattern: true
           body: The container cannot be reached by the Collector. Make sure they're in the same network.
       - status: failed
         regexp: 'connect: connection refused'
         log_record:
-          append_pattern: true
           body: The container is refusing PostgreSQL connections.
       - status: partial
         regexp: 'pq: password authentication failed for user'
         log_record:
-          append_pattern: true
           body: >-
             Please ensure your user credentials are correctly specified with
             `--set {{ configProperty "params" "username" "<username>" }}` and
@@ -51,7 +48,6 @@
       - status: partial
         regexp: 'pq: database .* does not exist'
         log_record:
-          append_pattern: true
           body: >-
             Make sure the target database is correctly specified using the
             `--set {{ configProperty "masterDBName" "<db>" }}` command or the
@@ -59,7 +55,6 @@
       - status: partial
         regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
         log_record:
-          append_pattern: true
           body: >-
             Make sure your PostgreSQL database has
             `shared_preload_libraries = 'pg_stat_statements'`

--- a/internal/receiver/discoveryreceiver/README.md
+++ b/internal/receiver/discoveryreceiver/README.md
@@ -99,12 +99,10 @@ receivers:
              - status: failed
                regexp: "Can't connect to MySQL server on .* [(]111[)]"
                log_record:
-                 append_pattern: true
                  body:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
              - status: partial
                regexp: 'Access denied for user'
                log_record:
-                 append_pattern: true
                  body: >-
                    Make sure your user credentials are correctly specified using the
                    `--set splunk.discovery.receivers.mysql.config.username="<username>"` and
@@ -266,11 +264,10 @@ expr: 'ExprEnv["some.field.with.periods"] contains "value"'
 
 ### LogRecord
 
-| Name             | Type              | Default                                                 | Docs                                                                        |
-|------------------|-------------------|---------------------------------------------------------|-----------------------------------------------------------------------------|
-| `body`           | string            | Emitted log statement message                           | The emitted log record's body                                               |
-| `attributes`     | map[string]string | Emitted log statements fields                           | The emitted log record's attributes                                         |
-| `append_pattern` | bool              | false                                                   | Whether to append the evaluated statement to the configured log record body |
+| Name             | Type              | Default                       | Docs                                |
+|------------------|-------------------|-------------------------------|-------------------------------------|
+| `body`           | string            | Emitted log statement message | The emitted log record's body       |
+| `attributes`     | map[string]string | Emitted log statements fields | The emitted log record's attributes |
 
 ## Status log record content
 

--- a/internal/receiver/discoveryreceiver/config.go
+++ b/internal/receiver/discoveryreceiver/config.go
@@ -84,9 +84,8 @@ type Match struct {
 
 // LogRecord is a definition of the desired plog.LogRecord content to emit for a match.
 type LogRecord struct {
-	Attributes    map[string]string `mapstructure:"attributes"`
-	Body          string            `mapstructure:"body"`
-	AppendPattern bool              `mapstructure:"append_pattern"`
+	Attributes map[string]string `mapstructure:"attributes"`
+	Body       string            `mapstructure:"body"`
 }
 
 func (cfg *Config) Validate() error {

--- a/internal/receiver/discoveryreceiver/receiver.go
+++ b/internal/receiver/discoveryreceiver/receiver.go
@@ -35,6 +35,7 @@ const (
 	observerNameAttr = "discovery.observer.name"
 	observerTypeAttr = "discovery.observer.type"
 	receiverRuleAttr = "discovery.receiver.rule"
+	matchedLogAttr   = "discovery.matched_log"
 )
 
 var (

--- a/internal/receiver/discoveryreceiver/statement_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator_test.go
@@ -15,9 +15,7 @@
 package discoveryreceiver
 
 import (
-	"fmt"
-	"runtime"
-	"strings"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -40,109 +38,83 @@ func TestStatementEvaluation(t *testing.T) {
 		{name: "expr", match: Match{Expr: "message == 'desired.statement' && ExprEnv['field.one'] == 'field.one.value' && field_two contains 'two.value'"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			for _, appendPattern := range []bool{true, false} {
-				t.Run(fmt.Sprintf("append_%v", appendPattern), func(t *testing.T) {
-					match := tc.match
-					match.Record = &LogRecord{
-						Body:          "desired body content",
-						AppendPattern: appendPattern,
-						Attributes: map[string]string{
-							"attr.one": "attr.one.value", "attr.two": "attr.two.value",
+			match := tc.match
+			match.Record = &LogRecord{
+				Body: "desired body content",
+				Attributes: map[string]string{
+					"attr.one": "attr.one.value", "attr.two": "attr.two.value",
+				},
+			}
+			for _, status := range discovery.StatusTypes {
+				match.Status = status
+				t.Run(string(status), func(t *testing.T) {
+					observerID := component.MustNewIDWithName("an_observer", "observer.name")
+					cfg := &Config{
+						Receivers: map[component.ID]ReceiverEntry{
+							component.MustNewIDWithName("a_receiver", "receiver.name"): {
+								Rule:   mustNewRule(`type == "container"`),
+								Status: &Status{Statements: []Match{match}},
+							},
 						},
+						WatchObservers: []component.ID{observerID},
 					}
-					for _, status := range discovery.StatusTypes {
-						match.Status = status
-						t.Run(string(status), func(t *testing.T) {
-							observerID := component.MustNewIDWithName("an_observer", "observer.name")
-							cfg := &Config{
-								Receivers: map[component.ID]ReceiverEntry{
-									component.MustNewIDWithName("a_receiver", "receiver.name"): {
-										Rule:   mustNewRule(`type == "container"`),
-										Status: &Status{Statements: []Match{match}},
-									},
-								},
-								WatchObservers: []component.ID{observerID},
-							}
-							require.NoError(t, cfg.Validate())
+					require.NoError(t, cfg.Validate())
 
-							// If debugging tests, replace the Nop Logger with a test instance to see
-							// all statements. Not in regular use to avoid spamming output.
-							// logger := zaptest.NewLogger(t)
-							logger := zap.NewNop()
-							cStore := newCorrelationStore(logger, time.Hour)
+					// If debugging tests, replace the Nop Logger with a test instance to see
+					// all statements. Not in regular use to avoid spamming output.
+					// logger := zaptest.NewLogger(t)
+					logger := zap.NewNop()
+					cStore := newCorrelationStore(logger, time.Hour)
 
-							emitCh := cStore.EmitCh()
-							emitWG := sync.WaitGroup{}
-							emitWG.Add(1)
-							go func() {
-								<-emitCh
-								emitWG.Done()
-							}()
+					emitCh := cStore.EmitCh()
+					emitWG := sync.WaitGroup{}
+					emitWG.Add(1)
+					go func() {
+						<-emitCh
+						emitWG.Done()
+					}()
 
-							receiverID := component.MustNewIDWithName("a_receiver", "receiver.name")
-							endpointID := observer.EndpointID("endpoint.id")
-							cStore.UpdateEndpoint(observer.Endpoint{ID: endpointID}, receiverID, observerID)
+					receiverID := component.MustNewIDWithName("a_receiver", "receiver.name")
+					endpointID := observer.EndpointID("endpoint.id")
+					cStore.UpdateEndpoint(observer.Endpoint{ID: endpointID}, receiverID, observerID)
 
-							se, err := newStatementEvaluator(logger, component.MustNewID("some_type"), cfg, cStore)
-							require.NoError(t, err)
+					se, err := newStatementEvaluator(logger, component.MustNewID("some_type"), cfg, cStore)
+					require.NoError(t, err)
 
-							evaluatedLogger := se.evaluatedLogger.With(
-								zap.String("name", `a_receiver/receiver.name/receiver_creator/rc.name/{endpoint=""}/endpoint.id`),
-							)
+					evaluatedLogger := se.evaluatedLogger.With(
+						zap.String("name", `a_receiver/receiver.name/receiver_creator/rc.name/{endpoint=""}/endpoint.id`),
+					)
 
-							for _, statement := range []string{
-								"undesired.statement",
-								"another.undesired.statement",
-								"desired.statement",
-								"desired.statement",
-								"desired.statement",
-							} {
-								evaluatedLogger.Info(
-									statement,
-									zap.String("field.one", "field.one.value"),
-									zap.String("field_two", "field.two.value"),
-								)
-							}
-
-							// wait for the emit channel to be processed
-							emitWG.Wait()
-
-							attrs := cStore.Attrs(endpointID)
-
-							// Validate "caller" attribute
-							callerAttr, ok := attrs["caller"]
-							require.True(t, ok)
-							_, expectedFile, _, _ := runtime.Caller(0)
-							// runtime doesn't use os.PathSeparator
-							splitPath := strings.Split(expectedFile, "/")
-							expectedCaller := splitPath[len(splitPath)-1]
-							require.Contains(t, callerAttr, expectedCaller)
-							delete(attrs, "caller")
-
-							// Validate the rest of the attributes
-							expectedMsg := "desired body content"
-							if match.Record.AppendPattern {
-								if match.Strict != "" {
-									expectedMsg = fmt.Sprintf("%s (evaluated \"desired.statement\")", expectedMsg)
-								} else {
-									expectedMsg = fmt.Sprintf("%s (evaluated \"{\\\"field.one\\\":\\\"field.one.value\\\",\\\"field_two\\\":\\\"field.two.value\\\",\\\"message\\\":\\\"desired.statement\\\"}\")", expectedMsg)
-								}
-							}
-							require.Equal(t, map[string]string{
-								"discovery.observer.id":   "an_observer/observer.name",
-								"discovery.receiver.name": "receiver.name",
-								"discovery.receiver.rule": `type == "container"`,
-								"discovery.receiver.type": "a_receiver",
-								"discovery.status":        string(status),
-								"discovery.message":       expectedMsg,
-								"name":                    `a_receiver/receiver.name/receiver_creator/rc.name/{endpoint=""}/endpoint.id`,
-								"attr.one":                "attr.one.value",
-								"attr.two":                "attr.two.value",
-								"field.one":               "field.one.value",
-								"field_two":               "field.two.value",
-							}, attrs)
-						})
+					for _, statement := range []string{
+						"undesired.statement",
+						"another.undesired.statement",
+						"desired.statement",
+						"desired.statement",
+						"desired.statement",
+					} {
+						evaluatedLogger.Info(
+							statement,
+							zap.String("field.one", "field.one.value"),
+							zap.String("field_two", "field.two.value"),
+							zap.Error(errors.New("some error")),
+						)
 					}
+
+					// wait for the emit channel to be processed
+					emitWG.Wait()
+
+					// Validate the attributes
+					require.Equal(t, map[string]string{
+						"discovery.observer.id":   "an_observer/observer.name",
+						"discovery.receiver.name": "receiver.name",
+						"discovery.receiver.rule": `type == "container"`,
+						"discovery.receiver.type": "a_receiver",
+						"discovery.status":        string(status),
+						"discovery.message":       "desired body content",
+						"discovery.matched_log":   "desired.statement (error: some error)",
+						"attr.one":                "attr.one.value",
+						"attr.two":                "attr.two.value",
+					}, cStore.Attrs(endpointID))
 				})
 			}
 		})

--- a/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
+++ b/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
@@ -43,15 +43,6 @@ receivers:
       - host_observer/with_name
       - host_observer/with/another/name
 
-# drop scrape_timestamp attributes until we can accept arbitrary values
-processors:
-  transform:
-    error_mode: ignore
-    log_statements:
-      - context: log
-        statements:
-          - delete_key(attributes["otel.entity.attributes"], "scrape_timestamp")
-
 exporters:
   otlp:
     endpoint: "${OTLP_ENDPOINT}"
@@ -72,5 +63,4 @@ service:
       exporters: [otlp]
     logs:
       receivers: [discovery]
-      processors: [transform]
       exporters: [otlp]

--- a/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
+++ b/tests/receivers/discovery/testdata/resource_logs/host_observer_simple_prometheus_statuses.yaml
@@ -46,12 +46,9 @@ resource_logs:
                 discovery.receiver.name: ""
                 discovery.receiver.rule: type == "hostport" and command contains "otelcol"
                 discovery.receiver.type: prometheus_simple
-                caller: <ANY>
                 discovery.status: failed
                 discovery.message: (strict) Port appears to not be serving prometheus metrics
-                kind: receiver
-                name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer)[::]-4318-TCP-1
-                target_labels: '{__name__="up", instance="[::]:4318", job="prometheus_simple/[::]:4318"}'
+                discovery.matched_log: Failed to scrape Prometheus endpoint
                 discovery.observer.name: ""
                 discovery.observer.type: host_observer
                 command: /otelcol --config /etc/config.yaml
@@ -61,4 +58,4 @@ resource_logs:
                 transport: TCP
                 type: hostport
                 service.type: prometheus_simple
-                service.name: prometheus_simple//receiver_creator/discovery{endpoint="[::]:4318"}/(host_observer)[::]-4318-TCP-1
+                service.name: otelcol

--- a/tests/receivers/mongodb/testdata/docker_observer_with_ssl_mongodb_config.yaml
+++ b/tests/receivers/mongodb/testdata/docker_observer_with_ssl_mongodb_config.yaml
@@ -28,17 +28,14 @@ receivers:
             - status: failed
               regexp: 'connect: network is unreachable'
               log_record:
-                append_pattern: true
                 body: The container cannot be reached by the Collector. Make sure they're in the same network.
             - status: failed
               regexp: 'connect: connection refused'
               log_record:
-                append_pattern: true
                 body: The container is refusing mongodb connections.
             - status: partial
               regexp: '.* unable to authenticate using mechanism .*'
               log_record:
-                append_pattern: true
                 body: >-
                     Please ensure your user credentials are correctly specified with
                     `--set {{ configProperty "username" "<username>" }}` and
@@ -53,9 +50,6 @@ receivers:
                   `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`
     watch_observers:
       - docker_observer
-
-# drop scrape_timestamp attributes until we can accept arbitrary values
-processors:
 
 exporters:
   debug:

--- a/tests/receivers/mongodb/testdata/docker_observer_without_ssl_mongodb_config.yaml
+++ b/tests/receivers/mongodb/testdata/docker_observer_without_ssl_mongodb_config.yaml
@@ -27,17 +27,14 @@ receivers:
             - status: failed
               regexp: 'connect: network is unreachable'
               log_record:
-                append_pattern: true
                 body: The container cannot be reached by the Collector. Make sure they're in the same network.
             - status: failed
               regexp: 'connect: connection refused'
               log_record:
-                append_pattern: true
                 body: The container is refusing mongodb connections.
             - status: partial
               regexp: '.* unable to authenticate using mechanism .*'
               log_record:
-                append_pattern: true
                 body: >-
                     Please ensure your user credentials are correctly specified with
                     `--set {{ configProperty "username" "<username>" }}` and
@@ -52,9 +49,6 @@ receivers:
                   `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`
     watch_observers:
       - docker_observer
-
-# drop scrape_timestamp attributes until we can accept arbitrary values
-processors:
 
 exporters:
   debug:

--- a/tests/receivers/mongodb/testdata/docker_observer_without_ssl_with_wrong_authentication_mongodb_config.yaml
+++ b/tests/receivers/mongodb/testdata/docker_observer_without_ssl_with_wrong_authentication_mongodb_config.yaml
@@ -27,17 +27,14 @@ receivers:
             - status: failed
               regexp: 'connect: network is unreachable'
               log_record:
-                append_pattern: true
                 body: The container cannot be reached by the Collector. Make sure they're in the same network.
             - status: failed
               regexp: 'connect: connection refused'
               log_record:
-                append_pattern: true
                 body: The container is refusing mongodb connections.
             - status: partial
               regexp: '.* unable to authenticate using mechanism .*'
               log_record:
-                append_pattern: true
                 body: >-
                     Please ensure your user credentials are correctly specified with
                     `--set {{ configProperty "username" "<username>" }}` and
@@ -52,9 +49,6 @@ receivers:
                   `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`
     watch_observers:
       - docker_observer
-
-# drop scrape_timestamp attributes until we can accept arbitrary values
-processors:
 
 exporters:
   debug:


### PR DESCRIPTION
Remove `append_pattern` option from log evaluation statements.
  - The matched log message is now set as `discovery.matched_log` entity attributes instead of being appended to the `discovery.message` attribute.
  - The matched log fields like `caller` and `stacktrace` are not sent as attributes anymore since it's not relevant to the emitted entities anymore and don't provide any value to the end users
