### PR TITLE
Use msi capabilities for puppet

### DIFF
--- a/.github/workflows/puppet-test.yml
+++ b/.github/workflows/puppet-test.yml
@@ -109,6 +109,8 @@ jobs:
       - name: Test puppet deployment
         id: pytest
         continue-on-error: true
+        env:
+          PUPPET_RELEASE: "${{ matrix.PUPPET_RELEASE }}"
         run: |
           distro="${{ matrix.DISTRO }}"
           if [[ "$distro" = "amazonlinux-2" ]]; then
@@ -122,12 +124,12 @@ jobs:
           fi
           python3 -u -m pytest -s --verbose -k "$tests" \
             internal/buildscripts/packaging/tests/deployments/puppet/puppet_test.py
-        env:
-          PUPPET_RELEASE: "${{ matrix.PUPPET_RELEASE }}"
 
       # qemu, networking, running systemd in containers, etc., can be flaky
       - name: Re-run failed tests
         if: ${{ steps.pytest.outcome == 'failure' }}
+        env:
+          PUPPET_RELEASE: "${{ matrix.PUPPET_RELEASE }}"
         run: |
           distro="${{ matrix.DISTRO }}"
           if [[ "$distro" = "amazonlinux-2" ]]; then
@@ -142,8 +144,6 @@ jobs:
           python3 -u -m pytest -s --verbose -k "$tests" \
             --last-failed \
             internal/buildscripts/packaging/tests/deployments/puppet/puppet_test.py
-        env:
-          PUPPET_RELEASE: "${{ matrix.PUPPET_RELEASE }}"
 
   puppet-test-windows:
     name: puppet-test-windows
@@ -157,6 +157,7 @@ jobs:
         OS: [ "windows-2022" ]
         PUPPET_RELEASE: [ "6.0.2", "7.21.0" ]
         TEST_CASE: [ "default", "custom_vars" ]
+        WIN_COLLECTOR_VERSION: [ "0.86.0", "latest" ]
       fail-fast: false
     steps:
       - name: Check out the codebase.
@@ -175,19 +176,23 @@ jobs:
       - name: Test puppet deployment
         id: pytest
         continue-on-error: true
+        env:
+          PUPPET_RELEASE: "${{ matrix.PUPPET_RELEASE }}"
+          WIN_COLLECTOR_VERSION: "${{ matrix.WIN_COLLECTOR_VERSION }}"
         run: |
+          if ($Env:WIN_COLLECTOR_VERSION -eq 'latest') { $Env:WIN_COLLECTOR_VERSION="$(curl -sS https://dl.signalfx.com/splunk-otel-collector/msi/release/latest.txt)" }
           pytest -s --verbose -m windows `
             -k ${{ matrix.TEST_CASE }} `
             internal/buildscripts/packaging/tests/deployments/puppet/puppet_test.py
-        env:
-          PUPPET_RELEASE: "${{ matrix.PUPPET_RELEASE }}"
 
       - name: Re-run failed tests
         if: ${{ steps.pytest.outcome == 'failure' }}
+        env:
+          PUPPET_RELEASE: "${{ matrix.PUPPET_RELEASE }}"
+          WIN_COLLECTOR_VERSION: "${{ matrix.WIN_COLLECTOR_VERSION }}"
         run: |
+          if ($Env:WIN_COLLECTOR_VERSION -eq 'latest') { $Env:WIN_COLLECTOR_VERSION="$(curl -sS https://dl.signalfx.com/splunk-otel-collector/msi/release/latest.txt)" }
           pytest -s --verbose -m windows `
             --last-failed `
             -k ${{ matrix.TEST_CASE }} `
             internal/buildscripts/packaging/tests/deployments/puppet/puppet_test.py
-        env:
-          PUPPET_RELEASE: "${{ matrix.PUPPET_RELEASE }}"

--- a/deployments/puppet/manifests/collector_win_config_options.pp
+++ b/deployments/puppet/manifests/collector_win_config_options.pp
@@ -1,0 +1,40 @@
+# Class for collecting the configuration options for the splunk-otel-collector service
+class splunk_otel_collector::collector_win_config_options {
+    $base_env_vars = {
+        'SPLUNK_ACCESS_TOKEN' => $splunk_otel_collector::splunk_access_token,
+        'SPLUNK_API_URL' => $splunk_otel_collector::splunk_api_url,
+        'SPLUNK_BUNDLE_DIR' => $splunk_otel_collector::splunk_bundle_dir,
+        'SPLUNK_COLLECTD_DIR' => $splunk_otel_collector::splunk_collectd_dir,
+        'SPLUNK_CONFIG' => $splunk_otel_collector::collector_config_dest,
+        'SPLUNK_HEC_TOKEN' => $splunk_otel_collector::splunk_hec_token,
+        'SPLUNK_HEC_URL' => $splunk_otel_collector::splunk_hec_url,
+        'SPLUNK_INGEST_URL' => $splunk_otel_collector::splunk_ingest_url,
+        'SPLUNK_MEMORY_TOTAL_MIB' => $splunk_otel_collector::splunk_memory_total_mib,
+        'SPLUNK_REALM' => $splunk_otel_collector::splunk_realm,
+        'SPLUNK_TRACE_URL' => $splunk_otel_collector::splunk_trace_url,
+    }
+
+    $ballast_size_mib = if $splunk_otel_collector::collector_version != 'latest' and
+        versioncmp($splunk_otel_collector::collector_version, '0.97.0') < 0 and
+        !$splunk_otel_collector::splunk_ballast_size_mib.strip().empty() {
+            { 'SPLUNK_BALLAST_SIZE_MIB' => $splunk_otel_collector::splunk_ballast_size_mib }
+        } else {
+            {}
+        }
+
+    $gomemlimit = if ($splunk_otel_collector::collector_version == 'latest' or
+        versioncmp($splunk_otel_collector::collector_version, '0.97.0') >= 0) and
+        !$splunk_otel_collector::gomemlimit.strip().empty() {
+            { 'GOMEMLIMIT' => $splunk_otel_collector::gomemlimit }
+        } else {
+            {}
+        }
+
+    $listen_interface = if !$splunk_otel_collector::splunk_listen_interface.strip().empty() {
+            { 'SPLUNK_LISTEN_INTERFACE' => $splunk_otel_collector::splunk_listen_interface }
+        } else {
+            {}
+        }
+
+    $collector_env_vars = stdlib::merge($base_env_vars, $ballast_size_mib, $gomemlimit, $listen_interface)
+}

--- a/deployments/puppet/manifests/collector_win_install.pp
+++ b/deployments/puppet/manifests/collector_win_install.pp
@@ -1,5 +1,7 @@
 # Download and install the splunk-otel-collector MSI on Windows
 class splunk_otel_collector::collector_win_install ($repo_url, $version, $package_name, $service_name) {
+  contain 'splunk_otel_collector::collector_win_config_options'
+
   $msi_name = "splunk-otel-collector-${version}-amd64.msi"
   $collector_path = "${::win_programfiles}\\Splunk\\OpenTelemetry Collector\\otelcol.exe"
   $registry_key = 'HKLM\SYSTEM\CurrentControlSet\Services\splunk-otel-collector'
@@ -11,8 +13,11 @@ class splunk_otel_collector::collector_win_install ($repo_url, $version, $packag
     }
 
     -> package { $package_name:
-      ensure => $version,
-      source => "${::win_temp}\\${msi_name}",
+      ensure          => $version,
+      source          => "${::win_temp}\\${msi_name}",
+      require         => Class['splunk_otel_collector::collector_win_config_options'],
+      # If the MSI is not configurable, the install_options below will be ignored during installation.
+      install_options => $splunk_otel_collector::collector_win_config_options::collector_env_vars,
     }
   }
 

--- a/deployments/puppet/manifests/collector_win_registry.pp
+++ b/deployments/puppet/manifests/collector_win_registry.pp
@@ -1,49 +1,29 @@
 # Class for setting the registry values for the splunk-otel-collector service
-class splunk_otel_collector::collector_win_registry () {
+class splunk_otel_collector::collector_win_registry {
+  # Ensure splunk_otel_collector::collector_win_config_options is applied first
+  require splunk_otel_collector::collector_win_config_options
+
   $unordered_collector_env_vars = $splunk_otel_collector::collector_additional_env_vars.map |$var, $value| {
     "${var}=${value}"
   }
-  + [
-    "SPLUNK_ACCESS_TOKEN=${splunk_otel_collector::splunk_access_token}",
-    "SPLUNK_API_URL=${splunk_otel_collector::splunk_api_url}",
-    "SPLUNK_BUNDLE_DIR=${splunk_otel_collector::splunk_bundle_dir}",
-    "SPLUNK_COLLECTD_DIR=${splunk_otel_collector::splunk_collectd_dir}",
-    "SPLUNK_CONFIG=${splunk_otel_collector::collector_config_dest}",
-    "SPLUNK_HEC_TOKEN=${splunk_otel_collector::splunk_hec_token}",
-    "SPLUNK_HEC_URL=${splunk_otel_collector::splunk_hec_url}",
-    "SPLUNK_INGEST_URL=${splunk_otel_collector::splunk_ingest_url}",
-    "SPLUNK_MEMORY_TOTAL_MIB=${splunk_otel_collector::splunk_memory_total_mib}",
-    "SPLUNK_REALM=${splunk_otel_collector::splunk_realm}",
-    "SPLUNK_TRACE_URL=${splunk_otel_collector::splunk_trace_url}",
-  ]
-  + if ($splunk_otel_collector::collector_version != 'latest' and
-  versioncmp($splunk_otel_collector::collector_version, '0.97.0') < 0 ) and
-  !$splunk_otel_collector::splunk_ballast_size_mib.strip().empty()
+  + if !empty($splunk_otel_collector::collector_additional_env_vars) or
+  versioncmp($splunk_otel_collector::collector_version, '0.98.0') < 0
   {
-    ["SPLUNK_BALLAST_SIZE_MIB=${splunk_otel_collector::splunk_ballast_size_mib}"]
-  } else {
-    []
-  }
-  + if ($splunk_otel_collector::collector_version == 'latest' or
-  versioncmp($splunk_otel_collector::collector_version, '0.97.0') >= 0 ) and
-  !$splunk_otel_collector::gomemlimit.strip().empty()
-  {
-    ["GOMEMLIMIT=${splunk_otel_collector::gomemlimit}"]
-  } else {
-    []
-  }
-  + if !$splunk_otel_collector::splunk_listen_interface.strip().empty() {
-    ["SPLUNK_LISTEN_INTERFACE=${splunk_otel_collector::splunk_listen_interface}"]
+    $splunk_otel_collector::collector_win_config_options::collector_env_vars.map |$var, $value| {
+      "${var}=${value}"
+    }
   } else {
     []
   }
 
   $collector_env_vars = sort($unordered_collector_env_vars)
 
-  registry_value { "HKLM\\SYSTEM\\CurrentControlSet\\Services\\splunk-otel-collector\\Environment":
-    ensure  => 'present',
-    type    => array,
-    data    => $collector_env_vars,
-    require => Registry_key["HKLM\\SYSTEM\\CurrentControlSet\\Services\\splunk-otel-collector"],
+  if !empty($collector_env_vars) {
+    registry_value { "HKLM\\SYSTEM\\CurrentControlSet\\Services\\splunk-otel-collector\\Environment":
+      ensure  => 'present',
+      type    => array,
+      data    => $collector_env_vars,
+      require => Registry_key["HKLM\\SYSTEM\\CurrentControlSet\\Services\\splunk-otel-collector"],
+    }
   }
 }

--- a/deployments/puppet/manifests/init.pp
+++ b/deployments/puppet/manifests/init.pp
@@ -195,9 +195,16 @@ class splunk_otel_collector (
       subscribe => [File[$collector_config_dest, $env_file_path]],
     }
   } else {
-    file { $collector_config_dest:
-      source  => $collector_config_source,
-      require => Class['splunk_otel_collector::collector_win_install'],
+    if $collector_config_source != $splunk_otel_collector::params::default_win_config_file {
+      file { $collector_config_dest:
+        source  => $collector_config_source,
+        require => Class['splunk_otel_collector::collector_win_install'],
+      }
+    } else {
+      file { $collector_config_dest:
+        ensure  => file,
+        require => Class['splunk_otel_collector::collector_win_install'],
+      }
     }
 
     -> class { 'splunk_otel_collector::collector_win_registry': }

--- a/deployments/puppet/manifests/params.pp
+++ b/deployments/puppet/manifests/params.pp
@@ -33,6 +33,7 @@ class splunk_otel_collector::params {
     $splunk_bundle_dir = "${collector_install_dir}\\agent-bundle"
     $splunk_collectd_dir = "${splunk_bundle_dir}\\run\\collectd"
     $collector_config_source = "${collector_install_dir}\\agent_config.yaml"
+    $default_win_config_file = $collector_config_source
     $collector_config_dest = "${collector_config_dir}\\agent_config.yaml"
     $fluentd_base_url = 'https://s3.amazonaws.com/packages.treasuredata.com'
     $fluentd_version = $fluentd_version_default

--- a/internal/buildscripts/packaging/tests/deployments/puppet/puppet_test.py
+++ b/internal/buildscripts/packaging/tests/deployments/puppet/puppet_test.py
@@ -429,6 +429,7 @@ WIN_PUPPET_MODULE_DEST_DIR = r"C:\ProgramData\PuppetLabs\code\environments\produ
 WIN_INSTALL_DIR = r"C:\Program Files\Splunk\OpenTelemetry Collector"
 WIN_CONFIG_PATH = r"C:\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml"
 
+WIN_COLLECTOR_VERSION = os.environ.get("WIN_COLLECTOR_VERSION", "123.456.789") # Windows require a pre-defined version, use an inexistent version to force a test failure 
 
 def run_win_puppet_setup(puppet_release):
     assert has_choco(), "choco not installed!"
@@ -466,7 +467,7 @@ def test_win_puppet_default():
     class {{ splunk_otel_collector:
         splunk_access_token => '{SPLUNK_ACCESS_TOKEN}',
         splunk_realm => '{SPLUNK_REALM}',
-        collector_version => '0.86.0',
+        collector_version => '{WIN_COLLECTOR_VERSION}',
     }}
     """
     run_win_puppet_agent(config)
@@ -496,7 +497,7 @@ def test_win_puppet_custom_vars():
 
     api_url = "https://fake-splunk-api.com"
     ingest_url = "https://fake-splunk-ingest.com"
-    config = CUSTOM_VARS_CONFIG.substitute(api_url=api_url, ingest_url=ingest_url, version="0.48.0")
+    config = CUSTOM_VARS_CONFIG.substitute(api_url=api_url, ingest_url=ingest_url, version=WIN_COLLECTOR_VERSION)
 
     run_win_puppet_agent(config)
 


### PR DESCRIPTION
**Description:**
Leverage the latest MSI capabilities so we don't rely on custom Puppet code to install the collector on Windows. At this point if the user wants to install only the collector on Windows they can directly use https://www.puppet.com/docs/puppet/8/types/package.html

The change itself move the handling of the configuration options (env. vars) to a step before installing the MSI. The MSI properties are passed on all versions since legacy versions would simply ignore the unknown properties. The code to setup the registry is only invoked when installing a MSI version that doesn't support the install properties or additional environment variables were specified for the setup (it is easy to setup everything in the registry than read the registry and merge the additional environment variables).

**Testing:**
Added tests in Windows to ensure that the latest version is being tested anyway.

**Documentation:**
This change is not noticeable to end users, they can keep using the same settings that they used before.