### PR TITLE
fix to kafkametrics k8s issues

### DIFF
--- a/cmd/otelcol/config/collector/config.d.linux/receivers/kafkametrics.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/kafkametrics.discovery.yaml
@@ -15,6 +15,7 @@
 #   config:
 #     default:
 #       protocol_version: 2.0.0
+#       brokers: '`endpoint`'
 #       scrapers:
 #         - brokers
 #         - topics

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/kafkametrics.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/kafkametrics.discovery.yaml
@@ -11,6 +11,7 @@ kafkametrics:
   config:
     default:
       protocol_version: 2.0.0
+      brokers: '`endpoint`'
       scrapers:
         - brokers
         - topics

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/kafkametrics.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/kafkametrics.discovery.yaml.tmpl
@@ -7,6 +7,7 @@
   config:
     default:
       protocol_version: 2.0.0
+      brokers: '`endpoint`'
       scrapers:
         - brokers
         - topics


### PR DESCRIPTION
**Description:** Kafkametrics server cannot communicate to brokers with localhost:9092/ 127.0.0.1:9092 endpoints. 


**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** locally

**Documentation:** <Describe the documentation added.>
