### PR TITLE
[chore] update xray scan jobs with only condition

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -191,8 +191,10 @@ fossa:
   - echo "${ARTIFACTORY_BASE_URL}/${local_repo}/${target}" | tee xray_artifact_path
 
 .xray-scan-package:
-  only:
-    - main
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    - if: $CI_COMMIT_BRANCH == "main"
   extends: .binary-scan
   stage: xray-scan
   variables:
@@ -402,8 +404,6 @@ instrumentation-deb:
       - xray_artifact_path
 
 xray-instrumentation-deb:
-  only:
-    - main
   extends: .xray-scan-package
   needs:
     - instrumentation-deb
@@ -421,8 +421,6 @@ instrumentation-rpm:
       - xray_artifact_path
 
 xray-instrumentation-rpm:
-  only:
-    - main
   extends: .xray-scan-package
   needs:
     - instrumentation-rpm
@@ -504,8 +502,6 @@ build-deb:
       - xray_artifact_path
 
 xray-collector-deb:
-  only:
-    - main
   extends: .xray-scan-package
   needs:
     - build-deb
@@ -525,8 +521,6 @@ build-rpm:
       - xray_artifact_path
 
 xray-collector-rpm:
-  only:
-    - main
   extends: .xray-scan-package
   needs:
     - build-rpm

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -402,6 +402,8 @@ instrumentation-deb:
       - xray_artifact_path
 
 xray-instrumentation-deb:
+  only:
+    - main
   extends: .xray-scan-package
   needs:
     - instrumentation-deb
@@ -419,6 +421,8 @@ instrumentation-rpm:
       - xray_artifact_path
 
 xray-instrumentation-rpm:
+  only:
+    - main
   extends: .xray-scan-package
   needs:
     - instrumentation-rpm
@@ -500,6 +504,8 @@ build-deb:
       - xray_artifact_path
 
 xray-collector-deb:
+  only:
+    - main
   extends: .xray-scan-package
   needs:
     - build-deb
@@ -519,6 +525,8 @@ build-rpm:
       - xray_artifact_path
 
 xray-collector-rpm:
+  only:
+    - main
   extends: .xray-scan-package
   needs:
     - build-rpm


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

xray-instrumentation-[rpm|deb] and xray-collector jobs are running in gitlab on schedule but failing due to dependent jobs not being configured to run on schedule. Not sure if these are intended to run on schedule. Updating the condition to use rules instead of only/except which are deprecated and to not run when trigger is schedule for now.

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
