### PR TITLE
Remove splunk_hec exporter from upstream_agent_config

### DIFF
--- a/cmd/otelcol/config/collector/upstream_agent_config.yaml
+++ b/cmd/otelcol/config/collector/upstream_agent_config.yaml
@@ -132,14 +132,6 @@ exporters:
     #ingest_url: http://${SPLUNK_GATEWAY_URL}:9943
     sync_host_metadata: true
     correlation:
-  # Logs for Splunk Cloud Platform and Log Observer Connect
-  # See https://docs.splunk.com/Observability/gdi/opentelemetry/components/splunk-hec-exporter.html
-  splunk_hec:
-    token: "${SPLUNK_HEC_TOKEN}"
-    endpoint: "${SPLUNK_HEC_URL}"
-    source: "otel"
-    sourcetype: "otel"
-    profiling_data_enabled: false
   splunk_hec/profiling:
     token: "${SPLUNK_ACCESS_TOKEN}"
     endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com/v1/log"


### PR DESCRIPTION
Jira: [DOCGUILD-26337](https://splunk.atlassian.net/browse/DOCGUILD-26337)

The user docs page [Send telemetry using the OpenTelemetry Collector Contrib project](https://docs.splunk.com/observability/en/gdi/other-ingestion-methods/upstream-collector.html) includes as a sample config the YAML file that this PR edits. The docs link directly to this YAML file, as you can see here: https://github.com/splunk/public-o11y-docs/blob/main/gdi/other-ingestion-methods/upstream-collector.rst#sample-configuration-for-splunk-observability-cloud

The YAML file does not use the `splunk_hec` exporter, as it is not ultimately used in the pipelines. However, I don't know if it is specified for another reason, so let's review this PR carefully.
