### PR TITLE
Upgrade to golang 1.21.12

### DIFF
--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -21,7 +21,7 @@ env:
   PYTHON_VERSION: '3.11'
   PIP_VERSION: '22.0.4'
   REQUIREMENTS_PATH: "internal/buildscripts/packaging/tests/requirements.txt"
-  GO_VERSION: 1.21.11
+  GO_VERSION: 1.21.12
 
 jobs:
   cross-compile:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.21.11
+  GO_VERSION: 1.21.12
 
 jobs:
   setup-environment:

--- a/.github/workflows/darwin-test.yml
+++ b/.github/workflows/darwin-test.yml
@@ -19,7 +19,7 @@ on:
       - '!internal/buildscripts/**'
 
 env:
-  GO_VERSION: '1.21.11'
+  GO_VERSION: '1.21.12'
 
 concurrency:
   group: darwin-test-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/gendependabot.yml
+++ b/.github/workflows/gendependabot.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/scripts/gendependabot.sh'
 
 env:
-  GO_VERSION: 1.21.11
+  GO_VERSION: 1.21.12
 
 jobs:
   gendependabot:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.21.11"
+  GO_VERSION: "1.21.12"
 jobs:
   agent-bundle-linux:
     runs-on: ${{ fromJSON('["ubuntu-20.04", "otel-arm64"]')[matrix.ARCH == 'arm64'] }}

--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.21.11
+  GO_VERSION: 1.21.12
 
 jobs:
   lint:

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -30,7 +30,7 @@ env:
   PYTHON_VERSION: '3.11'
   PIP_VERSION: '22.0.4'
   REQUIREMENTS_PATH: "internal/buildscripts/packaging/tests/requirements.txt"
-  GO_VERSION: 1.21.11
+  GO_VERSION: 1.21.12
 
 jobs:
   setup-environment:

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -14,7 +14,7 @@ on:
     - cron: '0 0 * * 1-5' # Every weekday at midnight UTC
 
 env:
-  GO_VERSION: '1.21.11'
+  GO_VERSION: '1.21.12'
 
 concurrency:
   group: vuln-scans-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.21.11
+  GO_VERSION: 1.21.12
 
 jobs:
   setup-environment:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -18,7 +18,7 @@ on:
       - '!internal/buildscripts/**'
 
 env:
-  GO_VERSION: '1.21.11'
+  GO_VERSION: '1.21.12'
 
 concurrency:
   group: windows-test-${{ github.event.pull_request.number || github.ref }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,7 +149,7 @@ fossa:
       fi
 
 .go-cache:
-  image: '${DOCKER_HUB_REPO}/golang:1.21.11'
+  image: '${DOCKER_HUB_REPO}/golang:1.21.12'
   variables:
     GOPATH: "$CI_PROJECT_DIR/.go"
   before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   collection cycles to improves performance of the collector for typical workloads. As a result, the collector will
   report higher memory usage, but it will be bound to the same configured limits. If you want to revert to the previous
   behavior, set the `GOGC` environment variable to `100`.
+- (Splunk) Upgrade to golang 1.21.12
 
 ### 🧰 Bug fixes 🧰
 

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/signalfx/splunk-otel-collector/internal/tools
 
 go 1.21.0
 
-toolchain go1.21.11
+toolchain go1.21.12
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/pkg/processor/timestampprocessor/go.mod
+++ b/pkg/processor/timestampprocessor/go.mod
@@ -2,7 +2,7 @@ module github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocesso
 
 go 1.21.0
 
-toolchain go1.21.11
+toolchain go1.21.12
 
 require (
 	github.com/stretchr/testify v1.9.0


### PR DESCRIPTION
For CVE-2024-24791, [GO-2024-2963](https://pkg.go.dev/vuln/GO-2024-2963)