### PR TITLE
Fix osfamily Fact

### DIFF
--- a/deployments/puppet/manifests/params.pp
+++ b/deployments/puppet/manifests/params.pp
@@ -26,7 +26,7 @@ class splunk_otel_collector::params {
     $auto_instrumentation_version = 'latest'
     $auto_instrumentation_java_agent_jar = '/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
 
-  } elsif $::osfamily == 'windows' {
+  } elsif $::osfamily == 'windows' or $::family == 'windows' {
     $collector_version = ''
     $collector_install_dir = "${::win_programfiles}\\Splunk\\OpenTelemetry Collector"
     $collector_config_dir = "${::win_programdata}\\Splunk\\OpenTelemetry Collector"


### PR DESCRIPTION


**Description:** 

Team, 

I am configuring the Splunk OTEL Collector using the puppet module and we encountered the issue that the osfamily was not part of the supported family. 

This is a windows box running Puppet 8.4.0, in this version puppet removed osfamily as mentioned here https://www.puppet.com/docs/puppet/8/core_facts.html#osfamily, it is currently a legacy fact. 

However, there is another server running a Puppet 6.17.0 and the osfamily exists there. 

Based on the forge https://forge.puppet.com/modules/signalfx/splunk_otel_collector/readme We support 6+

**Link to Splunk idea:** None

**Testing:** Explained above. Screenshots attached

**Documentation:** 
https://www.puppet.com/docs/puppet/8/core_facts.html#osfamily
https://forge.puppet.com/modules/signalfx/splunk_otel_collector/readme

Left side: Latest version
Right Side: Old version

![image](https://github.com/signalfx/splunk-otel-collector/assets/61165159/2833cf84-d881-4b6f-8ac2-1264da56688d)
![image](https://github.com/signalfx/splunk-otel-collector/assets/61165159/3c66bf03-43fd-4a18-8483-c7ba3a8f916c)
