### PR TITLE
ansible: use ubuntu-24.04 runner for windows tests

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -124,7 +124,7 @@ jobs:
   windows-test:
     name: Windows Test
     needs: lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
       fail-fast: false


### PR DESCRIPTION
Hopefully helps with vagrant/virtualbox flakiness