### PR TITLE
ansible: Fix windows tests

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -177,11 +177,22 @@ jobs:
       - name: Install test dependencies.
         run: pip3 install --use-pep517 -r ${GITHUB_WORKSPACE}/requirements.txt
 
+      - name: Download vagrant box
+        run: |
+          box=$( yq ".platforms[] | select(.name == \"${{ matrix.distro }}\") | .box" ./molecule/config/windows.yml )
+          box_version=$( yq ".platforms[] | select(.name == \"${{ matrix.distro }}\") | .box_version" ./molecule/config/windows.yml )
+          eval "box_version=${box_version}"
+          json=$( wget -nv -O- https://vagrantcloud.com/api/v2/vagrant/${box} )
+          url=$( echo "$json" | jq -r ".versions[] | select(.version == \"${box_version}\") | .providers[] | select(.name == \"virtualbox\") | .url" )
+          wget -nv -O /tmp/vagrant.box $url
+
       - name: Run Molecule tests.
         run: molecule --debug -v --base-config ./molecule/config/windows.yml test -s ${{ matrix.scenario }} -p ${{ matrix.distro }}
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_VAGRANT_BOX_URL: /tmp/vagrant.box
+          MOLECULE_VAGRANT_BOX_VERSION: " "  # version must not be set when using a local box
 
   push-release-tag:
     name: Push Release Tag

--- a/deployments/ansible/molecule/config/windows.yml
+++ b/deployments/ansible/molecule/config/windows.yml
@@ -10,7 +10,8 @@ driver:
 platforms:
   - name: "2016"
     box: cdaf/WindowsServer
-    box_version: 2022.09.01
+    box_version: ${MOLECULE_VAGRANT_BOX_VERSION:-2022.09.01}
+    box_url: ${MOLECULE_VAGRANT_BOX_URL}
     cpus: 2
     memory: 4096
     provider_options:
@@ -29,7 +30,8 @@ platforms:
       - "winrm.retry_delay = 10"
   - name: "2019"
     box: gusztavvargadr/windows-server-2019-standard
-    box_version: 1809.0.2312
+    box_version: ${MOLECULE_VAGRANT_BOX_VERSION:-1809.0.2312}
+    box_url: ${MOLECULE_VAGRANT_BOX_URL}
     cpus: 2
     memory: 4096
     provider_options:
@@ -38,7 +40,8 @@ platforms:
     instance_raw_config_args: *vagrant_args
   - name: "2022"
     box: gusztavvargadr/iis-windows-server
-    box_version: 2102.0.2312
+    box_version: ${MOLECULE_VAGRANT_BOX_VERSION:-2102.0.2312}
+    box_url: ${MOLECULE_VAGRANT_BOX_URL}
     cpus: 2
     memory: 4096
     provider_options:

--- a/deployments/ansible/molecule/shared/install_nodejs.yml
+++ b/deployments/ansible/molecule/shared/install_nodejs.yml
@@ -24,6 +24,10 @@
     src: https://nodejs.org/download/release/v16.20.2/node-v16.20.2-linux-x64.tar.gz
     dest: /usr/local
     remote_src: yes
+  register: result
+  retries: 5
+  delay: 60
+  until: result is not failed
 
 - name: "create symlinks in /usr/bin"
   file:


### PR DESCRIPTION
- Pre-download the windows vagrant box to allow starting the VM from a local box file instead of relying on the vagrant registry.
- Add retry when downloading nodejs for linux instrumentation tests