### PR TITLE
Update docker-otelcol for multiarch builds

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -26,21 +26,14 @@ concurrency:
 env:
   GO_VERSION: "1.21.10"
 jobs:
-  docker-otelcol:
-    name: docker-otelcol
-    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
+  agent-bundle-linux:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
         ARCH: [ "amd64", "arm64" ]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
       - uses: actions/cache@v4
         id: bundle-cache
         with:
@@ -53,16 +46,80 @@ jobs:
         with:
           platforms: ${{ matrix.ARCH }}
           image: tonistiigi/binfmt:qemu-v7.0.0
-      - run: |
-          make docker-otelcol ARCH=${{ matrix.ARCH }}
+      - run: make -C internal/signalfx-agent/bundle agent-bundle-linux ARCH=${{ matrix.ARCH }}
         env:
-          DOCKER_BUILDKIT: '1'
           BUNDLE_CACHE_HIT: "${{ steps.bundle-cache.outputs.cache-hit }}"
-      - run: docker save -o ./bin/image.tar otelcol:latest
       - uses: actions/upload-artifact@v4
         with:
-          name: otelcol-${{ matrix.ARCH }}
+          name: agent-bundle-linux-${{ matrix.ARCH }}
+          path: ./dist/agent-bundle_linux_${{ matrix.ARCH }}.tar.gz
+
+  docker-otelcol:
+    name: docker-otelcol
+    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
+    runs-on: ubuntu-20.04
+    needs: agent-bundle-linux
+    services:
+      # Start a local registry for pushing the multiarch manifest and images
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      # Multiarch images require more disk space
+      - uses: jlumbroso/free-disk-space@v1.3.1
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
+      - uses: actions/download-artifact@v4
+        with:
+          name: agent-bundle-linux-amd64
+          path: ./dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: agent-bundle-linux-arm64
+          path: ./dist
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,ppc64le
+          image: tonistiigi/binfmt:qemu-v7.0.0
+      - uses: docker/setup-buildx-action@v3
+        id: multiarch-otelcol-builder
+        with:
+          driver: docker-container   # Create a builder with the docker-container driver required for multiarch builds
+          driver-opts: network=host  # Required for the builder to push to the local registry service
+      - run: make docker-otelcol SKIP_BUNDLE=true ARCH=amd64,arm64,ppc64le IMAGE_NAME=localhost:5000/otelcol IMAGE_TAG=latest PUSH=true
+        env:
+          MULTIARCH_OTELCOL_BUILDER: ${{ steps.multiarch-otelcol-builder.outputs.name }}  # Use the builder created by the docker/setup-buildx-action step
+      - name: Save image archive for each platform to be loaded by downstream jobs
+        run: |
+          for arch in "amd64" "arm64" "ppc64le"; do
+            mkdir -p docker-otelcol/${arch}
+            docker pull --platform=linux/${arch} localhost:5000/otelcol:latest
+            docker tag localhost:5000/otelcol:latest otelcol:latest
+            docker save -o ./docker-otelcol/${arch}/image.tar otelcol:latest
+            docker rmi -f localhost:5000/otelcol:latest otelcol:latest
+          done
+      - uses: actions/upload-artifact@v4
+        with:
+          name: otelcol
           path: ./bin
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docker-otelcol-amd64
+          path: ./docker-otelcol/amd64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docker-otelcol-arm64
+          path: ./docker-otelcol/arm64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docker-otelcol-ppc64le
+          path: ./docker-otelcol/ppc64le
 
   integration-vet:
     name: integration-vet
@@ -83,14 +140,19 @@ jobs:
           cache-dependency-path: '**/go.sum'
       - uses: actions/download-artifact@v4
         with:
-          name: otelcol-${{ matrix.ARCH }}
+          name: otelcol
           path: ./bin
+      - uses: actions/download-artifact@v4
+        with:
+          name: docker-otelcol-${{ matrix.ARCH }}
+          path: ./docker-otelcol/${{ matrix.ARCH }}
       - uses: docker/setup-qemu-action@v3
         if: ${{ matrix.ARCH != 'amd64' }}
         with:
           platforms: ${{ matrix.ARCH }}
           image: tonistiigi/binfmt:qemu-v7.0.0
-      - run: docker load -i ./bin/image.tar
+      - run: docker load -i ./docker-otelcol/${{ matrix.ARCH }}/image.tar
+      - run: ln -sf otelcol_linux_${{ matrix.ARCH }} ./bin/otelcol
       - run: chmod a+x ./bin/*
       - run: make integration-vet
         env:
@@ -129,14 +191,19 @@ jobs:
           cache-dependency-path: '**/go.sum'
       - uses: actions/download-artifact@v4
         with:
-          name: otelcol-${{ matrix.ARCH }}
+          name: otelcol
           path: ./bin
+      - uses: actions/download-artifact@v4
+        with:
+          name: docker-otelcol-${{ matrix.ARCH }}
+          path: ./docker-otelcol/${{ matrix.ARCH }}
       - uses: docker/setup-qemu-action@v3
         if: ${{ matrix.ARCH != 'amd64' }}
         with:
           platforms: ${{ matrix.ARCH }}
           image: tonistiigi/binfmt:qemu-v7.0.0
-      - run: docker load -i ./bin/image.tar
+      - run: docker load -i ./docker-otelcol/${{ matrix.ARCH }}/image.tar
+      - run: ln -sf otelcol_linux_${{ matrix.ARCH }} ./bin/otelcol
       - run: chmod a+x ./bin/*
       - uses: shogo82148/actions-setup-redis@v1
         if: matrix.PROFILE == 'integration'

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/linux-package-test.yml'
       - 'cmd/otelcol/**'
       - 'internal/buildscripts/packaging/collect-libs.sh'
+      - 'internal/buildscripts/packaging/docker-otelcol.sh'
       - 'internal/buildscripts/packaging/fpm/**'
       - 'internal/buildscripts/packaging/installer/install.sh'
       - 'internal/buildscripts/packaging/jmx-metric-gatherer-release.txt'
@@ -255,13 +256,23 @@ jobs:
     # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
     runs-on: ubuntu-20.04
     needs: [cross-compile, agent-bundle-linux]
-    strategy:
-      matrix:
-        ARCH: [ "amd64", "arm64", "ppc64le" ]
-      fail-fast: false
     steps:
+      # Multiarch images require more disk space
+      - uses: jlumbroso/free-disk-space@v1.3.1
+
       - name: Check out the codebase.
         uses: actions/checkout@v4
+
+      # Required to export a multiarch manifest and images to the local image store
+      - name: Set up containerd image store
+        uses: crazy-max/ghaction-setup-docker@v3
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -270,37 +281,92 @@ jobs:
           cache-dependency-path: '**/go.sum'
 
       - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,ppc64le
+          image: tonistiigi/binfmt:qemu-v7.0.0
+
+      - name: Downloading binaries-linux_amd64
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-linux_amd64
+          path: ./bin
+
+      - name: Downloading binaries-linux_arm64
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-linux_arm64
+          path: ./bin
+
+      - name: Downloading binaries-linux_ppc64le
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-linux_ppc64le
+          path: ./bin
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: agent-bundle-linux-amd64
+          path: ./dist
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: agent-bundle-linux-arm64
+          path: ./dist
+
+      - name: Build the multiarch docker image
+        run: make docker-otelcol SKIP_COMPILE=true SKIP_BUNDLE=true ARCH=amd64,arm64,ppc64le
+
+      - name: Save the multiarch image archive to be loaded by downstream jobs
+        run: mkdir -p docker-otelcol && docker save -o ./docker-otelcol/image.tar otelcol:latest
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: otelcol
+          path: ./docker-otelcol
+
+  docker-otelcol-verify:
+    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
+    runs-on: ubuntu-20.04
+    needs: [docker-otelcol]
+    strategy:
+      matrix:
+        ARCH: [ "amd64", "arm64", "ppc64le" ]
+      fail-fast: false
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+
+      # Required to load a multiarch archive to the local image store
+      - name: Set up containerd image store
+        uses: crazy-max/ghaction-setup-docker@v3
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Set up QEMU
         if: ${{ matrix.ARCH != 'amd64' }}
         uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.ARCH }}
           image: tonistiigi/binfmt:qemu-v7.0.0
 
-      - name: Downloading binaries-linux_${{ matrix.ARCH }}
-        uses: actions/download-artifact@v4
-        with:
-          name: binaries-linux_${{ matrix.ARCH }}
-          path: ./bin
-
       - uses: actions/download-artifact@v4
-        if: ${{ matrix.ARCH != 'ppc64le' }}
         with:
-          name: agent-bundle-linux-${{ matrix.ARCH }}
-          path: ./dist
+          name: otelcol
+          path: ./docker-otelcol
 
-      - name: Build ${{ matrix.ARCH }} docker image
-        run: |
-          make docker-otelcol SKIP_COMPILE=true SKIP_BUNDLE=true ARCH=${{ matrix.ARCH }}
-
-      - name: Check image arch
-        run: |
-          # ensure that the arch in the image manifest is correct
-          [ "$( docker inspect --format='{{.Architecture}}' otelcol:${{ matrix.ARCH }} )" = "${{ matrix.ARCH }}" ] || exit 1
+      - name: Load multiarch docker image
+        run: docker load -i ./docker-otelcol/image.tar
 
       - name: Run docker image
         run: |
           # ensure the collector can start with the default config file
-          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:${{ matrix.ARCH }}
+          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
           sleep 10
           if [ -z "$( docker ps --filter=status=running --filter=name=otelcol -q )" ]; then
             docker logs otelcol
@@ -320,7 +386,7 @@ jobs:
             exit 1
           fi
           for config in $configs; do
-            docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_CONFIG=/etc/otel/collector/${config} -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:${{ matrix.ARCH }}
+            docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_CONFIG=/etc/otel/collector/${config} -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
             sleep 10
             if [ -z "$( docker ps --filter=status=running --filter=name=otelcol -q )" ]; then
               docker logs otelcol
@@ -333,7 +399,7 @@ jobs:
       - name: Check journalctl
         run: |
           # ensure journalctl can run with the collected libraries
-          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:${{ matrix.ARCH }}
+          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
           docker exec otelcol /bin/journalctl
           docker rm -f otelcol
 
@@ -341,7 +407,7 @@ jobs:
         if: ${{ matrix.ARCH != 'ppc64le' }}
         run: |
           # ensure python and java can run with the collected libraries
-          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:${{ matrix.ARCH }}
+          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
           docker exec otelcol /usr/lib/splunk-otel-collector/agent-bundle/bin/python --version
           docker exec otelcol /usr/lib/splunk-otel-collector/agent-bundle/jre/bin/java -version
           # ensure collectd-python plugins were installed

--- a/Makefile
+++ b/Makefile
@@ -148,25 +148,7 @@ delete-tag:
 
 .PHONY: docker-otelcol
 docker-otelcol:
-ifneq ($(SKIP_COMPILE), true)
-	$(MAKE) binaries-linux_$(ARCH)
-endif
-ifneq ($(filter $(ARCH), $(BUNDLE_SUPPORTED_ARCHS)),)
-ifneq ($(SKIP_BUNDLE), true)
-	$(MAKE) -C internal/signalfx-agent/bundle agent-bundle-linux ARCH=$(ARCH) DOCKER_REPO=$(DOCKER_REPO)
-endif
-endif
-	rm -rf ./cmd/otelcol/dist
-	mkdir -p ./cmd/otelcol/dist
-	cp ./bin/otelcol_linux_$(ARCH) ./cmd/otelcol/dist/otelcol
-	cp ./bin/migratecheckpoint_linux_$(ARCH) ./cmd/otelcol/dist/migratecheckpoint
-	cp ./internal/buildscripts/packaging/collect-libs.sh ./cmd/otelcol/dist/collect-libs.sh
-ifneq ($(filter $(ARCH), $(BUNDLE_SUPPORTED_ARCHS)),)
-	cp ./dist/agent-bundle_linux_$(ARCH).tar.gz ./cmd/otelcol/dist/agent-bundle.tar.gz
-endif
-	docker buildx build --platform linux/$(ARCH) -o type=image,name=otelcol:$(ARCH),push=false --build-arg ARCH=$(ARCH) --build-arg DOCKER_REPO=$(DOCKER_REPO) --build-arg JMX_METRIC_GATHERER_RELEASE=$(JMX_METRIC_GATHERER_RELEASE) ./cmd/otelcol/
-	docker tag otelcol:$(ARCH) otelcol:latest
-	rm -rf ./cmd/otelcol/dist
+	ARCH=$(ARCH) SKIP_COMPILE=$(SKIP_COMPILE) SKIP_BUNDLE=$(SKIP_BUNDLE) DOCKER_REPO=$(DOCKER_REPO) JMX_METRIC_GATHERER_RELEASE=$(JMX_METRIC_GATHERER_RELEASE) ./internal/buildscripts/packaging/docker-otelcol.sh
 
 .PHONY: binaries-all-sys
 binaries-all-sys: binaries-darwin_amd64 binaries-darwin_arm64 binaries-linux_amd64 binaries-linux_arm64 binaries-windows_amd64 binaries-linux_ppc64le

--- a/cmd/otelcol/Dockerfile
+++ b/cmd/otelcol/Dockerfile
@@ -3,9 +3,9 @@ FROM ${DOCKER_REPO}/alpine:3.17.0 as certs
 RUN apk --update add ca-certificates
 
 FROM ${DOCKER_REPO}/alpine:3.17.0 AS otelcol
-COPY dist/* /dist/
-RUN mv /dist/otelcol /
-RUN mv /dist/migratecheckpoint /
+ARG TARGETARCH
+COPY dist/otelcol_linux_${TARGETARCH} /otelcol
+COPY dist/migratecheckpoint_linux_${TARGETARCH} /migratecheckpoint
 # Note that this shouldn't be necessary, but in some cases the file seems to be
 # copied with the execute bit lost (see https://github.com/open-telemetry/opentelemetry-collector/issues/1317)
 RUN chmod 755 /otelcol
@@ -17,29 +17,27 @@ RUN mkdir -p /otel/collector /splunk-otel-collector /tmp/tmp
 RUN chmod 755 /tmp/tmp
 
 FROM ${DOCKER_REPO}/alpine:3.17.0 AS agent-bundle
-ARG ARCH="amd64"
-
+ARG TARGETARCH
 COPY --from=otelcol /etc_passwd /etc_passwd
 RUN cat /etc_passwd >> /etc/passwd
 COPY --from=otelcol --chown=999 /splunk-otel-collector /usr/lib/splunk-otel-collector
-COPY --from=otelcol --chown=999 /dist/* /dist/
+COPY --chown=999 dist/agent-bundle_linux_${TARGETARCH}.tar.gz /dist/
 USER splunk-otel-collector
-RUN if [[ "$ARCH" = "amd64" || "$ARCH" = "arm64" ]]; then \
-        mv /dist/agent-bundle.tar.gz /usr/lib/splunk-otel-collector && \
-        cd /usr/lib/splunk-otel-collector && tar -xzf agent-bundle.tar.gz && \
+RUN if [[ "$TARGETARCH" = "amd64" || "$TARGETARCH" = "arm64" ]]; then \
+        tar -C /usr/lib/splunk-otel-collector -xzf /dist/agent-bundle_linux_${TARGETARCH}.tar.gz && \
         # Absolute path of interpreter in smart agent dir is set in dependent binaries
         # requiring the interpreter location not to change.
-        /usr/lib/splunk-otel-collector/agent-bundle/bin/patch-interpreter /usr/lib/splunk-otel-collector/agent-bundle && \
-        rm -f agent-bundle.tar.gz; \
+        /usr/lib/splunk-otel-collector/agent-bundle/bin/patch-interpreter /usr/lib/splunk-otel-collector/agent-bundle; \
     else \
         mkdir -p /usr/lib/splunk-otel-collector/agent-bundle; \
     fi
+RUN rm -f /dist/agent-bundle_linux_${TARGETARCH}.tar.gz
 
 FROM ${DOCKER_REPO}/alpine:3.17.0 AS jmx
 ARG JMX_METRIC_GATHERER_RELEASE
 RUN JMX_METRICS_JAR=opentelemetry-jmx-metrics.jar && \
-URL=https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/${JMX_METRIC_GATHERER_RELEASE}/${JMX_METRICS_JAR} && \
-cd /tmp && wget "$URL";
+    URL=https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/${JMX_METRIC_GATHERER_RELEASE}/${JMX_METRICS_JAR} && \
+    cd /tmp && wget "$URL";
 
 FROM ${DOCKER_REPO}/debian:11.5 as journalctl
 RUN apt update
@@ -62,7 +60,6 @@ COPY --from=otelcol --chown=999 /otel/collector /etc/otel/collector
 COPY --from=otelcol --chown=999 /tmp/tmp /tmp
 COPY --from=agent-bundle --chown=999 /usr/lib/splunk-otel-collector /usr/lib/splunk-otel-collector
 COPY --from=jmx --chown=999 /tmp/opentelemetry-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
-
 
 COPY --from=journalctl --chown=999 /bin/journalctl /bin/journalctl
 COPY --from=journalctl --chown=999 /opt/journalctl /

--- a/internal/buildscripts/packaging/docker-otelcol.sh
+++ b/internal/buildscripts/packaging/docker-otelcol.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -eo pipefail
+
+export DOCKER_BUILDKIT=1
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_DIR="$( cd ${SCRIPT_DIR}/../../../ && pwd )"
+OTELCOL_DIR="${REPO_DIR}/cmd/otelcol"
+DIST_DIR="${OTELCOL_DIR}/dist"
+
+PUSH="${PUSH:-false}"
+ARCH="${ARCH:-amd64}"
+IMAGE_NAME="${IMAGE_NAME:-otelcol}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+SKIP_COMPILE="${SKIP_COMPILE:-false}"
+SKIP_BUNDLE="${SKIP_BUNDLE:-false}"
+DOCKER_REPO="${DOCKER_REPO:-docker.io}"
+JMX_METRIC_GATHERER_RELEASE="${JMX_METRIC_GATHERER_RELEASE:-}"
+MULTIARCH_OTELCOL_BUILDER="${MULTIARCH_OTELCOL_BUILDER:-}"
+DOCKER_OPTS="--provenance=false --build-arg DOCKER_REPO=${DOCKER_REPO} --build-arg JMX_METRIC_GATHERER_RELEASE=${JMX_METRIC_GATHERER_RELEASE} $OTELCOL_DIR"
+
+CONTAINERD_ENABLED="false"
+if docker info -f '{{ .DriverStatus }}' | grep -q "io.containerd.snapshotter"; then
+    # containerd image store is required to save a multiarch image locally
+    # https://docs.docker.com/storage/containerd/
+    CONTAINERD_ENABLED="true"
+fi
+
+archs=$(echo $ARCH | tr "," " ")
+platforms=""
+
+for arch in $archs; do
+    if [[ ! "$arch" =~ ^amd64|arm64|ppc64le$ ]]; then
+        echo "$arch not supported!" >&2
+        exit 1
+    fi
+done
+
+if [ -d "$DIST_DIR" ]; then
+    rm -rf "$DIST_DIR"
+fi
+mkdir -p "$DIST_DIR"
+cp "${SCRIPT_DIR}/collect-libs.sh" "$DIST_DIR"
+
+for arch in $archs; do
+    if [ "$SKIP_COMPILE" != "true" ]; then
+        make -C "$REPO_DIR" binaries-linux_${arch}
+    fi
+    for bin in otelcol_linux_${arch} migratecheckpoint_linux_${arch}; do
+        if [ ! -f "${REPO_DIR}/bin/${bin}" ]; then
+            echo "${REPO_DIR}/bin/${bin} not found!" >&2
+            exit 1
+        fi
+        cp "${REPO_DIR}/bin/${bin}" "$DIST_DIR"
+    done
+    if [[ "$arch" =~ ^amd64|arm64$ ]]; then
+        if [ "$SKIP_BUNDLE" != "true" ]; then
+            make -C "${REPO_DIR}/internal/signalfx-agent/bundle" agent-bundle-linux ARCH=${arch} DOCKER_REPO=${DOCKER_REPO}
+        fi
+    else
+        # create a dummy file to copy for the docker build
+        touch "${REPO_DIR}/dist/agent-bundle_linux_${arch}.tar.gz"
+    fi
+    if [ ! -f "${REPO_DIR}/dist/agent-bundle_linux_${arch}.tar.gz" ]; then
+        echo "${REPO_DIR}/dist/agent-bundle_linux_${arch}.tar.gz not found!" >&2
+        exit 1
+    fi
+    cp "${REPO_DIR}/dist/agent-bundle_linux_${arch}.tar.gz" "$DIST_DIR"
+    if [[ "$PUSH" = "true" || "$CONTAINERD_ENABLED" = "true" ]]; then
+        platforms="${platforms},linux/${arch}"
+    else
+        # multiarch images must be built and tagged individually when not pushing or not using the containerd image store
+        # https://github.com/docker/buildx/issues/59
+        docker buildx build --platform linux/${arch} --tag otelcol:${arch} --load $DOCKER_OPTS
+        docker tag otelcol:${arch} ${IMAGE_NAME}:${IMAGE_TAG}
+    fi
+done
+
+if [ -n "$platforms" ]; then
+    if [ -z "$MULTIARCH_OTELCOL_BUILDER" ]; then
+        # multiarch builds require a builder with the docker-container driver; create one if not specified
+        MULTIARCH_OTELCOL_BUILDER="docker-otelcol"
+        if ! docker buildx inspect --builder $MULTIARCH_OTELCOL_BUILDER >/dev/null 2>&1; then
+            docker buildx create --name $MULTIARCH_OTELCOL_BUILDER --driver docker-container --bootstrap
+        fi
+    fi
+    if [ "$PUSH" = "true" ]; then
+        DOCKER_OPTS="--push $DOCKER_OPTS"
+    else
+        DOCKER_OPTS="--load $DOCKER_OPTS"
+    fi
+    docker buildx build --builder $MULTIARCH_OTELCOL_BUILDER --platform ${platforms#,} --tag ${IMAGE_NAME}:${IMAGE_TAG} $DOCKER_OPTS
+fi


### PR DESCRIPTION
- Update the `docker-otelcol` makefile target and dockerfile to support multiarch builds, i.e. `make docker-otelcol ARCH=amd64,arm64,ppc64le`.  Requires either the manifest/images to be pushed, or the containerd image store to be enabled to save the manifest/images locally (limitations of buildkit and the docker engine). Otherwise, the images will be built for each platform individually as it previously did.
- Update github CI tests to support multiarch builds.
- The gitlab changes to support this will be in a separate PR.