### PR TITLE
puppet: Use structured os.family hash fact

### DIFF
--- a/.github/workflows/puppet-test.yml
+++ b/.github/workflows/puppet-test.yml
@@ -72,9 +72,10 @@ jobs:
             exit 1
           fi
           distro=$(for d in $dockerfiles; do echo -n "\"$d\","; done)
-          puppet_release='"6","7"'
+          puppet_release='"6","7","8"'
           with_instrumentation='"true","false"'
-          matrix="{\"DISTRO\": [${distro%,}], \"PUPPET_RELEASE\": [${puppet_release}], \"WITH_INSTRUMENTATION\": [${with_instrumentation}]}"
+          exclude='{"DISTRO": "debian-stretch", "PUPPET_RELEASE": "8"}, {"DISTRO": "ubuntu-xenial", "PUPPET_RELEASE": "8"}'  # puppet 8 not supported for these distros
+          matrix="{\"DISTRO\": [${distro%,}], \"PUPPET_RELEASE\": [${puppet_release}], \"WITH_INSTRUMENTATION\": [${with_instrumentation}], \"exclude\": [${exclude}]}"
           echo "$matrix" | jq
           echo "matrix=${matrix}" >> $GITHUB_OUTPUT
     outputs:
@@ -155,7 +156,7 @@ jobs:
     strategy:
       matrix:
         OS: [ "windows-2022" ]
-        PUPPET_RELEASE: [ "6.0.2", "7.21.0" ]
+        PUPPET_RELEASE: [ "6.0.2", "7.21.0", "8.1.0" ]
         TEST_CASE: [ "default", "custom_vars" ]
         WIN_COLLECTOR_VERSION: [ "0.86.0", "latest" ]
       fail-fast: false

--- a/deployments/puppet/CHANGELOG.md
+++ b/deployments/puppet/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## puppet-v0.17.0
+
+- Use `$facts['os']['family']` instead of the legacy `$::osfamily` fact
+
 ## puppet-v0.16.0
 
 - Initial support for [Splunk OpenTelemetry for .NET](https://github.com/signalfx/splunk-otel-dotnet) Auto

--- a/deployments/puppet/lib/facter/win_collector_path.rb
+++ b/deployments/puppet/lib/facter/win_collector_path.rb
@@ -2,7 +2,7 @@
 # Returns empty string if the key or the path does not exist.
 
 Facter.add(:win_collector_path) do
-  confine :osfamily => :windows
+  confine :kernel => 'windows'
   setcode do
     begin
       value = ''

--- a/deployments/puppet/lib/facter/win_collector_version.rb
+++ b/deployments/puppet/lib/facter/win_collector_version.rb
@@ -2,7 +2,7 @@
 # Returns empty string if the key does not exist.
 
 Facter.add(:win_collector_version) do
-  confine :osfamily => :windows
+  confine :kernel => 'windows'
   setcode do
     begin
       value = ''

--- a/deployments/puppet/lib/facter/win_programdata.rb
+++ b/deployments/puppet/lib/facter/win_programdata.rb
@@ -1,7 +1,7 @@
 # Returns the PROGRAMDATA env var on windows
 
 Facter.add(:win_programdata) do
-  confine :osfamily => :windows
+  confine :kernel => 'windows'
   setcode do
     ENV['PROGRAMDATA']
   end

--- a/deployments/puppet/lib/facter/win_programfiles.rb
+++ b/deployments/puppet/lib/facter/win_programfiles.rb
@@ -1,7 +1,7 @@
 # Returns the PROGRAMFILES env var on windows
 
 Facter.add(:win_programfiles) do
-  confine :osfamily => :windows
+  confine :kernel => 'windows'
   setcode do
     ENV['PROGRAMFILES']
   end

--- a/deployments/puppet/lib/facter/win_systemdrive.rb
+++ b/deployments/puppet/lib/facter/win_systemdrive.rb
@@ -1,7 +1,7 @@
 # Returns the SystemDrive env var on windows
 
 Facter.add(:win_systemdrive) do
-  confine :osfamily => :windows
+  confine :kernel => 'windows'
   setcode do
     ENV['SystemDrive']
   end

--- a/deployments/puppet/lib/facter/win_temp.rb
+++ b/deployments/puppet/lib/facter/win_temp.rb
@@ -1,7 +1,7 @@
 # Returns the TEMP env var on windows
 
 Facter.add(:win_temp) do
-  confine :osfamily => :windows
+  confine :kernel => 'windows'
   setcode do
     ENV['TEMP']
   end

--- a/deployments/puppet/manifests/collector_service_owner.pp
+++ b/deployments/puppet/manifests/collector_service_owner.pp
@@ -22,7 +22,7 @@ class splunk_otel_collector::collector_service_owner ($service_name, $service_us
         noop => true, }
     }
     else {
-      $shell = $::osfamily ? {
+      $shell = $facts['os']['family'] ? {
         'debian' => '/usr/sbin/nologin',
         default  => '/sbin/nologin',
       }

--- a/deployments/puppet/manifests/params.pp
+++ b/deployments/puppet/manifests/params.pp
@@ -4,7 +4,7 @@ class splunk_otel_collector::params {
   $fluentd_version_stretch = '3.7.1-0'
   $collector_additional_env_vars = {}
 
-  if $::osfamily == 'redhat' or $::osfamily == 'debian' or $::osfamily == 'suse' {
+  if $facts['os']['family'] == 'redhat' or $facts['os']['family'] == 'debian' or $facts['os']['family'] == 'suse' {
     $collector_version = 'latest'
     $collector_config_dir = '/etc/otel/collector'
     $fluentd_config_dir = "${collector_config_dir}/fluentd"
@@ -13,7 +13,7 @@ class splunk_otel_collector::params {
     $collector_config_source = "${collector_config_dir}/agent_config.yaml"
     $collector_config_dest = $collector_config_source
     $fluentd_base_url = 'https://packages.treasuredata.com'
-    if $::osfamily == 'debian' {
+    if $facts['os']['family'] == 'debian' {
       $fluentd_version = downcase($facts['os']['distro']['codename']) ? {
         'stretch' => $fluentd_version_stretch,
         default   => "${fluentd_version_default}-1",
@@ -26,7 +26,7 @@ class splunk_otel_collector::params {
     $auto_instrumentation_version = 'latest'
     $auto_instrumentation_java_agent_jar = '/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
 
-  } elsif $::osfamily == 'windows' {
+  } elsif $facts['os']['family'] == 'windows' {
     $collector_version = ''
     $collector_install_dir = "${::win_programfiles}\\Splunk\\OpenTelemetry Collector"
     $collector_config_dir = "${::win_programdata}\\Splunk\\OpenTelemetry Collector"
@@ -42,6 +42,6 @@ class splunk_otel_collector::params {
     $auto_instrumentation_version = ''
     $auto_instrumentation_java_agent_jar = ''
   } else {
-    fail("Your OS (${::osfamily}) is not supported by the Splunk OpenTelemetry Collector")
+    fail("Your OS (${facts['os']['family']}) is not supported by the Splunk OpenTelemetry Collector")
   }
 }

--- a/deployments/puppet/metadata.json
+++ b/deployments/puppet/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx-splunk_otel_collector",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "Splunk, Inc.",
   "summary": "This module installs the Splunk OpenTelemetry Collector via distro packages and configures it.",
   "license": "Apache-2.0",
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 4.1.0 <= 7.0.0"
+      "version_requirement": ">= 4.1.0"
     },
     {
       "name": "puppet/yum",

--- a/deployments/puppet/spec/classes/init_spec.rb
+++ b/deployments/puppet/spec/classes/init_spec.rb
@@ -9,15 +9,9 @@ describe 'splunk_otel_collector' do
   end
 
   on_supported_os.each do |os, facts|
-    if os.include? "windows"
-        next
-    end
+    let(:facts) { facts }
     context "on #{os}" do
       let(:params) { { 'splunk_access_token' => "testing", 'splunk_realm' => 'test' } }
-      let(:facts) do
-        facts
-      end
-
       it { is_expected.to compile.with_all_deps }
     end
   end

--- a/internal/buildscripts/packaging/tests/deployments/puppet/images/deb/Dockerfile.debian-bullseye
+++ b/internal/buildscripts/packaging/tests/deployments/puppet/images/deb/Dockerfile.debian-bullseye
@@ -32,8 +32,13 @@ RUN rm -f /usr/lib/tmpfiles.d/tmp.conf;
 RUN systemctl set-default multi-user.target
 ENV init /lib/systemd/systemd
 
-RUN puppet module install puppetlabs-stdlib --version 4.24.0
-RUN puppet module install puppetlabs-apt --version 7.0.0
+RUN if [ $PUPPET_RELEASE -lt 8 ]; then \
+      puppet module install puppetlabs-stdlib --version 4.24.0 && \
+      puppet module install puppetlabs-apt --version 7.0.0; \
+    else \
+      puppet module install puppetlabs-stdlib --version 9.0.0 && \
+      puppet module install puppetlabs-apt --version 9.1.0; \
+    fi
 
 COPY deployments/puppet /etc/puppetlabs/code/environments/production/modules/splunk_otel_collector
 

--- a/internal/buildscripts/packaging/tests/deployments/puppet/images/deb/Dockerfile.debian-buster
+++ b/internal/buildscripts/packaging/tests/deployments/puppet/images/deb/Dockerfile.debian-buster
@@ -32,8 +32,13 @@ RUN rm -f /usr/lib/tmpfiles.d/tmp.conf;
 RUN systemctl set-default multi-user.target
 ENV init /lib/systemd/systemd
 
-RUN puppet module install puppetlabs-stdlib --version 4.24.0
-RUN puppet module install puppetlabs-apt --version 7.0.0
+RUN if [ $PUPPET_RELEASE -lt 8 ]; then \
+      puppet module install puppetlabs-stdlib --version 4.24.0 && \
+      puppet module install puppetlabs-apt --version 7.0.0; \
+    else \
+      puppet module install puppetlabs-stdlib --version 9.0.0 && \
+      puppet module install puppetlabs-apt --version 9.1.0; \
+    fi
 
 COPY deployments/puppet /etc/puppetlabs/code/environments/production/modules/splunk_otel_collector
 

--- a/internal/buildscripts/packaging/tests/deployments/puppet/images/deb/Dockerfile.ubuntu-bionic
+++ b/internal/buildscripts/packaging/tests/deployments/puppet/images/deb/Dockerfile.ubuntu-bionic
@@ -28,8 +28,13 @@ RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
 RUN systemctl set-default multi-user.target
 ENV init /lib/systemd/systemd
 
-RUN puppet module install puppetlabs-stdlib --version 4.24.0
-RUN puppet module install puppetlabs-apt --version 7.0.0
+RUN if [ $PUPPET_RELEASE -lt 8 ]; then \
+      puppet module install puppetlabs-stdlib --version 4.24.0 && \
+      puppet module install puppetlabs-apt --version 7.0.0; \
+    else \
+      puppet module install puppetlabs-stdlib --version 9.0.0 && \
+      puppet module install puppetlabs-apt --version 9.1.0; \
+    fi
 
 COPY deployments/puppet /etc/puppetlabs/code/environments/production/modules/splunk_otel_collector
 

--- a/internal/buildscripts/packaging/tests/deployments/puppet/images/deb/Dockerfile.ubuntu-focal
+++ b/internal/buildscripts/packaging/tests/deployments/puppet/images/deb/Dockerfile.ubuntu-focal
@@ -28,8 +28,13 @@ RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
 RUN systemctl set-default multi-user.target
 ENV init /lib/systemd/systemd
 
-RUN puppet module install puppetlabs-stdlib --version 4.24.0
-RUN puppet module install puppetlabs-apt --version 7.0.0
+RUN if [ $PUPPET_RELEASE -lt 8 ]; then \
+      puppet module install puppetlabs-stdlib --version 4.24.0 && \
+      puppet module install puppetlabs-apt --version 7.0.0; \
+    else \
+      puppet module install puppetlabs-stdlib --version 9.0.0 && \
+      puppet module install puppetlabs-apt --version 9.1.0; \
+    fi
 
 COPY deployments/puppet /etc/puppetlabs/code/environments/production/modules/splunk_otel_collector
 

--- a/internal/buildscripts/packaging/tests/deployments/puppet/images/deb/Dockerfile.ubuntu-jammy
+++ b/internal/buildscripts/packaging/tests/deployments/puppet/images/deb/Dockerfile.ubuntu-jammy
@@ -28,8 +28,13 @@ RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
 RUN systemctl set-default multi-user.target
 ENV init /lib/systemd/systemd
 
-RUN puppet module install puppetlabs-stdlib --version 4.24.0
-RUN puppet module install puppetlabs-apt --version 7.0.0
+RUN if [ $PUPPET_RELEASE -lt 8 ]; then \
+      puppet module install puppetlabs-stdlib --version 4.24.0 && \
+      puppet module install puppetlabs-apt --version 7.0.0; \
+    else \
+      puppet module install puppetlabs-stdlib --version 9.0.0 && \
+      puppet module install puppetlabs-apt --version 9.1.0; \
+    fi
 
 COPY deployments/puppet /etc/puppetlabs/code/environments/production/modules/splunk_otel_collector
 

--- a/internal/buildscripts/packaging/tests/deployments/puppet/puppet_test.py
+++ b/internal/buildscripts/packaging/tests/deployments/puppet/puppet_test.py
@@ -126,8 +126,8 @@ def verify_env_file(container, api_url=SPLUNK_API_URL, ingest_url=SPLUNK_INGEST_
 
 
 def skip_if_necessary(distro, puppet_release):
-    if distro == "ubuntu-focal":
-        pytest.skip("requires https://github.com/puppetlabs/puppetlabs-release/issues/271 to be resolved")
+    if distro in ("debian-stretch", "ubuntu-xenial") and int(puppet_release) >= 8:
+        pytest.skip(f"Puppet {puppet_release} not supported for {distro}")
 
 
 def node_package_installed(container):
@@ -160,6 +160,8 @@ class {{ splunk_otel_collector:
 )
 @pytest.mark.parametrize("puppet_release", PUPPET_RELEASE)
 def test_puppet_default(distro, puppet_release):
+    skip_if_necessary(distro, puppet_release)
+
     if distro in DEB_DISTROS:
         dockerfile = IMAGES_DIR / "deb" / f"Dockerfile.{distro}"
     else:
@@ -201,6 +203,8 @@ class {{ splunk_otel_collector:
 )
 @pytest.mark.parametrize("puppet_release", PUPPET_RELEASE)
 def test_puppet_with_custom_vars(distro, puppet_release):
+    skip_if_necessary(distro, puppet_release)
+
     if distro in DEB_DISTROS:
         dockerfile = IMAGES_DIR / "deb" / f"Dockerfile.{distro}"
     else:
@@ -253,6 +257,8 @@ class {{ splunk_otel_collector:
 @pytest.mark.parametrize("version", ["0.86.0", "latest"])
 @pytest.mark.parametrize("with_systemd", ["true", "false"])
 def test_puppet_with_default_instrumentation(distro, puppet_release, version, with_systemd):
+    skip_if_necessary(distro, puppet_release)
+
     if distro in DEB_DISTROS:
         dockerfile = IMAGES_DIR / "deb" / f"Dockerfile.{distro}"
     else:
@@ -352,6 +358,8 @@ class {{ splunk_otel_collector:
 @pytest.mark.parametrize("version", ["0.86.0", "latest"])
 @pytest.mark.parametrize("with_systemd", ["true", "false"])
 def test_puppet_with_custom_instrumentation(distro, puppet_release, version, with_systemd):
+    skip_if_necessary(distro, puppet_release)
+
     if distro in DEB_DISTROS:
         dockerfile = IMAGES_DIR / "deb" / f"Dockerfile.{distro}"
     else:


### PR DESCRIPTION
- Use `$facts['os']['family']` instead of the legacy `$::osfamily` fact
- Add test support for puppet 8

Replaces https://github.com/signalfx/splunk-otel-collector/pull/4996