### PR TITLE
Sign old windows 2019 and 2022 manifests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -846,6 +846,7 @@ build-push-windows-image:
         if ($LASTEXITCODE -ne 0) { exit 1 }
       }
     - echo "${IMAGE_NAME}:${IMAGE_TAG}" > tags
+    - echo "${OLD_IMAGE_NAME}:${IMAGE_TAG}" >> tags
     - (Get-Content -Raw -Path tags) -replace "`r`n", "`n"| Set-Content -NoNewline tags_to_sign_${env:WIN_VERSION}
   after_script:
     - |


### PR DESCRIPTION
Sign the deprecated `quay.io/signalfx/splunk-otel-collector-windows` 2019 and 2022 manifests.