### PR TITLE
Remove centos-8 from chef tests

### DIFF
--- a/deployments/chef/kitchen.yml
+++ b/deployments/chef/kitchen.yml
@@ -31,11 +31,6 @@ platforms:
       image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-8
-    driver:
-      image: dokken/centos-8
-      pid_one_command: /usr/lib/systemd/systemd
-
   - name: centos-9
     driver:
       image: dokken/centos-stream-9


### PR DESCRIPTION
Chef tests for centos-8 are failing since mirror doesn't have a version 8 anymore (which is already EOL), some removing it to avoid failures.

Failed run: https://github.com/signalfx/splunk-otel-collector/actions/runs/9654110000/job/26687077886#step:4:67
