### PR TITLE
Remove centos-7 from chef tests

### DIFF
--- a/deployments/chef/kitchen.yml
+++ b/deployments/chef/kitchen.yml
@@ -26,11 +26,6 @@ platforms:
       image: dokken/amazonlinux-2
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-7
-    driver:
-      image: dokken/centos-7
-      pid_one_command: /usr/lib/systemd/systemd
-
   - name: centos-9
     driver:
       image: dokken/centos-stream-9


### PR DESCRIPTION
Chef tests for centos-7 are failing since mirror doesn't exist anymore, although, we could replace the mirror there is no point in doing it since centos-7 just reached EOL so removing it.

* https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve
* https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/
* https://github.com/signalfx/splunk-otel-collector/actions/runs/9752697846/job/26950277365#step:4:4228

