### PR TITLE
[OTL-2836] Set hosts in MongoDB config from autodiscover endpoint

### DIFF
--- a/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
@@ -19,6 +19,9 @@
 #       tls:
 #         insecure_skip_verify: true
 #         insecure: false
+#       hosts:
+#         - endpoint: '`endpoint`'
+#           transport: tcp
 #   status:
 #     metrics:
 #       - status: successful

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
@@ -15,6 +15,9 @@ mongodb:
       tls:
         insecure_skip_verify: true
         insecure: false
+      hosts:
+        - endpoint: '`endpoint`'
+          transport: tcp
   status:
     metrics:
       - status: successful

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
@@ -11,6 +11,9 @@
       tls:
         insecure_skip_verify: true
         insecure: false
+      hosts:
+        - endpoint: '`endpoint`'
+          transport: tcp
   status:
     metrics:
       - status: successful


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`endpoint` is coming from receiver creator when it matches an endpoint provided by an observer extension. The `mongodb` receiver uses the `endpoint` in a slightly different way than expected, as an item in a `hosts` map, rather than directly as an `endpoint` config option. This updates the receiver creator's way of creating `mongodb` as the target receiver, setting the endpoint properly in the `hosts` config option.

I was able to see that the option is being picked up properly, and the MongoDB receiver's config is setup as expected, but discovery didn't succeed due to docker's IP configuration on my local machine. Posting PR as draft while I investigate locally.