### PR TITLE
ansible: Support splunk-otel-java v2

### DIFF
--- a/deployments/ansible/CHANGELOG.md
+++ b/deployments/ansible/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## ansible-v0.29.0
+
+### 🛑 Breaking changes 🛑
+
+- The default for the `splunk_otel_auto_instrumentation_otlp_endpoint` option has been changed from `http://127.0.0.1:4317`
+  to `''` (empty), i.e. defer to the default `OTEL_EXPORTER_OTLP_ENDPOINT` value for each activated SDK.
+
+### 💡 Enhancements 💡
+
+- Add support for the `splunk_otel_auto_instrumentation_otlp_endpoint_protocol` and `splunk_otel_auto_instrumentation_metrics_exporter`
+  options to configure the `OTEL_EXPORTER_OTLP_PROTOCOL` and `OTEL_METRICS_EXPORTER` environment variables, respectively.
+
 ## ansible-v0.28.0
 
 - Initial support for [Splunk OpenTelemetry for .NET](https://github.com/signalfx/splunk-otel-dotnet) Auto

--- a/deployments/ansible/galaxy.yml
+++ b/deployments/ansible/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: signalfx
 name: splunk_otel_collector
 description: Ansible collection for Splunk OpenTelemetry Collector
-version: 0.28.0
+version: 0.29.0
 readme: README.md
 authors:
   - Splunk Inc.

--- a/deployments/ansible/molecule/with_instrumentation_preload_custom/converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_custom/converge.yml
@@ -12,7 +12,9 @@
     splunk_otel_auto_instrumentation_enable_profiler: true
     splunk_otel_auto_instrumentation_enable_profiler_memory: true
     splunk_otel_auto_instrumentation_enable_metrics: true
+    splunk_otel_auto_instrumentation_metrics_exporter: none
     splunk_otel_auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
+    splunk_otel_auto_instrumentation_otlp_endpoint_protocol: grpc
   tasks:
     - name: "Install nodejs for tests"
       ansible.builtin.import_tasks: ../shared/install_nodejs.yml

--- a/deployments/ansible/molecule/with_instrumentation_preload_custom/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_custom/verify.yml
@@ -173,3 +173,29 @@
         - java.conf
         - node.conf
         - dotnet.conf
+
+    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_PROTOCOL
+      ansible.builtin.lineinfile:
+        line: OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+        dest: "/etc/splunk/zeroconfig/{{ item }}"
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+      loop:
+        - java.conf
+        - node.conf
+        - dotnet.conf
+
+    - name: Assert instrumentation config contains OTEL_METRICS_EXPORTER
+      ansible.builtin.lineinfile:
+        line: OTEL_METRICS_EXPORTER=none
+        dest: "/etc/splunk/zeroconfig/{{ item }}"
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+      loop:
+        - java.conf
+        - node.conf
+        - dotnet.conf

--- a/deployments/ansible/molecule/with_instrumentation_preload_default/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_default/verify.yml
@@ -151,11 +151,37 @@
         - node.conf
         - dotnet.conf
 
-    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_ENDPOINT
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_ENDPOINT
       ansible.builtin.lineinfile:
-        line: OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
+        regexp: '.*OTEL_EXPORTER_OTLP_ENDPOINT.*'
         dest: "/etc/splunk/zeroconfig/{{ item }}"
-        state: present
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+      loop:
+        - java.conf
+        - node.conf
+        - dotnet.conf
+
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_PROTOCOL
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_EXPORTER_OTLP_PROTOCOL.*'
+        dest: "/etc/splunk/zeroconfig/{{ item }}"
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+      loop:
+        - java.conf
+        - node.conf
+        - dotnet.conf
+
+    - name: Assert instrumentation config does not contain OTEL_METRICS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_METRICS_EXPORTER.*'
+        dest: "/etc/splunk/zeroconfig/{{ item }}"
+        state: absent
       check_mode: yes
       register: config
       failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_preload_dotnet/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_dotnet/verify.yml
@@ -133,11 +133,29 @@
       register: config
       failed_when: config is changed
 
-    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_ENDPOINT
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_ENDPOINT
       ansible.builtin.lineinfile:
-        line: OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
+        regexp: '.*OTEL_EXPORTER_OTLP_ENDPOINT.*'
         dest: /etc/splunk/zeroconfig/dotnet.conf
-        state: present
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_PROTOCOL
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_EXPORTER_OTLP_PROTOCOL.*'
+        dest: /etc/splunk/zeroconfig/dotnet.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_METRICS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_METRICS_EXPORTER.*'
+        dest: /etc/splunk/zeroconfig/dotnet.conf
+        state: absent
       check_mode: yes
       register: config
       failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_preload_java/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_java/verify.yml
@@ -124,11 +124,29 @@
       register: config
       failed_when: config is changed
 
-    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_ENDPOINT
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_ENDPOINT
       ansible.builtin.lineinfile:
-        line: OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
+        regexp: '.*OTEL_EXPORTER_OTLP_ENDPOINT.*'
         dest: /etc/splunk/zeroconfig/java.conf
-        state: present
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_PROTOCOL
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_EXPORTER_OTLP_PROTOCOL.*'
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_METRICS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_METRICS_EXPORTER.*'
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: absent
       check_mode: yes
       register: config
       failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_preload_nodejs/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_nodejs/verify.yml
@@ -122,11 +122,29 @@
       register: config
       failed_when: config is changed
 
-    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_ENDPOINT
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_ENDPOINT
       ansible.builtin.lineinfile:
-        line: OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
+        regexp: '.*OTEL_EXPORTER_OTLP_ENDPOINT.*'
         dest: /etc/splunk/zeroconfig/node.conf
-        state: present
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_PROTOCOL
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_EXPORTER_OTLP_PROTOCOL.*'
+        dest: /etc/splunk/zeroconfig/node.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_METRICS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_METRICS_EXPORTER.*'
+        dest: /etc/splunk/zeroconfig/node.conf
+        state: absent
       check_mode: yes
       register: config
       failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_preload_without_npm/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_without_npm/verify.yml
@@ -139,11 +139,35 @@
         - java.conf
         - dotnet.conf
 
-    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_ENDPOINT
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_ENDPOINT
       ansible.builtin.lineinfile:
-        line: OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
+        regexp: '.*OTEL_EXPORTER_OTLP_ENDPOINT.*'
         dest: "/etc/splunk/zeroconfig/{{ item }}"
-        state: present
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+      loop:
+        - java.conf
+        - dotnet.conf
+
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_PROTOCOL
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_EXPORTER_OTLP_PROTOCOL.*'
+        dest: "/etc/splunk/zeroconfig/{{ item }}"
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+      loop:
+        - java.conf
+        - dotnet.conf
+
+    - name: Assert instrumentation config does not contain OTEL_METRICS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_METRICS_EXPORTER.*'
+        dest: "/etc/splunk/zeroconfig/{{ item }}"
+        state: absent
       check_mode: yes
       register: config
       failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_systemd_custom/converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_custom/converge.yml
@@ -12,7 +12,9 @@
     splunk_otel_auto_instrumentation_enable_profiler: true
     splunk_otel_auto_instrumentation_enable_profiler_memory: true
     splunk_otel_auto_instrumentation_enable_metrics: true
+    splunk_otel_auto_instrumentation_metrics_exporter: none
     splunk_otel_auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
+    splunk_otel_auto_instrumentation_otlp_endpoint_protocol: grpc
   tasks:
     - name: "Install nodejs for tests"
       ansible.builtin.import_tasks: ../shared/install_nodejs.yml

--- a/deployments/ansible/molecule/with_instrumentation_systemd_custom/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_custom/verify.yml
@@ -137,3 +137,21 @@
       check_mode: yes
       register: config
       failed_when: config is changed
+
+    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_PROTOCOL
+      ansible.builtin.lineinfile:
+        line: DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL=grpc"
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config contains OTEL_METRICS_EXPORTER
+      ansible.builtin.lineinfile:
+        line: DefaultEnvironment="OTEL_METRICS_EXPORTER=none"
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_systemd_default/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_default/verify.yml
@@ -130,11 +130,29 @@
       register: config
       failed_when: config is changed
 
-    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_ENDPOINT
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_ENDPOINT
       ansible.builtin.lineinfile:
-        line: DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317"
+        regexp: '.*OTEL_EXPORTER_OTLP_ENDPOINT.*'
         dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
-        state: present
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_PROTOCOL
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_EXPORTER_OTLP_PROTOCOL.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_METRICS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_METRICS_EXPORTER.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
       check_mode: yes
       register: config
       failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_systemd_dotnet/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_dotnet/verify.yml
@@ -130,11 +130,29 @@
       register: config
       failed_when: config is changed
 
-    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_ENDPOINT
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_ENDPOINT
       ansible.builtin.lineinfile:
-        line: DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317"
+        regexp: '.*OTEL_EXPORTER_OTLP_ENDPOINT.*'
         dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
-        state: present
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_PROTOCOL
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_EXPORTER_OTLP_PROTOCOL.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_METRICS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_METRICS_EXPORTER.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
       check_mode: yes
       register: config
       failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_systemd_java/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_java/verify.yml
@@ -131,11 +131,29 @@
       register: config
       failed_when: config is changed
 
-    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_ENDPOINT
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_ENDPOINT
       ansible.builtin.lineinfile:
-        line: DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317"
+        regexp: '.*OTEL_EXPORTER_OTLP_ENDPOINT.*'
         dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
-        state: present
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_PROTOCOL
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_EXPORTER_OTLP_PROTOCOL.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_METRICS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_METRICS_EXPORTER.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
       check_mode: yes
       register: config
       failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_systemd_nodejs/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_nodejs/verify.yml
@@ -129,11 +129,29 @@
       register: config
       failed_when: config is changed
 
-    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_ENDPOINT
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_ENDPOINT
       ansible.builtin.lineinfile:
-        line: DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317"
+        regexp: '.*OTEL_EXPORTER_OTLP_ENDPOINT.*'
         dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
-        state: present
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_PROTOCOL
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_EXPORTER_OTLP_PROTOCOL.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_METRICS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_METRICS_EXPORTER.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
       check_mode: yes
       register: config
       failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_systemd_without_npm/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_without_npm/verify.yml
@@ -131,11 +131,29 @@
       register: config
       failed_when: config is changed
 
-    - name: Assert instrumentation config contains OTEL_EXPORTER_OTLP_ENDPOINT
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_ENDPOINT
       ansible.builtin.lineinfile:
-        line: DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317"
+        regexp: '.*OTEL_EXPORTER_OTLP_ENDPOINT.*'
         dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
-        state: present
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_EXPORTER_OTLP_PROTOCOL
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_EXPORTER_OTLP_PROTOCOL.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_METRICS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_METRICS_EXPORTER.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
       check_mode: yes
       register: config
       failed_when: config is changed

--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -299,11 +299,10 @@ to take effect.
   value for each activated SDK)
 
 - `splunk_otel_auto_instrumentation_otlp_endpoint_protocol` (Linux only): Set
-  the protocol for `splunk_otel_auto_instrumentation_otlp_endpoint`, for
-  example `grpc` or `http/protobuf`. The value will be set to the
-  `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable. Only applicable if
-  `splunk_otel_auto_instrumentation_version` is `latest` or >= `0.104.0` and
-  `splunk_otel_auto_instrumentation_otlp_endpoint` is non-empty.
+  the protocol for the OTLP endpoint, for example `grpc` or `http/protobuf`.
+  The value will be set to the `OTEL_EXPORTER_OTLP_PROTOCOL` environment
+  variable. Only applicable if `splunk_otel_auto_instrumentation_version` is
+  `latest` or >= `0.104.0`.
   (**default:** ``, i.e. defer to the default `OTEL_EXPORTER_OTLP_PROTOCOL`
   value for each activated SDK)
 

--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -292,9 +292,29 @@ to take effect.
   disable exporting instrumentation metrics. (**default**: `false`)
 
 - `splunk_otel_auto_instrumentation_otlp_endpoint` (Linux only): Set the OTLP
-  gRPC endpoint for captured traces. Only applicable if
+  endpoint for captured traces. The value will be set to the
+  `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable. Only applicable if
   `splunk_otel_auto_instrumentation_version` is `latest` or >= `0.87.0`.
-  (**default:** `http://127.0.0.1:4317`)
+  (**default:** ``, i.e. defer to the default `OTEL_EXPORTER_OTLP_ENDPOINT`
+  value for each activated SDK)
+
+- `splunk_otel_auto_instrumentation_otlp_endpoint_protocol` (Linux only): Set
+  the protocol for `splunk_otel_auto_instrumentation_otlp_endpoint`, for
+  example `grpc` or `http/protobuf`. The value will be set to the
+  `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable. Only applicable if
+  `splunk_otel_auto_instrumentation_version` is `latest` or >= `0.104.0` and
+  `splunk_otel_auto_instrumentation_otlp_endpoint` is non-empty.
+  (**default:** ``, i.e. defer to the default `OTEL_EXPORTER_OTLP_PROTOCOL`
+  value for each activated SDK)
+
+- `splunk_otel_auto_instrumentation_metrics_exporter` (Linux only):
+  Comma-separated list of exporters for collected metrics by all activated
+  SDKs, for example `otlp,prometheus`. Set the value to `none` to disable
+  collection and export of metrics. The value will be set to the
+  `OTEL_METRICS_EXPORTER` environment variable. Only applicable if
+  `splunk_otel_auto_instrumentation_version` is `latest` or >= `0.104.0`.
+  (**default:** ```, i.e. defer to the default `OTEL_METRICS_EXPORTER` value
+  for each activated SDK)
 
 ### Auto Instrumentation for .NET on Windows
 

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -73,7 +73,9 @@ splunk_otel_auto_instrumentation_disable_telemetry: false
 splunk_otel_auto_instrumentation_enable_profiler: false
 splunk_otel_auto_instrumentation_enable_profiler_memory: false
 splunk_otel_auto_instrumentation_enable_metrics: false
-splunk_otel_auto_instrumentation_otlp_endpoint: http://127.0.0.1:4317
+splunk_otel_auto_instrumentation_metrics_exporter: ""
+splunk_otel_auto_instrumentation_otlp_endpoint: ""
+splunk_otel_auto_instrumentation_otlp_endpoint_protocol: ""
 splunk_otel_auto_instrumentation_sdks:
   - java
   - nodejs

--- a/deployments/ansible/roles/collector/templates/00-splunk-otel-auto-instrumentation.conf.j2
+++ b/deployments/ansible/roles/collector/templates/00-splunk-otel-auto-instrumentation.conf.j2
@@ -28,9 +28,9 @@ DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED={{ splunk_otel_auto_instrumen
 DefaultEnvironment="SPLUNK_METRICS_ENABLED={{ splunk_otel_auto_instrumentation_enable_metrics | string | lower }}"
 {% if splunk_otel_auto_instrumentation_otlp_endpoint is defined and splunk_otel_auto_instrumentation_otlp_endpoint %}
 DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT={{ splunk_otel_auto_instrumentation_otlp_endpoint }}"
+{% endif %}
 {% if splunk_otel_auto_instrumentation_otlp_endpoint_protocol is defined and splunk_otel_auto_instrumentation_otlp_endpoint_protocol %}
 DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL={{ splunk_otel_auto_instrumentation_otlp_endpoint_protocol }}"
-{% endif %}
 {% endif %}
 {% if splunk_otel_auto_instrumentation_metrics_exporter is defined and splunk_otel_auto_instrumentation_metrics_exporter %}
 DefaultEnvironment="OTEL_METRICS_EXPORTER={{ splunk_otel_auto_instrumentation_metrics_exporter }}"

--- a/deployments/ansible/roles/collector/templates/00-splunk-otel-auto-instrumentation.conf.j2
+++ b/deployments/ansible/roles/collector/templates/00-splunk-otel-auto-instrumentation.conf.j2
@@ -26,4 +26,12 @@ DefaultEnvironment="OTEL_SERVICE_NAME={{ splunk_otel_auto_instrumentation_servic
 DefaultEnvironment="SPLUNK_PROFILER_ENABLED={{ splunk_otel_auto_instrumentation_enable_profiler | string | lower }}"
 DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED={{ splunk_otel_auto_instrumentation_enable_profiler_memory | string | lower }}"
 DefaultEnvironment="SPLUNK_METRICS_ENABLED={{ splunk_otel_auto_instrumentation_enable_metrics | string | lower }}"
+{% if splunk_otel_auto_instrumentation_otlp_endpoint is defined and splunk_otel_auto_instrumentation_otlp_endpoint %}
 DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT={{ splunk_otel_auto_instrumentation_otlp_endpoint }}"
+{% if splunk_otel_auto_instrumentation_otlp_endpoint_protocol is defined and splunk_otel_auto_instrumentation_otlp_endpoint_protocol %}
+DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL={{ splunk_otel_auto_instrumentation_otlp_endpoint_protocol }}"
+{% endif %}
+{% endif %}
+{% if splunk_otel_auto_instrumentation_metrics_exporter is defined and splunk_otel_auto_instrumentation_metrics_exporter %}
+DefaultEnvironment="OTEL_METRICS_EXPORTER={{ splunk_otel_auto_instrumentation_metrics_exporter }}"
+{% endif %}

--- a/deployments/ansible/roles/collector/templates/dotnet.conf.j2
+++ b/deployments/ansible/roles/collector/templates/dotnet.conf.j2
@@ -17,4 +17,12 @@ OTEL_SERVICE_NAME={{ splunk_otel_auto_instrumentation_service_name }}
 SPLUNK_PROFILER_ENABLED={{ splunk_otel_auto_instrumentation_enable_profiler | string | lower }}
 SPLUNK_PROFILER_MEMORY_ENABLED={{ splunk_otel_auto_instrumentation_enable_profiler_memory | string | lower }}
 SPLUNK_METRICS_ENABLED={{ splunk_otel_auto_instrumentation_enable_metrics | string | lower }}
+{% if splunk_otel_auto_instrumentation_otlp_endpoint is defined and splunk_otel_auto_instrumentation_otlp_endpoint %}
 OTEL_EXPORTER_OTLP_ENDPOINT={{ splunk_otel_auto_instrumentation_otlp_endpoint }}
+{% if splunk_otel_auto_instrumentation_otlp_endpoint_protocol is defined and splunk_otel_auto_instrumentation_otlp_endpoint_protocol %}
+OTEL_EXPORTER_OTLP_PROTOCOL={{ splunk_otel_auto_instrumentation_otlp_endpoint_protocol }}
+{% endif %}
+{% endif %}
+{% if splunk_otel_auto_instrumentation_metrics_exporter is defined and splunk_otel_auto_instrumentation_metrics_exporter %}
+OTEL_METRICS_EXPORTER={{ splunk_otel_auto_instrumentation_metrics_exporter }}
+{% endif %}

--- a/deployments/ansible/roles/collector/templates/dotnet.conf.j2
+++ b/deployments/ansible/roles/collector/templates/dotnet.conf.j2
@@ -19,9 +19,9 @@ SPLUNK_PROFILER_MEMORY_ENABLED={{ splunk_otel_auto_instrumentation_enable_profil
 SPLUNK_METRICS_ENABLED={{ splunk_otel_auto_instrumentation_enable_metrics | string | lower }}
 {% if splunk_otel_auto_instrumentation_otlp_endpoint is defined and splunk_otel_auto_instrumentation_otlp_endpoint %}
 OTEL_EXPORTER_OTLP_ENDPOINT={{ splunk_otel_auto_instrumentation_otlp_endpoint }}
+{% endif %}
 {% if splunk_otel_auto_instrumentation_otlp_endpoint_protocol is defined and splunk_otel_auto_instrumentation_otlp_endpoint_protocol %}
 OTEL_EXPORTER_OTLP_PROTOCOL={{ splunk_otel_auto_instrumentation_otlp_endpoint_protocol }}
-{% endif %}
 {% endif %}
 {% if splunk_otel_auto_instrumentation_metrics_exporter is defined and splunk_otel_auto_instrumentation_metrics_exporter %}
 OTEL_METRICS_EXPORTER={{ splunk_otel_auto_instrumentation_metrics_exporter }}

--- a/deployments/ansible/roles/collector/templates/java.conf.j2
+++ b/deployments/ansible/roles/collector/templates/java.conf.j2
@@ -10,4 +10,12 @@ OTEL_SERVICE_NAME={{ splunk_otel_auto_instrumentation_service_name }}
 SPLUNK_PROFILER_ENABLED={{ splunk_otel_auto_instrumentation_enable_profiler | string | lower }}
 SPLUNK_PROFILER_MEMORY_ENABLED={{ splunk_otel_auto_instrumentation_enable_profiler_memory | string | lower }}
 SPLUNK_METRICS_ENABLED={{ splunk_otel_auto_instrumentation_enable_metrics | string | lower }}
+{% if splunk_otel_auto_instrumentation_otlp_endpoint is defined and splunk_otel_auto_instrumentation_otlp_endpoint %}
 OTEL_EXPORTER_OTLP_ENDPOINT={{ splunk_otel_auto_instrumentation_otlp_endpoint }}
+{% if splunk_otel_auto_instrumentation_otlp_endpoint_protocol is defined and splunk_otel_auto_instrumentation_otlp_endpoint_protocol %}
+OTEL_EXPORTER_OTLP_PROTOCOL={{ splunk_otel_auto_instrumentation_otlp_endpoint_protocol }}
+{% endif %}
+{% endif %}
+{% if splunk_otel_auto_instrumentation_metrics_exporter is defined and splunk_otel_auto_instrumentation_metrics_exporter %}
+OTEL_METRICS_EXPORTER={{ splunk_otel_auto_instrumentation_metrics_exporter }}
+{% endif %}

--- a/deployments/ansible/roles/collector/templates/java.conf.j2
+++ b/deployments/ansible/roles/collector/templates/java.conf.j2
@@ -12,9 +12,9 @@ SPLUNK_PROFILER_MEMORY_ENABLED={{ splunk_otel_auto_instrumentation_enable_profil
 SPLUNK_METRICS_ENABLED={{ splunk_otel_auto_instrumentation_enable_metrics | string | lower }}
 {% if splunk_otel_auto_instrumentation_otlp_endpoint is defined and splunk_otel_auto_instrumentation_otlp_endpoint %}
 OTEL_EXPORTER_OTLP_ENDPOINT={{ splunk_otel_auto_instrumentation_otlp_endpoint }}
+{% endif %}
 {% if splunk_otel_auto_instrumentation_otlp_endpoint_protocol is defined and splunk_otel_auto_instrumentation_otlp_endpoint_protocol %}
 OTEL_EXPORTER_OTLP_PROTOCOL={{ splunk_otel_auto_instrumentation_otlp_endpoint_protocol }}
-{% endif %}
 {% endif %}
 {% if splunk_otel_auto_instrumentation_metrics_exporter is defined and splunk_otel_auto_instrumentation_metrics_exporter %}
 OTEL_METRICS_EXPORTER={{ splunk_otel_auto_instrumentation_metrics_exporter }}

--- a/deployments/ansible/roles/collector/templates/node.conf.j2
+++ b/deployments/ansible/roles/collector/templates/node.conf.j2
@@ -10,4 +10,12 @@ OTEL_SERVICE_NAME={{ splunk_otel_auto_instrumentation_service_name }}
 SPLUNK_PROFILER_ENABLED={{ splunk_otel_auto_instrumentation_enable_profiler | string | lower }}
 SPLUNK_PROFILER_MEMORY_ENABLED={{ splunk_otel_auto_instrumentation_enable_profiler_memory | string | lower }}
 SPLUNK_METRICS_ENABLED={{ splunk_otel_auto_instrumentation_enable_metrics | string | lower }}
+{% if splunk_otel_auto_instrumentation_otlp_endpoint is defined and splunk_otel_auto_instrumentation_otlp_endpoint %}
 OTEL_EXPORTER_OTLP_ENDPOINT={{ splunk_otel_auto_instrumentation_otlp_endpoint }}
+{% if splunk_otel_auto_instrumentation_otlp_endpoint_protocol is defined and splunk_otel_auto_instrumentation_otlp_endpoint_protocol %}
+OTEL_EXPORTER_OTLP_PROTOCOL={{ splunk_otel_auto_instrumentation_otlp_endpoint_protocol }}
+{% endif %}
+{% endif %}
+{% if splunk_otel_auto_instrumentation_metrics_exporter is defined and splunk_otel_auto_instrumentation_metrics_exporter %}
+OTEL_METRICS_EXPORTER={{ splunk_otel_auto_instrumentation_metrics_exporter }}
+{% endif %}

--- a/deployments/ansible/roles/collector/templates/node.conf.j2
+++ b/deployments/ansible/roles/collector/templates/node.conf.j2
@@ -12,9 +12,9 @@ SPLUNK_PROFILER_MEMORY_ENABLED={{ splunk_otel_auto_instrumentation_enable_profil
 SPLUNK_METRICS_ENABLED={{ splunk_otel_auto_instrumentation_enable_metrics | string | lower }}
 {% if splunk_otel_auto_instrumentation_otlp_endpoint is defined and splunk_otel_auto_instrumentation_otlp_endpoint %}
 OTEL_EXPORTER_OTLP_ENDPOINT={{ splunk_otel_auto_instrumentation_otlp_endpoint }}
+{% endif %}
 {% if splunk_otel_auto_instrumentation_otlp_endpoint_protocol is defined and splunk_otel_auto_instrumentation_otlp_endpoint_protocol %}
 OTEL_EXPORTER_OTLP_PROTOCOL={{ splunk_otel_auto_instrumentation_otlp_endpoint_protocol }}
-{% endif %}
 {% endif %}
 {% if splunk_otel_auto_instrumentation_metrics_exporter is defined and splunk_otel_auto_instrumentation_metrics_exporter %}
 OTEL_METRICS_EXPORTER={{ splunk_otel_auto_instrumentation_metrics_exporter }}


### PR DESCRIPTION
Similar to the installer script changes in #5029:
- change the default for `splunk_otel_auto_instrumentation_otlp_endpoint` from `http://127.0.0.1:4317` to empty
- add new `splunk_otel_auto_instrumentation_metrics_exporter` and `splunk_otel_auto_instrumentation_otlp_endpoint_protocol` options