### PR TITLE
[chore] Remove redundant config provider schema validation

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -22,7 +22,6 @@ import (
 	"regexp"
 	"runtime"
 	"runtime/debug"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -91,7 +90,6 @@ type Settings struct {
 	discoveryPropertiesFile *stringPointerFlagValue
 	setProperties           []string
 	colCoreArgs             []string
-	supportedURISchemes     []string
 	discoveryProperties     []string
 	versionFlag             bool
 	noConvertConfig         bool
@@ -190,11 +188,6 @@ func loadConfMapProviders(s *Settings) error {
 		envProvider.Scheme():  envProvider,
 		fileProvider.Scheme(): fileProvider,
 	}
-
-	for p := range s.confMapProviders {
-		s.supportedURISchemes = append(s.supportedURISchemes, p)
-	}
-	sort.Strings(s.supportedURISchemes)
 
 	// though supported, these schemes shouldn't be advertised for use w/ --config
 	s.confMapProviders[s.discovery.PropertyScheme()] = s.discovery.PropertyProvider()
@@ -550,10 +543,6 @@ func checkInputConfigs(settings *Settings) error {
 	for _, filePath := range settings.configPaths.value {
 		scheme, location, isURI := parseURI(filePath)
 		if isURI {
-			if _, ok := settings.confMapProviders[scheme]; !ok {
-				log.Printf("%q is an unsupported config provider scheme for this Collector distribution (not in %v).", scheme, settings.supportedURISchemes)
-				continue
-			}
 			if scheme != fileProvider.Scheme() {
 				continue
 			}

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -575,27 +575,6 @@ func TestConfigArgEnvURIForm(t *testing.T) {
 
 }
 
-func TestConfigArgUnsupportedURI(t *testing.T) {
-	t.Cleanup(clearEnv(t))
-
-	oldWriter := log.Default().Writer()
-	defer func() {
-		log.Default().SetOutput(oldWriter)
-	}()
-
-	logs := new(bytes.Buffer)
-	log.Default().SetOutput(logs)
-
-	settings, err := New([]string{"--config", "invalid:invalid"})
-	// though invalid, we defer failing to collector service
-	require.NoError(t, err)
-	require.NotNil(t, settings)
-	require.Equal(t, []string{"invalid:invalid"}, settings.configPaths.value)
-	require.Equal(t, settings.configPaths.value, settings.ResolverURIs())
-
-	require.Contains(t, logs.String(), `"invalid" is an unsupported config provider scheme for this Collector distribution (not in [env file]).`)
-}
-
 func TestCheckRuntimeParams_MemTotal(t *testing.T) {
 	t.Cleanup(setRequiredEnvVars(t))
 	require.NoError(t, os.Setenv(ConfigEnvVar, localGatewayConfig))


### PR DESCRIPTION
This removes an extra validation of the schema in place where it not expected.

Now, if schema isn't set correctly, user still gets a message like:
```
2024/05/20 14:47:39 main.go:78: unsupported scheme on URI "fil:./config.yaml"
```

Before this change, the additional line was reported at the top of the output
```
2024/05/20 14:47:39 settings.go:554: "fil" is an unsupported config provider scheme for this Collector distribution (not in [env file]).
2024/05/20 14:47:39 settings.go:480: Set config to [fil:./config.yaml]
2024/05/20 14:47:39 settings.go:541: Set memory limit to 460 MiB
2024/05/20 14:47:39 settings.go:526: Set soft memory limit set to 460 MiB
2024/05/20 14:47:39 settings.go:416: set "SPLUNK_LISTEN_INTERFACE" to "0.0.0.0"
2024/05/20 14:47:39 main.go:78: unsupported scheme on URI "fil:./config.yaml"
```
