### PR TITLE
Add Active Directory DS receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🚀 New components 🚀
 
 - (Splunk) Add [upstream](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/rabbitmqreceiver) Opentelemetry Collector RabbitMQ receiver ([#4980](https://github.com/signalfx/splunk-otel-collector/pull/4980))
-- (Splunk) Add Active Directory Domain Services Receiver
+- (Splunk) Add Active Directory Domain Services Receiver ([#4994](https://github.com/signalfx/splunk-otel-collector/pull/4994))
 
 ## v0.102.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🚀 New components 🚀
 
 - (Splunk) Add [upstream](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/rabbitmqreceiver) Opentelemetry Collector RabbitMQ receiver ([#4980](https://github.com/signalfx/splunk-otel-collector/pull/4980))
-- (Splunk) Add Active Directory Domain Services Receiver ([#4994](https://github.com/signalfx/splunk-otel-collector/pull/4994))
+- (Splunk) Add Active Directory Domain Services receiver ([#4994](https://github.com/signalfx/splunk-otel-collector/pull/4994))
 
 ## v0.102.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🚀 New components 🚀
 
 - (Splunk) Add [upstream](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/rabbitmqreceiver) Opentelemetry Collector RabbitMQ receiver ([#4980](https://github.com/signalfx/splunk-otel-collector/pull/4980))
+- (Splunk) Add Active Directory Domain Services Receiver
 
 ## v0.102.1
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -13,6 +13,7 @@ The distribution offers support for the following components.
 
 | Receivers                                                                                                                                     | Stability        |
 |:----------------------------------------------------------------------------------------------------------------------------------------------|:-----------------|
+| [active_directory_ds](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/activedirectorydsreceiver)       | [beta]           |
 | [awscontainerinsights](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscontainerinsightreceiver)      | [beta]           |
 | [awsecscontainermetrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver) | [beta]           |
 | [apache](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/apachereceiver)                                 | [alpha]          |

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.102.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.102.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.102.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.102.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.102.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.102.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.102.0

--- a/go.sum
+++ b/go.sum
@@ -1362,6 +1362,7 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsampling
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.102.0/go.mod h1:8hPQU8tprx79lDkMq4aqxU3WEurKYGVe9fM2p1VYN9I=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.102.0 h1:0TQZTCWFmOQ4OAEIvIV1Ds74X1d5kQYalYJFivsuqzo=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.102.0/go.mod h1:2T6Wk8q8IoUGtbigSs1/IHCUEt7Q7t+tNRtcKlZSw5M=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.102.0 h1:u6GSvTRVdDVWlR8GjZQ08RWa77Et0wtMt4zaqEIgKgw=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.102.0/go.mod h1:+51Evw9XySUq9xEmNpCbGvezpfxreDGRDaLCPKcaiOU=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.102.0 h1:5LREf19LeKhqNSwo3wItSy4JoSExjl6QNRB0Zj8T6DU=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.102.0/go.mod h1:AZmeqAcOp/ewg1mNbjB5krZOAnbELKTsZCEDT8ZzlkU=

--- a/go.sum
+++ b/go.sum
@@ -1362,6 +1362,7 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsampling
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.102.0/go.mod h1:8hPQU8tprx79lDkMq4aqxU3WEurKYGVe9fM2p1VYN9I=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.102.0 h1:0TQZTCWFmOQ4OAEIvIV1Ds74X1d5kQYalYJFivsuqzo=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.102.0/go.mod h1:2T6Wk8q8IoUGtbigSs1/IHCUEt7Q7t+tNRtcKlZSw5M=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.102.0/go.mod h1:+51Evw9XySUq9xEmNpCbGvezpfxreDGRDaLCPKcaiOU=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.102.0 h1:5LREf19LeKhqNSwo3wItSy4JoSExjl6QNRB0Zj8T6DU=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.102.0/go.mod h1:AZmeqAcOp/ewg1mNbjB5krZOAnbELKTsZCEDT8ZzlkU=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.102.0 h1:6rv1z6GzSzbfOvukVp5hmDJ7+6dt2D29cIWBc8mLAjA=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -54,6 +54,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver"
@@ -152,6 +153,7 @@ func Get() (otelcol.Factories, error) {
 	}
 
 	receivers, err := receiver.MakeFactoryMap(
+		activedirectorydsreceiver.NewFactory(),
 		awscontainerinsightreceiver.NewFactory(),
 		awsecscontainermetricsreceiver.NewFactory(),
 		apachereceiver.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -43,7 +43,7 @@ func TestDefaultComponents(t *testing.T) {
 		"file_storage",
 	}
 	expectedReceivers := []string{
-		"activedirectorydsreceiver",
+		"active_directory_ds",
 		"awscontainerinsightreceiver",
 		"awsecscontainermetrics",
 		"azureeventhub",

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -43,6 +43,7 @@ func TestDefaultComponents(t *testing.T) {
 		"file_storage",
 	}
 	expectedReceivers := []string{
+		"activedirectorydsreceiver",
 		"awscontainerinsightreceiver",
 		"awsecscontainermetrics",
 		"azureeventhub",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Add upstream [Active Directory DS receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/activedirectorydsreceiver) to the Splunk distro.
