### PR TITLE
Do not run CLA Assistant on repository forks

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   ContributorLicenseAgreement:
+    if: github.repository == 'signalfx/splunk-otel-collector'
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"


### PR DESCRIPTION
Whenever I use my branch to test some GH action changes I get the error for this action, by default it should run only on the original repository, not on forks.

There are other GH actions that may deserve the same but this one is a low hanging fruit. I will look at others as I do other GH action tests in my fork.