### PR TITLE
Added Mongodb versions 6.0 and 7.0 to the list of auto discovery inte…

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -339,7 +339,7 @@ jobs:
           for service in "mongodb" "kafkametrics"; do
             for arch in "amd64" "arm64"; do
               if [ "$service" = "mongodb" ]; then
-                for mongodb_version in "4.0" "4.4" "5.0"; do
+                for mongodb_version in "4.0" "4.4" "5.0" "6.0" "7.0"; do
                   includes="${includes},{\"SERVICE\": \"${service}\", \"ARCH\": \"${arch}\", \"MONGODB_VERSION\": \"${mongodb_version}\"}"
                 done
               else

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
@@ -21,7 +21,6 @@
 #         insecure: false
 #       hosts:
 #         - endpoint: '`endpoint`'
-#           transport: tcp
 #       timeout: 5s
 #   status:
 #     metrics:

--- a/docker/mongodb/scripts/run.sh
+++ b/docker/mongodb/scripts/run.sh
@@ -1,22 +1,36 @@
 #!/bin/bash
 
+VER=${1}
+
+run_mongo_commandline () {
+if (( $(echo "$VER > 5.9" | bc -l) )); then
+    nohup gosu mongodb mongosh admin --eval "help" > /dev/null 2>&1
+else
+    nohup gosu mongodb mongo admin --eval "help" > /dev/null 2>&1
+fi
+}
+
 sleep 5
 
 chown -R mongodb:mongodb /home/mongodb
 
 nohup gosu mongodb mongod --dbpath=/data/db &
 
-nohup gosu mongodb mongo admin --eval "help" > /dev/null 2>&1
+run_mongo_commandline $VER
+
 RET=$?
 
 while [[ "$RET" -ne 0 ]]; do
   echo "Waiting for MongoDB to start..."
-  mongo admin --eval "help" > /dev/null 2>&1
+  run_mongo_commandline $VER
   RET=$?
   sleep 2
 done
 
-bash /home/mongodb/scripts/setup_user.sh
-
+if (( $(echo "$VER > 5.9" | bc -l) )); then
+    bash /home/mongodb/scripts/setup_user_newer_ver.sh
+else
+    bash /home/mongodb/scripts/setup_user.sh
+fi
 
 gosu mongodb mongod --dbpath=/data/db --config mongod.conf

--- a/docker/mongodb/scripts/setup_user_newer_ver.sh
+++ b/docker/mongodb/scripts/setup_user_newer_ver.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+echo "************************************************************"
+echo "Setting up users..."
+echo "************************************************************"
+
+setup_permissions() {
+  mongosh <<EOF
+  use admin
+  db.createUser( { user: "user1",
+                 pwd: "user1",
+                 customData: { employeeId: 12345 },
+                 roles: [ { role: "clusterMonitor", db: "admin" },
+                          { role: "readAnyDatabase", db: "admin" },
+                          "readWrite"] },
+               { w: "majority" , wtimeout: 500000 } );
+EOF
+}
+
+
+echo "Configuring ${USER} permissions. . ."
+end=$((SECONDS+20))
+while [ $SECONDS -lt $end ]; do
+    if setup_permissions; then
+        echo "Permissions configured!"
+        break
+    fi
+    echo "Trying again in 5 seconds. . ."
+    sleep 5
+done
+
+# create root user
+nohup gosu mongodb mongosh DBNAME --eval "db.createUser({user: 'admin1', pwd: 'pass1', roles:[{ role: 'root', db: 'admin' }, { role: 'read', db: 'local' }]});"
+
+# create app user/database
+nohup gosu mongodb mongosh DBNAME --eval "db.createUser({ user: 'NEWUSER', pwd: 'PASSWORD', roles: [{ role: 'readWrite', db: 'admin' }, { role: 'read', db: 'local' }]});"
+
+
+nohup gosu mongodb mongosh DBNAME --eval "db.createUser({ user: 'testUser', pwd: 'testPass', roles: [{ role: 'clusterMonitor', db: 'admin' }, { role: 'read', db: 'local' }]});"
+
+
+echo "************************************************************"
+echo "Shutting down"
+echo "************************************************************"
+nohup gosu mongodb mongosh admin --eval "db.shutdownServer();"

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
@@ -17,7 +17,6 @@ mongodb:
         insecure: false
       hosts:
         - endpoint: '`endpoint`'
-          transport: tcp
       timeout: 5s
   status:
     metrics:

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
@@ -13,7 +13,6 @@
         insecure: false
       hosts:
         - endpoint: '`endpoint`'
-          transport: tcp
       timeout: 5s
   status:
     metrics:


### PR DESCRIPTION
…gration tests

**Description:** added support for Mongodb 6.0 and 7.0 auto-discovery integration tests. Also fixed Mongodb discovery . `transport: tcp` is no longer valid config.

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
