### PR TITLE
[chore] [receiver/discovery] Remove redundant correlationStore interface

### DIFF
--- a/internal/receiver/discoveryreceiver/correlation.go
+++ b/internal/receiver/discoveryreceiver/correlation.go
@@ -41,30 +41,14 @@ type correlation struct {
 	stale       bool
 }
 
-// correlationStore provides a centralized interface for up-to-date correlations
-// and receiver attributes as a message passing mechanism by observed components.
-// It manages a reaping loop to prevent stale endpoint buildup over time.
-type correlationStore interface {
-	UpdateEndpoint(endpoint observer.Endpoint, receiverID component.ID, observerID component.ID)
-	MarkStale(endpointID observer.EndpointID)
-	GetOrCreate(endpointID observer.EndpointID, receiverID component.ID) correlation
-	Attrs(endpointID observer.EndpointID) map[string]string
-	UpdateAttrs(endpointID observer.EndpointID, attrs map[string]string)
-	EmitCh() chan correlation
-	Endpoints(updatedBefore time.Time) []observer.Endpoint
-	// Start the reaping loop to prevent unnecessary endpoint buildup
-	Start()
-	// Stop the reaping loop
-	Stop()
-}
-
-// store is a collection of mappings used as an instantaneous record of
+// correlationStore is a collection of mappings used as an instantaneous record of
 // 1. endpoints to their associated correlations
 // 2. receivers to their endpoint-agnostic Attrs used as a message
 // passing mechanism (currently just for embedded config values).
 // This way the pre-created receiver instances can have attrs
 // before they are created via endpoint.
-type store struct {
+// It manages a reaping loop to prevent stale endpoint buildup over time.
+type correlationStore struct {
 	logger *zap.Logger
 	// correlations is a ~synchronized map[endpointID]*corr
 	correlations  *sync.Map
@@ -77,8 +61,8 @@ type store struct {
 	ttl          time.Duration
 }
 
-func newCorrelationStore(logger *zap.Logger, ttl time.Duration) correlationStore {
-	return &store{
+func newCorrelationStore(logger *zap.Logger, ttl time.Duration) *correlationStore {
+	return &correlationStore{
 		logger:        logger,
 		correlations:  &sync.Map{},
 		endpointLocks: newKeyLock(),
@@ -91,7 +75,7 @@ func newCorrelationStore(logger *zap.Logger, ttl time.Duration) correlationStore
 }
 
 // UpdateEndpoint updates or creates correlation timestamps and states by endpoint.ID and receiverID.
-func (s *store) UpdateEndpoint(endpoint observer.Endpoint, receiverID component.ID, observerID component.ID) {
+func (s *correlationStore) UpdateEndpoint(endpoint observer.Endpoint, receiverID component.ID, observerID component.ID) {
 	endpointUnlock := s.endpointLocks.Lock(endpoint.ID)
 	defer endpointUnlock()
 	c, ok := s.correlations.LoadOrStore(endpoint.ID, &correlation{
@@ -111,7 +95,7 @@ func (s *store) UpdateEndpoint(endpoint observer.Endpoint, receiverID component.
 }
 
 // MarkStale marks an endpoint as stale to be reaped.
-func (s *store) MarkStale(endpointID observer.EndpointID) {
+func (s *correlationStore) MarkStale(endpointID observer.EndpointID) {
 	endpointUnlock := s.endpointLocks.Lock(endpointID)
 	defer endpointUnlock()
 	c, ok := s.correlations.Load(endpointID)
@@ -121,13 +105,8 @@ func (s *store) MarkStale(endpointID observer.EndpointID) {
 	}
 }
 
-// EmitCh returns a channel to emit endpoints immediately.
-func (s *store) EmitCh() chan correlation {
-	return s.emitCh
-}
-
 // Endpoints returns all active endpoints that have not been updated since the provided time.
-func (s *store) Endpoints(updatedBefore time.Time) []observer.Endpoint {
+func (s *correlationStore) Endpoints(updatedBefore time.Time) []observer.Endpoint {
 	var endpoints []observer.Endpoint
 	s.correlations.Range(func(eID, c any) bool {
 		endpointID := eID.(observer.EndpointID)
@@ -143,7 +122,7 @@ func (s *store) Endpoints(updatedBefore time.Time) []observer.Endpoint {
 }
 
 // GetOrCreate returns an existing receiver/endpoint correlation or creates a new one.
-func (s *store) GetOrCreate(endpointID observer.EndpointID, receiverID component.ID) correlation {
+func (s *correlationStore) GetOrCreate(endpointID observer.EndpointID, receiverID component.ID) correlation {
 	endpointUnlock := s.endpointLocks.Lock(endpointID)
 	defer endpointUnlock()
 	c, ok := s.correlations.Load(endpointID)
@@ -159,7 +138,7 @@ func (s *store) GetOrCreate(endpointID observer.EndpointID, receiverID component
 	return corr
 }
 
-func (s *store) Attrs(endpointID observer.EndpointID) map[string]string {
+func (s *correlationStore) Attrs(endpointID observer.EndpointID) map[string]string {
 	unlock := s.endpointLocks.Lock(endpointID)
 	defer unlock()
 	rInfo, _ := s.attrs.LoadOrStore(endpointID, map[string]string{})
@@ -171,7 +150,7 @@ func (s *store) Attrs(endpointID observer.EndpointID) map[string]string {
 	return cp
 }
 
-func (s *store) UpdateAttrs(endpointID observer.EndpointID, attrs map[string]string) {
+func (s *correlationStore) UpdateAttrs(endpointID observer.EndpointID, attrs map[string]string) {
 	unlock := s.endpointLocks.Lock(endpointID)
 	defer unlock()
 	rAttrs, _ := s.attrs.LoadOrStore(endpointID, map[string]string{})
@@ -182,7 +161,7 @@ func (s *store) UpdateAttrs(endpointID observer.EndpointID, attrs map[string]str
 	s.attrs.Store(endpointID, receiverAttrs)
 }
 
-func (s *store) Start() {
+func (s *correlationStore) Start() {
 	go func() {
 		timer := time.NewTicker(s.reapInterval)
 		for {
@@ -197,12 +176,12 @@ func (s *store) Start() {
 	}()
 }
 
-func (s *store) Stop() {
+func (s *correlationStore) Stop() {
 	s.sentinel <- struct{}{}
 }
 
 // reap will remove all removed endpoints whose last update is past the ttl
-func (s *store) reap() {
+func (s *correlationStore) reap() {
 	s.correlations.Range(func(eID, c any) bool {
 		endpointID := eID.(observer.EndpointID)
 		endpointUnlock := s.endpointLocks.Lock(endpointID)

--- a/internal/receiver/discoveryreceiver/correlation_test.go
+++ b/internal/receiver/discoveryreceiver/correlation_test.go
@@ -28,9 +28,7 @@ import (
 
 func TestNewCorrelationStore(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cs := newCorrelationStore(logger, time.Hour)
-	cStore, ok := cs.(*store)
-	require.True(t, ok)
+	cStore := newCorrelationStore(logger, time.Hour)
 	require.NotNil(t, cStore)
 	require.Same(t, logger, cStore.logger)
 	require.Equal(t, time.Hour, cStore.ttl)
@@ -151,9 +149,7 @@ func TestAttrs(t *testing.T) {
 }
 
 func TestReaperLoop(t *testing.T) {
-	cs := newCorrelationStore(zaptest.NewLogger(t), time.Nanosecond)
-	cStore, ok := cs.(*store)
-	require.True(t, ok)
+	cStore := newCorrelationStore(zaptest.NewLogger(t), time.Nanosecond)
 	require.NotNil(t, cStore)
 	// update the reapInterval so as not to wait 30 seconds for test logic
 	cStore.reapInterval = time.Millisecond
@@ -165,13 +161,13 @@ func TestReaperLoop(t *testing.T) {
 	}
 	observerID := component.MustNewIDWithName("observer", "name")
 
-	cs.Start()
-	t.Cleanup(cs.Stop)
+	cStore.Start()
+	t.Cleanup(cStore.Stop)
 
 	receiverID := component.MustNewIDWithName("receiver", "name")
-	cs.UpdateEndpoint(endpoint, receiverID, observerID)
+	cStore.UpdateEndpoint(endpoint, receiverID, observerID)
 
-	corr := cs.GetOrCreate(endpointID, receiverID)
+	corr := cStore.GetOrCreate(endpointID, receiverID)
 	require.False(t, corr.stale)
 	rMap, ok := cStore.correlations.Load(endpointID)
 	require.True(t, ok)
@@ -179,7 +175,7 @@ func TestReaperLoop(t *testing.T) {
 	require.True(t, isCorr)
 	require.False(t, fetchedCorr.stale)
 
-	cs.MarkStale(endpointID)
+	cStore.MarkStale(endpointID)
 
 	// repeat check once to ensure loop-driven removal
 	_, hasEndpoint := cStore.correlations.Load(endpointID)

--- a/internal/receiver/discoveryreceiver/endpoint_tracker_test.go
+++ b/internal/receiver/discoveryreceiver/endpoint_tracker_test.go
@@ -186,7 +186,7 @@ func TestEndpointToPLogsHappyPath(t *testing.T) {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
 			corr := newCorrelationStore(zap.NewNop(), time.Hour)
-			corr.(*store).attrs.Store(test.endpoint.ID, map[string]string{discovery.StatusAttr: "successful"})
+			corr.attrs.Store(test.endpoint.ID, map[string]string{discovery.StatusAttr: "successful"})
 			events, failed, err := entityStateEvents(
 				component.MustNewIDWithName("observer_type", "observer.name"),
 				[]observer.Endpoint{test.endpoint}, corr, t0,
@@ -300,7 +300,7 @@ func TestEndpointToPLogsInvalidEndpoints(t *testing.T) {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
 			corr := newCorrelationStore(zap.NewNop(), time.Hour)
-			corr.(*store).attrs.Store(test.endpoint.ID, map[string]string{discovery.StatusAttr: "successful"})
+			corr.attrs.Store(test.endpoint.ID, map[string]string{discovery.StatusAttr: "successful"})
 			events, failed, err := entityStateEvents(
 				component.MustNewIDWithName("observer_type", "observer.name"),
 				[]observer.Endpoint{test.endpoint}, corr, t0,
@@ -348,7 +348,7 @@ func FuzzEndpointToPlogs(f *testing.F) {
 				observerTypeSanitized = discovery.NoType.Type()
 			}
 			corr := newCorrelationStore(zap.NewNop(), time.Hour)
-			corr.(*store).attrs.Store(observer.EndpointID(endpointID), map[string]string{discovery.StatusAttr: "successful"})
+			corr.attrs.Store(observer.EndpointID(endpointID), map[string]string{discovery.StatusAttr: "successful"})
 			events, failed, err := entityStateEvents(
 				component.MustNewIDWithName(observerTypeSanitized.String(), observerName), []observer.Endpoint{
 					{
@@ -647,7 +647,7 @@ func TestUpdateEndpoints(t *testing.T) {
 			et.updateEndpoints(tt.endpoints, component.MustNewIDWithName("observer_type", "observer.name"))
 
 			var correlationsCount int
-			et.correlations.(*store).correlations.Range(func(_, _ interface{}) bool {
+			et.correlations.correlations.Range(func(_, _ interface{}) bool {
 				correlationsCount++
 				return true
 			})
@@ -695,7 +695,7 @@ func TestEntityEmittingLifecycle(t *testing.T) {
 	require.Empty(t, ch)
 
 	// Once the status attribute is set, the entity should be emitted.
-	corr.(*store).attrs.Store(portEndpoint.ID, map[string]string{discovery.StatusAttr: "successful"})
+	corr.attrs.Store(portEndpoint.ID, map[string]string{discovery.StatusAttr: "successful"})
 
 	// Wait for at least 2 entity events to be emitted to confirm periodic emitting is working.
 	require.Eventually(t, func() bool { return len(ch) >= 2 }, 1*time.Second, 60*time.Millisecond)

--- a/internal/receiver/discoveryreceiver/evaluator.go
+++ b/internal/receiver/discoveryreceiver/evaluator.go
@@ -38,14 +38,14 @@ type exprEnvFunc func(pattern string) map[string]any
 type evaluator struct {
 	logger       *zap.Logger
 	config       *Config
-	correlations correlationStore
+	correlations *correlationStore
 	// this ~sync.Map(map[string]struct{}) keeps track of
 	// whether we've already emitted a record for the statement and can skip processing.
 	alreadyLogged *sync.Map
 	exprEnv       exprEnvFunc
 }
 
-func newEvaluator(logger *zap.Logger, config *Config, correlations correlationStore, envFunc exprEnvFunc) *evaluator {
+func newEvaluator(logger *zap.Logger, config *Config, correlations *correlationStore, envFunc exprEnvFunc) *evaluator {
 	return &evaluator{
 		logger:        logger,
 		config:        config,

--- a/internal/receiver/discoveryreceiver/metric_evaluator.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator.go
@@ -43,7 +43,7 @@ type metricEvaluator struct {
 	*evaluator
 }
 
-func newMetricEvaluator(logger *zap.Logger, cfg *Config, correlations correlationStore) *metricEvaluator {
+func newMetricEvaluator(logger *zap.Logger, cfg *Config, correlations *correlationStore) *metricEvaluator {
 	return &metricEvaluator{
 		evaluator: newEvaluator(logger, cfg, correlations,
 			// TODO: provide more capable env w/ resource and metric attributes
@@ -121,7 +121,7 @@ func (m *metricEvaluator) evaluateMetrics(md pmetric.Metrics) {
 		attrs[discovery.StatusAttr] = string(match.Status)
 		m.correlations.UpdateAttrs(endpointID, attrs)
 
-		m.correlations.EmitCh() <- corr
+		m.correlations.emitCh <- corr
 		return
 	}
 }

--- a/internal/receiver/discoveryreceiver/metric_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator_test.go
@@ -77,7 +77,7 @@ func TestMetricEvaluation(t *testing.T) {
 
 					cStore := newCorrelationStore(logger, time.Hour)
 
-					emitCh := cStore.EmitCh()
+					emitCh := cStore.emitCh
 					emitWG := sync.WaitGroup{}
 					emitWG.Add(1)
 					go func() {

--- a/internal/receiver/discoveryreceiver/statement_evaluator.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator.go
@@ -40,7 +40,8 @@ type statementEvaluator struct {
 	id              component.ID
 }
 
-func newStatementEvaluator(logger *zap.Logger, id component.ID, config *Config, correlations correlationStore) (*statementEvaluator, error) {
+func newStatementEvaluator(logger *zap.Logger, id component.ID, config *Config,
+	correlations *correlationStore) (*statementEvaluator, error) {
 	zapConfig := zap.NewProductionConfig()
 	zapConfig.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
 	zapConfig.Sampling.Initial = 1
@@ -197,7 +198,7 @@ func (se *statementEvaluator) evaluateStatement(statement *statussources.Stateme
 		attrs[discovery.StatusAttr] = string(match.Status)
 		se.correlations.UpdateAttrs(endpointID, attrs)
 
-		se.correlations.EmitCh() <- corr
+		se.correlations.emitCh <- corr
 		return
 	}
 }

--- a/internal/receiver/discoveryreceiver/statement_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator_test.go
@@ -61,7 +61,7 @@ func TestStatementEvaluation(t *testing.T) {
 					logger := zap.NewNop()
 					cStore := newCorrelationStore(logger, time.Hour)
 
-					emitCh := cStore.EmitCh()
+					emitCh := cStore.emitCh
 					emitWG := sync.WaitGroup{}
 					emitWG.Add(1)
 					go func() {


### PR DESCRIPTION
The interface has only one implementation in the same package so it doesn't introduce any value. Following up https://github.com/signalfx/splunk-otel-collector/pull/4728#discussion_r1580027610