### PR TITLE
Avoid issues with receivers trying to update its dimensions to Splunk Observability

### DIFF
--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -9,6 +9,8 @@ extensions:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:6060"
     egress:
       endpoint: "https://api.${SPLUNK_REALM}.signalfx.com"
+      headers:
+        "X-SF-TOKEN": "${SPLUNK_ACCESS_TOKEN}"      
   zpages:
     endpoint: "${SPLUNK_LISTEN_INTERFACE}:55679"
 


### PR DESCRIPTION

**Description:**
Currently, if a receiver has a dummy token it gets an error similar to this one: Jul 04 14:25:19 christhianb-o11y2 otelcol[522]: 2024-07-04T14:25:19.870Z        
  error        dimensions/dimclient.go:247         Unable to update dimension, retrying       
  {"kind": "exporter", "data_type": "metrics", "name": "signalfx/internal", "error": 
  "error making HTTP request to https://api.us1.signalfx.com/v2/dimension/gcp_id/ps-1234/_/sfxagent: 
  Patch \"https://api.us1.signalfx.com/v2/dimension/...."

Once a valid token is configured it disappears. 
However, the purpose of configuring a Gateway would be to rely on this host to send everything to Splunk Observability. Right after the proposed change is applied, the receiver's call starts using a valid token(Gateway Token) and the error disappears.


**Link to Splunk idea:** None

**Testing:**
Tested the following environment:
Agent -> Gateway -> Splunk Observability

**Documentation:** 
Based on docs:
https://docs.splunk.com/observability/en/gdi/opentelemetry/deployment-modes.html#when-to-use-data-forwarding-gateway-mode
Consolidate API token management
We can accomplish this by merging this change.
