### PR TITLE
Ignore pid attribute value

### DIFF
--- a/tests/receivers/kong/kong_test.go
+++ b/tests/receivers/kong/kong_test.go
@@ -30,6 +30,7 @@ func TestKongMetrics(t *testing.T) {
 		pmetrictest.IgnoreTimestamp(),
 		pmetrictest.IgnoreStartTimestamp(),
 		pmetrictest.IgnoreMetricAttributeValue("node_id"),
+		pmetrictest.IgnoreMetricAttributeValue("pid"),
 		pmetrictest.IgnoreMetricValues(),
 		pmetrictest.IgnoreResourceMetricsOrder(),
 		pmetrictest.IgnoreScopeMetricsOrder(),


### PR DESCRIPTION
Fixes a flaky test:
```
2024-05-28T17:56:39.430Z	INFO	testutils/collector_container.go:267	2024-05-28T17:56:39.430Z	info	zapgrpc/zapgrpc.go:176	[core] [Channel #1]Channel Connectivity change to READY	{"grpc_log": true}
    golden.go:71: 
        	Error Trace:	/home/runner/work/splunk-otel-collector/splunk-otel-collector/tests/testutils/golden.go:77
        	            				/opt/hostedtoolcache/go/1.21.10/x64/src/runtime/asm_amd64.s:1650
        	Error:      	Received unexpected error:
        	            	the following errors occurred:
        	            	 -  resource "map[http.scheme:http net.host.port:18001 service.instance.id:localhost:18001 service.name:kong]": scope "otelcol/prometheusreceiver": metric "kong_memory_workers_lua_vms_bytes": missing expected datapoint: map[kong_subsystem:http node_id: pid:2435]
        	            	 -  resource "map[http.scheme:http net.host.port:18001 service.instance.id:localhost:18001 service.name:kong]": scope "otelcol/prometheusreceiver": metric "kong_memory_workers_lua_vms_bytes": unexpected datapoint: map[kong_subsystem:http node_id: pid:2438]
```