### PR TITLE
Upgrade golang to 1.21.11

### DIFF
--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -21,7 +21,7 @@ env:
   PYTHON_VERSION: '3.11'
   PIP_VERSION: '22.0.4'
   REQUIREMENTS_PATH: "internal/buildscripts/packaging/tests/requirements.txt"
-  GO_VERSION: 1.21.10
+  GO_VERSION: 1.21.11
 
 jobs:
   cross-compile:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.21.10
+  GO_VERSION: 1.21.11
 
 jobs:
   setup-environment:

--- a/.github/workflows/darwin-test.yml
+++ b/.github/workflows/darwin-test.yml
@@ -19,7 +19,7 @@ on:
       - '!internal/buildscripts/**'
 
 env:
-  GO_VERSION: '1.21.10'
+  GO_VERSION: '1.21.11'
 
 concurrency:
   group: darwin-test-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/gendependabot.yml
+++ b/.github/workflows/gendependabot.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/scripts/gendependabot.sh'
 
 env:
-  GO_VERSION: 1.21.10
+  GO_VERSION: 1.21.11
 
 jobs:
   gendependabot:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.21.10"
+  GO_VERSION: "1.21.11"
 jobs:
   agent-bundle-linux:
     runs-on: ubuntu-20.04

--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.21.10
+  GO_VERSION: 1.21.11
 
 jobs:
   lint:

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -30,7 +30,7 @@ env:
   PYTHON_VERSION: '3.11'
   PIP_VERSION: '22.0.4'
   REQUIREMENTS_PATH: "internal/buildscripts/packaging/tests/requirements.txt"
-  GO_VERSION: 1.21.10
+  GO_VERSION: 1.21.11
 
 jobs:
   setup-environment:

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -12,7 +12,7 @@ on:
       - '.snyk'
 
 env:
-  GO_VERSION: '1.21.10'
+  GO_VERSION: '1.21.11'
 
 concurrency:
   group: vuln-scans-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.21.10
+  GO_VERSION: 1.21.11
 
 jobs:
   setup-environment:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -18,7 +18,7 @@ on:
       - '!internal/buildscripts/**'
 
 env:
-  GO_VERSION: '1.21.10'
+  GO_VERSION: '1.21.11'
 
 concurrency:
   group: windows-test-${{ github.event.pull_request.number || github.ref }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,7 +121,7 @@ fossa:
       fi
 
 .go-cache:
-  image: '${DOCKER_HUB_REPO}/golang:1.21.10'
+  image: '${DOCKER_HUB_REPO}/golang:1.21.11'
   variables:
     GOPATH: "$CI_PROJECT_DIR/.go"
   before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 💡 Enhancements 💡
+
+- (Splunk) Upgrade golang to 1.21.11
+
 ## v0.102.0
 
 ### 🛑 Breaking changes 🛑

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/signalfx/splunk-otel-collector/internal/tools
 
 go 1.21.0
 
-toolchain go1.21.10
+toolchain go1.21.11
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/pkg/processor/timestampprocessor/go.mod
+++ b/pkg/processor/timestampprocessor/go.mod
@@ -2,7 +2,7 @@ module github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocesso
 
 go 1.21.0
 
-toolchain go1.21.10
+toolchain go1.21.11
 
 require (
 	github.com/stretchr/testify v1.9.0


### PR DESCRIPTION
For CVE-2024-24790, [GO-2024-2887](https://pkg.go.dev/vuln/GO-2024-2887)