### PR TITLE
Multiarch docker-otelcol build and manifest

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -26,21 +26,14 @@ concurrency:
 env:
   GO_VERSION: "1.21.10"
 jobs:
-  docker-otelcol:
-    name: docker-otelcol
-    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
+  agent-bundle-linux:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ARCH: [ "amd64", "arm64" ]
+        ARCH: ["amd64", "arm64"]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
       - uses: actions/cache@v4
         id: bundle-cache
         with:
@@ -53,16 +46,80 @@ jobs:
         with:
           platforms: ${{ matrix.ARCH }}
           image: tonistiigi/binfmt:qemu-v7.0.0
-      - run: |
-          make docker-otelcol ARCH=${{ matrix.ARCH }}
+      - run: make -C internal/signalfx-agent/bundle agent-bundle-linux ARCH=${{ matrix.ARCH }}
         env:
-          DOCKER_BUILDKIT: '1'
           BUNDLE_CACHE_HIT: "${{ steps.bundle-cache.outputs.cache-hit }}"
-      - run: docker save -o ./bin/image.tar otelcol:latest
       - uses: actions/upload-artifact@v4
         with:
-          name: otelcol-${{ matrix.ARCH }}
+          name: agent-bundle-linux-${{ matrix.ARCH }}
+          path: ./dist/agent-bundle_linux_${{ matrix.ARCH }}.tar.gz
+
+  docker-otelcol:
+    name: docker-otelcol
+    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
+    runs-on: ubuntu-20.04
+    needs: agent-bundle-linux
+    services:
+      # Start a local registry for pushing the multiarch manifest and images
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      # Multiarch images require more disk space
+      - uses: jlumbroso/free-disk-space@v1.3.1
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
+      - uses: actions/download-artifact@v4
+        with:
+          name: agent-bundle-linux-amd64
+          path: ./dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: agent-bundle-linux-arm64
+          path: ./dist
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,ppc64le
+          image: tonistiigi/binfmt:qemu-v7.0.0
+      - uses: docker/setup-buildx-action@v3
+        id: multiarch-otelcol-builder
+        with:
+          driver: docker-container   # Create a builder with the docker-container driver required for multiarch builds
+          driver-opts: network=host  # Required for the builder to push to the local registry service
+      - run: make docker-otelcol SKIP_BUNDLE=true ARCH=amd64,arm64,ppc64le IMAGE_NAME=localhost:5000/otelcol IMAGE_TAG=latest PUSH=true
+        env:
+          MULTIARCH_OTELCOL_BUILDER: ${{ steps.multiarch-otelcol-builder.outputs.name }}  # Use the builder created by the docker/setup-buildx-action step
+      - name: Save image archive for each platform to be loaded by downstream jobs
+        run: |
+          for arch in "amd64" "arm64" "ppc64le"; do
+            mkdir -p docker-otelcol/${arch}
+            docker pull --platform=linux/${arch} localhost:5000/otelcol:latest
+            docker tag localhost:5000/otelcol:latest otelcol:latest
+            docker save -o ./docker-otelcol/${arch}/image.tar otelcol:latest
+            docker rmi -f localhost:5000/otelcol:latest otelcol:latest
+          done
+      - uses: actions/upload-artifact@v4
+        with:
+          name: otelcol
           path: ./bin
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docker-otelcol-amd64
+          path: ./docker-otelcol/amd64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docker-otelcol-arm64
+          path: ./docker-otelcol/arm64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docker-otelcol-ppc64le
+          path: ./docker-otelcol/ppc64le
 
   integration-vet:
     name: integration-vet
@@ -83,14 +140,19 @@ jobs:
           cache-dependency-path: '**/go.sum'
       - uses: actions/download-artifact@v4
         with:
-          name: otelcol-${{ matrix.ARCH }}
+          name: otelcol
           path: ./bin
+      - uses: actions/download-artifact@v4
+        with:
+          name: docker-otelcol-${{ matrix.ARCH }}
+          path: ./docker-otelcol/${{ matrix.ARCH }}
       - uses: docker/setup-qemu-action@v3
         if: ${{ matrix.ARCH != 'amd64' }}
         with:
           platforms: ${{ matrix.ARCH }}
           image: tonistiigi/binfmt:qemu-v7.0.0
-      - run: docker load -i ./bin/image.tar
+      - run: docker load -i ./docker-otelcol/${{ matrix.ARCH }}/image.tar
+      - run: ln -sf otelcol_linux_${{ matrix.ARCH }} ./bin/otelcol
       - run: chmod a+x ./bin/*
       - run: make integration-vet
         env:
@@ -129,14 +191,19 @@ jobs:
           cache-dependency-path: '**/go.sum'
       - uses: actions/download-artifact@v4
         with:
-          name: otelcol-${{ matrix.ARCH }}
+          name: otelcol
           path: ./bin
+      - uses: actions/download-artifact@v4
+        with:
+          name: docker-otelcol-${{ matrix.ARCH }}
+          path: ./docker-otelcol/${{ matrix.ARCH }}
       - uses: docker/setup-qemu-action@v3
         if: ${{ matrix.ARCH != 'amd64' }}
         with:
           platforms: ${{ matrix.ARCH }}
           image: tonistiigi/binfmt:qemu-v7.0.0
-      - run: docker load -i ./bin/image.tar
+      - run: docker load -i ./docker-otelcol/${{ matrix.ARCH }}/image.tar
+      - run: ln -sf otelcol_linux_${{ matrix.ARCH }} ./bin/otelcol
       - run: chmod a+x ./bin/*
       - uses: shogo82148/actions-setup-redis@v1
         if: matrix.PROFILE == 'integration'

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/linux-package-test.yml'
       - 'cmd/otelcol/**'
       - 'internal/buildscripts/packaging/collect-libs.sh'
+      - 'internal/buildscripts/packaging/docker-otelcol.sh'
       - 'internal/buildscripts/packaging/fpm/**'
       - 'internal/buildscripts/packaging/installer/install.sh'
       - 'internal/buildscripts/packaging/jmx-metric-gatherer-release.txt'
@@ -255,13 +256,23 @@ jobs:
     # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
     runs-on: ubuntu-20.04
     needs: [cross-compile, agent-bundle-linux]
-    strategy:
-      matrix:
-        ARCH: [ "amd64", "arm64", "ppc64le" ]
-      fail-fast: false
     steps:
+      # Multiarch images require more disk space
+      - uses: jlumbroso/free-disk-space@v1.3.1
+
       - name: Check out the codebase.
         uses: actions/checkout@v4
+
+      # Required to export a multiarch manifest and images to the local image store
+      - name: Set up containerd image store
+        uses: crazy-max/ghaction-setup-docker@v3
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -270,37 +281,92 @@ jobs:
           cache-dependency-path: '**/go.sum'
 
       - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,ppc64le
+          image: tonistiigi/binfmt:qemu-v7.0.0
+
+      - name: Downloading binaries-linux_amd64
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-linux_amd64
+          path: ./bin
+
+      - name: Downloading binaries-linux_arm64
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-linux_arm64
+          path: ./bin
+
+      - name: Downloading binaries-linux_ppc64le
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-linux_ppc64le
+          path: ./bin
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: agent-bundle-linux-amd64
+          path: ./dist
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: agent-bundle-linux-arm64
+          path: ./dist
+
+      - name: Build the multiarch docker image
+        run: make docker-otelcol SKIP_COMPILE=true SKIP_BUNDLE=true ARCH=amd64,arm64,ppc64le
+
+      - name: Save the multiarch image archive to be loaded by downstream jobs
+        run: mkdir -p docker-otelcol && docker save -o ./docker-otelcol/image.tar otelcol:latest
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: otelcol
+          path: ./docker-otelcol
+
+  docker-otelcol-verify:
+    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
+    runs-on: ubuntu-20.04
+    needs: [docker-otelcol]
+    strategy:
+      matrix:
+        ARCH: [ "amd64", "arm64", "ppc64le" ]
+      fail-fast: false
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+
+      # Required to load a multiarch archive to the local image store
+      - name: Set up containerd image store
+        uses: crazy-max/ghaction-setup-docker@v3
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Set up QEMU
         if: ${{ matrix.ARCH != 'amd64' }}
         uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.ARCH }}
           image: tonistiigi/binfmt:qemu-v7.0.0
 
-      - name: Downloading binaries-linux_${{ matrix.ARCH }}
-        uses: actions/download-artifact@v4
-        with:
-          name: binaries-linux_${{ matrix.ARCH }}
-          path: ./bin
-
       - uses: actions/download-artifact@v4
-        if: ${{ matrix.ARCH != 'ppc64le' }}
         with:
-          name: agent-bundle-linux-${{ matrix.ARCH }}
-          path: ./dist
+          name: otelcol
+          path: ./docker-otelcol
 
-      - name: Build ${{ matrix.ARCH }} docker image
-        run: |
-          make docker-otelcol SKIP_COMPILE=true SKIP_BUNDLE=true ARCH=${{ matrix.ARCH }}
-
-      - name: Check image arch
-        run: |
-          # ensure that the arch in the image manifest is correct
-          [ "$( docker inspect --format='{{.Architecture}}' otelcol:${{ matrix.ARCH }} )" = "${{ matrix.ARCH }}" ] || exit 1
+      - name: Load multiarch docker image
+        run: docker load -i ./docker-otelcol/image.tar
 
       - name: Run docker image
         run: |
           # ensure the collector can start with the default config file
-          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:${{ matrix.ARCH }}
+          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
           sleep 10
           if [ -z "$( docker ps --filter=status=running --filter=name=otelcol -q )" ]; then
             docker logs otelcol
@@ -320,7 +386,7 @@ jobs:
             exit 1
           fi
           for config in $configs; do
-            docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_CONFIG=/etc/otel/collector/${config} -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:${{ matrix.ARCH }}
+            docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_CONFIG=/etc/otel/collector/${config} -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
             sleep 10
             if [ -z "$( docker ps --filter=status=running --filter=name=otelcol -q )" ]; then
               docker logs otelcol
@@ -333,7 +399,7 @@ jobs:
       - name: Check journalctl
         run: |
           # ensure journalctl can run with the collected libraries
-          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:${{ matrix.ARCH }}
+          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
           docker exec otelcol /bin/journalctl
           docker rm -f otelcol
 
@@ -341,7 +407,7 @@ jobs:
         if: ${{ matrix.ARCH != 'ppc64le' }}
         run: |
           # ensure python and java can run with the collected libraries
-          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:${{ matrix.ARCH }}
+          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
           docker exec otelcol /usr/lib/splunk-otel-collector/agent-bundle/bin/python --version
           docker exec otelcol /usr/lib/splunk-otel-collector/agent-bundle/jre/bin/java -version
           # ensure collectd-python plugins were installed

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -47,18 +47,14 @@ jobs:
           output-format: "table"
           path: "."
 
-  docker-otelcol:
+  agent-bundle-linux:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ARCH: [ "amd64", "arm64" ]
+        ARCH: ["amd64", "arm64"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
       - uses: actions/cache@v4
         id: bundle-cache
         with:
@@ -71,16 +67,72 @@ jobs:
         with:
           platforms: ${{ matrix.ARCH }}
           image: tonistiigi/binfmt:qemu-v7.0.0
-      - run: |
-          make docker-otelcol ARCH=${{ matrix.ARCH }}
+      - run: make -C internal/signalfx-agent/bundle agent-bundle-linux ARCH=${{ matrix.ARCH }}
         env:
-          DOCKER_BUILDKIT: '1'
           BUNDLE_CACHE_HIT: "${{ steps.bundle-cache.outputs.cache-hit }}"
-      - run: mkdir -p dist && docker save -o dist/image.tar otelcol:latest
       - uses: actions/upload-artifact@v4
         with:
-          name: otelcol-${{ matrix.ARCH }}
+          name: agent-bundle-linux-${{ matrix.ARCH }}
+          path: ./dist/agent-bundle_linux_${{ matrix.ARCH }}.tar.gz
+
+  docker-otelcol:
+    runs-on: ubuntu-20.04
+    needs: agent-bundle-linux
+    services:
+      # Start a local registry for pushing the multiarch manifest and images
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      # Multiarch images require more disk space
+      - uses: jlumbroso/free-disk-space@v1.3.1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
+      - uses: actions/download-artifact@v4
+        with:
+          name: agent-bundle-linux-amd64
           path: ./dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: agent-bundle-linux-arm64
+          path: ./dist
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,ppc64le
+          image: tonistiigi/binfmt:qemu-v7.0.0
+      - uses: docker/setup-buildx-action@v3
+        id: multiarch-otelcol-builder
+        with:
+          driver: docker-container   # Create a builder with the docker-container driver required for multiarch builds
+          driver-opts: network=host  # Required for the builder to push to the local registry service
+      - run: make docker-otelcol SKIP_BUNDLE=true ARCH=amd64,arm64,ppc64le IMAGE_NAME=localhost:5000/otelcol IMAGE_TAG=latest PUSH=true
+        env:
+          MULTIARCH_OTELCOL_BUILDER: ${{ steps.multiarch-otelcol-builder.outputs.name }}  # Use the builder created by the docker/setup-buildx-action step
+      - name: Save image archive for each platform to be loaded by downstream jobs
+        run: |
+          for arch in "amd64" "arm64" "ppc64le"; do
+            mkdir -p docker-otelcol/${arch}
+            docker pull --platform=linux/${arch} localhost:5000/otelcol:latest
+            docker tag localhost:5000/otelcol:latest otelcol:latest
+            docker save -o ./docker-otelcol/${arch}/image.tar otelcol:latest
+            docker rmi -f localhost:5000/otelcol:latest otelcol:latest
+          done
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docker-otelcol-amd64
+          path: ./docker-otelcol/amd64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docker-otelcol-arm64
+          path: ./docker-otelcol/arm64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docker-otelcol-ppc64le
+          path: ./docker-otelcol/ppc64le
 
   binaries-windows_amd64:
     runs-on: ubuntu-20.04
@@ -105,7 +157,7 @@ jobs:
     needs: docker-otelcol
     strategy:
       matrix:
-        ARCH: [ "amd64", "arm64" ]
+        ARCH: [ "amd64", "arm64", "ppc64le" ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -116,9 +168,9 @@ jobs:
           image: tonistiigi/binfmt:qemu-v7.0.0
       - uses: actions/download-artifact@v4
         with:
-          name: otelcol-${{ matrix.ARCH }}
-          path: ./dist
-      - run: docker load -i ./dist/image.tar
+          name: docker-otelcol-${{ matrix.ARCH }}
+          path: ./docker-otelcol/${{ matrix.ARCH }}
+      - run: docker load -i ./docker-otelcol/${{ matrix.ARCH }}/image.tar
       - name: Run trivy image scan
         uses: aquasecurity/trivy-action@0.21.0
         with:
@@ -134,7 +186,7 @@ jobs:
     needs: docker-otelcol
     strategy:
       matrix:
-        ARCH: [ "amd64", "arm64" ]
+        ARCH: [ "amd64", "arm64", "ppc64le" ]
       fail-fast: false
     env:
       GRYPE_PLATFORM: ${{ matrix.ARCH }}
@@ -147,9 +199,9 @@ jobs:
           image: tonistiigi/binfmt:qemu-v7.0.0
       - uses: actions/download-artifact@v4
         with:
-          name: otelcol-${{ matrix.ARCH }}
-          path: ./dist
-      - run: docker load -i ./dist/image.tar
+          name: docker-otelcol-${{ matrix.ARCH }}
+          path: ./docker-otelcol/${{ matrix.ARCH }}
+      - run: docker load -i ./docker-otelcol/${{ matrix.ARCH }}/image.tar
       - uses: anchore/scan-action@v3
         with:
           severity-cutoff: "high"
@@ -209,15 +261,15 @@ jobs:
     needs: docker-otelcol
     strategy:
       matrix:
-        ARCH: [ "amd64", "arm64" ]
+        ARCH: [ "amd64", "arm64", "ppc64le" ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: otelcol-${{ matrix.ARCH }}
-          path: ./dist
-      - run: docker load -i ./dist/image.tar
+          name: docker-otelcol-${{ matrix.ARCH }}
+          path: ./docker-otelcol/${{ matrix.ARCH }}
+      - run: docker load -i ./docker-otelcol/${{ matrix.ARCH }}/image.tar
       - uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,9 @@
 default:
-  image: '${DOCKER_CICD_REPO}/ci-container/debian-buster:1.8.0'
+  image: '${DOCKER_CICD_REPO}/ci-container/debian-buster:3.1.1'
+
+variables:
+  WIN_2019_BASE_IMAGE: mcr.microsoft.com/windows/servercore:1809
+  WIN_2022_BASE_IMAGE: mcr.microsoft.com/windows/servercore:ltsc2022
 
 stages:
   - update-deps
@@ -11,7 +15,6 @@ stages:
   - release
   - docker-manifest-release
   - github-release
-  - sign-image
 
 include:
   - project: 'prodsec/scp-scanning/gitlab-checkmarx'
@@ -58,15 +61,12 @@ fossa:
 
 .sign-docker:
   extends: .trigger-filter
-  stage: sign-image
-  before_script:
-    - *docker-reader-role
-    - docker login -u $CIRCLECI_QUAY_USERNAME -p $CIRCLECI_QUAY_PASSWORD quay.io
+  retry: 2
   script:
+    - docker login -u $CIRCLECI_QUAY_USERNAME -p $CIRCLECI_QUAY_PASSWORD quay.io
     - echo "listing images to be signed"
     - cat tags_to_sign
     - cat tags_to_sign | xargs -L1 artifact-ci sign docker
-
 
 .get-artifactory-stage: &get-artifactory-stage
   - |
@@ -101,6 +101,9 @@ fossa:
     paths:
       - .cache/pip
   retry: 2
+  id_tokens:  # http://go/gitlab-17
+    CI_JOB_JWT:
+      aud: $CICD_VAULT_ADDR
   script:
     - *get-artifactory-stage
     - *aws-releaser-role
@@ -226,6 +229,7 @@ compile:
     - .trigger-filter
     - .go-cache
   stage: build
+  needs: []
   parallel:
     matrix:
       - TARGET: [binaries-darwin_amd64, binaries-darwin_arm64, binaries-linux_amd64, binaries-linux_arm64, binaries-windows_amd64, binaries-linux_ppc64le]
@@ -247,10 +251,14 @@ compile:
 libsplunk:
   extends: .trigger-filter
   stage: build
+  needs: []
   retry: 2
   parallel:
     matrix:
       - ARCH: ["amd64", "arm64"]
+  id_tokens:  # http://go/gitlab-17
+    CI_JOB_JWT:
+      aud: $CICD_VAULT_ADDR
   script:
     - *docker-reader-role
     - make -C instrumentation dist ARCH=${ARCH} DOCKER_REPO=${DOCKER_HUB_REPO}
@@ -264,6 +272,8 @@ agent-bundle-linux:
     - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
     - if: $CI_PIPELINE_SOURCE == "schedule"
   stage: build
+  needs: []
+  retry: 2
   resource_group: agent-bundle-linux-${ARCH}
   parallel:
     matrix:
@@ -273,6 +283,9 @@ agent-bundle-linux:
         TAG: arm
   tags:
     - $TAG
+  id_tokens:  # http://go/gitlab-17
+    CI_JOB_JWT:
+      aud: $CICD_VAULT_ADDR
   script:
     - *docker-reader-role
     - docker login -u $CIRCLECI_QUAY_USERNAME -p $CIRCLECI_QUAY_PASSWORD quay.io
@@ -284,8 +297,9 @@ agent-bundle-linux:
 agent-bundle-windows:
   extends: .trigger-filter
   stage: build
+  needs: []
   tags:
-    - windows
+    - splunk-otel-collector-windows
   variables:
     PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
   cache:
@@ -375,28 +389,6 @@ sign-osx:
     paths:
       - dist/signed/otelcol_darwin_${ARCH}
 
-build-linux-image:
-  extends: .trigger-filter
-  stage: package
-  needs:
-    - compile
-    - agent-bundle-linux
-  parallel:
-    matrix:
-      - ARCH: [amd64, arm64, ppc64le]
-  retry: 2
-  script:
-    - *docker-reader-role
-    - make docker-otelcol ARCH=${ARCH} DOCKER_REPO=${DOCKER_HUB_REPO} SKIP_COMPILE=true SKIP_BUNDLE=true
-    - arch=$( docker inspect --format='{{.Architecture}}' otelcol:${ARCH} )
-    - if [[ "$arch" != "$ARCH" ]]; then exit 1; fi
-  after_script:
-    - mkdir -p dist
-    - docker save -o dist/otelcol-${ARCH}.tar otelcol:${ARCH}
-  artifacts:
-    paths:
-      - dist/otelcol-*.tar
-
 .build-tar-deb-rpm:
   stage: package
   needs:
@@ -451,6 +443,9 @@ build-msi:
     # build the MSI with the signed exe
     - mkdir -p bin
     - cp -f dist/signed/otelcol_windows_amd64.exe bin/otelcol_windows_amd64.exe
+  id_tokens:  # http://go/gitlab-17
+    CI_JOB_JWT:
+      aud: $CICD_VAULT_ADDR
   script:
     - *docker-reader-role
     - make msi SKIP_COMPILE=true VERSION=${CI_COMMIT_TAG:-} DOCKER_REPO=${DOCKER_HUB_REPO}
@@ -465,7 +460,7 @@ msi-custom-actions-package:
     - job: msi-custom-actions-assemblies
       artifacts: true
   tags:
-    - windows
+    - splunk-otel-collector-windows
   script:
     - $WixPath = "${Env:ProgramFiles(x86)}\WiX Toolset v3.14"
     - $sfxcaDll = "${WixPath}\SDK\x64\sfxca.dll"
@@ -667,227 +662,221 @@ verify-signed-packages:
         fi
       done
 
-push-linux-image:
+build-push-linux-image:
   extends: .trigger-filter
   stage: release
   dependencies:
-    - build-linux-image
+    - compile
+    - agent-bundle-linux
   retry: 2
-  before_script:
-    - docker load -i dist/otelcol-amd64.tar
-    - docker load -i dist/otelcol-arm64.tar
-    - docker load -i dist/otelcol-ppc64le.tar
+  id_tokens:  # http://go/gitlab-17
+    CI_JOB_JWT:
+      aud: $CICD_VAULT_ADDR
   script:
+    - *docker-reader-role
     - docker login -u $CIRCLECI_QUAY_USERNAME -p $CIRCLECI_QUAY_PASSWORD quay.io
     - |
       # Set env vars
       set -e
       if [[ -n "${CI_COMMIT_TAG:-}" ]]; then
         IMAGE_NAME="quay.io/signalfx/splunk-otel-collector"
-        MANIFEST_TAG=${CI_COMMIT_TAG#v}
+        IMAGE_TAG=${CI_COMMIT_TAG#v}
       else
         IMAGE_NAME="quay.io/signalfx/splunk-otel-collector-dev"
-        MANIFEST_TAG=$CI_COMMIT_SHA
+        IMAGE_TAG=${CI_COMMIT_SHA}
       fi
-    - |
-      # Tag and push images
-      set -e
-      for arch in "amd64" "arm64" "ppc64le"; do
-        ARCH_TAG="${MANIFEST_TAG}-${arch}"
-        echo "Tagging and pushing ${IMAGE_NAME}:${ARCH_TAG}"
-        docker tag otelcol:${arch} ${IMAGE_NAME}:${ARCH_TAG}
-        docker push ${IMAGE_NAME}:${ARCH_TAG}
-        echo "${IMAGE_NAME}:${ARCH_TAG}" >> tags
-        if [[ "${CI_COMMIT_BRANCH:-}" = "main" ]] || [[ "${CI_COMMIT_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          # only push latest tag for main and stable releases; no need to sign them as signing is made for digest
-          LATEST_TAG="latest-${arch}"
-          echo "Tagging and pushing ${IMAGE_NAME}:${LATEST_TAG}"
-          docker tag ${IMAGE_NAME}:${ARCH_TAG} ${IMAGE_NAME}:${LATEST_TAG}
-          docker push ${IMAGE_NAME}:${LATEST_TAG}
-        fi
-      done
-    - |
-      # Create and push image manifests
-      set -e
-      echo "${IMAGE_NAME}:${MANIFEST_TAG}" >> tags
-      echo "Creating and pushing ${IMAGE_NAME}:${MANIFEST_TAG} manifest"
-      docker manifest create ${IMAGE_NAME}:${MANIFEST_TAG} --amend ${IMAGE_NAME}:${MANIFEST_TAG}-amd64 --amend ${IMAGE_NAME}:${MANIFEST_TAG}-arm64 --amend ${IMAGE_NAME}:${MANIFEST_TAG}-ppc64le
-      docker manifest push ${IMAGE_NAME}:${MANIFEST_TAG}
+      LATEST_TAG=""
       if [[ "${CI_COMMIT_BRANCH:-}" = "main" ]] || [[ "${CI_COMMIT_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        # only push latest manifest tag for main and stable releases
-        echo "Creating and pushing ${IMAGE_NAME}:latest manifest"
-        docker manifest create ${IMAGE_NAME}:latest --amend ${IMAGE_NAME}:latest-amd64 --amend ${IMAGE_NAME}:latest-arm64 --amend ${IMAGE_NAME}:latest-ppc64le
-        docker manifest push ${IMAGE_NAME}:latest
+        # Only push latest tag for main and stable releases
+        LATEST_TAG="latest"
       fi
-    - docker pull ${IMAGE_NAME}:${MANIFEST_TAG}
-    - docker inspect --format='{{.RepoDigests}}' ${IMAGE_NAME}:${MANIFEST_TAG}-amd64 | tee dist/linux_amd64_digest.txt
-    - docker inspect --format='{{.RepoDigests}}' ${IMAGE_NAME}:${MANIFEST_TAG}-arm64 | tee dist/linux_arm64_digest.txt
-    - docker inspect --format='{{.RepoDigests}}' ${IMAGE_NAME}:${MANIFEST_TAG}-ppc64le | tee dist/linux_ppc64le_digest.txt
-    - docker manifest inspect ${IMAGE_NAME}:${MANIFEST_TAG} | tee dist/manifest_digest.txt
-    - mv tags tags_to_sign
+    - echo "Building and pushing ${IMAGE_NAME}:${IMAGE_TAG}"
+    - make docker-otelcol ARCH=amd64,arm64,ppc64le DOCKER_REPO=${DOCKER_HUB_REPO} IMAGE_NAME=${IMAGE_NAME} IMAGE_TAG=${IMAGE_TAG} SKIP_COMPILE=true SKIP_BUNDLE=true PUSH=true
+    - |
+      # DEPRECATED
+      # Create and push manifests for each arch
+      set -eo pipefail
+      json=$( docker buildx imagetools inspect --raw ${IMAGE_NAME}:${IMAGE_TAG} )
+      for arch in "amd64" "arm64" "ppc64le"; do
+        arch_tag="${IMAGE_TAG}-${arch}"
+        echo "Creating and pushing ${IMAGE_NAME}:${arch_tag} manifest"
+        echo "$json" | jq -r ".manifests[] | select(.platform.architecture == \"${arch}\" and .platform.os == \"linux\")" | tee ${arch}.json
+        docker buildx imagetools create --tag ${IMAGE_NAME}:${arch_tag} --file ${arch}.json
+        if [[ -n "$LATEST_TAG" ]]; then
+          latest_tag="${LATEST_TAG}-${arch}"
+          echo "Creating and pushing ${IMAGE_NAME}:${latest_tag} manifest"
+          docker buildx imagetools create --tag ${IMAGE_NAME}:${latest_tag} ${IMAGE_NAME}:${arch_tag}
+        fi
+        echo "${IMAGE_NAME}:${arch_tag}" > tags_to_sign_${arch}
+      done
   artifacts:
     paths:
-      - dist/linux_amd64_digest.txt
-      - dist/linux_arm64_digest.txt
-      - dist/linux_ppc64le_digest.txt
-      - dist/manifest_digest.txt
-      - tags_to_sign
+      - tags_to_sign_*
 
 sign-linux-image:
   extends: .sign-docker
-  dependencies:
-    - push-linux-image
+  stage: release
+  parallel:
+    matrix:
+      - ARCH: [amd64, arm64, ppc64le]
+  needs:
+    - build-push-linux-image
+  before_script:
+    - mv tags_to_sign_${ARCH} tags_to_sign
 
-build-push-windows2019-image:
+build-push-windows-image:
   extends: .trigger-filter
   stage: release
+  parallel:
+    matrix:
+      - WIN_VERSION: ["2019", "2022"]
   dependencies:
     - sign-exe
     - agent-bundle-windows
   tags:
-    - windows
+    - splunk-otel-collector-windows${WIN_VERSION}
   retry: 2
+  variables:
+    ErrorActionPreference: stop
   before_script:
     - Copy-Item .\dist\signed\otelcol_windows_amd64.exe .\cmd\otelcol\otelcol.exe
     - Copy-Item .\dist\agent-bundle_windows_amd64.zip .\cmd\otelcol\agent-bundle_windows_amd64.zip
+    - docker image prune --force
   script:
-    - docker login -u $env:CIRCLECI_QUAY_USERNAME -p $env:CIRCLECI_QUAY_PASSWORD quay.io
     - |
-      $ErrorActionPreference = 'Stop'
+      docker login -u $env:CIRCLECI_QUAY_USERNAME -p $env:CIRCLECI_QUAY_PASSWORD quay.io
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - |
+      # Set env vars
       if ($env:CI_COMMIT_TAG) {
-        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows"
+        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector"
+        $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows"
         $tagNumber = $env:CI_COMMIT_TAG.TrimStart("v")
-        $IMAGE_TAG = "${tagNumber}-2019"
+        $IMAGE_TAG = "${tagNumber}-${env:WIN_VERSION}"
       } else {
-        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows-dev"
-        $IMAGE_TAG = "${env:CI_COMMIT_SHA}-2019"
+        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-dev"
+        $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows-dev"
+        $IMAGE_TAG = "${env:CI_COMMIT_SHA}-${env:WIN_VERSION}"
       }
-      $JMX_METRIC_GATHERER_RELEASE = $(Get-Content internal\buildscripts\packaging\jmx-metric-gatherer-release.txt)
+      if ($env:WIN_VERSION -eq "2019") {
+        $BASE_IMAGE = $env:WIN_2019_BASE_IMAGE
+      } else {
+        $BASE_IMAGE = $env:WIN_2022_BASE_IMAGE
+      }
+      $LATEST_TAG = ""
+      if ($env:CI_COMMIT_BRANCH -eq "main" -or $env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$') {
+        # Only push latest tag for main and stable releases
+        $LATEST_TAG = "latest-${env:WIN_VERSION}"
+      }
+    - |
+      docker pull $BASE_IMAGE
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+      docker image prune --force
+    - $JMX_METRIC_GATHERER_RELEASE = $(Get-Content internal\buildscripts\packaging\jmx-metric-gatherer-release.txt)
+    - |
       echo "Building ${IMAGE_NAME}:${IMAGE_TAG}"
-      docker build -t ${IMAGE_NAME}:${IMAGE_TAG} --build-arg BASE_IMAGE=mcr.microsoft.com/windows/servercore:1809 --build-arg JMX_METRIC_GATHERER_RELEASE=${JMX_METRIC_GATHERER_RELEASE} -f .\cmd\otelcol\Dockerfile.windows .\cmd\otelcol\
-      $os_version = (docker manifest inspect mcr.microsoft.com/windows/servercore:1809 | ConvertFrom-Json).manifests[0].platform."os.version"
-      docker manifest annotate --os "windows" --arch "amd64" --os-version ${os_version} ${IMAGE_NAME}:${IMAGE_TAG}
+      docker build -t ${IMAGE_NAME}:${IMAGE_TAG} --build-arg BASE_IMAGE=${BASE_IMAGE} --build-arg JMX_METRIC_GATHERER_RELEASE=${JMX_METRIC_GATHERER_RELEASE} -f .\cmd\otelcol\Dockerfile.windows .\cmd\otelcol\
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - |
       echo "Pushing ${IMAGE_NAME}:${IMAGE_TAG}"
       docker push ${IMAGE_NAME}:${IMAGE_TAG}
-      echo "${IMAGE_NAME}:${IMAGE_TAG}" >> tags
-      if ($env:CI_COMMIT_BRANCH -eq "main" -or $env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$') {
-        # only push latest tag for main and stable releases; no need to sign them as signing is made for digest
-        echo "Tagging and pushing ${IMAGE_NAME}:latest-2019"
-        docker tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:latest-2019
-        docker push ${IMAGE_NAME}:latest-2019
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - |
+      # DEPRECATED
+      echo "Tagging and pushing ${OLD_IMAGE_NAME}:${IMAGE_TAG}"
+      docker tag ${IMAGE_NAME}:${IMAGE_TAG} ${OLD_IMAGE_NAME}:${IMAGE_TAG}
+      docker push ${OLD_IMAGE_NAME}:${IMAGE_TAG}
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - |
+      echo "Getting os.version from ${BASE_IMAGE}"
+      $os_version = (docker manifest inspect $BASE_IMAGE | ConvertFrom-Json).manifests[0].platform."os.version"
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+      echo "$os_version"
+    - |
+      echo "Creating and pushing ${IMAGE_NAME}:${IMAGE_TAG} manifest"
+      docker manifest rm ${IMAGE_NAME}:${IMAGE_TAG}
+      docker manifest create ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:${IMAGE_TAG}
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+      docker manifest annotate --os "windows" --arch "amd64" --os-version ${os_version} ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:${IMAGE_TAG}
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+      docker manifest push ${IMAGE_NAME}:${IMAGE_TAG} --purge
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - |
+      # DEPRECATED
+      echo "Creating and pushing ${OLD_IMAGE_NAME}:${IMAGE_TAG} manifest"
+      docker manifest rm ${OLD_IMAGE_NAME}:${IMAGE_TAG}
+      docker manifest create ${OLD_IMAGE_NAME}:${IMAGE_TAG} ${OLD_IMAGE_NAME}:${IMAGE_TAG}
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+      docker manifest annotate --os "windows" --arch "amd64" --os-version ${os_version} ${OLD_IMAGE_NAME}:${IMAGE_TAG} ${OLD_IMAGE_NAME}:${IMAGE_TAG}
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+      docker manifest push ${OLD_IMAGE_NAME}:${IMAGE_TAG} --purge
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - |
+      if ($LATEST_TAG) {
+        echo "Tagging and pushing ${IMAGE_NAME}:${LATEST_TAG}"
+        docker tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        docker push ${IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        echo "Creating and pushing ${IMAGE_NAME}:${LATEST_TAG} manifest"
+        docker manifest rm ${IMAGE_NAME}:${LATEST_TAG}
+        docker manifest create ${IMAGE_NAME}:${LATEST_TAG} ${IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        docker manifest annotate --os "windows" --arch "amd64" --os-version ${os_version} ${IMAGE_NAME}:${LATEST_TAG} ${IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        docker manifest push ${IMAGE_NAME}:${LATEST_TAG} --purge
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        docker rmi -f ${IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
       }
-    - docker inspect --format='{{.RepoDigests}}' ${IMAGE_NAME}:${IMAGE_TAG} | Tee-Object -FilePath dist/windows_2019_digest.txt
-    - (Get-Content -Raw -Path tags) -replace "`r`n", "`n"| Set-Content -NoNewline tags_to_sign
+    - |
+      # DEPRECATED
+      if ($LATEST_TAG) {
+        echo "Tagging and pushing ${OLD_IMAGE_NAME}:${LATEST_TAG}"
+        docker tag ${OLD_IMAGE_NAME}:${IMAGE_TAG} ${OLD_IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        docker push ${OLD_IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        echo "Creating and pushing ${OLD_IMAGE_NAME}:${LATEST_TAG} manifest"
+        docker manifest rm ${OLD_IMAGE_NAME}:${LATEST_TAG}
+        docker manifest create ${OLD_IMAGE_NAME}:${LATEST_TAG} ${OLD_IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        docker manifest annotate --os "windows" --arch "amd64" --os-version ${os_version} ${OLD_IMAGE_NAME}:${LATEST_TAG} ${OLD_IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        docker manifest push ${OLD_IMAGE_NAME}:${LATEST_TAG} --purge
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        docker rmi -f ${OLD_IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+      }
+    - |
+      docker rmi -f ${IMAGE_NAME}:${IMAGE_TAG}
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - |
+      # DEPRECATED
+      docker rmi -f ${OLD_IMAGE_NAME}:${IMAGE_TAG}
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - echo "${IMAGE_NAME}:${IMAGE_TAG}" > tags
+    - (Get-Content -Raw -Path tags) -replace "`r`n", "`n"| Set-Content -NoNewline tags_to_sign_${env:WIN_VERSION}
   after_script:
-    - docker image prune --all --force
+    - docker image prune --force
+    - |
+      if (Test-Path -Path C:\Users\Administrator\Desktop\ops-scripts\docker-leak-check.exe) {
+        C:\Users\Administrator\Desktop\ops-scripts\docker-leak-check.exe -remove
+      }
   artifacts:
     paths:
-      - dist/windows_2019_digest.txt
-      - tags_to_sign
+      - tags_to_sign_${WIN_VERSION}
 
-sign-windows2019-image:
+sign-windows-image:
   extends: .sign-docker
-  dependencies:
-    - build-push-windows2019-image
-
-build-push-windows2022-image:
-  extends: .trigger-filter
   stage: release
-  dependencies:
-    - sign-exe
-    - agent-bundle-windows
-  tags:
-    - windows2022
-  retry: 2
+  parallel:
+    matrix:
+      - WIN_VERSION: ["2019", "2022"]
+  needs:
+    - build-push-windows-image
   before_script:
-    - Copy-Item .\dist\signed\otelcol_windows_amd64.exe .\cmd\otelcol\otelcol.exe
-    - Copy-Item .\dist\agent-bundle_windows_amd64.zip .\cmd\otelcol\agent-bundle_windows_amd64.zip
-  script:
-    - docker login -u $env:CIRCLECI_QUAY_USERNAME -p $env:CIRCLECI_QUAY_PASSWORD quay.io
-    - |
-      $ErrorActionPreference = 'Stop'
-      if ($env:CI_COMMIT_TAG) {
-        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows"
-        $tagNumber = $env:CI_COMMIT_TAG.TrimStart("v")
-        $IMAGE_TAG = "${tagNumber}-2022"
-      } else {
-        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows-dev"
-        $IMAGE_TAG = "${env:CI_COMMIT_SHA}-2022"
-      }
-      $JMX_METRIC_GATHERER_RELEASE = $(Get-Content internal\buildscripts\packaging\jmx-metric-gatherer-release.txt)
-      echo "Building ${IMAGE_NAME}:${IMAGE_TAG}"
-      docker build -t ${IMAGE_NAME}:${IMAGE_TAG} --build-arg BASE_IMAGE=mcr.microsoft.com/windows/servercore:ltsc2022 --build-arg JMX_METRIC_GATHERER_RELEASE=${JMX_METRIC_GATHERER_RELEASE} -f .\cmd\otelcol\Dockerfile.windows .\cmd\otelcol\
-      $os_version = (docker manifest inspect mcr.microsoft.com/windows/servercore:ltsc2022 | ConvertFrom-Json).manifests[0].platform."os.version"
-      docker manifest annotate --os "windows" --arch "amd64" --os-version ${os_version} ${IMAGE_NAME}:${IMAGE_TAG}
-      echo "Pushing ${IMAGE_NAME}:${IMAGE_TAG}"
-      docker push ${IMAGE_NAME}:${IMAGE_TAG}
-      echo "${IMAGE_NAME}:${IMAGE_TAG}" >> tags
-      if ($env:CI_COMMIT_BRANCH -eq "main" -or $env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$') {
-        # only push latest tag for main and stable releases; no need to sign them as signing is made for digest
-        echo "Tagging and pushing ${IMAGE_NAME}:latest-2022"
-        docker tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:latest-2022
-        docker push ${IMAGE_NAME}:latest-2022
-      }
-    - docker inspect --format='{{.RepoDigests}}' ${IMAGE_NAME}:${IMAGE_TAG} | Tee-Object -FilePath dist/windows_2022_digest.txt
-    - (Get-Content -Raw -Path tags) -replace "`r`n", "`n"| Set-Content -NoNewline tags_to_sign
-  after_script:
-    - docker image prune --all --force
-    - C:\Users\Administrator\Desktop\ops-scripts\docker-leak-check.exe -remove
-  artifacts:
-    paths:
-      - dist/windows_2022_digest.txt
-      - tags_to_sign
-
-sign-windows2022-image:
-  extends: .sign-docker
-  dependencies:
-    - build-push-windows2022-image
-
-build-push-windows-multiarch-image:
-  extends: .trigger-filter
-  stage: docker-manifest-release
-  tags:
-    - windows2022
-  retry: 2
-  script:
-    - docker login -u $env:CIRCLECI_QUAY_USERNAME -p $env:CIRCLECI_QUAY_PASSWORD quay.io
-    - |
-      $ErrorActionPreference = 'Stop'
-      if ($env:CI_COMMIT_TAG) {
-        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows"
-        $tagNumber = $env:CI_COMMIT_TAG.TrimStart("v")
-        $IMAGE_TAG = "${tagNumber}"
-      } else {
-        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows-dev"
-        $IMAGE_TAG = "${env:CI_COMMIT_SHA}"
-      }
-      echo "Building ${IMAGE_NAME}:${IMAGE_TAG}"
-      docker manifest create ${IMAGE_NAME}:${IMAGE_TAG} --amend ${IMAGE_NAME}:${IMAGE_TAG}-2019 --amend ${IMAGE_NAME}:${IMAGE_TAG}-2022
-      echo "Pushing ${IMAGE_NAME}:${IMAGE_TAG}"
-      docker manifest push ${IMAGE_NAME}:${IMAGE_TAG}
-      echo "${IMAGE_NAME}:${IMAGE_TAG}" >> tags
-      if ($env:CI_COMMIT_BRANCH -eq "main" -or $env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$') {
-        # only push latest tag for main and stable releases.
-        echo "Tagging and pushing ${IMAGE_NAME}:latest"
-        docker manifest rm ${IMAGE_NAME}:latest
-        docker manifest create ${IMAGE_NAME}:latest ${IMAGE_NAME}:latest-2019 ${IMAGE_NAME}:latest-2022
-        docker manifest push ${IMAGE_NAME}:latest --purge
-      }
-      docker pull ${IMAGE_NAME}:${IMAGE_TAG}
-      docker inspect --format='{{.RepoDigests}}' ${IMAGE_NAME}:${IMAGE_TAG} | Tee-Object -FilePath dist/windows_multiarch_digest.txt
-    - (Get-Content -Raw -Path tags) -replace "`r`n", "`n"| Set-Content -NoNewline tags_to_sign
-  after_script:
-    - docker image prune --all --force
-    - C:\Users\Administrator\Desktop\ops-scripts\docker-leak-check.exe -remove
-  artifacts:
-    paths:
-      - dist/windows_multiarch_digest.txt
-      - tags_to_sign
-
-sign-windows-multiarch-image:
-  extends: .sign-docker
-  dependencies:
-    - build-push-windows-multiarch-image
+    - mv tags_to_sign_${WIN_VERSION} tags_to_sign
 
 release-debs:
   extends:
@@ -1025,7 +1014,7 @@ choco-release:
   dependencies:
     - sign-msi
   tags:
-    - windows
+    - splunk-otel-collector-windows
   script:
     - |
       $ErrorActionPreference = 'Stop'
@@ -1047,6 +1036,121 @@ choco-release:
     paths:
       - dist/signed/*.nupkg
 
+push-multiarch-manifest:
+  extends: .trigger-filter
+  stage: docker-manifest-release
+  parallel:
+    matrix:
+      - MANIFEST: [multiarch, windows_multiarch]
+  needs:
+    - sign-linux-image
+    - sign-windows-image
+  retry: 2
+  script:
+    - docker login -u $CIRCLECI_QUAY_USERNAME -p $CIRCLECI_QUAY_PASSWORD quay.io
+    - |
+      # Set env vars
+      if [[ -n "${CI_COMMIT_TAG:-}" ]]; then
+        MANIFEST_NAME="quay.io/signalfx/splunk-otel-collector"
+        WIN_MANIFEST_NAME="quay.io/signalfx/splunk-otel-collector-windows"
+        MANIFEST_TAG=${CI_COMMIT_TAG#v}
+      else
+        MANIFEST_NAME="quay.io/signalfx/splunk-otel-collector-dev"
+        WIN_MANIFEST_NAME="quay.io/signalfx/splunk-otel-collector-windows-dev"
+        MANIFEST_TAG=${CI_COMMIT_SHA}
+      fi
+      LATEST_TAG=""
+      if [[ "${CI_COMMIT_BRANCH:-}" = "main" ]] || [[ "${CI_COMMIT_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        # Only push latest manifest tag for main and stable releases
+        LATEST_TAG="latest"
+      fi
+      if [[ "$MANIFEST" = "windows_multiarch" ]]; then
+        MANIFEST_NAME=$WIN_MANIFEST_NAME
+      fi
+    - |
+      set -e
+      if [[ "$MANIFEST" = "multiarch" ]]; then
+        # Update the linux multiarch manifest to include the windows images
+        echo "Updating and pushing ${MANIFEST_NAME}:${MANIFEST_TAG} manifest"
+        docker buildx imagetools create --tag ${MANIFEST_NAME}:${MANIFEST_TAG} \
+          ${MANIFEST_NAME}:${MANIFEST_TAG} \
+          ${MANIFEST_NAME}:${MANIFEST_TAG}-2019 \
+          ${MANIFEST_NAME}:${MANIFEST_TAG}-2022
+      else
+        # DEPRECATED
+        # Create the windows multiarch manifest for the windows images
+        echo "Creating and pushing ${MANIFEST_NAME}:${MANIFEST_TAG} manifest"
+        docker buildx imagetools create --tag ${MANIFEST_NAME}:${MANIFEST_TAG} \
+          ${MANIFEST_NAME}:${MANIFEST_TAG}-2019 \
+          ${MANIFEST_NAME}:${MANIFEST_TAG}-2022
+      fi
+    - |
+      set -e
+      if [[ -n "$LATEST_TAG" ]]; then
+        echo "Creating and pushing ${MANIFEST_NAME}:${LATEST_TAG} manifest"
+        docker buildx imagetools create --tag ${MANIFEST_NAME}:${LATEST_TAG} ${MANIFEST_NAME}:${MANIFEST_TAG}
+      fi
+    - |
+      # Check the manifests
+      set -eo pipefail
+      for tag in $MANIFEST_TAG $LATEST_TAG; do
+        json=$( docker buildx imagetools inspect --raw ${MANIFEST_NAME}:${tag} )
+        echo "${MANIFEST_NAME}:${tag} manifest:"
+        echo "$json"
+        # Check number of images in the manifest
+        count=$( echo "$json" | jq -r ".manifests | length" )
+        if [[ "$MANIFEST" = "multiarch" && $count -ne 5 ]]; then
+          exit 1
+        elif [[ "$MANIFEST" = "windows_multiarch" && $count -ne 2 ]]; then
+          exit 1
+        fi
+        # Check the manifest for the linux images
+        if [[ "$MANIFEST" != "windows_multiarch" ]]; then
+          for arch in "amd64" "arm64" "ppc64le"; do
+            found=$( echo "$json" | jq -r ".manifests[] | select(.platform.architecture == \"${arch}\" and .platform.os == \"linux\")" )
+            if [[ -z "$found" ]]; then
+              echo "linux/${arch} not found in ${MANIFEST_NAME}:${tag}"
+              exit 1
+            fi
+          done
+        fi
+        # Check the manifest for the windows images
+        for base_image in "$WIN_2019_BASE_IMAGE" "$WIN_2022_BASE_IMAGE"; do
+          os_version=$( docker buildx imagetools inspect --raw $base_image | jq -r '.manifests[0] | .platform."os.version"' )
+          found=$( echo "$json" | jq -r ".manifests[] | select(.platform.architecture == \"amd64\" and .platform.os == \"windows\" and .platform.\"os.version\" == \"${os_version}\")" )
+          if [[ -z "$found" ]]; then
+            echo "windows/amd64/${os_version} not found in ${MANIFEST_NAME}:${tag}"
+            exit 1
+          fi
+        done
+      done
+    - |
+      # Get the manifest digest
+      set -eo pipefail
+      digest=$( docker buildx imagetools inspect --format '{{json .Manifest}}' ${MANIFEST_NAME}:${MANIFEST_TAG} | jq -r '.digest' )
+      if [[ ! "$digest" =~ ^sha256:[A-Fa-f0-9]{64}$ ]]; then
+        echo "Invalid digest for ${MANIFEST_NAME}:${MANIFEST_TAG}: $digest"
+        exit 1
+      fi
+    - mkdir -p dist
+    - echo "[${MANIFEST_NAME}@${digest}]" | tee dist/${MANIFEST}_digest.txt
+    - echo "${MANIFEST_NAME}:${MANIFEST_TAG}" > tags_to_sign_${MANIFEST}
+  artifacts:
+    paths:
+      - dist/${MANIFEST}_digest.txt
+      - tags_to_sign_${MANIFEST}
+
+sign-multiarch-manifest:
+  extends: .sign-docker
+  stage: docker-manifest-release
+  parallel:
+    matrix:
+      - MANIFEST: [multiarch, windows_multiarch]
+  needs:
+    - push-multiarch-manifest
+  before_script:
+    - mv tags_to_sign_${MANIFEST} tags_to_sign
+
 github-release:
   extends:
     - .trigger-filter
@@ -1061,10 +1165,7 @@ github-release:
     - release-rpms
     - sign-msi
     - sign-tar
-    - push-linux-image
-    - build-push-windows2019-image
-    - build-push-windows2022-image
-    - build-push-windows-multiarch-image
+    - push-multiarch-manifest
     - choco-release
     - sign-agent-bundles
   script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### 🚩 Deprecations 🚩
+
+- (Splunk) The following docker images/manifests are deprecated and may not be published in a future release:
+  - `quay.io/signalfx/splunk-otel-collector:<version>-amd64`
+  - `quay.io/signalfx/splunk-otel-collector:<version>-arm64`
+  - `quay.io/signalfx/splunk-otel-collector:<version>-ppc64le`
+  - `quay.io/signalfx/splunk-otel-collector-windows:<version>`
+  - `quay.io/signalfx/splunk-otel-collector-windows:<version>-2019`
+  - `quay.io/signalfx/splunk-otel-collector-windows:<version>-2022`
+
+  Starting with this release, the `quay.io/signalfx/splunk-otel-collector:<version>` docker image manifest has been updated to support all of the following platforms:
+  - Linux (amd64, arm64, ppc64le)
+  - Windows (2019 amd64, 2022 amd64)
+
+  Please update any configurations to use `quay.io/signalfx/splunk-otel-collector:<version>` for this and future releases.
+
 ## v0.101.0
 
 ### 🛑 Breaking changes 🛑

--- a/Makefile
+++ b/Makefile
@@ -148,25 +148,7 @@ delete-tag:
 
 .PHONY: docker-otelcol
 docker-otelcol:
-ifneq ($(SKIP_COMPILE), true)
-	$(MAKE) binaries-linux_$(ARCH)
-endif
-ifneq ($(filter $(ARCH), $(BUNDLE_SUPPORTED_ARCHS)),)
-ifneq ($(SKIP_BUNDLE), true)
-	$(MAKE) -C internal/signalfx-agent/bundle agent-bundle-linux ARCH=$(ARCH) DOCKER_REPO=$(DOCKER_REPO)
-endif
-endif
-	rm -rf ./cmd/otelcol/dist
-	mkdir -p ./cmd/otelcol/dist
-	cp ./bin/otelcol_linux_$(ARCH) ./cmd/otelcol/dist/otelcol
-	cp ./bin/migratecheckpoint_linux_$(ARCH) ./cmd/otelcol/dist/migratecheckpoint
-	cp ./internal/buildscripts/packaging/collect-libs.sh ./cmd/otelcol/dist/collect-libs.sh
-ifneq ($(filter $(ARCH), $(BUNDLE_SUPPORTED_ARCHS)),)
-	cp ./dist/agent-bundle_linux_$(ARCH).tar.gz ./cmd/otelcol/dist/agent-bundle.tar.gz
-endif
-	docker buildx build --platform linux/$(ARCH) -o type=image,name=otelcol:$(ARCH),push=false --build-arg ARCH=$(ARCH) --build-arg DOCKER_REPO=$(DOCKER_REPO) --build-arg JMX_METRIC_GATHERER_RELEASE=$(JMX_METRIC_GATHERER_RELEASE) ./cmd/otelcol/
-	docker tag otelcol:$(ARCH) otelcol:latest
-	rm -rf ./cmd/otelcol/dist
+	ARCH=$(ARCH) SKIP_COMPILE=$(SKIP_COMPILE) SKIP_BUNDLE=$(SKIP_BUNDLE) DOCKER_REPO=$(DOCKER_REPO) JMX_METRIC_GATHERER_RELEASE=$(JMX_METRIC_GATHERER_RELEASE) ./internal/buildscripts/packaging/docker-otelcol.sh
 
 .PHONY: binaries-all-sys
 binaries-all-sys: binaries-darwin_amd64 binaries-darwin_arm64 binaries-linux_amd64 binaries-linux_arm64 binaries-windows_amd64 binaries-linux_ppc64le

--- a/cmd/otelcol/Dockerfile
+++ b/cmd/otelcol/Dockerfile
@@ -3,9 +3,9 @@ FROM ${DOCKER_REPO}/alpine:3.17.0 as certs
 RUN apk --update add ca-certificates
 
 FROM ${DOCKER_REPO}/alpine:3.17.0 AS otelcol
-COPY dist/* /dist/
-RUN mv /dist/otelcol /
-RUN mv /dist/migratecheckpoint /
+ARG TARGETARCH
+COPY dist/otelcol_linux_${TARGETARCH} /otelcol
+COPY dist/migratecheckpoint_linux_${TARGETARCH} /migratecheckpoint
 # Note that this shouldn't be necessary, but in some cases the file seems to be
 # copied with the execute bit lost (see https://github.com/open-telemetry/opentelemetry-collector/issues/1317)
 RUN chmod 755 /otelcol
@@ -17,29 +17,27 @@ RUN mkdir -p /otel/collector /splunk-otel-collector /tmp/tmp
 RUN chmod 755 /tmp/tmp
 
 FROM ${DOCKER_REPO}/alpine:3.17.0 AS agent-bundle
-ARG ARCH="amd64"
-
+ARG TARGETARCH
 COPY --from=otelcol /etc_passwd /etc_passwd
 RUN cat /etc_passwd >> /etc/passwd
 COPY --from=otelcol --chown=999 /splunk-otel-collector /usr/lib/splunk-otel-collector
-COPY --from=otelcol --chown=999 /dist/* /dist/
+COPY --chown=999 dist/agent-bundle_linux_${TARGETARCH}.tar.gz /dist/
 USER splunk-otel-collector
-RUN if [[ "$ARCH" = "amd64" || "$ARCH" = "arm64" ]]; then \
-        mv /dist/agent-bundle.tar.gz /usr/lib/splunk-otel-collector && \
-        cd /usr/lib/splunk-otel-collector && tar -xzf agent-bundle.tar.gz && \
+RUN if [[ "$TARGETARCH" = "amd64" || "$TARGETARCH" = "arm64" ]]; then \
+        tar -C /usr/lib/splunk-otel-collector -xzf /dist/agent-bundle_linux_${TARGETARCH}.tar.gz && \
         # Absolute path of interpreter in smart agent dir is set in dependent binaries
         # requiring the interpreter location not to change.
-        /usr/lib/splunk-otel-collector/agent-bundle/bin/patch-interpreter /usr/lib/splunk-otel-collector/agent-bundle && \
-        rm -f agent-bundle.tar.gz; \
+        /usr/lib/splunk-otel-collector/agent-bundle/bin/patch-interpreter /usr/lib/splunk-otel-collector/agent-bundle; \
     else \
         mkdir -p /usr/lib/splunk-otel-collector/agent-bundle; \
     fi
+RUN rm -f /dist/agent-bundle_linux_${TARGETARCH}.tar.gz
 
 FROM ${DOCKER_REPO}/alpine:3.17.0 AS jmx
 ARG JMX_METRIC_GATHERER_RELEASE
 RUN JMX_METRICS_JAR=opentelemetry-jmx-metrics.jar && \
-URL=https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/${JMX_METRIC_GATHERER_RELEASE}/${JMX_METRICS_JAR} && \
-cd /tmp && wget "$URL";
+    URL=https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/${JMX_METRIC_GATHERER_RELEASE}/${JMX_METRICS_JAR} && \
+    cd /tmp && wget "$URL";
 
 FROM ${DOCKER_REPO}/debian:11.5 as journalctl
 RUN apt update
@@ -62,7 +60,6 @@ COPY --from=otelcol --chown=999 /otel/collector /etc/otel/collector
 COPY --from=otelcol --chown=999 /tmp/tmp /tmp
 COPY --from=agent-bundle --chown=999 /usr/lib/splunk-otel-collector /usr/lib/splunk-otel-collector
 COPY --from=jmx --chown=999 /tmp/opentelemetry-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
-
 
 COPY --from=journalctl --chown=999 /bin/journalctl /bin/journalctl
 COPY --from=journalctl --chown=999 /opt/journalctl /

--- a/internal/buildscripts/packaging/docker-otelcol.sh
+++ b/internal/buildscripts/packaging/docker-otelcol.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -eo pipefail
+
+export DOCKER_BUILDKIT=1
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_DIR="$( cd ${SCRIPT_DIR}/../../../ && pwd )"
+OTELCOL_DIR="${REPO_DIR}/cmd/otelcol"
+DIST_DIR="${OTELCOL_DIR}/dist"
+
+PUSH="${PUSH:-false}"
+ARCH="${ARCH:-amd64}"
+IMAGE_NAME="${IMAGE_NAME:-otelcol}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+SKIP_COMPILE="${SKIP_COMPILE:-false}"
+SKIP_BUNDLE="${SKIP_BUNDLE:-false}"
+DOCKER_REPO="${DOCKER_REPO:-docker.io}"
+JMX_METRIC_GATHERER_RELEASE="${JMX_METRIC_GATHERER_RELEASE:-}"
+DOCKER_OPTS="--provenance=false --build-arg DOCKER_REPO=${DOCKER_REPO} --build-arg JMX_METRIC_GATHERER_RELEASE=${JMX_METRIC_GATHERER_RELEASE} $OTELCOL_DIR"
+MULTIARCH_OTELCOL_BUILDER="${MULTIARCH_OTELCOL_BUILDER:-}"
+
+CONTAINERD_ENABLED="false"
+if docker info -f '{{ .DriverStatus }}' | grep -q "io.containerd.snapshotter"; then
+    # containerd image store is required to save a multiarch image locally
+    # https://docs.docker.com/storage/containerd/
+    CONTAINERD_ENABLED="true"
+fi
+
+archs=$(echo $ARCH | tr "," " ")
+platforms=""
+
+for arch in $archs; do
+    if [[ ! "$arch" =~ ^amd64|arm64|ppc64le$ ]]; then
+        echo "$arch not supported!" >&2
+        exit 1
+    fi
+done
+
+if [ -d "$DIST_DIR" ]; then
+    rm -rf "$DIST_DIR"
+fi
+mkdir -p "$DIST_DIR"
+cp "${SCRIPT_DIR}/collect-libs.sh" "$DIST_DIR"
+
+for arch in $archs; do
+    if [ "$SKIP_COMPILE" != "true" ]; then
+        make -C $REPO_DIR binaries-linux_${arch}
+    fi
+    for bin in otelcol_linux_${arch} migratecheckpoint_linux_${arch}; do
+        if [ ! -f "${REPO_DIR}/bin/${bin}" ]; then
+            echo "${REPO_DIR}/bin/${bin} not found!" >&2
+            exit 1
+        fi
+        cp "${REPO_DIR}/bin/${bin}" "${DIST_DIR}"
+    done
+    if [[ "$arch" =~ ^amd64|arm64$ ]]; then
+        if [ "$SKIP_BUNDLE" != "true" ]; then
+            make -C ${REPO_DIR}/internal/signalfx-agent/bundle agent-bundle-linux ARCH=${arch} DOCKER_REPO=${DOCKER_REPO}
+        fi
+    else
+        # create a dummy file to copy for the docker build
+        touch ${REPO_DIR}/dist/agent-bundle_linux_${arch}.tar.gz
+    fi
+    if [ ! -f ${REPO_DIR}/dist/agent-bundle_linux_${arch}.tar.gz ]; then
+        echo "${REPO_DIR}/dist/agent-bundle_linux_${arch}.tar.gz not found!" >&2
+        exit 1
+    fi
+    cp "${REPO_DIR}/dist/agent-bundle_linux_${arch}.tar.gz" "${DIST_DIR}"
+    if [[ "$PUSH" = "true" || "$CONTAINERD_ENABLED" = "true" ]]; then
+        platforms="${platforms},linux/${arch}"
+    else
+        # multiarch images must be built and tagged individually when not pushing or not using the containerd image store
+        # https://github.com/docker/buildx/issues/59
+        docker buildx build --platform linux/${arch} --tag ${IMAGE_NAME}:${arch} --load $DOCKER_OPTS
+        docker tag ${IMAGE_NAME}:${arch} ${IMAGE_NAME}:${IMAGE_TAG}
+    fi
+done
+
+if [[ -n "$platforms" ]]; then
+    if [[ -z "$MULTIARCH_OTELCOL_BUILDER" ]]; then
+        MULTIARCH_OTELCOL_BUILDER="docker-otelcol"
+        docker buildx rm $MULTIARCH_OTELCOL_BUILDER 2>/dev/null || true
+        # multiarch builds require the docker-container driver
+        docker buildx create --name $MULTIARCH_OTELCOL_BUILDER --driver docker-container
+    fi
+    if [[ "$PUSH" = "true" ]]; then
+        DOCKER_OPTS="--push $DOCKER_OPTS"
+    else
+        DOCKER_OPTS="--load $DOCKER_OPTS"
+    fi
+    docker buildx build --builder $MULTIARCH_OTELCOL_BUILDER --platform ${platforms#,} --tag ${IMAGE_NAME}:${IMAGE_TAG} $DOCKER_OPTS
+fi

--- a/internal/buildscripts/packaging/release/gh-release-notes.sh
+++ b/internal/buildscripts/packaging/release/gh-release-notes.sh
@@ -25,13 +25,9 @@ SCRIPT_DIR="$( cd "$( dirname ${BASH_SOURCE[0]} )" && pwd )"
 REPO_DIR="$( cd "$SCRIPT_DIR"/../../../../ && pwd )"
 
 VERSION="$1"
-LINUX_AMD64_DIGEST="${2:-${REPO_DIR}/dist/linux_amd64_digest.txt}"
-LINUX_ARM64_DIGEST="${2:-${REPO_DIR}/dist/linux_arm64_digest.txt}"
-LINUX_PPC64LE_DIGEST="${2:-${REPO_DIR}/dist/linux_ppc64le_digest.txt}"
-WINDOWS_2019_DIGEST="${3:-${REPO_DIR}/dist/windows_2019_digest.txt}"
-WINDOWS_2022_DIGEST="${3:-${REPO_DIR}/dist/windows_2022_digest.txt}"
-WINDOWS_MULTIARCH_DIGEST="${3:-${REPO_DIR}/dist/windows_multiarch_digest.txt}"
-CHANGELOG="${4:-${REPO_DIR}/CHANGELOG.md}"
+MULTIARCH_DIGEST="$( get_digest "${REPO_DIR}/dist/multiarch_digest.txt" )"
+WINDOWS_MULTIARCH_DIGEST="$( get_digest "${REPO_DIR}/dist/windows_multiarch_digest.txt" )"
+CHANGELOG="${REPO_DIR}/CHANGELOG.md"
 
 changes="$( awk -v version="$VERSION" '/^## / { if (p) { exit }; if ($2 == version) { p=1; next } } p && NF' "$CHANGELOG" )"
 
@@ -39,23 +35,14 @@ if [[ -z "$changes" ]] || [[ "$changes" =~ ^[[:space:]]+$ ]]; then
   changes="Release notes in progress."
 fi
 
-linux_amd64_digest="$( get_digest "$LINUX_AMD64_DIGEST" )"
-linux_arm64_digest="$( get_digest "$LINUX_ARM64_DIGEST" )"
-linux_ppc64le_digest="$( get_digest "$LINUX_PPC64LE_DIGEST" )"
+cat <<EOH
+$changes
 
-windows_2019_digest="$( get_digest "$WINDOWS_2019_DIGEST" )"
-windows_2022_digest="$( get_digest "$WINDOWS_2022_DIGEST" )"
-windows_multiarch_digest="$( get_digest "$WINDOWS_MULTIARCH_DIGEST" )"
-
-changes="""$changes
-
-> Docker Images:
-> - \`quay.io/signalfx/splunk-otel-collector:${VERSION#v}-amd64\` (digest: \`$linux_amd64_digest\`)
-> - \`quay.io/signalfx/splunk-otel-collector:${VERSION#v}-arm64\` (digest: \`$linux_arm64_digest\`)
-> - \`quay.io/signalfx/splunk-otel-collector:${VERSION#v}-ppc64le\` (digest: \`$linux_ppc64le_digest\`)
-> - \`quay.io/signalfx/splunk-otel-collector-windows:${VERSION#v}\` (digest: \`$windows_multiarch_digest\`)
-> - \`quay.io/signalfx/splunk-otel-collector-windows:${VERSION#v}-2019\` (digest: \`$windows_2019_digest\`)
-> - \`quay.io/signalfx/splunk-otel-collector-windows:${VERSION#v}-2022\` (digest: \`$windows_2022_digest\`)
-"""
-
-echo "$changes"
+> Docker Image Manifests:
+> - Linux (amd64, arm64, ppc64le) and Windows (2019 amd64, 2022 amd64):
+>   - \`quay.io/signalfx/splunk-otel-collector:${VERSION#v}\`
+>   - digest: \`$MULTIARCH_DIGEST\`
+> - Windows (2019 amd64, 2022 amd64):
+>   - \`quay.io/signalfx/splunk-otel-collector-windows:${VERSION#v}\`
+>   - digest: \`$WINDOWS_MULTIARCH_DIGEST\`
+EOH


### PR DESCRIPTION
- Support multiarch docker builds for linux, i.e. `make docker-otelcol ARCH=amd64,arm64,ppc64le`.  Requires either the manifest/images to be pushed, or the containerd image store to be enabled to save the manifest/images locally (limitations of buildkit and the docker engine).  Otherwise, the images will be built for each platform individually as it previously did.
- Gitlab CI updates:
  - Include the windows 2019 and 2022 images in the `quay.io/signalfx/splunk-otel-collector` manifest for releases, in addition to the linux images.
  - Push manifests for each individual linux and windows images (for backward compatibility until we decide to stop in a future release).
  - Push the windows manifests/images to both `quay.io/signalfx/splunk-otel-collector` and `quay.io/signalfx/splunk-otel-collector-windows` (for backward compatibility until we decide to stop in a future release).
  - Miscellaneous fixes/improvements.
- Update github CI tests to support multiarch builds.