### PR TITLE
[chore] [discovery] Update mongodb default config

### DIFF
--- a/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
@@ -21,7 +21,6 @@
 #         insecure: false
 #       hosts:
 #         - endpoint: '`endpoint`'
-#           transport: tcp
 #       timeout: 5s
 #   status:
 #     metrics:

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
@@ -17,7 +17,6 @@ mongodb:
         insecure: false
       hosts:
         - endpoint: '`endpoint`'
-          transport: tcp
       timeout: 5s
   status:
     metrics:

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
@@ -13,7 +13,6 @@
         insecure: false
       hosts:
         - endpoint: '`endpoint`'
-          transport: tcp
       timeout: 5s
   status:
     metrics:


### PR DESCRIPTION
Remove host.transport config option since it's removed upstream.
