### PR TITLE
Set default image for integration tests to otelcol:latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ SKIP_BUNDLE=false
 # for local docker build testing or
 # SPLUNK_OTEL_COLLECTOR_IMAGE='' make -e otelcol integration-test
 # for local binary testing (agent-bundle configuration required)
-export SPLUNK_OTEL_COLLECTOR_IMAGE?=quay.io/signalfx/splunk-otel-collector-dev:latest
+export SPLUNK_OTEL_COLLECTOR_IMAGE?=otelcol:latest
 
 # Docker repository used.
 DOCKER_REPO?=docker.io

--- a/tests/receivers/smartagent/collectd-activemq/collectd_activemq_test.go
+++ b/tests/receivers/smartagent/collectd-activemq/collectd_activemq_test.go
@@ -133,6 +133,7 @@ func checkMetricsPresence(t *testing.T, metricNames []string, configFile string)
 		dockerHost = "host.docker.internal"
 	}
 	p, err := testutils.NewCollectorContainer().
+		WithImage(testutils.GetCollectorImageOrSkipTest(t)).
 		WithConfigPath(filepath.Join("testdata", configFile)).
 		WithLogger(logger).
 		WithEnv(map[string]string{"OTLP_ENDPOINT": fmt.Sprintf("%s:%d", dockerHost, port)}).

--- a/tests/receivers/smartagent/collectd-cassandra/collectd_cassandra_test.go
+++ b/tests/receivers/smartagent/collectd-cassandra/collectd_cassandra_test.go
@@ -138,6 +138,7 @@ func checkMetricsPresence(t *testing.T, metricNames []string, configFile string)
 		dockerHost = "host.docker.internal"
 	}
 	p, err := testutils.NewCollectorContainer().
+		WithImage(testutils.GetCollectorImageOrSkipTest(t)).
 		WithConfigPath(filepath.Join("testdata", configFile)).
 		WithLogger(logger).
 		WithEnv(map[string]string{"OTLP_ENDPOINT": fmt.Sprintf("%s:%d", dockerHost, port)}).

--- a/tests/receivers/smartagent/collectd-kafka/collectd_kafka_test.go
+++ b/tests/receivers/smartagent/collectd-kafka/collectd_kafka_test.go
@@ -135,6 +135,7 @@ func checkMetricsPresence(t *testing.T, metricNames []string, configFile string)
 		dockerHost = "host.docker.internal"
 	}
 	p, err := testutils.NewCollectorContainer().
+		WithImage(testutils.GetCollectorImageOrSkipTest(t)).
 		WithConfigPath(filepath.Join("testdata", configFile)).
 		WithLogger(logger).
 		WithEnv(map[string]string{"OTLP_ENDPOINT": fmt.Sprintf("%s:%d", dockerHost, port)}).

--- a/tests/receivers/smartagent/collectd-tomcat/tomcat_test.go
+++ b/tests/receivers/smartagent/collectd-tomcat/tomcat_test.go
@@ -74,6 +74,7 @@ func checkMetricsPresence(t *testing.T, metricNames []string, configFile string)
 		dockerHost = "host.docker.internal"
 	}
 	p, err := testutils.NewCollectorContainer().
+		WithImage(testutils.GetCollectorImageOrSkipTest(t)).
 		WithConfigPath(filepath.Join("testdata", configFile)).
 		WithLogger(logger).
 		WithEnv(map[string]string{"OTLP_ENDPOINT": fmt.Sprintf("%s:%d", dockerHost, port)}).

--- a/tests/testutils/README.md
+++ b/tests/testutils/README.md
@@ -144,7 +144,7 @@ collector, err = testutils.NewCollectorProcess().WithArgs("--tested-feature", "-
 
 The `CollectorContainer` is an equivalent helper type to the `CollectorProcess` but will run a container in host network
 mode for an arbitrary Collector image and tag using the config you provide.  If an image is not specified it will use a default
-of `"quay.io/signalfx/splunk-otel-collector-dev:latest"`.
+of `"otelcol:latest"` (the default local image tag built via `make docker-otelcol`).
 
 ```go
 import "github.com/signafx/splunk-otel-collector/tests/testutils"

--- a/tests/testutils/collector_container.go
+++ b/tests/testutils/collector_container.go
@@ -60,7 +60,7 @@ func NewCollectorContainer() CollectorContainer {
 	return CollectorContainer{Args: []string{}, Container: NewContainer(), Mounts: map[string]string{}}
 }
 
-// quay.io/signalfx/splunk-otel-collector:latest by default
+// otelcol:latest by default
 func (collector CollectorContainer) WithImage(image string) CollectorContainer {
 	collector.Image = image
 	return collector
@@ -114,7 +114,7 @@ func (collector CollectorContainer) WithMount(path string, mountPoint string) Co
 
 func (collector CollectorContainer) Build() (Collector, error) {
 	if collector.Image == "" && collector.Container.Dockerfile.Context == "" {
-		collector.Image = "quay.io/signalfx/splunk-otel-collector:latest"
+		collector.Image = "otelcol:latest"
 	}
 
 	if collector.Logger == nil {

--- a/tests/testutils/collector_container_test.go
+++ b/tests/testutils/collector_container_test.go
@@ -87,7 +87,7 @@ func TestCollectorContainerBuildDefaults(t *testing.T) {
 	collector, ok := c.(*CollectorContainer)
 	require.True(t, ok)
 
-	assert.Equal(t, "quay.io/signalfx/splunk-otel-collector:latest", collector.Image)
+	assert.Equal(t, "otelcol:latest", collector.Image)
 	assert.Equal(t, "", collector.ConfigPath)
 	assert.NotNil(t, collector.Logger)
 	assert.Equal(t, "info", collector.LogLevel)
@@ -134,7 +134,7 @@ func TestCollectorContainerLogging(t *testing.T) {
 	collector, ok := c.(*CollectorContainer)
 	require.True(t, ok)
 
-	assert.Equal(t, "quay.io/signalfx/splunk-otel-collector:latest", collector.Image)
+	assert.Equal(t, "otelcol:latest", collector.Image)
 	assert.Equal(t, "", collector.ConfigPath)
 	assert.NotNil(t, collector.Logger)
 	assert.Equal(t, "info", collector.LogLevel)

--- a/tests/testutils/golden.go
+++ b/tests/testutils/golden.go
@@ -54,6 +54,7 @@ func CheckGoldenFile(t *testing.T, configFile string, expectedFilePath string, o
 		dockerHost = "host.docker.internal"
 	}
 	p, err := NewCollectorContainer().
+		WithImage(GetCollectorImageOrSkipTest(t)).
 		WithExposedPorts("55679:55679", "55554:55554"). // This is required for tests that read the zpages or the config.
 		WithConfigPath(filepath.Join("testdata", configFile)).
 		WithLogger(logger).
@@ -97,6 +98,7 @@ func CheckGoldenFileWithMount(t *testing.T, configFile string, expectedFilePath 
 		dockerHost = "host.docker.internal"
 	}
 	cc := NewCollectorContainer().
+		WithImage(GetCollectorImageOrSkipTest(t)).
 		WithExposedPorts("55679:55679", "55554:55554"). // This is required for tests that read the zpages or the config.
 		WithConfigPath(filepath.Join("testdata", configFile)).
 		WithLogger(logger).
@@ -149,6 +151,7 @@ func CheckGoldenFileWithCollectorOptions(t *testing.T, configFile string, expect
 	collectorContainer := NewCollectorContainer()
 	collectorOptionsFunc(&collectorContainer)
 	p, err := collectorContainer.
+		WithImage(GetCollectorImageOrSkipTest(t)).
 		WithExposedPorts("55679:55679", "55554:55554"). // This is required for tests that read the zpages or the config.
 		WithConfigPath(filepath.Join("testdata", configFile)).
 		WithLogger(logger).


### PR DESCRIPTION
- Change default image for integration tests from `quay.io/signalfx/splunk-otel-collector-dev:latest` to `otelcol:latest`
- Update smartagent and golden file tests to actually test with the image from the `SPLUNK_OTEL_COLLECTOR_IMAGE` env var or skip