### PR TITLE
Pin versions for docker services

### DIFF
--- a/docker/couchbase/Dockerfile
+++ b/docker/couchbase/Dockerfile
@@ -1,4 +1,4 @@
-ARG COUCHBASE_VERSION=latest
+ARG COUCHBASE_VERSION=7.6.1
 FROM couchbase/server:${COUCHBASE_VERSION}
 COPY entrypoint.sh /config-entrypoint.sh
 EXPOSE 8091

--- a/docker/haproxy/Dockerfile
+++ b/docker/haproxy/Dockerfile
@@ -1,4 +1,4 @@
-ARG HAPROXY_VERSION=latest
+ARG HAPROXY_VERSION=2.9
 FROM haproxy:${HAPROXY_VERSION}
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
 EXPOSE 8080

--- a/docker/httpd/Dockerfile
+++ b/docker/httpd/Dockerfile
@@ -1,3 +1,3 @@
-FROM dragas/thttpd
+FROM dragas/thttpd@sha256:6e37de232de78f331e013b23119f805ab138baad3ab29d0885b45bb684ae3a79
 
 COPY metrics /var/www/http/

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:latest
+FROM mysql:8.4
 ENV MYSQL_DATABASE testdb
 ENV MYSQL_USER testuser
 ENV MYSQL_PASSWORD testpass

--- a/docker/redis_client/Dockerfile
+++ b/docker/redis_client/Dockerfile
@@ -1,4 +1,4 @@
-FROM redis
+FROM redis:7.2
 
 COPY init.sh /usr/local/bin/init.sh
 

--- a/docker/redis_server/Dockerfile
+++ b/docker/redis_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM redis
+FROM redis:7.2
 
 COPY redis.conf /usr/local/etc/redis/redis.conf
 

--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/solr:latest
+FROM bitnami/solr:9
 
 ENV SOLR_JETTY_HOST 0.0.0.0
 ENTRYPOINT ["bash", "-c"]


### PR DESCRIPTION
Since the services in the `docker` directory are not currently in sync with the `quay.io/splunko11ytest` images, pin the versions in the dockerfiles to help reduce integration test failures when the the services need to be rebuilt and the latest base images have been updated.