### PR TITLE
Reuse discovery receiver's obsreport for receivercreator

### DIFF
--- a/internal/receiver/discoveryreceiver/receiver.go
+++ b/internal/receiver/discoveryreceiver/receiver.go
@@ -175,7 +175,6 @@ func (d *discoveryReceiver) createAndSetReceiverCreator() error {
 	}
 	id := component.MustNewIDWithName(receiverCreatorFactory.Type().String(), d.settings.ID.String())
 	// receiverCreatorConfig.SetIDName(d.settings.ID.String())
-
 	receiverCreatorSettings := receiver.Settings{
 		ID: id,
 		TelemetrySettings: component.TelemetrySettings{
@@ -186,6 +185,7 @@ func (d *discoveryReceiver) createAndSetReceiverCreator() error {
 			TracerProvider: tnoop.NewTracerProvider(),
 			MeterProvider:  mnoop.NewMeterProvider(),
 			MetricsLevel:   configtelemetry.LevelDetailed,
+			ReportStatus:   d.settings.TelemetrySettings.ReportStatus,
 		},
 		BuildInfo: component.BuildInfo{
 			Command: "discovery",


### PR DESCRIPTION
Without this, we get the following error

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3008a0b]


goroutine 86 [running]:
go.opentelemetry.io/collector/internal/sharedcomponent.(*Component[...]).Start.func1()
    	go.opentelemetry.io/collector@v0.104.0/internal/sharedcomponent/sharedcomponent.go:94 +0xcb
sync.(*Once).doSlow(0x410c85?, 0x7772e2fdd878?)
    	sync/once.go:74 +0xbf
sync.(*Once).Do(...)
    	sync/once.go:65
go.opentelemetry.io/collector/internal/sharedcomponent.(*Component[...]).Start(0xc00238ee60?, {0x7d76ba8?, 0xc002c1e230?}, {0x7d252b8?, 0xc0028a1650?})
    	go.opentelemetry.io/collector@v0.104.0/internal/sharedcomponent/sharedcomponent.go:89 +0x9b
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver.(*jmxMetricReceiver).Start(0xc002c223c0, {0x7d76978, 0xcb69ec0}, {0x7d252b8, 0xc0028a1650})
    	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver@v0.104.0/receiver.go:99 +0x911
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator.(*wrappedReceiver).Start(0xc002c21260, {0x7d76978, 0xcb69ec0}, {0x7d252b8, 0xc0028a1650})
    	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator@v0.104.0/runner.go:224 +0x154
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator.(*receiverRunner).start(0xc0022641c0, {{{{0xc002254cc0, 0x3}}, {0xc002254cc4, 0x9}}, 0xc002c20420, {0xc0022580f0, 0x45}}, 0xc0022580f0?, 0xc002225a40)
    	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator@v0.104.0/runner.go:110 +0xef8
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator.(*observerHandler).OnAdd(0xc002c220f0, {0xc002c0c300?, 0x5, 0x7d77ee0?})
    	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator@v0.104.0/observerhandler.go:150 +0x1632
github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer.(*EndpointsWatcher).updateAndNotifyOfEndpoints(0x0?, {0x7d77ee0, 0xc002c220f0}, {0xc002c222d0?, 0x0?, 0x0?}, 0x0?)
    	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer@v0.104.0/endpointswatcher.go:111 +0x1a3
created by github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer.(*EndpointsWatcher).notifyOfLatestEndpoints in goroutine 1
    	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer@v0.104.0/endpointswatcher.go:96 +0x1fb
```

To reproduce, download and extract (`tar -xzvf repro-splunk-jmx.tar.gz`) the following

[splunk discovery -- bugs out](https://drive.google.com/file/d/1bwFB1Nz224GK69GweFntNCKDsznhtPdC/view?usp=drive_link) (check the otelcol-config.yaml and change to the logs pipeline from the metrics pipeline to see it.. May also need to change process name in reproduce.sh for macs if on arm)