### PR TITLE
[receiver/discovery] Replace `log_record` field to `message`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- (Splunk) `receiver/discovery`: Replace `log_record` field with `message` in evaluation statements ([#4583](https://github.com/signalfx/splunk-otel-collector/pull/4583))
+
 ### 🚩 Deprecations 🚩
 
 - (Splunk) The following docker images/manifests are deprecated and may not be published in a future release:

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/kafkametrics.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/kafkametrics.discovery.yaml
@@ -23,14 +23,11 @@
 #     metrics:
 #       - status: successful
 #         strict: kafka.brokers
-#         log_record:
-#           body: kafkametrics receiver is working!
+#         message: kafkametrics receiver is working!
 #     statements:
 #       - status: failed
 #         regexp: 'connect: network is unreachable'
-#         log_record:
-#           body: The container cannot be reached by the Collector. Make sure they're in the same network.
+#         message: The container cannot be reached by the Collector. Make sure they're in the same network.
 #       - status: failed
 #         regexp: 'connect: connection refused'
-#         log_record:
-#           body: The container is refusing kafka server connections.
+#         message: The container is refusing kafka server connections.

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
@@ -27,27 +27,22 @@
 #     metrics:
 #       - status: successful
 #         strict: mongodb.database.count
-#         log_record:
-#           body: mongodb receiver is working!
+#         message: mongodb receiver is working!
 #     statements:
 #       - status: failed
 #         regexp: 'connect: network is unreachable'
-#         log_record:
-#           body: The container cannot be reached by the Collector. Make sure they're in the same network.
+#         message: The container cannot be reached by the Collector. Make sure they're in the same network.
 #       - status: failed
 #         regexp: 'connect: connection refused'
-#         log_record:
-#           body: The container is refusing mongodb connections.
+#         message: The container is refusing mongodb connections.
 #       - status: partial
 #         regexp: '.* unable to authenticate using mechanism .*'
-#         log_record:
-#           body: >-
-#               Please ensure your user credentials are correctly specified with
-#               `SPLUNK_DISCOVERY_RECEIVERS_mongodb_CONFIG_username="<username>"` and
-#               `SPLUNK_DISCOVERY_RECEIVERS_mongodb_CONFIG_password="<password>"` environment variables.
+#         message: >-
+#           Please ensure your user credentials are correctly specified with
+#           `SPLUNK_DISCOVERY_RECEIVERS_mongodb_CONFIG_username="<username>"` and
+#           `SPLUNK_DISCOVERY_RECEIVERS_mongodb_CONFIG_password="<password>"` environment variables.
 #       - status: partial
 #         regexp: '.* failed to fetch index stats metrics: (Unauthorized) not authorized on admin to execute command .*'
-#         log_record:
-#           body: >-
-#             Make sure the account used to access Mongodb has been given a clusterMonitor role in order to collect metrics.
-#             `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`
+#         message: >-
+#           Make sure the account used to access Mongodb has been given a clusterMonitor role in order to collect metrics.
+#           `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/mysql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/mysql.discovery.yaml
@@ -20,17 +20,14 @@
 #     metrics:
 #       - status: successful
 #         strict: mysql.locks
-#         log_record:
-#           body: Mysql receiver is working!
+#         message: Mysql receiver is working!
 #     statements:
 #       - status: failed
 #         regexp: "Can't connect to MySQL server on .* [(]111[)]"
-#         log_record:
-#           body:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
+#         message:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
 #       - status: partial
 #         regexp: 'Access denied for user'
-#         log_record:
-#           body: >-
-#             Make sure your user credentials are correctly specified using the
-#             `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_username="<username>"` and
-#             `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_password="<password>"` environment variables.
+#         message: >-
+#           Make sure your user credentials are correctly specified using the
+#           `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_username="<username>"` and
+#           `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_password="<password>"` environment variables.

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/oracledb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/oracledb.discovery.yaml
@@ -21,35 +21,28 @@
 #     metrics:
 #       - status: successful
 #         strict: oracledb.cpu_time
-#         log_record:
-#           body: oracledb receiver is working!
+#         message: oracledb receiver is working!
 #     statements:
 #       - status: failed
 #         regexp: "connection refused"
-#         log_record:
-#           body: The container is not serving http connections.
+#         message: The container is not serving http connections.
 #       - status: failed
 #         regexp: "received goaway and there are no active streams"
-#         log_record:
-#           body: Unable to connect and scrape metrics.
+#         message: Unable to connect and scrape metrics.
 #       - status: failed
 #         regexp: "dial tcp: lookup"
-#         log_record:
-#           body: Unable to resolve oracledb tcp endpoint
+#         message: Unable to resolve oracledb tcp endpoint
 #       - status: failed
 #         regexp: 'error executing select .*: EOF'
-#         log_record:
-#           body: Unable to execute select from oracledb. Verify endpoint and user permissions.
+#         message: Unable to execute select from oracledb. Verify endpoint and user permissions.
 #       - status: partial
 #         regexp: "listener does not currently know of service requested"
-#         log_record:
-#           body: >-
-#             Make sure your oracledb service is correctly specified using the
-#             `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_service="<service>"` environment variable.
+#         message: >-
+#           Make sure your oracledb service is correctly specified using the
+#           `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_service="<service>"` environment variable.
 #       - status: partial
 #         regexp: 'invalid username/password'
-#         log_record:
-#           body: >-
-#             Make sure your user credentials are correctly specified using the
-#             `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_username="<username>"` and
-#             `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_password="<password>"` environment variables.
+#         message: >-
+#           Make sure your user credentials are correctly specified using the
+#           `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_username="<username>"` and
+#           `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_password="<password>"` environment variables.

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/postgresql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/postgresql.discovery.yaml
@@ -20,44 +20,37 @@
 #     metrics:
 #       - status: successful
 #         strict: postgresql.commits
-#         log_record:
-#           body: PostgreSQL receiver is working!
+#         message: PostgreSQL receiver is working!
 #     statements:
 #       - status: failed
 #         regexp: 'connect: network is unreachable'
-#         log_record:
-#           body: The container cannot be reached by the Collector. Make sure they're in the same network.
+#         message: The container cannot be reached by the Collector. Make sure they're in the same network.
 #       - status: failed
 #         regexp: 'connect: connection refused'
-#         log_record:
-#           body: The container is refusing PostgreSQL connections.
+#         message: The container is refusing PostgreSQL connections.
 #       - status: partial
 #         regexp: 'pq: password authentication failed for user'
-#         log_record:
-#           body: >-
-#             Please ensure your user credentials are correctly specified with
-#             `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_username="<username>"` and
-#             `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_password="<password>"` environment variables.
+#         message: >-
+#           Please ensure your user credentials are correctly specified with
+#           `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_username="<username>"` and
+#           `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_password="<password>"` environment variables.
 #       - status: partial
 #         regexp: 'pq: database .* does not exist'
-#         log_record:
-#           body: >-
-#             Make sure the target database is correctly specified using the
-#             `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_databases="[<db>]"` environment variable.
+#         message: >-
+#           Make sure the target database is correctly specified using the
+#           `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_databases="[<db>]"` environment variable.
 #       - status: partial
 #         regexp: 'pq: SSL is not enabled on the server'
-#         log_record:
-#           body: >-
-#             Make sure the target database has SSL enabled or set insecure using the
-#             `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_tls_x3a__x3a_insecure="<boolean>"` environment variable.
+#         message: >-
+#           Make sure the target database has SSL enabled or set insecure using the
+#           `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_tls_x3a__x3a_insecure="<boolean>"` environment variable.
 #       - status: partial
 #         regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
-#         log_record:
-#           body: >-
-#             Make sure your PostgreSQL database has
-#             `shared_preload_libraries = 'pg_stat_statements'`
-#             in the postgresql.conf file and that
-#             `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-#             has been run for each database you would like to monitor.
-#             For example:
-#             `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`
+#         message: >-
+#           Make sure your PostgreSQL database has
+#           `shared_preload_libraries = 'pg_stat_statements'`
+#           in the postgresql.conf file and that
+#           `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+#           has been run for each database you would like to monitor.
+#           For example:
+#           `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/redis.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/redis.discovery.yaml
@@ -18,36 +18,29 @@
 #     metrics:
 #       - status: successful
 #         strict: redis.uptime
-#         log_record:
-#           body: redis receiver is working!
+#         message: redis receiver is working!
 #     statements:
 #       - status: failed
 #         regexp: "connection refused"
-#         log_record:
-#           body: The container is not serving http connections.
+#         message: The container is not serving http connections.
 #       - status: failed
 #         regexp: "received goaway and there are no active streams"
-#         log_record:
-#           body: Unable to connect and scrape metrics.
+#         message: Unable to connect and scrape metrics.
 #       - status: failed
 #         regexp: "dial tcp: lookup"
-#         log_record:
-#           body: Unable to resolve redis tcp endpoint
+#         message: Unable to resolve redis tcp endpoint
 #       - status: partial
 #         regexp: 'NOAUTH Authentication required.'
-#         log_record:
-#           body: >-
-#             Make sure your user credentials are correctly specified using the
-#             `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variable.
+#         message: >-
+#           Make sure your user credentials are correctly specified using the
+#           `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variable.
 #       - status: partial
 #         regexp: 'called without any password configured for the default user'
-#         log_record:
-#           body: >-
-#             Make sure your user credentials are correctly specified using the
-#             `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variable.
+#         message: >-
+#           Make sure your user credentials are correctly specified using the
+#           `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variable.
 #       - status: partial
 #         regexp: 'WRONGPASS invalid username-password pair or user is disabled'
-#         log_record:
-#           body: >-
-#             Make sure your user credentials are correctly specified using the
-#             `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variable.
+#         message: >-
+#           Make sure your user credentials are correctly specified using the
+#           `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variable.

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-collectd-mysql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-collectd-mysql.discovery.yaml
@@ -24,29 +24,24 @@
 #     metrics:
 #       - status: successful
 #         strict: mysql_octets.rx
-#         log_record:
-#           body: smartagent/collectd/mysql receiver is working!
+#         message: smartagent/collectd/mysql receiver is working!
 #     statements:
 #       - status: failed
 #         regexp: "mysql plugin: Failed to connect to database .* at server .* Can't connect to MySQL server on .* [(]111[)]"
-#         log_record:
-#           body: The container is refusing MySQL connections.
+#         message: The container is refusing MySQL connections.
 #       - status: partial
 #         regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* [(]using password: .*[)]'
-#         log_record:
-#           body: >-
-#             Make sure your user credentials are correctly specified using the
-#             `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_username="<username>"` and
-#             `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_password="<password>"` environment variables.
+#         message: >-
+#           Make sure your user credentials are correctly specified using the
+#           `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_username="<username>"` and
+#           `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_password="<password>"` environment variables.
 #       - status: partial
 #         regexp: 'mysql plugin: Failed to connect to database .* at server .* Unknown database'
-#         log_record:
-#           body: >-
-#             Make sure your MySQL databases are correctly specified using the
-#             `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.
+#         message: >-
+#           Make sure your MySQL databases are correctly specified using the
+#           `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.
 #       - status: partial
 #         regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* to database'
-#         log_record:
-#           body: >-
-#             Make sure your MySQL databases and auth information are correctly specified using the
-#             `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.
+#         message: >-
+#           Make sure your MySQL databases and auth information are correctly specified using the
+#           `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-collectd-nginx.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-collectd-nginx.discovery.yaml
@@ -22,14 +22,11 @@
 #     metrics:
 #       - status: successful
 #         strict: connections.accepted
-#         log_record:
-#           body: smartagent/collectd/nginx receiver is working!
+#         message: smartagent/collectd/nginx receiver is working!
 #     statements:
 #       - status: failed
 #         regexp: "nginx plugin: curl_easy_perform failed: Operation timed out after"
-#         log_record:
-#           body: The container is not serving http connections.
+#         message: The container is not serving http connections.
 #       - status: failed
 #         regexp: "read-function of plugin .* failed"
-#         log_record:
-#           body: The integration is unable to read metrics from this endpoint.
+#         message: The integration is unable to read metrics from this endpoint.

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-postgresql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/smartagent-postgresql.discovery.yaml
@@ -24,47 +24,40 @@
 #     metrics:
 #       - status: successful
 #         strict: postgres_query_count
-#         log_record:
-#           body: PostgreSQL receiver is working!
+#         message: PostgreSQL receiver is working!
 #       - status: partial
 #         strict: postgres_rows_inserted
-#         log_record:
-#           body: >-
-#             Make sure that
-#             `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-#             has been run for each database you would like to monitor.
-#             For example:
-#             `psql --dbname "<db-name>" -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"`
+#         message: >-
+#           Make sure that
+#           `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+#           has been run for each database you would like to monitor.
+#           For example:
+#           `psql --dbname "<db-name>" -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"`
 #     statements:
 #       - status: failed
 #         regexp: 'connect: network is unreachable'
-#         log_record:
-#           body: The container cannot be reached by the Collector. Make sure they're in the same network.
+#         message: The container cannot be reached by the Collector. Make sure they're in the same network.
 #       - status: failed
 #         regexp: 'connect: connection refused'
-#         log_record:
-#           body: The container is refusing PostgreSQL connections.
+#         message: The container is refusing PostgreSQL connections.
 #       - status: partial
 #         regexp: 'pq: password authentication failed for user'
-#         log_record:
-#           body: >-
-#             Please ensure your user credentials are correctly specified with
-#             `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_username="<username>"` and
-#             `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_password="<password>"` environment variables.
+#         message: >-
+#           Please ensure your user credentials are correctly specified with
+#           `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_username="<username>"` and
+#           `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_password="<password>"` environment variables.
 #       - status: partial
 #         regexp: 'pq: database .* does not exist'
-#         log_record:
-#           body: >-
-#             Make sure the target database is correctly specified using the
-#             `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_masterDBName="<db>"` environment variable.
+#         message: >-
+#           Make sure the target database is correctly specified using the
+#           `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_masterDBName="<db>"` environment variable.
 #       - status: partial
 #         regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
-#         log_record:
-#           body: >-
-#             Make sure your PostgreSQL database has
-#             `shared_preload_libraries = 'pg_stat_statements'`
-#             in the postgresql.conf file and that
-#             `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-#             has been run for each database you would like to monitor.
-#             For example:
-#             `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`
+#         message: >-
+#           Make sure your PostgreSQL database has
+#           `shared_preload_libraries = 'pg_stat_statements'`
+#           in the postgresql.conf file and that
+#           `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+#           has been run for each database you would like to monitor.
+#           For example:
+#           `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`

--- a/internal/confmapprovider/discovery/bundle/README.md
+++ b/internal/confmapprovider/discovery/bundle/README.md
@@ -29,10 +29,9 @@ Example `redis.discovery.yaml.tmpl`:
     statements:
       partial:
         - regexp: 'ERR AUTH.*'
-          log_record:
-            body: >-
-              Please ensure your redis password is correctly specified with
-              `{{ configPropertyEnvVar "password" "<username>" }}` environment variable.
+          message: >-
+            Please ensure your redis password is correctly specified with
+            `{{ configPropertyEnvVar "password" "<username>" }}` environment variable.
 ```
 
 After adding the required new component filename prefix to the `Components` instance in [`components.go`](./components.go)
@@ -52,11 +51,10 @@ redis:
     statements:
       partial:
         - regexp: 'ERR AUTH.*'
-          log_record:
-            body: >-
-              Please ensure your redis password is correctly specified with
-              `--set splunk.discovery.receivers.redis.config.password="<password>"` or
-              `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<username>"` environment variable.
+          message: >-
+            Please ensure your redis password is correctly specified with
+            `--set splunk.discovery.receivers.redis.config.password="<password>"` or
+            `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<username>"` environment variable.
 ```
 
 In order for this to be included in the [Windows](./bundledfs_windows.go) and [Linux](./bundledfs_others.go) `BundledFS`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/kafkametrics.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/kafkametrics.discovery.yaml
@@ -19,14 +19,11 @@ kafkametrics:
     metrics:
       - status: successful
         strict: kafka.brokers
-        log_record:
-          body: kafkametrics receiver is working!
+        message: kafkametrics receiver is working!
     statements:
       - status: failed
         regexp: 'connect: network is unreachable'
-        log_record:
-          body: The container cannot be reached by the Collector. Make sure they're in the same network.
+        message: The container cannot be reached by the Collector. Make sure they're in the same network.
       - status: failed
         regexp: 'connect: connection refused'
-        log_record:
-          body: The container is refusing kafka server connections.
+        message: The container is refusing kafka server connections.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/kafkametrics.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/kafkametrics.discovery.yaml.tmpl
@@ -15,14 +15,11 @@
     metrics:
       - status: successful
         strict: kafka.brokers
-        log_record:
-          body: kafkametrics receiver is working!
+        message: kafkametrics receiver is working!
     statements:
       - status: failed
         regexp: 'connect: network is unreachable'
-        log_record:
-          body: The container cannot be reached by the Collector. Make sure they're in the same network.
+        message: The container cannot be reached by the Collector. Make sure they're in the same network.
       - status: failed
         regexp: 'connect: connection refused'
-        log_record:
-          body: The container is refusing kafka server connections.
+        message: The container is refusing kafka server connections.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
@@ -23,27 +23,22 @@ mongodb:
     metrics:
       - status: successful
         strict: mongodb.database.count
-        log_record:
-          body: mongodb receiver is working!
+        message: mongodb receiver is working!
     statements:
       - status: failed
         regexp: 'connect: network is unreachable'
-        log_record:
-          body: The container cannot be reached by the Collector. Make sure they're in the same network.
+        message: The container cannot be reached by the Collector. Make sure they're in the same network.
       - status: failed
         regexp: 'connect: connection refused'
-        log_record:
-          body: The container is refusing mongodb connections.
+        message: The container is refusing mongodb connections.
       - status: partial
         regexp: '.* unable to authenticate using mechanism .*'
-        log_record:
-          body: >-
-              Please ensure your user credentials are correctly specified with
-              `SPLUNK_DISCOVERY_RECEIVERS_mongodb_CONFIG_username="<username>"` and
-              `SPLUNK_DISCOVERY_RECEIVERS_mongodb_CONFIG_password="<password>"` environment variables.
+        message: >-
+          Please ensure your user credentials are correctly specified with
+          `SPLUNK_DISCOVERY_RECEIVERS_mongodb_CONFIG_username="<username>"` and
+          `SPLUNK_DISCOVERY_RECEIVERS_mongodb_CONFIG_password="<password>"` environment variables.
       - status: partial
         regexp: '.* failed to fetch index stats metrics: (Unauthorized) not authorized on admin to execute command .*'
-        log_record:
-          body: >-
-            Make sure the account used to access Mongodb has been given a clusterMonitor role in order to collect metrics.
-            `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`
+        message: >-
+          Make sure the account used to access Mongodb has been given a clusterMonitor role in order to collect metrics.
+          `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
@@ -19,27 +19,22 @@
     metrics:
       - status: successful
         strict: mongodb.database.count
-        log_record:
-          body: mongodb receiver is working!
+        message: mongodb receiver is working!
     statements:
       - status: failed
         regexp: 'connect: network is unreachable'
-        log_record:
-          body: The container cannot be reached by the Collector. Make sure they're in the same network.
+        message: The container cannot be reached by the Collector. Make sure they're in the same network.
       - status: failed
         regexp: 'connect: connection refused'
-        log_record:
-          body: The container is refusing mongodb connections.
+        message: The container is refusing mongodb connections.
       - status: partial
         regexp: '.* unable to authenticate using mechanism .*'
-        log_record:
-          body: >-
-              Please ensure your user credentials are correctly specified with
-              `{{ configPropertyEnvVar "username" "<username>" }}` and
-              `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
+        message: >-
+          Please ensure your user credentials are correctly specified with
+          `{{ configPropertyEnvVar "username" "<username>" }}` and
+          `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
       - status: partial
         regexp: '.* failed to fetch index stats metrics: (Unauthorized) not authorized on admin to execute command .*'
-        log_record:
-          body: >-
-            Make sure the account used to access Mongodb has been given a clusterMonitor role in order to collect metrics.
-            `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`
+        message: >-
+          Make sure the account used to access Mongodb has been given a clusterMonitor role in order to collect metrics.
+          `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml
@@ -16,17 +16,14 @@ mysql:
     metrics:
       - status: successful
         strict: mysql.locks
-        log_record:
-          body: Mysql receiver is working!
+        message: Mysql receiver is working!
     statements:
       - status: failed
         regexp: "Can't connect to MySQL server on .* [(]111[)]"
-        log_record:
-          body:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
+        message:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
       - status: partial
         regexp: 'Access denied for user'
-        log_record:
-          body: >-
-            Make sure your user credentials are correctly specified using the
-            `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_username="<username>"` and
-            `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_password="<password>"` environment variables.
+        message: >-
+          Make sure your user credentials are correctly specified using the
+          `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_username="<username>"` and
+          `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_password="<password>"` environment variables.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml.tmpl
@@ -12,17 +12,14 @@
     metrics:
       - status: successful
         strict: mysql.locks
-        log_record:
-          body: Mysql receiver is working!
+        message: Mysql receiver is working!
     statements:
       - status: failed
         regexp: "Can't connect to MySQL server on .* [(]111[)]"
-        log_record:
-          body:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
+        message:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
       - status: partial
         regexp: 'Access denied for user'
-        log_record:
-          body: >-
-            Make sure your user credentials are correctly specified using the
-            `{{ configPropertyEnvVar "username" "<username>" }}` and
-            `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
+        message: >-
+          Make sure your user credentials are correctly specified using the
+          `{{ configPropertyEnvVar "username" "<username>" }}` and
+          `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml
@@ -17,35 +17,28 @@ oracledb:
     metrics:
       - status: successful
         strict: oracledb.cpu_time
-        log_record:
-          body: oracledb receiver is working!
+        message: oracledb receiver is working!
     statements:
       - status: failed
         regexp: "connection refused"
-        log_record:
-          body: The container is not serving http connections.
+        message: The container is not serving http connections.
       - status: failed
         regexp: "received goaway and there are no active streams"
-        log_record:
-          body: Unable to connect and scrape metrics.
+        message: Unable to connect and scrape metrics.
       - status: failed
         regexp: "dial tcp: lookup"
-        log_record:
-          body: Unable to resolve oracledb tcp endpoint
+        message: Unable to resolve oracledb tcp endpoint
       - status: failed
         regexp: 'error executing select .*: EOF'
-        log_record:
-          body: Unable to execute select from oracledb. Verify endpoint and user permissions.
+        message: Unable to execute select from oracledb. Verify endpoint and user permissions.
       - status: partial
         regexp: "listener does not currently know of service requested"
-        log_record:
-          body: >-
-            Make sure your oracledb service is correctly specified using the
-            `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_service="<service>"` environment variable.
+        message: >-
+          Make sure your oracledb service is correctly specified using the
+          `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_service="<service>"` environment variable.
       - status: partial
         regexp: 'invalid username/password'
-        log_record:
-          body: >-
-            Make sure your user credentials are correctly specified using the
-            `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_username="<username>"` and
-            `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_password="<password>"` environment variables.
+        message: >-
+          Make sure your user credentials are correctly specified using the
+          `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_username="<username>"` and
+          `SPLUNK_DISCOVERY_RECEIVERS_oracledb_CONFIG_password="<password>"` environment variables.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml.tmpl
@@ -13,35 +13,28 @@
     metrics:
       - status: successful
         strict: oracledb.cpu_time
-        log_record:
-          body: oracledb receiver is working!
+        message: oracledb receiver is working!
     statements:
       - status: failed
         regexp: "connection refused"
-        log_record:
-          body: The container is not serving http connections.
+        message: The container is not serving http connections.
       - status: failed
         regexp: "received goaway and there are no active streams"
-        log_record:
-          body: Unable to connect and scrape metrics.
+        message: Unable to connect and scrape metrics.
       - status: failed
         regexp: "dial tcp: lookup"
-        log_record:
-          body: Unable to resolve oracledb tcp endpoint
+        message: Unable to resolve oracledb tcp endpoint
       - status: failed
         regexp: 'error executing select .*: EOF'
-        log_record:
-          body: Unable to execute select from oracledb. Verify endpoint and user permissions.
+        message: Unable to execute select from oracledb. Verify endpoint and user permissions.
       - status: partial
         regexp: "listener does not currently know of service requested"
-        log_record:
-          body: >-
-            Make sure your oracledb service is correctly specified using the
-            `{{ configPropertyEnvVar "service" "<service>" }}` environment variable.
+        message: >-
+          Make sure your oracledb service is correctly specified using the
+          `{{ configPropertyEnvVar "service" "<service>" }}` environment variable.
       - status: partial
         regexp: 'invalid username/password'
-        log_record:
-          body: >-
-            Make sure your user credentials are correctly specified using the
-            `{{ configPropertyEnvVar "username" "<username>" }}` and
-            `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
+        message: >-
+          Make sure your user credentials are correctly specified using the
+          `{{ configPropertyEnvVar "username" "<username>" }}` and
+          `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml
@@ -16,44 +16,37 @@ postgresql:
     metrics:
       - status: successful
         strict: postgresql.commits
-        log_record:
-          body: PostgreSQL receiver is working!
+        message: PostgreSQL receiver is working!
     statements:
       - status: failed
         regexp: 'connect: network is unreachable'
-        log_record:
-          body: The container cannot be reached by the Collector. Make sure they're in the same network.
+        message: The container cannot be reached by the Collector. Make sure they're in the same network.
       - status: failed
         regexp: 'connect: connection refused'
-        log_record:
-          body: The container is refusing PostgreSQL connections.
+        message: The container is refusing PostgreSQL connections.
       - status: partial
         regexp: 'pq: password authentication failed for user'
-        log_record:
-          body: >-
-            Please ensure your user credentials are correctly specified with
-            `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_username="<username>"` and
-            `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_password="<password>"` environment variables.
+        message: >-
+          Please ensure your user credentials are correctly specified with
+          `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_username="<username>"` and
+          `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_password="<password>"` environment variables.
       - status: partial
         regexp: 'pq: database .* does not exist'
-        log_record:
-          body: >-
-            Make sure the target database is correctly specified using the
-            `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_databases="[<db>]"` environment variable.
+        message: >-
+          Make sure the target database is correctly specified using the
+          `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_databases="[<db>]"` environment variable.
       - status: partial
         regexp: 'pq: SSL is not enabled on the server'
-        log_record:
-          body: >-
-            Make sure the target database has SSL enabled or set insecure using the
-            `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_tls_x3a__x3a_insecure="<boolean>"` environment variable.
+        message: >-
+          Make sure the target database has SSL enabled or set insecure using the
+          `SPLUNK_DISCOVERY_RECEIVERS_postgresql_CONFIG_tls_x3a__x3a_insecure="<boolean>"` environment variable.
       - status: partial
         regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
-        log_record:
-          body: >-
-            Make sure your PostgreSQL database has
-            `shared_preload_libraries = 'pg_stat_statements'`
-            in the postgresql.conf file and that
-            `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-            has been run for each database you would like to monitor.
-            For example:
-            `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`
+        message: >-
+          Make sure your PostgreSQL database has
+          `shared_preload_libraries = 'pg_stat_statements'`
+          in the postgresql.conf file and that
+          `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+          has been run for each database you would like to monitor.
+          For example:
+          `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml.tmpl
@@ -12,44 +12,37 @@
     metrics:
       - status: successful
         strict: postgresql.commits
-        log_record:
-          body: PostgreSQL receiver is working!
+        message: PostgreSQL receiver is working!
     statements:
       - status: failed
         regexp: 'connect: network is unreachable'
-        log_record:
-          body: The container cannot be reached by the Collector. Make sure they're in the same network.
+        message: The container cannot be reached by the Collector. Make sure they're in the same network.
       - status: failed
         regexp: 'connect: connection refused'
-        log_record:
-          body: The container is refusing PostgreSQL connections.
+        message: The container is refusing PostgreSQL connections.
       - status: partial
         regexp: 'pq: password authentication failed for user'
-        log_record:
-          body: >-
-            Please ensure your user credentials are correctly specified with
-            `{{ configPropertyEnvVar "username" "<username>" }}` and
-            `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
+        message: >-
+          Please ensure your user credentials are correctly specified with
+          `{{ configPropertyEnvVar "username" "<username>" }}` and
+          `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
       - status: partial
         regexp: 'pq: database .* does not exist'
-        log_record:
-          body: >-
-            Make sure the target database is correctly specified using the
-            `{{ configPropertyEnvVar "databases" "[<db>]" }}` environment variable.
+        message: >-
+          Make sure the target database is correctly specified using the
+          `{{ configPropertyEnvVar "databases" "[<db>]" }}` environment variable.
       - status: partial
         regexp: 'pq: SSL is not enabled on the server'
-        log_record:
-          body: >-
-            Make sure the target database has SSL enabled or set insecure using the
-            `{{ configPropertyEnvVar "tls::insecure" "<boolean>" }}` environment variable.
+        message: >-
+          Make sure the target database has SSL enabled or set insecure using the
+          `{{ configPropertyEnvVar "tls::insecure" "<boolean>" }}` environment variable.
       - status: partial
         regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
-        log_record:
-          body: >-
-            Make sure your PostgreSQL database has
-            `shared_preload_libraries = 'pg_stat_statements'`
-            in the postgresql.conf file and that
-            `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-            has been run for each database you would like to monitor.
-            For example:
-            `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`
+        message: >-
+          Make sure your PostgreSQL database has
+          `shared_preload_libraries = 'pg_stat_statements'`
+          in the postgresql.conf file and that
+          `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+          has been run for each database you would like to monitor.
+          For example:
+          `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml
@@ -14,36 +14,29 @@ redis:
     metrics:
       - status: successful
         strict: redis.uptime
-        log_record:
-          body: redis receiver is working!
+        message: redis receiver is working!
     statements:
       - status: failed
         regexp: "connection refused"
-        log_record:
-          body: The container is not serving http connections.
+        message: The container is not serving http connections.
       - status: failed
         regexp: "received goaway and there are no active streams"
-        log_record:
-          body: Unable to connect and scrape metrics.
+        message: Unable to connect and scrape metrics.
       - status: failed
         regexp: "dial tcp: lookup"
-        log_record:
-          body: Unable to resolve redis tcp endpoint
+        message: Unable to resolve redis tcp endpoint
       - status: partial
         regexp: 'NOAUTH Authentication required.'
-        log_record:
-          body: >-
-            Make sure your user credentials are correctly specified using the
-            `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variable.
+        message: >-
+          Make sure your user credentials are correctly specified using the
+          `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variable.
       - status: partial
         regexp: 'called without any password configured for the default user'
-        log_record:
-          body: >-
-            Make sure your user credentials are correctly specified using the
-            `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variable.
+        message: >-
+          Make sure your user credentials are correctly specified using the
+          `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variable.
       - status: partial
         regexp: 'WRONGPASS invalid username-password pair or user is disabled'
-        log_record:
-          body: >-
-            Make sure your user credentials are correctly specified using the
-            `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variable.
+        message: >-
+          Make sure your user credentials are correctly specified using the
+          `SPLUNK_DISCOVERY_RECEIVERS_redis_CONFIG_password="<password>"` environment variable.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml.tmpl
@@ -10,36 +10,29 @@
     metrics:
       - status: successful
         strict: redis.uptime
-        log_record:
-          body: redis receiver is working!
+        message: redis receiver is working!
     statements:
       - status: failed
         regexp: "connection refused"
-        log_record:
-          body: The container is not serving http connections.
+        message: The container is not serving http connections.
       - status: failed
         regexp: "received goaway and there are no active streams"
-        log_record:
-          body: Unable to connect and scrape metrics.
+        message: Unable to connect and scrape metrics.
       - status: failed
         regexp: "dial tcp: lookup"
-        log_record:
-          body: Unable to resolve redis tcp endpoint
+        message: Unable to resolve redis tcp endpoint
       - status: partial
         regexp: 'NOAUTH Authentication required.'
-        log_record:
-          body: >-
-            Make sure your user credentials are correctly specified using the
-            `{{ configPropertyEnvVar "password" "<password>" }}` environment variable.
+        message: >-
+          Make sure your user credentials are correctly specified using the
+          `{{ configPropertyEnvVar "password" "<password>" }}` environment variable.
       - status: partial
         regexp: 'called without any password configured for the default user'
-        log_record:
-          body: >-
-            Make sure your user credentials are correctly specified using the
-            `{{ configPropertyEnvVar "password" "<password>" }}` environment variable.
+        message: >-
+          Make sure your user credentials are correctly specified using the
+          `{{ configPropertyEnvVar "password" "<password>" }}` environment variable.
       - status: partial
         regexp: 'WRONGPASS invalid username-password pair or user is disabled'
-        log_record:
-          body: >-
-            Make sure your user credentials are correctly specified using the
-            `{{ configPropertyEnvVar "password" "<password>" }}` environment variable.
+        message: >-
+          Make sure your user credentials are correctly specified using the
+          `{{ configPropertyEnvVar "password" "<password>" }}` environment variable.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml
@@ -20,29 +20,24 @@ smartagent/collectd/mysql:
     metrics:
       - status: successful
         strict: mysql_octets.rx
-        log_record:
-          body: smartagent/collectd/mysql receiver is working!
+        message: smartagent/collectd/mysql receiver is working!
     statements:
       - status: failed
         regexp: "mysql plugin: Failed to connect to database .* at server .* Can't connect to MySQL server on .* [(]111[)]"
-        log_record:
-          body: The container is refusing MySQL connections.
+        message: The container is refusing MySQL connections.
       - status: partial
         regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* [(]using password: .*[)]'
-        log_record:
-          body: >-
-            Make sure your user credentials are correctly specified using the
-            `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_username="<username>"` and
-            `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_password="<password>"` environment variables.
+        message: >-
+          Make sure your user credentials are correctly specified using the
+          `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_username="<username>"` and
+          `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_password="<password>"` environment variables.
       - status: partial
         regexp: 'mysql plugin: Failed to connect to database .* at server .* Unknown database'
-        log_record:
-          body: >-
-            Make sure your MySQL databases are correctly specified using the
-            `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.
+        message: >-
+          Make sure your MySQL databases are correctly specified using the
+          `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.
       - status: partial
         regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* to database'
-        log_record:
-          body: >-
-            Make sure your MySQL databases and auth information are correctly specified using the
-            `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.
+        message: >-
+          Make sure your MySQL databases and auth information are correctly specified using the
+          `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_collectd_x2f_mysql_CONFIG_databases="[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]"` environment variable.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-mysql.discovery.yaml.tmpl
@@ -16,29 +16,24 @@
     metrics:
       - status: successful
         strict: mysql_octets.rx
-        log_record:
-          body: smartagent/collectd/mysql receiver is working!
+        message: smartagent/collectd/mysql receiver is working!
     statements:
       - status: failed
         regexp: "mysql plugin: Failed to connect to database .* at server .* Can't connect to MySQL server on .* [(]111[)]"
-        log_record:
-          body: The container is refusing MySQL connections.
+        message: The container is refusing MySQL connections.
       - status: partial
         regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* [(]using password: .*[)]'
-        log_record:
-          body: >-
-            Make sure your user credentials are correctly specified using the
-            `{{ configPropertyEnvVar "username" "<username>" }}` and
-            `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
+        message: >-
+          Make sure your user credentials are correctly specified using the
+          `{{ configPropertyEnvVar "username" "<username>" }}` and
+          `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
       - status: partial
         regexp: 'mysql plugin: Failed to connect to database .* at server .* Unknown database'
-        log_record:
-          body: >-
-            Make sure your MySQL databases are correctly specified using the
-            `{{ configPropertyEnvVar "databases" "[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]" }}` environment variable.
+        message: >-
+          Make sure your MySQL databases are correctly specified using the
+          `{{ configPropertyEnvVar "databases" "[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]" }}` environment variable.
       - status: partial
         regexp: 'mysql plugin: Failed to connect to database .* at server .* Access denied for user .* to database'
-        log_record:
-          body: >-
-            Make sure your MySQL databases and auth information are correctly specified using the
-            `{{ configPropertyEnvVar "databases" "[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]" }}` environment variable.
+        message: >-
+          Make sure your MySQL databases and auth information are correctly specified using the
+          `{{ configPropertyEnvVar "databases" "[{name: '<db-name-0>'}, {name: '<db-name-1>', username: '<username>', password: '<password>'}]" }}` environment variable.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-nginx.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-nginx.discovery.yaml
@@ -18,14 +18,11 @@ smartagent/collectd/nginx:
     metrics:
       - status: successful
         strict: connections.accepted
-        log_record:
-          body: smartagent/collectd/nginx receiver is working!
+        message: smartagent/collectd/nginx receiver is working!
     statements:
       - status: failed
         regexp: "nginx plugin: curl_easy_perform failed: Operation timed out after"
-        log_record:
-          body: The container is not serving http connections.
+        message: The container is not serving http connections.
       - status: failed
         regexp: "read-function of plugin .* failed"
-        log_record:
-          body: The integration is unable to read metrics from this endpoint.
+        message: The integration is unable to read metrics from this endpoint.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-nginx.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-collectd-nginx.discovery.yaml.tmpl
@@ -14,14 +14,11 @@
     metrics:
       - status: successful
         strict: connections.accepted
-        log_record:
-          body: smartagent/collectd/nginx receiver is working!
+        message: smartagent/collectd/nginx receiver is working!
     statements:
       - status: failed
         regexp: "nginx plugin: curl_easy_perform failed: Operation timed out after"
-        log_record:
-          body: The container is not serving http connections.
+        message: The container is not serving http connections.
       - status: failed
         regexp: "read-function of plugin .* failed"
-        log_record:
-          body: The integration is unable to read metrics from this endpoint.
+        message: The integration is unable to read metrics from this endpoint.

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml
@@ -20,47 +20,40 @@ smartagent/postgresql:
     metrics:
       - status: successful
         strict: postgres_query_count
-        log_record:
-          body: PostgreSQL receiver is working!
+        message: PostgreSQL receiver is working!
       - status: partial
         strict: postgres_rows_inserted
-        log_record:
-          body: >-
-            Make sure that
-            `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-            has been run for each database you would like to monitor.
-            For example:
-            `psql --dbname "<db-name>" -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"`
+        message: >-
+          Make sure that
+          `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+          has been run for each database you would like to monitor.
+          For example:
+          `psql --dbname "<db-name>" -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"`
     statements:
       - status: failed
         regexp: 'connect: network is unreachable'
-        log_record:
-          body: The container cannot be reached by the Collector. Make sure they're in the same network.
+        message: The container cannot be reached by the Collector. Make sure they're in the same network.
       - status: failed
         regexp: 'connect: connection refused'
-        log_record:
-          body: The container is refusing PostgreSQL connections.
+        message: The container is refusing PostgreSQL connections.
       - status: partial
         regexp: 'pq: password authentication failed for user'
-        log_record:
-          body: >-
-            Please ensure your user credentials are correctly specified with
-            `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_username="<username>"` and
-            `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_password="<password>"` environment variables.
+        message: >-
+          Please ensure your user credentials are correctly specified with
+          `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_username="<username>"` and
+          `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_params_x3a__x3a_password="<password>"` environment variables.
       - status: partial
         regexp: 'pq: database .* does not exist'
-        log_record:
-          body: >-
-            Make sure the target database is correctly specified using the
-            `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_masterDBName="<db>"` environment variable.
+        message: >-
+          Make sure the target database is correctly specified using the
+          `SPLUNK_DISCOVERY_RECEIVERS_smartagent_x2f_postgresql_CONFIG_masterDBName="<db>"` environment variable.
       - status: partial
         regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
-        log_record:
-          body: >-
-            Make sure your PostgreSQL database has
-            `shared_preload_libraries = 'pg_stat_statements'`
-            in the postgresql.conf file and that
-            `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-            has been run for each database you would like to monitor.
-            For example:
-            `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`
+        message: >-
+          Make sure your PostgreSQL database has
+          `shared_preload_libraries = 'pg_stat_statements'`
+          in the postgresql.conf file and that
+          `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+          has been run for each database you would like to monitor.
+          For example:
+          `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/smartagent-postgresql.discovery.yaml.tmpl
@@ -16,47 +16,40 @@
     metrics:
       - status: successful
         strict: postgres_query_count
-        log_record:
-          body: PostgreSQL receiver is working!
+        message: PostgreSQL receiver is working!
       - status: partial
         strict: postgres_rows_inserted
-        log_record:
-          body: >-
-            Make sure that
-            `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-            has been run for each database you would like to monitor.
-            For example:
-            `psql --dbname "<db-name>" -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"`
+        message: >-
+          Make sure that
+          `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+          has been run for each database you would like to monitor.
+          For example:
+          `psql --dbname "<db-name>" -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"`
     statements:
       - status: failed
         regexp: 'connect: network is unreachable'
-        log_record:
-          body: The container cannot be reached by the Collector. Make sure they're in the same network.
+        message: The container cannot be reached by the Collector. Make sure they're in the same network.
       - status: failed
         regexp: 'connect: connection refused'
-        log_record:
-          body: The container is refusing PostgreSQL connections.
+        message: The container is refusing PostgreSQL connections.
       - status: partial
         regexp: 'pq: password authentication failed for user'
-        log_record:
-          body: >-
-            Please ensure your user credentials are correctly specified with
-            `{{ configPropertyEnvVar "params" "username" "<username>" }}` and
-            `{{ configPropertyEnvVar "params" "password" "<password>" }}` environment variables.
+        message: >-
+          Please ensure your user credentials are correctly specified with
+          `{{ configPropertyEnvVar "params" "username" "<username>" }}` and
+          `{{ configPropertyEnvVar "params" "password" "<password>" }}` environment variables.
       - status: partial
         regexp: 'pq: database .* does not exist'
-        log_record:
-          body: >-
-            Make sure the target database is correctly specified using the
-            `{{ configPropertyEnvVar "masterDBName" "<db>" }}` environment variable.
+        message: >-
+          Make sure the target database is correctly specified using the
+          `{{ configPropertyEnvVar "masterDBName" "<db>" }}` environment variable.
       - status: partial
         regexp: 'pq: pg_stat_statements must be loaded via shared_preload_libraries'
-        log_record:
-          body: >-
-            Make sure your PostgreSQL database has
-            `shared_preload_libraries = 'pg_stat_statements'`
-            in the postgresql.conf file and that
-            `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
-            has been run for each database you would like to monitor.
-            For example:
-            `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`
+        message: >-
+          Make sure your PostgreSQL database has
+          `shared_preload_libraries = 'pg_stat_statements'`
+          in the postgresql.conf file and that
+          `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+          has been run for each database you would like to monitor.
+          For example:
+          `psql --dbname "<db-name>" -c "CREATE EXTENSION pg_stat_statements;"`

--- a/internal/confmapprovider/discovery/config_test.go
+++ b/internal/confmapprovider/discovery/config_test.go
@@ -238,30 +238,24 @@ var expectedConfig = Config{
 					"metrics": map[any]any{
 						"successful": []any{
 							map[any]any{
-								"strict": "postgres_block_hit_ratio",
-								"log_record": map[any]any{
-									"body": "postgresql SA receiver working!",
-								},
+								"strict":  "postgres_block_hit_ratio",
+								"message": "postgresql SA receiver working!",
 							},
 						},
 					},
 					"statements": map[any]any{
 						"failed": []any{
 							map[any]any{
-								"regexp": ".* connect: connection refused",
-								"log_record": map[any]any{
-									"body": "container appears to not be accepting postgres connections",
-								},
+								"regexp":  ".* connect: connection refused",
+								"message": "container appears to not be accepting postgres connections",
 							},
 						},
 						"partial": []any{
 							map[any]any{
 								"regexp": ".*pq: password authentication failed for user.*",
-								"log_record": map[any]any{
-									"body": "Please ensure that your password is correctly specified " +
-										"in `splunk.discovery.receivers.smartagent/postgresql.config.params.username` and " +
-										"`splunk.discovery.receivers.smartagent/postgresql.config.params.password`",
-								},
+								"message": "Please ensure that your password is correctly specified " +
+									"in `splunk.discovery.receivers.smartagent/postgresql.config.params.username` and " +
+									"`splunk.discovery.receivers.smartagent/postgresql.config.params.password`",
 							},
 						},
 					},
@@ -287,36 +281,28 @@ var expectedConfig = Config{
 					"metrics": map[any]any{
 						"successful": []any{
 							map[any]any{
-								"regexp": ".*",
-								"log_record": map[any]any{
-									"body": "smartagent/collectd-redis receiver successful metric status",
-								},
+								"regexp":  ".*",
+								"message": "smartagent/collectd-redis receiver successful metric status",
 							},
 						},
 					},
 					"statements": map[any]any{
 						"failed": []any{
 							map[any]any{
-								"regexp": `raise ValueError\(\"Unknown Redis response`,
-								"log_record": map[any]any{
-									"body": "container appears to not actually be redis",
-								},
+								"regexp":  `raise ValueError\(\"Unknown Redis response`,
+								"message": "container appears to not actually be redis",
 							},
 							map[any]any{
-								"regexp": "^redis_info plugin: Error connecting to .* - ConnectionRefusedError.*$",
-								"log_record": map[any]any{
-									"body": "container appears to not be accepting redis connections",
-								},
+								"regexp":  "^redis_info plugin: Error connecting to .* - ConnectionRefusedError.*$",
+								"message": "container appears to not be accepting redis connections",
 							},
 						},
 						"partial": []any{
 							map[any]any{
 								"regexp": "^redis_info plugin: Error .* - RedisError\\('-(WRONGPASS|NOAUTH|ERR AUTH).*$",
-								"log_record": map[any]any{
-									"body": "Please ensure that your redis password is correctly specified in " +
-										"`splunk.discovery.receivers.smartagent/collectd/redis.config.auth` or via the " +
-										"`SPLUNK_DISCOVERY_RECEIVERS_SMARTAGENT_COLLECTD_REDIS_CONFIG_AUTH` environment variable.",
-								},
+								"message": "Please ensure that your redis password is correctly specified in " +
+									"`splunk.discovery.receivers.smartagent/collectd/redis.config.auth` or via the " +
+									"`SPLUNK_DISCOVERY_RECEIVERS_SMARTAGENT_COLLECTD_REDIS_CONFIG_AUTH` environment variable.",
 							},
 						},
 					},

--- a/internal/confmapprovider/discovery/testdata/config.d/receivers/smartagent-collectd-redis.discovery.yaml
+++ b/internal/confmapprovider/discovery/testdata/config.d/receivers/smartagent-collectd-redis.discovery.yaml
@@ -11,19 +11,15 @@ smartagent/collectd/redis:
     metrics:
       successful:
         - regexp: '.*'
-          log_record:
-            body: smartagent/collectd-redis receiver successful metric status
+          message: smartagent/collectd-redis receiver successful metric status
     statements:
       failed:
         - regexp: 'raise ValueError\(\"Unknown Redis response'
-          log_record:
-            body: container appears to not actually be redis
+          message: container appears to not actually be redis
         - regexp: '^redis_info plugin: Error connecting to .* - ConnectionRefusedError.*$'
-          log_record:
-            body: container appears to not be accepting redis connections
+          message: container appears to not be accepting redis connections
       partial:
         - regexp: "^redis_info plugin: Error .* - RedisError\\('-(WRONGPASS|NOAUTH|ERR AUTH).*$"
-          log_record:
-            body: >-
+          message: >-
               Please ensure that your redis password is correctly specified in `splunk.discovery.receivers.smartagent/collectd/redis.config.auth`
               or via the `SPLUNK_DISCOVERY_RECEIVERS_SMARTAGENT_COLLECTD_REDIS_CONFIG_AUTH` environment variable.

--- a/internal/confmapprovider/discovery/testdata/config.d/receivers/smartagent-postgres.discovery.yaml
+++ b/internal/confmapprovider/discovery/testdata/config.d/receivers/smartagent-postgres.discovery.yaml
@@ -18,16 +18,13 @@ smartagent/postgresql:
     metrics:
       successful:
        - strict: postgres_block_hit_ratio
-         log_record:
-           body: postgresql SA receiver working!
+         message: postgresql SA receiver working!
     statements:
        failed:
          - regexp: '.* connect: connection refused'
-           log_record:
-             body: container appears to not be accepting postgres connections
+           message: container appears to not be accepting postgres connections
        partial:
          - regexp: '.*pq: password authentication failed for user.*'
-           log_record:
-             body: >-
+           message: >-
                Please ensure that your password is correctly specified in `splunk.discovery.receivers.smartagent/postgresql.config.params.username`
                and `splunk.discovery.receivers.smartagent/postgresql.config.params.password`

--- a/internal/receiver/discoveryreceiver/README.md
+++ b/internal/receiver/discoveryreceiver/README.md
@@ -93,20 +93,17 @@ receivers:
            metrics:
              - status: successful
                strict: mysql.locks
-               log_record:
-                 body: Mysql receiver is working!
+               message: Mysql receiver is working!
            statements:
              - status: failed
                regexp: "Can't connect to MySQL server on .* [(]111[)]"
-               log_record:
-                 body:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
+               message:  The container cannot be reached by the Collector. The container is refusing MySQL connections.
              - status: partial
                regexp: 'Access denied for user'
-               log_record:
-                 body: >-
-                   Make sure your user credentials are correctly specified using the
-                   `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_username="<username>"` and
-                   `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_password="<password>"` environment variables.
+               message: >-
+                 Make sure your user credentials are correctly specified using the
+                 `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_username="<username>"` and
+                 `SPLUNK_DISCOVERY_RECEIVERS_mysql_CONFIG_password="<password>"` environment variables.
 exporters:
   debug:
     verbosity: detailed

--- a/internal/receiver/discoveryreceiver/config.go
+++ b/internal/receiver/discoveryreceiver/config.go
@@ -75,17 +75,11 @@ type Status struct {
 // Match defines the rules for the desired match type and resulting log record
 // content emitted by the Discovery receiver
 type Match struct {
-	Status discovery.StatusType `mapstructure:"status"`
-	Record *LogRecord           `mapstructure:"log_record"`
-	Strict string               `mapstructure:"strict"`
-	Regexp string               `mapstructure:"regexp"`
-	Expr   string               `mapstructure:"expr"`
-}
-
-// LogRecord is a definition of the desired plog.LogRecord content to emit for a match.
-type LogRecord struct {
-	Attributes map[string]string `mapstructure:"attributes"`
-	Body       string            `mapstructure:"body"`
+	Status  discovery.StatusType `mapstructure:"status"`
+	Message string               `mapstructure:"message"`
+	Strict  string               `mapstructure:"strict"`
+	Regexp  string               `mapstructure:"regexp"`
+	Expr    string               `mapstructure:"expr"`
 }
 
 func (cfg *Config) Validate() error {

--- a/internal/receiver/discoveryreceiver/config_test.go
+++ b/internal/receiver/discoveryreceiver/config_test.go
@@ -55,39 +55,27 @@ func TestValidConfig(t *testing.T) {
 				Status: &Status{
 					Metrics: []Match{
 						{
-							Status: discovery.Successful,
-							Record: &LogRecord{
-								Attributes: map[string]string{
-									"attr_one": "attr_one_val",
-									"attr_two": "attr_two_val",
-								},
-								Body: "smartagent/redis receiver successful status",
-							},
-							Strict: "",
-							Regexp: ".*",
-							Expr:   "",
+							Status:  discovery.Successful,
+							Message: "smartagent/redis receiver successful status",
+							Strict:  "",
+							Regexp:  ".*",
+							Expr:    "",
 						},
 					},
 					Statements: []Match{
 						{
-							Status: discovery.Failed,
-							Strict: "",
-							Regexp: "ConnectionRefusedError",
-							Expr:   "",
-							Record: &LogRecord{
-								Attributes: map[string]string{},
-								Body:       "container appears to not be accepting redis connections",
-							},
+							Status:  discovery.Failed,
+							Strict:  "",
+							Regexp:  "ConnectionRefusedError",
+							Expr:    "",
+							Message: "container appears to not be accepting redis connections",
 						},
 						{
-							Status: discovery.Partial,
-							Strict: "",
-							Regexp: "(WRONGPASS|NOAUTH|ERR AUTH)",
-							Expr:   "",
-							Record: &LogRecord{
-								Attributes: nil,
-								Body:       "desired log invalid auth log body",
-							},
+							Status:  discovery.Partial,
+							Strict:  "",
+							Regexp:  "(WRONGPASS|NOAUTH|ERR AUTH)",
+							Expr:    "",
+							Message: "desired log invalid auth log body",
 						},
 					},
 				},

--- a/internal/receiver/discoveryreceiver/metric_evaluator.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator.go
@@ -117,19 +117,7 @@ func (m *metricEvaluator) evaluateMetrics(md pmetric.Metrics) {
 		m.correlateResourceAttributes(m.config, attrs, corr)
 
 		attrs[receiverRuleAttr] = rEntry.Rule.String()
-
-		desiredRecord := match.Record
-		if desiredRecord == nil {
-			desiredRecord = &LogRecord{}
-		}
-		var desiredMsg string
-		if desiredRecord.Body != "" {
-			desiredMsg = desiredRecord.Body
-		}
-		attrs[discovery.MessageAttr] = desiredMsg
-		for k, v := range desiredRecord.Attributes {
-			attrs[k] = v
-		}
+		attrs[discovery.MessageAttr] = match.Message
 		attrs[discovery.StatusAttr] = string(match.Status)
 		m.correlations.UpdateAttrs(endpointID, attrs)
 

--- a/internal/receiver/discoveryreceiver/metric_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator_test.go
@@ -58,12 +58,7 @@ func TestMetricEvaluation(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			match := tc.match
-			match.Record = &LogRecord{
-				Body: "desired body content",
-				Attributes: map[string]string{
-					"one": "one.value", "two": "two.value",
-				},
-			}
+			match.Message = "desired body content"
 			for _, status := range discovery.StatusTypes {
 				match.Status = status
 				t.Run(string(status), func(t *testing.T) {
@@ -133,8 +128,6 @@ func TestMetricEvaluation(t *testing.T) {
 						"discovery.receiver.type": "a_receiver",
 						"discovery.status":        string(status),
 						"discovery.message":       "desired body content",
-						"one":                     "one.value",
-						"two":                     "two.value",
 						"extra_attr":              "target_resource",
 					}, cStore.Attrs(endpointID))
 				})

--- a/internal/receiver/discoveryreceiver/statement_evaluator.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator.go
@@ -186,14 +186,7 @@ func (se *statementEvaluator) evaluateStatement(statement *statussources.Stateme
 		attrs[discovery.ReceiverNameAttr] = receiverID.Name()
 		attrs[discovery.MessageAttr] = statement.Message
 		attrs[receiverRuleAttr] = rEntry.Rule.String()
-
-		var desiredRecord LogRecord
-		if match.Record != nil {
-			desiredRecord = *match.Record
-		}
-		if desiredRecord.Body != "" {
-			attrs[discovery.MessageAttr] = desiredRecord.Body
-		}
+		attrs[discovery.MessageAttr] = match.Message
 
 		// set original message as "discovery.matched_log" attribute
 		attrs[matchedLogAttr] = statement.Message
@@ -201,11 +194,6 @@ func (se *statementEvaluator) evaluateStatement(statement *statussources.Stateme
 			attrs[matchedLogAttr] += fmt.Sprintf(" (error: %v)", err)
 		}
 
-		if len(desiredRecord.Attributes) > 0 {
-			for k, v := range desiredRecord.Attributes {
-				attrs[k] = v
-			}
-		}
 		attrs[discovery.StatusAttr] = string(match.Status)
 		se.correlations.UpdateAttrs(endpointID, attrs)
 

--- a/internal/receiver/discoveryreceiver/statement_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator_test.go
@@ -39,12 +39,7 @@ func TestStatementEvaluation(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			match := tc.match
-			match.Record = &LogRecord{
-				Body: "desired body content",
-				Attributes: map[string]string{
-					"attr.one": "attr.one.value", "attr.two": "attr.two.value",
-				},
-			}
+			match.Message = "desired body content"
 			for _, status := range discovery.StatusTypes {
 				match.Status = status
 				t.Run(string(status), func(t *testing.T) {
@@ -112,8 +107,6 @@ func TestStatementEvaluation(t *testing.T) {
 						"discovery.status":        string(status),
 						"discovery.message":       "desired body content",
 						"discovery.matched_log":   "desired.statement (error: some error)",
-						"attr.one":                "attr.one.value",
-						"attr.two":                "attr.two.value",
 					}, cStore.Attrs(endpointID))
 				})
 			}

--- a/internal/receiver/discoveryreceiver/testdata/config.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/config.yaml
@@ -18,18 +18,11 @@ discovery:
         metrics:
           - status: successful
             regexp: '.*'
-            log_record:
-              body: smartagent/redis receiver successful status
-              attributes:
-                attr_one: attr_one_val
-                attr_two: attr_two_val
+            message: smartagent/redis receiver successful status
         statements:
           - status: failed
             regexp: ConnectionRefusedError
-            log_record:
-              attributes: {}
-              body: container appears to not be accepting redis connections
+            message: container appears to not be accepting redis connections
           - status: partial
             regexp: (WRONGPASS|NOAUTH|ERR AUTH)
-            log_record:
-              body: desired log invalid auth log body
+            message: desired log invalid auth log body

--- a/tests/general/discoverymode/testdata/docker-observer-config.d/receivers/internal-prometheus.discovery.yaml
+++ b/tests/general/discoverymode/testdata/docker-observer-config.d/receivers/internal-prometheus.discovery.yaml
@@ -17,5 +17,4 @@ prometheus_simple:
     metrics:
       - status: successful
         strict: prometheus_tsdb_time_retentions_total
-        log_record:
-          body: prometheus detected
+        message: prometheus detected

--- a/tests/general/discoverymode/testdata/host-observer-config.d/receivers/internal-prometheus.discovery.yaml
+++ b/tests/general/discoverymode/testdata/host-observer-config.d/receivers/internal-prometheus.discovery.yaml
@@ -20,5 +20,4 @@ prometheus_simple:
     metrics:
       - status: successful
         strict: otelcol_process_uptime
-        log_record:
-          body: internal collector prometheus exporter detected
+        message: internal collector prometheus exporter detected

--- a/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
+++ b/tests/receivers/discovery/testdata/host_observer_simple_prometheus_config.yaml
@@ -21,22 +21,18 @@ receivers:
           metrics:
             - status: successful
               regexp: ^otelcol_process_uptime$
-              log_record:
-                body: Successfully connected to prometheus server
+              message: Successfully connected to prometheus server
           statements:
             # Only the first matching statement match will be applied
             - status: failed
               strict: Failed to scrape Prometheus endpoint
-              log_record:
-                body: (strict) Port appears to not be serving prometheus metrics
+              message: (strict) Port appears to not be serving prometheus metrics
             - status: failed
               regexp: '"message":"Failed to scrape Prometheus endpoint"'
-              log_record:
-                body: (regexp) Port appears to not be serving prometheus metrics
+              message: (regexp) Port appears to not be serving prometheus metrics
             - status: failed
               expr: message == 'Failed to scrape Prometheus endpoint' && target_labels contains 'up'
-              log_record:
-                body: (expr) Port appears to not be serving prometheus metrics
+              message: (expr) Port appears to not be serving prometheus metrics
 
     watch_observers:
       - host_observer

--- a/tests/receivers/mongodb/testdata/docker_observer_with_ssl_mongodb_config.yaml
+++ b/tests/receivers/mongodb/testdata/docker_observer_with_ssl_mongodb_config.yaml
@@ -17,28 +17,23 @@ receivers:
           metrics:
             - status: successful
               strict: mongodb.index.size
-              log_record:
-                body: mongodb receiver is working!
+              message: mongodb receiver is working!
           statements:
             - status: failed
               regexp: 'connect: network is unreachable'
-              log_record:
-                body: The container cannot be reached by the Collector. Make sure they're in the same network.
+              message: The container cannot be reached by the Collector. Make sure they're in the same network.
             - status: failed
               regexp: 'connect: connection refused'
-              log_record:
-                body: The container is refusing mongodb connections.
+              message: The container is refusing mongodb connections.
             - status: partial
               regexp: '.* unable to authenticate using mechanism .*'
-              log_record:
-                body: >-
+              message: >-
                     Please ensure your user credentials are correctly specified with
                     `{{ configPropertyEnvVar "username" "<username>" }}` and
                     `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
             - status: partial
               regexp: '.*not authorized on admin to execute command.*'
-              log_record:
-                body: >-
+              message: >-
                   Make sure the account used to access Mongodb has been given a clusterMonitor role in order to collect metrics.
                   `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`
     watch_observers:

--- a/tests/receivers/mongodb/testdata/docker_observer_without_ssl_mongodb_config.yaml
+++ b/tests/receivers/mongodb/testdata/docker_observer_without_ssl_mongodb_config.yaml
@@ -17,28 +17,23 @@ receivers:
           metrics:
             - status: successful
               strict: mongodb.index.size
-              log_record:
-                body: mongodb receiver is working!
+              message: mongodb receiver is working!
           statements:
             - status: failed
               regexp: 'connect: network is unreachable'
-              log_record:
-                body: The container cannot be reached by the Collector. Make sure they're in the same network.
+              message: The container cannot be reached by the Collector. Make sure they're in the same network.
             - status: failed
               regexp: 'connect: connection refused'
-              log_record:
-                body: The container is refusing mongodb connections.
+              message: The container is refusing mongodb connections.
             - status: partial
               regexp: '.* unable to authenticate using mechanism .*'
-              log_record:
-                body: >-
+              message: >-
                     Please ensure your user credentials are correctly specified with
                     `{{ configPropertyEnvVar "username" "<username>" }}` and
                     `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
             - status: partial
               regexp: '.*not authorized on admin to execute command.*'
-              log_record:
-                body: >-
+              message: >-
                   Make sure the account used to access Mongodb has been given a clusterMonitor role in order to collect metrics.
                   `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`
     watch_observers:

--- a/tests/receivers/mongodb/testdata/docker_observer_without_ssl_with_wrong_authentication_mongodb_config.yaml
+++ b/tests/receivers/mongodb/testdata/docker_observer_without_ssl_with_wrong_authentication_mongodb_config.yaml
@@ -17,28 +17,23 @@ receivers:
           metrics:
             - status: successful
               strict: mongodb.index.size
-              log_record:
-                body: mongodb receiver is working!
+              message: mongodb receiver is working!
           statements:
             - status: failed
               regexp: 'connect: network is unreachable'
-              log_record:
-                body: The container cannot be reached by the Collector. Make sure they're in the same network.
+              message: The container cannot be reached by the Collector. Make sure they're in the same network.
             - status: failed
               regexp: 'connect: connection refused'
-              log_record:
-                body: The container is refusing mongodb connections.
+              message: The container is refusing mongodb connections.
             - status: partial
               regexp: '.* unable to authenticate using mechanism .*'
-              log_record:
-                body: >-
+              message: >-
                     Please ensure your user credentials are correctly specified with
                     `{{ configPropertyEnvVar "username" "<username>" }}` and
                     `{{ configPropertyEnvVar "password" "<password>" }}` environment variables.
             - status: partial
               regexp: '.*not authorized on admin to execute command.*'
-              log_record:
-                body: >-
+              message: >-
                   Make sure the account used to access Mongodb has been given a clusterMonitor role in order to collect metrics.
                   `db.grantRolesToUser('someUser', [{ role: 'clusterMonitor', db: 'admin' }])`
     watch_observers:


### PR DESCRIPTION
`log_record` field isn't relevant anymore since we don't send discovery events as log records. The provided value is set to `discovery.message` entity attribute and sent to the backend on a regular basis. 

The additional `log_record.attributes` field is not being used. If needed in the future, it can be added as another field in the statement section itself.
