### PR TITLE
Reduce CI test flakiness of windows-test job

### DIFF
--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v4
 
+      - name: Ensure required ports in the dynamic range are available
+        run: |
+          $ErrorActionPreference = 'Continue'
+          & ${{ github.workspace }}\.github\workflows\scripts\win-required-ports.ps1
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Ensure that the required port on the Windows dynamic range is available prior to running the collector.

Many of the failures related to starting the collector on CI are due to the fact that a port in the dynamic range is taken by some applications on Windows. This change ensures that the required port is available for the Windows tests that start the collector with the default configuration.

Same was done for other Windows tests, `windows-test` was missed, see #4653