### PR TITLE
Use ltsc2019 tag for windows 2019 base image

### DIFF
--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -183,7 +183,7 @@ jobs:
           Copy-Item .\bin\otelcol_windows_amd64.exe .\cmd\otelcol\otelcol.exe
           Copy-Item .\dist\agent-bundle_windows_amd64.zip .\cmd\otelcol\agent-bundle_windows_amd64.zip
           if ("${{ matrix.OS }}" -eq "windows-2019") {
-            $base_image = "mcr.microsoft.com/windows/servercore:1809"
+            $base_image = "mcr.microsoft.com/windows/servercore:ltsc2019"
           } else {
             $base_image = "mcr.microsoft.com/windows/servercore:ltsc2022"
           }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ default:
   image: '${DOCKER_CICD_REPO}/ci-container/debian-buster:3.1.1'
 
 variables:
-  WIN_2019_BASE_IMAGE: mcr.microsoft.com/windows/servercore:1809
+  WIN_2019_BASE_IMAGE: mcr.microsoft.com/windows/servercore:ltsc2019
   WIN_2022_BASE_IMAGE: mcr.microsoft.com/windows/servercore:ltsc2022
 
 stages:


### PR DESCRIPTION
The image is the same, so no noticeable changes to the collector image.
```
$ docker buildx imagetools inspect mcr.microsoft.com/windows/servercore:1809
Name:      mcr.microsoft.com/windows/servercore:1809
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:41f42aa4ad39d85e4d30642b8111ca6454ca2275f188f012934b9afbaf63a647
           
Manifests: 
  Name:       mcr.microsoft.com/windows/servercore:1809@sha256:f44fdada7eb2e71f80c964b2759421f4f7645a2df97a12aa82f66a8d50410414
  MediaType:  application/vnd.docker.distribution.manifest.v2+json
  Platform:   windows/amd64
  OSVersion:  10.0.17763.6054
  OSFeatures: win32k
```
```
$ docker buildx imagetools inspect mcr.microsoft.com/windows/servercore:ltsc2019
Name:      mcr.microsoft.com/windows/servercore:ltsc2019
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:41f42aa4ad39d85e4d30642b8111ca6454ca2275f188f012934b9afbaf63a647
           
Manifests: 
  Name:       mcr.microsoft.com/windows/servercore:ltsc2019@sha256:f44fdada7eb2e71f80c964b2759421f4f7645a2df97a12aa82f66a8d50410414
  MediaType:  application/vnd.docker.distribution.manifest.v2+json
  Platform:   windows/amd64
  OSVersion:  10.0.17763.6054
  OSFeatures: win32k
```