### PR TITLE
[discovery] Fix crashing collector if discovered mongodb isn't reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🧰 Bug fixes 🧰
+
+- (Splunk) `discovery`: Fix crashing collector if discovered mongodb isn't reachable in Kubernetes ([#4911](https://github.com/signalfx/splunk-otel-collector/pull/4911)))
+
 ## v0.101.0
 
 ### 🛑 Breaking changes 🛑

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
@@ -22,6 +22,7 @@
 #       hosts:
 #         - endpoint: '`endpoint`'
 #           transport: tcp
+#       timeout: 5s
 #   status:
 #     metrics:
 #       - status: successful

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
@@ -18,6 +18,7 @@ mongodb:
       hosts:
         - endpoint: '`endpoint`'
           transport: tcp
+      timeout: 5s
   status:
     metrics:
       - status: successful

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
@@ -14,6 +14,7 @@
       hosts:
         - endpoint: '`endpoint`'
           transport: tcp
+      timeout: 5s
   status:
     metrics:
       - status: successful


### PR DESCRIPTION
Reduce the connection timeout to 5s seconds. Otherwise, it's the 60s for every Mongodb query, which accumulates to a significant delay and makes the collector killed in k8s.
