### PR TITLE
added to components.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - (Splunk) Add Azure Monitor receiver ([#4971](https://github.com/signalfx/splunk-otel-collector/pull/4971))
 - (Splunk) Add [upstream](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/rabbitmqreceiver) Opentelemetry Collector RabbitMQ receiver ([#4980](https://github.com/signalfx/splunk-otel-collector/pull/4980))
 - (Splunk) Add Active Directory Domain Services receiver ([#4994](https://github.com/signalfx/splunk-otel-collector/pull/4994))
+- (Splunk) Add Splunk Enterprise receiver ([]())
 
 ## v0.102.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - (Splunk) Add Azure Monitor receiver ([#4971](https://github.com/signalfx/splunk-otel-collector/pull/4971))
 - (Splunk) Add [upstream](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/rabbitmqreceiver) Opentelemetry Collector RabbitMQ receiver ([#4980](https://github.com/signalfx/splunk-otel-collector/pull/4980))
 - (Splunk) Add Active Directory Domain Services receiver ([#4994](https://github.com/signalfx/splunk-otel-collector/pull/4994))
-- (Splunk) Add Splunk Enterprise receiver ([]())
+- (Splunk) Add Splunk Enterprise receiver ([#4998](https://github.com/signalfx/splunk-otel-collector/pull/4998))
 
 ## v0.102.1
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -12,8 +12,8 @@ The distribution offers support for the following components.
 <div>
 
 | Receivers                                                                                                                                     | Stability        |
-|:----------------------------------------------------------------------------------------------------------------------------------------------|:-----------------|
-| [active_directory_ds](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/activedirectorydsreceiver)       | [beta]           |
+| :-------------------------------------------------------------------------------------------------------------------------------------------- | :--------------- |
+| [active_directory_ds](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/activedirectorydsreceiver)         | [beta]           |
 | [awscontainerinsights](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscontainerinsightreceiver)      | [beta]           |
 | [awsecscontainermetrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver) | [beta]           |
 | [apache](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/apachereceiver)                                 | [alpha]          |
@@ -52,6 +52,7 @@ The distribution offers support for the following components.
 | [simpleprometheus](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/simpleprometheusreceiver)             | [beta]           |
 | [smartagent](../pkg/receiver/smartagentreceiver)                                                                                              | [beta]           |
 | [solace](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/solacereceiver)                                 | [beta]           |
+| [splunkenterprise](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/splunkenterprisereceiver)             | [beta]           |
 | [splunk_hec](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/splunkhecreceiver)                          | [beta]           |
 | [sqlquery](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlqueryreceiver)                             | [alpha]          |
 | [sqlserver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlserverreceiver)                           | [beta]           |
@@ -71,7 +72,7 @@ The distribution offers support for the following components.
 <div>
 
 | Processors                                                                                                                                  | Stability        |
-|:--------------------------------------------------------------------------------------------------------------------------------------------|:-----------------|
+| :------------------------------------------------------------------------------------------------------------------------------------------ | :--------------- |
 | [attributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor)                     | [alpha]          |
 | [batch](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor)                                       | [beta]           |
 | [cumulativetodelta](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor)       | [beta]           |
@@ -96,7 +97,7 @@ The distribution offers support for the following components.
 <div>
 
 | Exporters                                                                                                                   | Stability        |
-|:----------------------------------------------------------------------------------------------------------------------------|:-----------------|
+| :-------------------------------------------------------------------------------------------------------------------------- | :--------------- |
 | [awss3](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awss3exporter)                 | [alpha]          |
 | [debug](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter)                         | [in development] |
 | [file](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter)                   | [alpha]          |
@@ -116,7 +117,7 @@ The distribution offers support for the following components.
 <div>
 
 | Extensions                                                                                                                          | Stability |
-|:------------------------------------------------------------------------------------------------------------------------------------|:----------|
+| :---------------------------------------------------------------------------------------------------------------------------------- | :-------- |
 | [ack](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/ackextension)                           | [alpha]   |
 | [basicauth](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension)               | [beta]    |
 | [docker_observer](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/dockerobserver)    | [beta]    |
@@ -138,7 +139,7 @@ The distribution offers support for the following components.
 <div>
 
 | Connectors                                                                                                                | Stability        |
-|:--------------------------------------------------------------------------------------------------------------------------|:-----------------|
+| :------------------------------------------------------------------------------------------------------------------------ | :--------------- |
 | [count](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/countconnector)             | [in development] |
 | [forward](https://github.com/open-telemetry/opentelemetry-collector/tree/main/connector/forwardconnector)                 | [beta]           |
 | [routing](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/routingconnector)         | [alpha]          |

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver v0.103.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver v0.103.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver v0.103.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver v0.103.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver v0.103.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.103.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.103.0

--- a/go.sum
+++ b/go.sum
@@ -1438,6 +1438,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometh
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver v0.103.0/go.mod h1:ofMwxpiAs54Cuv09BD2hW1lLZeD62GRtfTqrz/+1S18=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver v0.103.0 h1:8NSskDiAYnj36SBkx4/v3m+Z19Pitxt9LaqBvdu/s0c=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver v0.103.0/go.mod h1:ylHnYxVBISeZQjOaVPzqls7RdUZun0O+Wxq+pMwbqIg=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver v0.103.0 h1:RXtOEaWvKSq/IbI5xRL42EkeZMAipPT7og57BXrfMBI=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver v0.103.0/go.mod h1:Qf2FyVol5xSyMT4rMO6NaS++jW338PKXCFgOe66IiIY=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver v0.103.0 h1:scBYx7i02BIGGrv3B5G8NY+hkBPnU4UZj4MBX/+G8II=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver v0.103.0/go.mod h1:yKcoARhrC8afaaft7trvIqbPR38VYfgSSrzdhF7rFNI=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.103.0 h1:O6KqVBEJgwPS6A+vZBRSZiztQLpX3VmYnJ4l4+xx+Ek=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -89,6 +89,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver"
@@ -195,6 +196,7 @@ func Get() (otelcol.Factories, error) {
 		simpleprometheusreceiver.NewFactory(),
 		smartagentreceiver.NewFactory(),
 		solacereceiver.NewFactory(),
+		splunkenterprisereceiver.NewFactory(),
 		splunkhecreceiver.NewFactory(),
 		sqlqueryreceiver.NewFactory(),
 		sqlserverreceiver.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -84,6 +84,7 @@ func TestDefaultComponents(t *testing.T) {
 		"signalfxgatewayprometheusremotewrite",
 		"smartagent",
 		"solace",
+		"splunkenterprise",
 		"splunk_hec",
 		"sqlquery",
 		"sqlserver",


### PR DESCRIPTION
**Description:** 

Added upstream [Splunk Enterprise](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/splunkenterprisereceiver) receiver to the Splunk-otelcol distro.