### PR TITLE
Fix Collector methods in the tests utils

### DIFF
--- a/tests/testutils/collector_container.go
+++ b/tests/testutils/collector_container.go
@@ -56,63 +56,63 @@ type CollectorContainer struct {
 }
 
 // To be used as a builder whose Build() method provides the actual instance capable of launching the process.
-func NewCollectorContainer() CollectorContainer {
-	return CollectorContainer{Args: []string{}, Container: NewContainer(), Mounts: map[string]string{}}
+func NewCollectorContainer() *CollectorContainer {
+	return &CollectorContainer{Args: []string{}, Container: NewContainer(), Mounts: map[string]string{}}
 }
 
 // otelcol:latest by default
-func (collector CollectorContainer) WithImage(image string) CollectorContainer {
+func (collector *CollectorContainer) WithImage(image string) *CollectorContainer {
 	collector.Image = image
 	return collector
 }
 
-func (collector CollectorContainer) WithExposedPorts(ports ...string) CollectorContainer {
+func (collector *CollectorContainer) WithExposedPorts(ports ...string) *CollectorContainer {
 	collector.Ports = append(collector.Ports, ports...)
 	return collector
 }
 
 // Will use bundled config by default
-func (collector CollectorContainer) WithConfigPath(path string) Collector {
+func (collector *CollectorContainer) WithConfigPath(path string) Collector {
 	collector.ConfigPath = path
-	return &collector
+	return collector
 }
 
 // []string{} by default
-func (collector CollectorContainer) WithArgs(args ...string) Collector {
+func (collector *CollectorContainer) WithArgs(args ...string) Collector {
 	collector.Args = args
-	return &collector
+	return collector
 }
 
 // empty by default
-func (collector CollectorContainer) WithEnv(env map[string]string) Collector {
+func (collector *CollectorContainer) WithEnv(env map[string]string) Collector {
 	for k, v := range env {
 		collector.Container.Env[k] = v
 	}
-	return &collector
+	return collector
 }
 
 // Nop logger by default
-func (collector CollectorContainer) WithLogger(logger *zap.Logger) Collector {
+func (collector *CollectorContainer) WithLogger(logger *zap.Logger) Collector {
 	collector.Logger = logger
-	return &collector
+	return collector
 }
 
 // "info" by default, but currently a noop
-func (collector CollectorContainer) WithLogLevel(level string) Collector {
+func (collector *CollectorContainer) WithLogLevel(level string) Collector {
 	collector.LogLevel = level
-	return &collector
+	return collector
 }
 
-func (collector CollectorContainer) WillFail(fail bool) Collector {
+func (collector *CollectorContainer) WillFail(fail bool) Collector {
 	collector.Fail = fail
-	return &collector
+	return collector
 }
-func (collector CollectorContainer) WithMount(path string, mountPoint string) Collector {
+func (collector *CollectorContainer) WithMount(path string, mountPoint string) Collector {
 	collector.Mounts[path] = mountPoint
-	return &collector
+	return collector
 }
 
-func (collector CollectorContainer) Build() (Collector, error) {
+func (collector *CollectorContainer) Build() (Collector, error) {
 	if collector.Image == "" && collector.Container.Dockerfile.Context == "" {
 		collector.Image = "otelcol:latest"
 	}
@@ -165,7 +165,7 @@ func (collector CollectorContainer) Build() (Collector, error) {
 
 	collector.Container = *(collector.Container.Build())
 
-	return &collector, nil
+	return collector, nil
 }
 
 func (collector *CollectorContainer) Start() error {

--- a/tests/testutils/collector_process.go
+++ b/tests/testutils/collector_process.go
@@ -49,60 +49,60 @@ type CollectorProcess struct {
 	Fail             bool
 }
 
-func (collector CollectorProcess) WithMount(string, string) Collector {
-	return &collector
+func (collector *CollectorProcess) WithMount(string, string) Collector {
+	return collector
 }
 
 // To be used as a builder whose Build() method provides the actual instance capable of launching the process.
-func NewCollectorProcess() CollectorProcess {
-	return CollectorProcess{Env: map[string]string{}}
+func NewCollectorProcess() *CollectorProcess {
+	return &CollectorProcess{Env: map[string]string{}}
 }
 
 // Nearest `bin/otelcol` by default
-func (collector CollectorProcess) WithPath(path string) CollectorProcess {
+func (collector *CollectorProcess) WithPath(path string) *CollectorProcess {
 	collector.Path = path
 	return collector
 }
 
 // Required
-func (collector CollectorProcess) WithConfigPath(path string) Collector {
+func (collector *CollectorProcess) WithConfigPath(path string) Collector {
 	collector.ConfigPath = path
-	return &collector
+	return collector
 }
 
 // []string{"--set=service.telemetry.logs.level={collector.LogLevel}", "--config", collector.ConfigPath, "--set=service.telemetry.metrics.level=none"} by default
-func (collector CollectorProcess) WithArgs(args ...string) Collector {
+func (collector *CollectorProcess) WithArgs(args ...string) Collector {
 	collector.Args = args
-	return &collector
+	return collector
 }
 
 // empty by default
-func (collector CollectorProcess) WithEnv(env map[string]string) Collector {
+func (collector *CollectorProcess) WithEnv(env map[string]string) Collector {
 	for k, v := range env {
 		collector.Env[k] = v
 	}
-	return &collector
+	return collector
 }
 
 // Nop logger by default
-func (collector CollectorProcess) WithLogger(logger *zap.Logger) Collector {
+func (collector *CollectorProcess) WithLogger(logger *zap.Logger) Collector {
 	collector.Logger = logger
-	return &collector
+	return collector
 }
 
 // info by default
-func (collector CollectorProcess) WithLogLevel(level string) Collector {
+func (collector *CollectorProcess) WithLogLevel(level string) Collector {
 	collector.LogLevel = level
-	return &collector
+	return collector
 }
 
 // noop at this time
-func (collector CollectorProcess) WillFail(fail bool) Collector {
+func (collector *CollectorProcess) WillFail(fail bool) Collector {
 	collector.Fail = fail
-	return &collector
+	return collector
 }
 
-func (collector CollectorProcess) Build() (Collector, error) {
+func (collector *CollectorProcess) Build() (Collector, error) {
 	if collector.Path == "" {
 		collectorPath, err := findCollectorPath()
 		if err != nil {
@@ -137,7 +137,7 @@ func (collector CollectorProcess) Build() (Collector, error) {
 		EnvironmentVariables: collector.Env,
 	}
 	collector.Process = subprocess.NewSubprocess(collector.subprocessConfig, collector.Logger)
-	return &collector, nil
+	return collector, nil
 }
 
 func (collector *CollectorProcess) Start() error {

--- a/tests/testutils/golden.go
+++ b/tests/testutils/golden.go
@@ -148,15 +148,13 @@ func CheckGoldenFileWithCollectorOptions(t *testing.T, configFile string, expect
 	if runtime.GOOS == "darwin" {
 		dockerHost = "host.docker.internal"
 	}
-	collectorContainer := NewCollectorContainer()
-	collectorOptionsFunc(&collectorContainer)
-	p, err := collectorContainer.
+	collectorContainer := NewCollectorContainer().
 		WithImage(GetCollectorImageOrSkipTest(t)).
 		WithExposedPorts("55679:55679", "55554:55554"). // This is required for tests that read the zpages or the config.
 		WithConfigPath(filepath.Join("testdata", configFile)).
 		WithLogger(logger).
-		WithEnv(map[string]string{"OTLP_ENDPOINT": fmt.Sprintf("%s:%d", dockerHost, port)}).
-		Build()
+		WithEnv(map[string]string{"OTLP_ENDPOINT": fmt.Sprintf("%s:%d", dockerHost, port)})
+	p, err := collectorOptionsFunc(collectorContainer).Build()
 	require.NoError(t, err)
 	require.NoError(t, p.Start())
 	t.Cleanup(func() {

--- a/tests/testutils/testcase.go
+++ b/tests/testutils/testcase.go
@@ -168,7 +168,7 @@ func (t *Testcase) SplunkOtelCollectorContainer(configFilename string, builders 
 	}
 
 	var c Collector
-	c, shutdown = t.newCollector(&cc, configFilename, builders...)
+	c, shutdown = t.newCollector(cc, configFilename, builders...)
 	return c.(*CollectorContainer), shutdown
 }
 
@@ -177,7 +177,7 @@ func (t *Testcase) SplunkOtelCollectorProcess(configFilename string, builders ..
 	cp := NewCollectorProcess()
 
 	var c Collector
-	c, shutdown = t.newCollector(&cp, configFilename, builders...)
+	c, shutdown = t.newCollector(cp, configFilename, builders...)
 	return c.(*CollectorProcess), shutdown
 }
 


### PR DESCRIPTION
When a receiver argument is passed by value to a method, mutating the argument doesn't affect the original copy. So, most of the methods like WithArgs don't actually work. This change fixes it, making the receiver argument passed by its pointer.
