### PR TITLE
Fix ansible tests for centos 8

### DIFF
--- a/deployments/ansible/molecule/default/Dockerfile.j2
+++ b/deployments/ansible/molecule/default/Dockerfile.j2
@@ -1,10 +1,6 @@
 {% if item.image not in ["opensuse12", "opensuse15", "centos9"] %}
 FROM geerlingguy/docker-{{ item.image }}-ansible:latest
-{% if item.image == "centos8" %}
-RUN sed -i 's|#mirrorlist|mirrorlist|g' /etc/yum.repos.d/CentOS*.repo
-RUN sed -i 's|^baseurl|#baseurl|' /etc/yum.repos.d/CentOS*.repo
-RUN sed -i 's|\$releasever|8-stream|g' /etc/yum.repos.d/CentOS*.repo
-{% elif item.image == "debian9" %}
+{% if item.image == "debian9" %}
 RUN sed -i 's|http://.*.debian.org|http://archive.debian.org|' /etc/apt/sources.list
 RUN sed -i '/stretch-updates/d' /etc/apt/sources.list
 {% endif %}


### PR DESCRIPTION
Remove custom dockerfile instructions for the `centos-8` test image.