### PR TITLE
update centos7 yum repo to use the archive

### DIFF
--- a/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.centos-7
+++ b/internal/buildscripts/packaging/tests/images/rpm/Dockerfile.centos-7
@@ -5,6 +5,8 @@ FROM centos:7
 ENV container docker
 
 RUN echo 'fastestmirror=1' >> /etc/yum.conf
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's/mirrorlist/#mirrorlist/g'  /etc/yum.repos.d/CentOS-*
 RUN yum install -y curl procps initscripts systemd wget
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \

--- a/internal/buildscripts/packaging/tests/images/tar/Dockerfile.tar-centos-7
+++ b/internal/buildscripts/packaging/tests/images/tar/Dockerfile.tar-centos-7
@@ -4,6 +4,8 @@ FROM centos:7
 
 ENV container docker
 
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's/mirrorlist/#mirrorlist/g'  /etc/yum.repos.d/CentOS-*
 RUN yum install -y curl procps initscripts systemd wget
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \

--- a/internal/buildscripts/packaging/tests/instrumentation/images/rpm/Dockerfile.centos-7
+++ b/internal/buildscripts/packaging/tests/instrumentation/images/rpm/Dockerfile.centos-7
@@ -9,6 +9,8 @@ ARG TARGETARCH
 ENV container docker
 
 RUN echo 'fastestmirror=1' >> /etc/yum.conf
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's/mirrorlist/#mirrorlist/g'  /etc/yum.repos.d/CentOS-*
 RUN yum install -y curl procps initscripts python3 systemd wget
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Replaces yum repo with the archived centos repo (no updates) since centos 7 is officially EOL starting June 30th 2024.

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
