### PR TITLE
Check for token before running snyk scans

### DIFF
--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -10,6 +10,8 @@ on:
       - '.grype.yaml'
       - '.trivyignore'
       - '.snyk'
+  schedule:
+    - cron: '0 0 * * 1-5' # Every weekday at midnight UTC
 
 env:
   GO_VERSION: '1.21.11'
@@ -187,8 +189,24 @@ jobs:
       - run: choco install -y grype
       - run: grype --fail-on high --only-fixed -o table otelcol-windows:latest
 
+  check-snyk-token:
+    runs-on: ubuntu-latest
+    outputs:
+      has-snyk-token: ${{ steps.snyk-token-check.outputs.defined }}
+    steps:
+      - name: Check for snyk token
+        id: snyk-token-check
+        run: |
+          if [ -n "${{ secrets.SNYK_TOKEN }}" ]; then
+            echo "defined=true" >> $GITHUB_OUTPUT
+          else
+            echo "defined=false" >> $GITHUB_OUTPUT
+          fi
+
   snyk-fs-scan:
     runs-on: ubuntu-latest
+    needs: check-snyk-token
+    if: ${{ needs.check-snyk-token.outputs.has-snyk-token == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
@@ -206,24 +224,31 @@ jobs:
 
   snyk-docker-scan:
     runs-on: ubuntu-latest
-    needs: docker-otelcol
+    needs: [docker-otelcol, check-snyk-token]
+    if: ${{ needs.check-snyk-token.outputs.has-snyk-token == 'true' }}
     strategy:
       matrix:
         ARCH: [ "amd64", "arm64" ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+        if: ${{ matrix.ARCH != 'amd64' }}
+        with:
+          platforms: ${{ matrix.ARCH }}
+          image: tonistiigi/binfmt:qemu-v7.0.0
       - uses: actions/download-artifact@v4
         with:
           name: otelcol-${{ matrix.ARCH }}
           path: ./dist
       - run: docker load -i ./dist/image.tar
       - uses: snyk/actions/docker@master
+        continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: "otelcol:latest"
-          args: --file=cmd/otelcol/Dockerfile --severity-threshold=high --sarif-file-output=snyk.sarif --policy-path=.snyk
+          args: --file=cmd/otelcol/Dockerfile --severity-threshold=high --sarif-file-output=snyk.sarif --policy-path=.snyk --platform=linux/${{ matrix.ARCH }}
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
Run snyk scan jobs only if the token is available. The snyk token secret is unavailable for PRs from external contributors, including dependabot, which causes the workflow to fail.

Also:
- Run the vulnerability scan workflow every weekday at midnight
- Fix snyk scan for arm64 collector images