### PR TITLE
Fix broken Tanzu doc links

### DIFF
--- a/deployments/cloudfoundry/bosh/README.md
+++ b/deployments/cloudfoundry/bosh/README.md
@@ -1,7 +1,7 @@
 # Splunk OpenTelemetry Collector BOSH Release
 
 This directory contains a BOSH Release of the [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector).
-The BOSH release can be used to deploy the collector so that it will act as a [Loggregator Firehose nozzle](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/nozzle.html).
+The BOSH release can be used to deploy the collector so that it will act as a [Loggregator Firehose nozzle](https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/tile-dev-guide/nozzle.html).
 
 ## Releasing
 

--- a/deployments/cloudfoundry/buildpack/README.md
+++ b/deployments/cloudfoundry/buildpack/README.md
@@ -5,7 +5,7 @@ the Splunk OpenTelemetry Collector for use with PCF apps.
 
 The buildpack's default functionality, as described in this document, is to deploy the OpenTelemetry Collector
 as a sidecar for the given app that's being deployed. The Collector is able to observe the app as a 
-[nozzle](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/nozzle.html) to
+[nozzle](https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/tile-dev-guide/nozzle.html) to
 the [Loggregator Firehose](https://docs.cloudfoundry.org/loggregator/architecture.html).
 The Loggregator Firehose is one of the architectures Cloud Foundry
 uses to emit logs and metrics. This means that the Splunk OpenTelemetry Collector will be observing all

--- a/deployments/cloudfoundry/tile/DEVELOPMENT.md
+++ b/deployments/cloudfoundry/tile/DEVELOPMENT.md
@@ -2,15 +2,15 @@
 
 ## VMware Tanzu Tile Documentation
 
-[Tanzu Tile Introduction](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/tile-basics.html)
+[Tanzu Tile Introduction](https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/tile-dev-guide/tile-basics.html)
 
-[How Tiles Work](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/tile-structure.html)
+[How Tiles Work](https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/tile-dev-guide/tile-structure.html)
 
 ## Tile Software Dependencies
 
-[Tile Generator](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/tile-generator.html)
+[Tile Generator](https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/tile-dev-guide/tile-generator.html)
 
-[PCF CLI](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/pcf-command.html)
+[PCF CLI](https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/tile-dev-guide/pcf-command.html)
 
 ## Development Workflow
 

--- a/deployments/cloudfoundry/tile/README.md
+++ b/deployments/cloudfoundry/tile/README.md
@@ -1,7 +1,7 @@
 # Splunk OpenTelemetry Collector Tanzu Tile
 
 This directory is used to generate a Tanzu tile of the [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector).
-The Tanzu tile uses the BOSH release to deploy the collector as a [loggregator firehose nozzle](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/nozzle.html).
+The Tanzu tile uses the BOSH release to deploy the collector as a [loggregator firehose nozzle](https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/tile-dev-guide/nozzle.html).
 
 ## Dependencies
 
@@ -10,7 +10,7 @@ The `release` script requires:
 - `jq`
 - `wget`
 - [Bosh CLI](https://bosh.io/docs/cli-v2-install/)
-- [Tile Generator](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/tile-generator.html)
+- [Tile Generator](https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/tile-dev-guide/tile-generator.html)
 
 ## Releasing
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Our `linkChecker` CI action [started failing](https://github.com/signalfx/splunk-otel-collector/actions/runs/9468176772/job/26083932834?pr=4969) due to broken Tanzu links. I contacted the Tanzu team and was informed that the URL has been moved from: 
```
https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/index.html
```
to
```
https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/tile-dev-guide/index.html
```
I've updated all links accordingly.