### PR TITLE
Use msi capabilities for chef

### DIFF
--- a/deployments/chef/recipes/collector_win_config_options.rb
+++ b/deployments/chef/recipes/collector_win_config_options.rb
@@ -1,0 +1,29 @@
+# Cookbook:: splunk_otel_collector
+# Recipe:: collector_win_config_options
+
+collector_env_vars = [
+  { name: 'SPLUNK_ACCESS_TOKEN', type: :string, data: node['splunk_otel_collector']['splunk_access_token'].to_s },
+  { name: 'SPLUNK_API_URL', type: :string, data: node['splunk_otel_collector']['splunk_api_url'].to_s },
+  { name: 'SPLUNK_BUNDLE_DIR', type: :string, data: node['splunk_otel_collector']['splunk_bundle_dir'].to_s },
+  { name: 'SPLUNK_COLLECTD_DIR', type: :string, data: node['splunk_otel_collector']['splunk_collectd_dir'].to_s },
+  { name: 'SPLUNK_CONFIG', type: :string, data: node['splunk_otel_collector']['collector_config_dest'].to_s },
+  { name: 'SPLUNK_HEC_TOKEN', type: :string, data: node['splunk_otel_collector']['splunk_hec_token'].to_s },
+  { name: 'SPLUNK_HEC_URL', type: :string, data: node['splunk_otel_collector']['splunk_hec_url'].to_s },
+  { name: 'SPLUNK_INGEST_URL', type: :string, data: node['splunk_otel_collector']['splunk_ingest_url'].to_s },
+  { name: 'SPLUNK_REALM', type: :string, data: node['splunk_otel_collector']['splunk_realm'].to_s },
+  { name: 'SPLUNK_MEMORY_TOTAL_MIB', type: :string, data: node['splunk_otel_collector']['splunk_memory_total_mib'].to_s },
+  { name: 'SPLUNK_TRACE_URL', type: :string, data: node['splunk_otel_collector']['splunk_trace_url'].to_s },
+]
+
+unless node['splunk_otel_collector']['gomemlimit'].to_s.strip.empty?
+  collector_env_vars.push({ name: 'GOMEMLIMIT', type: :string, data: node['splunk_otel_collector']['gomemlimit'].to_s })
+end
+unless node['splunk_otel_collector']['splunk_listen_interface'].to_s.strip.empty?
+  collector_env_vars.push({ name: 'SPLUNK_LISTEN_INTERFACE', type: :string, data: node['splunk_otel_collector']['splunk_listen_interface'].to_s })
+end
+
+node['splunk_otel_collector']['collector_additional_env_vars'].each do |key, value|
+  collector_env_vars.push({ name: key, type: :string, data: value.to_s })
+end
+
+node['splunk_otel_collector']['collector_win_env_vars'] = collector_env_vars

--- a/deployments/chef/recipes/collector_win_config_options.rb
+++ b/deployments/chef/recipes/collector_win_config_options.rb
@@ -26,4 +26,4 @@ node['splunk_otel_collector']['collector_additional_env_vars'].each do |key, val
   collector_env_vars.push({ name: key, type: :string, data: value.to_s })
 end
 
-node['splunk_otel_collector']['collector_win_env_vars'] = collector_env_vars
+node.default['splunk_otel_collector']['collector_win_env_vars'] = collector_env_vars

--- a/deployments/chef/recipes/collector_win_install.rb
+++ b/deployments/chef/recipes/collector_win_install.rb
@@ -21,11 +21,11 @@ remote_file 'Download msi' do
 end
 
 msi_is_configurable = Gem::Version.new(collector_version) >= Gem::Version.new('0.98.0')
-node['splunk_otel_collector']['collector_msi_is_configurable'] = msi_is_configurable
+node.default['splunk_otel_collector']['collector_msi_is_configurable'] = msi_is_configurable
 msi_install_properties = node['splunk_otel_collector']['collector_win_env_vars']
-  .reject { |k, v| v.nil? || v == '' }
-  .map { |k, v| "#{k}=\"#{v}\"" }
-  .join(' ')
+                         .reject { |_, v| v.nil? || v == '' }
+                         .map { |k, v| "#{k}=\"#{v}\"" }
+                         .join(' ')
 
 windows_package 'splunk-otel-collector' do
   source "#{ENV['TEMP']}/splunk-otel-collector-#{collector_version}-amd64.msi"

--- a/deployments/chef/recipes/collector_win_install.rb
+++ b/deployments/chef/recipes/collector_win_install.rb
@@ -20,8 +20,16 @@ remote_file 'Download msi' do
   only_if { !::File.exist?(node['splunk_otel_collector']['collector_version_file']) || (::File.readlines(node['splunk_otel_collector']['collector_version_file']).first.strip != collector_version) }
 end
 
+msi_is_configurable = Gem::Version.new(collector_version) >= Gem::Version.new('0.98.0')
+node['splunk_otel_collector']['collector_msi_is_configurable'] = msi_is_configurable
+msi_install_properties = node['splunk_otel_collector']['collector_win_env_vars']
+  .reject { |k, v| v.nil? || v == '' }
+  .map { |k, v| "#{k}=\"#{v}\"" }
+  .join(' ')
+
 windows_package 'splunk-otel-collector' do
   source "#{ENV['TEMP']}/splunk-otel-collector-#{collector_version}-amd64.msi"
+  options msi_install_properties # If the MSI is not configurable, this will be ignored during installation.
   action :install
   notifies :restart, 'windows_service[splunk-otel-collector]', :delayed
   only_if { !::File.exist?(node['splunk_otel_collector']['collector_version_file']) || (::File.readlines(node['splunk_otel_collector']['collector_version_file']).first.strip != collector_version) }

--- a/deployments/chef/recipes/collector_win_install.rb
+++ b/deployments/chef/recipes/collector_win_install.rb
@@ -27,8 +27,6 @@ msi_install_properties = node['splunk_otel_collector']['collector_win_env_vars']
                          .map { |item| "#{item[:name]}=\"#{item[:data]}\"" }
                          .join(' ')
 
-puts("msi_install_properties: #{msi_install_properties}")
-
 windows_package 'splunk-otel-collector' do
   source "#{ENV['TEMP']}/splunk-otel-collector-#{collector_version}-amd64.msi"
   options msi_install_properties # If the MSI is not configurable, this will be ignored during installation.

--- a/deployments/chef/recipes/collector_win_install.rb
+++ b/deployments/chef/recipes/collector_win_install.rb
@@ -23,8 +23,8 @@ end
 msi_is_configurable = Gem::Version.new(collector_version) >= Gem::Version.new('0.98.0')
 node.default['splunk_otel_collector']['collector_msi_is_configurable'] = msi_is_configurable
 msi_install_properties = node['splunk_otel_collector']['collector_win_env_vars']
-                         .reject { |_, v| v.nil? || v == '' }
-                         .map { |k, v| "#{k}=\"#{v}\"" }
+                         .reject { |item| item[:data].nil? || item[:data] == '' }
+                         .map { |item| "#{item[:name]}=\"#{item[:data]}\"" }
                          .join(' ')
 
 puts("msi_install_properties: #{msi_install_properties}")

--- a/deployments/chef/recipes/collector_win_install.rb
+++ b/deployments/chef/recipes/collector_win_install.rb
@@ -27,6 +27,8 @@ msi_install_properties = node['splunk_otel_collector']['collector_win_env_vars']
                          .map { |k, v| "#{k}=\"#{v}\"" }
                          .join(' ')
 
+puts("msi_install_properties: #{msi_install_properties}")
+
 windows_package 'splunk-otel-collector' do
   source "#{ENV['TEMP']}/splunk-otel-collector-#{collector_version}-amd64.msi"
   options msi_install_properties # If the MSI is not configurable, this will be ignored during installation.

--- a/deployments/chef/recipes/collector_win_registry.rb
+++ b/deployments/chef/recipes/collector_win_registry.rb
@@ -1,30 +1,7 @@
 # Cookbook:: splunk_otel_collector
 # Recipe:: collector_win_registry
 
-collector_env_vars = [
-  { name: 'SPLUNK_ACCESS_TOKEN', type: :string, data: node['splunk_otel_collector']['splunk_access_token'].to_s },
-  { name: 'SPLUNK_API_URL', type: :string, data: node['splunk_otel_collector']['splunk_api_url'].to_s },
-  { name: 'SPLUNK_BUNDLE_DIR', type: :string, data: node['splunk_otel_collector']['splunk_bundle_dir'].to_s },
-  { name: 'SPLUNK_COLLECTD_DIR', type: :string, data: node['splunk_otel_collector']['splunk_collectd_dir'].to_s },
-  { name: 'SPLUNK_CONFIG', type: :string, data: node['splunk_otel_collector']['collector_config_dest'].to_s },
-  { name: 'SPLUNK_HEC_TOKEN', type: :string, data: node['splunk_otel_collector']['splunk_hec_token'].to_s },
-  { name: 'SPLUNK_HEC_URL', type: :string, data: node['splunk_otel_collector']['splunk_hec_url'].to_s },
-  { name: 'SPLUNK_INGEST_URL', type: :string, data: node['splunk_otel_collector']['splunk_ingest_url'].to_s },
-  { name: 'SPLUNK_REALM', type: :string, data: node['splunk_otel_collector']['splunk_realm'].to_s },
-  { name: 'SPLUNK_MEMORY_TOTAL_MIB', type: :string, data: node['splunk_otel_collector']['splunk_memory_total_mib'].to_s },
-  { name: 'SPLUNK_TRACE_URL', type: :string, data: node['splunk_otel_collector']['splunk_trace_url'].to_s },
-]
-
-unless node['splunk_otel_collector']['gomemlimit'].to_s.strip.empty?
-  collector_env_vars.push({ name: 'GOMEMLIMIT', type: :string, data: node['splunk_otel_collector']['gomemlimit'].to_s })
-end
-unless node['splunk_otel_collector']['splunk_listen_interface'].to_s.strip.empty?
-  collector_env_vars.push({ name: 'SPLUNK_LISTEN_INTERFACE', type: :string, data: node['splunk_otel_collector']['splunk_listen_interface'].to_s })
-end
-
-node['splunk_otel_collector']['collector_additional_env_vars'].each do |key, value|
-  collector_env_vars.push({ name: key, type: :string, data: value.to_s })
-end
+collector_env_vars = node['splunk_otel_collector']['collector_win_env_vars']
 
 collector_env_vars_strings = []
 collector_env_vars.each do |item|

--- a/deployments/chef/recipes/default.rb
+++ b/deployments/chef/recipes/default.rb
@@ -14,7 +14,7 @@ if platform_family?('windows')
 
   # Older MSI versions can't properly setup the collector configuration
   # in this case, we need to use the registry to set the environment variables.
-  if !node['splunk_otel_collector']['collector_msi_is_configurable']
+  unless node['splunk_otel_collector']['collector_msi_is_configurable']
     include_recipe 'splunk_otel_collector::collector_win_registry'
   end
 

--- a/deployments/chef/recipes/default.rb
+++ b/deployments/chef/recipes/default.rb
@@ -9,8 +9,14 @@ ruby_block 'splunk-access-token-unset' do
 end
 
 if platform_family?('windows')
+  include_recipe 'splunk_otel_collector::collector_win_config_options'
   include_recipe 'splunk_otel_collector::collector_win_install'
-  include_recipe 'splunk_otel_collector::collector_win_registry'
+
+  # Older MSI versions can't properly setup the collector configuration
+  # in this case, we need to use the registry to set the environment variables.
+  if !node['splunk_otel_collector']['collector_msi_is_configurable']
+    include_recipe 'splunk_otel_collector::collector_win_registry'
+  end
 
   directory ::File.dirname(node['splunk_otel_collector']['collector_config_dest']) do
     action :create


### PR DESCRIPTION
**Description:**
Leverage the latest MSI capabilities so we don't rely on custom Chef code to install the collector on Windows. At this point if the user wants to install only the collector on Windows they can directly use https://docs.chef.io/resources/windows_package/

The change itself move the handling of the configuration options (env. vars) to a step before installing the MSI. The MSI properties are passed on all versions since legacy versions would simply ignore the unknown properties. The code to setup the registry is only invoked when installing a MSI version that doesn't support the install properties.

**Testing:** CI

**Documentation:**
This change is not noticeable to end users, they can keep using the same settings that they used before.