### PR TITLE
Fix chef tests

### DIFF
--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -25,6 +25,10 @@ defaults:
   run:
     working-directory: 'deployments/chef'
 
+env:
+  CHEF_VERSION: "22.12.1024"
+  CHEF_LICENSE: accept
+
 jobs:
   chef-lint-spec-test:
     name: chef-lint-spec-test
@@ -89,7 +93,7 @@ jobs:
       - name: Install chef
         uses: actionshub/chef-install@3.0.0
         with:
-          version: 21.12.720
+          version: ${{ env.CHEF_VERSION }}
 
       - run: kitchen test ${{ matrix.DISTRO }}
 
@@ -112,12 +116,10 @@ jobs:
       - name: Install chef
         uses: actionshub/chef-install@3.0.0
         with:
-          version: 21.12.720
+          version: ${{ env.CHEF_VERSION }}
 
       - name: Install kitchen-docker
-        run: |
-          chef env --chef-license accept
-          chef gem install kitchen-docker -v 2.12.0
+        run: chef gem install kitchen-docker -v 2.12.0
 
       - name: kitchen test ${{ matrix.SUITE }}-${{ matrix.DISTRO }}
         run: |

--- a/deployments/chef/kitchen.yml
+++ b/deployments/chef/kitchen.yml
@@ -3,6 +3,9 @@ driver:
   name: dokken
   chef_license: accept
   privileged: true
+  cgroupns_host: true
+  volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup:rw
 
 transport:
   name: dokken
@@ -22,43 +25,31 @@ platforms:
     driver:
       image: dokken/amazonlinux-2
       pid_one_command: /usr/lib/systemd/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: centos-7
     driver:
       image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: centos-8
     driver:
       image: dokken/centos-8
       pid_one_command: /usr/lib/systemd/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: centos-9
     driver:
       image: dokken/centos-stream-9
       pid_one_command: /usr/lib/systemd/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: rockylinux-8
     driver:
       image: dokken/rockylinux-8
       pid_one_command: /usr/lib/systemd/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: rockylinux-9
     driver:
       image: dokken/rockylinux-9
       pid_one_command: /usr/lib/systemd/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: debian-9
     driver:
@@ -67,29 +58,21 @@ platforms:
         RUN sed -i 's|http://.*.debian.org|http://archive.debian.org|' /etc/apt/sources.list
         RUN sed -i '/stretch-updates/d' /etc/apt/sources.list
       pid_one_command: /bin/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: debian-10
     driver:
       image: dokken/debian-10
       pid_one_command: /bin/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: debian-11
     driver:
       image: dokken/debian-11
       pid_one_command: /bin/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: debian-12
     driver:
       image: dokken/debian-12
       pid_one_command: /bin/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: opensuse-12
     driver:
@@ -109,50 +92,36 @@ platforms:
             rm -f /usr/lib/systemd/system/anaconda.target.wants/*;
         ENV init /sbin/init
       pid_one_command: /sbin/init
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: opensuse-15
     driver:
       image: dokken/opensuse-leap-15
       pid_one_command: /usr/lib/systemd/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: oraclelinux-7
     driver:
       image: dokken/oraclelinux-7
       pid_one_command: /usr/lib/systemd/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: oraclelinux-8
     driver:
       image: dokken/oraclelinux-8
       pid_one_command: /usr/lib/systemd/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04
       pid_one_command: /bin/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: ubuntu-22.04
     driver:
       image: dokken/ubuntu-22.04
       pid_one_command: /bin/systemd
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
 suites:
   - name: default


### PR DESCRIPTION
- Update chef workstation version to `22.12.1024` (versions 21.x have reached EOS)
- Update driver options for the updated `dokken` plugin included with the new chef workstation