### PR TITLE
snyk: ignore GO-2024-2567 false positive

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -7,4 +7,9 @@ ignore:
         reason: 'false positive: https://github.com/opencontainers/runc/issues/4263'
         expires: 2099-01-01T00:00:00.000Z
         created: 2024-05-08T15:09:58.177Z
+  SNYK-GOLANG-GITHUBCOMJACKCPGXV4-7416900:
+    - '*':
+        reason: 'false positive; only affects v5: https://pkg.go.dev/vuln/GO-2024-2567'
+        expires: 2099-01-01T00:00:00.000Z
+        created: 2024-07-08T16:27:22.186Z
 patch: {}


### PR DESCRIPTION
- Update snyk to ignore [SNYK-GOLANG-GITHUBCOMJACKCPGXV4-7416900](https://security.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMJACKCPGXV4-7416900).
- [GO-2024-2567](https://pkg.go.dev/vuln/GO-2024-2567) only affects v5 and we are currently only dependent on v4.