### PR TITLE
chef: support splunk-otel-java v2

### DIFF
--- a/deployments/chef/CHANGELOG.md
+++ b/deployments/chef/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## chef-v0.15.0
+
+- Breaking Change: The default for the `auto_instrumentation_otlp_endpoint` option has been changed from
+  `http://127.0.0.1:4317` to `''` (empty), i.e. defer to the default `OTEL_EXPORTER_OTLP_ENDPOINT` value for each
+  activated SDK.
+- Add support for the `auto_instrumentation_otlp_endpoint_protocol` and `auto_instrumentation_metrics_exporter` options
+  to configure the `OTEL_EXPORTER_OTLP_PROTOCOL` and `OTEL_METRICS_EXPORTER` environment variables, respectively.
+
 ## chef-v0.14.0
 
 - Initial support for [Splunk OpenTelemetry for .NET](https://github.com/signalfx/splunk-otel-dotnet) Auto

--- a/deployments/chef/README.md
+++ b/deployments/chef/README.md
@@ -271,9 +271,26 @@ after installation/configuration in order for any change to take effect.
 - `auto_instrumentation_enable_metrics` (Linux only): Enable or disable
   exporting instrumentation metrics. (**default**: `false`)
 
-- `auto_instrumentation_otlp_endpoint` (Linux only): Set the OTLP gRPC endpoint
-  for captured traces. Only applicable if `auto_instrumentation_version` is
-  `latest` or >= `0.87.0`. (**default:** `http://127.0.0.1:4317`)
+- `auto_instrumentation_otlp_endpoint` (Linux only): Set the OTLP endpoint for
+  captured traces. The value will be set to the `OTEL_EXPORTER_OTLP_ENDPOINT`
+  environment variable. Only applicable if `auto_instrumentation_version` is
+  `latest` or >= `0.87.0`. (**default:** `''`, i.e. defer to the default
+  `OTEL_EXPORTER_OTLP_ENDPOINT` value for each activated SDK)
+
+- `auto_instrumentation_otlp_endpoint_protocol` (Linux only): Set the protocol
+  for the OTLP endpoint, for example `grpc` or `http/protobuf`. The value will
+  be set to the `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable. Only
+  applicable if `auto_instrumentation_version` is `latest` or >= `0.104.0`.
+  (**default:** `''`, i.e. defer to the default `OTEL_EXPORTER_OTLP_PROTOCOL`
+  value for each activated SDK)
+
+- `auto_instrumentation_metrics_exporter` (Linux only): Comma-separated list of
+  exporters for collected metrics by all activated SDKs, for example
+  `otlp,prometheus`. Set the value to `none` to disable collection and export
+  of metrics. The value will be set to the `OTEL_METRICS_EXPORTER` environment
+  variable. Only applicable if `auto_instrumentation_version` is `latest` or >=
+  `0.104.0`. (**default:** `''`, i.e. defer to the default
+  `OTEL_METRICS_EXPORTER` value for each activated SDK)
 
 ### Auto Instrumentation for .NET on Windows
 

--- a/deployments/chef/attributes/default.rb
+++ b/deployments/chef/attributes/default.rb
@@ -99,7 +99,9 @@ elsif platform_family?('debian', 'rhel', 'amazon', 'suse')
   default['splunk_otel_collector']['auto_instrumentation_enable_profiler'] = false
   default['splunk_otel_collector']['auto_instrumentation_enable_profiler_memory'] = false
   default['splunk_otel_collector']['auto_instrumentation_enable_metrics'] = false
-  default['splunk_otel_collector']['auto_instrumentation_otlp_endpoint'] = 'http://127.0.0.1:4317'
+  default['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] = ''
+  default['splunk_otel_collector']['auto_instrumentation_otlp_endpoint'] = ''
+  default['splunk_otel_collector']['auto_instrumentation_otlp_endpoint_protocol'] = ''
   default['splunk_otel_collector']['with_auto_instrumentation_sdks'] = %w(java nodejs dotnet)
   default['splunk_otel_collector']['auto_instrumentation_npm_path'] = 'npm'
 end

--- a/deployments/chef/kitchen.yml
+++ b/deployments/chef/kitchen.yml
@@ -175,6 +175,8 @@ suites:
         auto_instrumentation_enable_profiler_memory: true
         auto_instrumentation_enable_metrics: true
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
+        auto_instrumentation_otlp_endpoint_protocol: grpc
+        auto_instrumentation_metrics_exporter: none
 
   - name: with_default_systemd_instrumentation
     run_list:
@@ -208,6 +210,8 @@ suites:
         auto_instrumentation_enable_profiler_memory: true
         auto_instrumentation_enable_metrics: true
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
+        auto_instrumentation_otlp_endpoint_protocol: grpc
+        auto_instrumentation_metrics_exporter: none
 
   - name: with_default_preload_java_instrumentation
     run_list:
@@ -237,6 +241,8 @@ suites:
         auto_instrumentation_enable_profiler_memory: true
         auto_instrumentation_enable_metrics: true
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
+        auto_instrumentation_otlp_endpoint_protocol: grpc
+        auto_instrumentation_metrics_exporter: none
 
   - name: with_default_systemd_java_instrumentation
     run_list:
@@ -267,6 +273,8 @@ suites:
         auto_instrumentation_enable_profiler_memory: true
         auto_instrumentation_enable_metrics: true
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
+        auto_instrumentation_otlp_endpoint_protocol: grpc
+        auto_instrumentation_metrics_exporter: none
 
   - name: with_default_preload_node_instrumentation
     run_list:
@@ -302,6 +310,8 @@ suites:
         auto_instrumentation_enable_profiler_memory: true
         auto_instrumentation_enable_metrics: true
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
+        auto_instrumentation_otlp_endpoint_protocol: grpc
+        auto_instrumentation_metrics_exporter: none
 
   - name: with_default_systemd_node_instrumentation
     run_list:
@@ -338,6 +348,8 @@ suites:
         auto_instrumentation_enable_profiler_memory: true
         auto_instrumentation_enable_metrics: true
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
+        auto_instrumentation_otlp_endpoint_protocol: grpc
+        auto_instrumentation_metrics_exporter: none
 
   - name: with_default_preload_dotnet_instrumentation
     run_list:
@@ -367,6 +379,8 @@ suites:
         auto_instrumentation_enable_profiler_memory: true
         auto_instrumentation_enable_metrics: true
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
+        auto_instrumentation_otlp_endpoint_protocol: grpc
+        auto_instrumentation_metrics_exporter: none
 
   - name: with_default_systemd_dotnet_instrumentation
     run_list:
@@ -397,6 +411,8 @@ suites:
         auto_instrumentation_enable_profiler_memory: true
         auto_instrumentation_enable_metrics: true
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
+        auto_instrumentation_otlp_endpoint_protocol: grpc
+        auto_instrumentation_metrics_exporter: none
 
   - name: with_default_preload_instrumentation_without_npm
     run_list:

--- a/deployments/chef/metadata.rb
+++ b/deployments/chef/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Splunk, Inc.'
 maintainer_email 'signalfx-support@splunk.com'
 license 'Apache-2.0'
 description 'Install/Configure the Splunk OpenTelemetry Collector'
-version '0.14.0'
+version '0.15.0'
 chef_version '>= 16.0'
 
 supports 'amazon'

--- a/deployments/chef/templates/00-splunk-otel-auto-instrumentation.conf.erb
+++ b/deployments/chef/templates/00-splunk-otel-auto-instrumentation.conf.erb
@@ -26,4 +26,12 @@ DefaultEnvironment="OTEL_SERVICE_NAME=<%= node['splunk_otel_collector']['auto_in
 DefaultEnvironment="SPLUNK_PROFILER_ENABLED=<%= node['splunk_otel_collector']['auto_instrumentation_enable_profiler'].to_s.downcase %>"
 DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED=<%= node['splunk_otel_collector']['auto_instrumentation_enable_profiler_memory'].to_s.downcase %>"
 DefaultEnvironment="SPLUNK_METRICS_ENABLED=<%= node['splunk_otel_collector']['auto_instrumentation_enable_metrics'].to_s.downcase %>"
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint']) && node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint'] != "" -%>
 DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=<%= node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint'] %>"
+<% end -%>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint_protocol']) && node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint_protocol'] != "" -%>
+DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL=<%= node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint_protocol'] %>"
+<% end -%>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_metrics_exporter']) && node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] != "" -%>
+DefaultEnvironment="OTEL_METRICS_EXPORTER=<%= node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] %>"
+<% end -%>

--- a/deployments/chef/templates/dotnet.conf.erb
+++ b/deployments/chef/templates/dotnet.conf.erb
@@ -17,4 +17,12 @@ OTEL_SERVICE_NAME=<%= node['splunk_otel_collector']['auto_instrumentation_servic
 SPLUNK_PROFILER_ENABLED=<%= node['splunk_otel_collector']['auto_instrumentation_enable_profiler'].to_s.downcase %>
 SPLUNK_PROFILER_MEMORY_ENABLED=<%= node['splunk_otel_collector']['auto_instrumentation_enable_profiler_memory'].to_s.downcase %>
 SPLUNK_METRICS_ENABLED=<%= node['splunk_otel_collector']['auto_instrumentation_enable_metrics'].to_s.downcase %>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint']) && node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint'] != "" -%>
 OTEL_EXPORTER_OTLP_ENDPOINT=<%= node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint'] %>
+<% end -%>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint_protocol']) && node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint_protocol'] != "" -%>
+OTEL_EXPORTER_OTLP_PROTOCOL=<%= node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint_protocol'] %>
+<% end -%>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_metrics_exporter']) && node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] != "" -%>
+OTEL_METRICS_EXPORTER=<%= node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] %>
+<% end -%>

--- a/deployments/chef/templates/java.conf.erb
+++ b/deployments/chef/templates/java.conf.erb
@@ -10,4 +10,12 @@ OTEL_SERVICE_NAME=<%= node['splunk_otel_collector']['auto_instrumentation_servic
 SPLUNK_PROFILER_ENABLED=<%= node['splunk_otel_collector']['auto_instrumentation_enable_profiler'].to_s.downcase %>
 SPLUNK_PROFILER_MEMORY_ENABLED=<%= node['splunk_otel_collector']['auto_instrumentation_enable_profiler_memory'].to_s.downcase %>
 SPLUNK_METRICS_ENABLED=<%= node['splunk_otel_collector']['auto_instrumentation_enable_metrics'].to_s.downcase %>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint']) && node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint'] != "" -%>
 OTEL_EXPORTER_OTLP_ENDPOINT=<%= node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint'] %>
+<% end -%>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint_protocol']) && node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint_protocol'] != "" -%>
+OTEL_EXPORTER_OTLP_PROTOCOL=<%= node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint_protocol'] %>
+<% end -%>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_metrics_exporter']) && node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] != "" -%>
+OTEL_METRICS_EXPORTER=<%= node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] %>
+<% end -%>

--- a/deployments/chef/templates/node.conf.erb
+++ b/deployments/chef/templates/node.conf.erb
@@ -10,4 +10,12 @@ OTEL_SERVICE_NAME=<%= node['splunk_otel_collector']['auto_instrumentation_servic
 SPLUNK_PROFILER_ENABLED=<%= node['splunk_otel_collector']['auto_instrumentation_enable_profiler'].to_s.downcase %>
 SPLUNK_PROFILER_MEMORY_ENABLED=<%= node['splunk_otel_collector']['auto_instrumentation_enable_profiler_memory'].to_s.downcase %>
 SPLUNK_METRICS_ENABLED=<%= node['splunk_otel_collector']['auto_instrumentation_enable_metrics'].to_s.downcase %>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint']) && node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint'] != "" -%>
 OTEL_EXPORTER_OTLP_ENDPOINT=<%= node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint'] %>
+<% end -%>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint_protocol']) && node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint_protocol'] != "" -%>
+OTEL_EXPORTER_OTLP_PROTOCOL=<%= node['splunk_otel_collector']['auto_instrumentation_otlp_endpoint_protocol'] %>
+<% end -%>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_metrics_exporter']) && node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] != "" -%>
+OTEL_METRICS_EXPORTER=<%= node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] %>
+<% end -%>

--- a/deployments/chef/test/integration/with_custom_preload_dotnet_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_preload_dotnet_instrumentation/test.rb
@@ -48,6 +48,8 @@ describe file('/etc/splunk/zeroconfig/dotnet.conf') do
   its('content') { should match /^SPLUNK_PROFILER_MEMORY_ENABLED=true$/ }
   its('content') { should match /^SPLUNK_METRICS_ENABLED=true$/ }
   its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
+  its('content') { should match /^OTEL_EXPORTER_OTLP_PROTOCOL=grpc$/ }
+  its('content') { should match /^OTEL_METRICS_EXPORTER=none$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_custom_preload_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_preload_instrumentation/test.rb
@@ -35,6 +35,8 @@ describe file('/etc/splunk/zeroconfig/java.conf') do
   its('content') { should match /^SPLUNK_PROFILER_MEMORY_ENABLED=true$/ }
   its('content') { should match /^SPLUNK_METRICS_ENABLED=true$/ }
   its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
+  its('content') { should match /^OTEL_EXPORTER_OTLP_PROTOCOL=grpc$/ }
+  its('content') { should match /^OTEL_METRICS_EXPORTER=none$/ }
 end
 
 describe file('/etc/splunk/zeroconfig/node.conf') do
@@ -45,6 +47,8 @@ describe file('/etc/splunk/zeroconfig/node.conf') do
   its('content') { should match /^SPLUNK_PROFILER_MEMORY_ENABLED=true$/ }
   its('content') { should match /^SPLUNK_METRICS_ENABLED=true$/ }
   its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
+  its('content') { should match /^OTEL_EXPORTER_OTLP_PROTOCOL=grpc$/ }
+  its('content') { should match /^OTEL_METRICS_EXPORTER=none$/ }
 end
 
 describe file('/etc/splunk/zeroconfig/dotnet.conf') do
@@ -62,6 +66,8 @@ describe file('/etc/splunk/zeroconfig/dotnet.conf') do
   its('content') { should match /^SPLUNK_PROFILER_MEMORY_ENABLED=true$/ }
   its('content') { should match /^SPLUNK_METRICS_ENABLED=true$/ }
   its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
+  its('content') { should match /^OTEL_EXPORTER_OTLP_PROTOCOL=grpc$/ }
+  its('content') { should match /^OTEL_METRICS_EXPORTER=none$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_custom_preload_java_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_preload_java_instrumentation/test.rb
@@ -41,6 +41,8 @@ describe file('/etc/splunk/zeroconfig/java.conf') do
   its('content') { should match /^SPLUNK_PROFILER_MEMORY_ENABLED=true$/ }
   its('content') { should match /^SPLUNK_METRICS_ENABLED=true$/ }
   its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
+  its('content') { should match /^OTEL_EXPORTER_OTLP_PROTOCOL=grpc$/ }
+  its('content') { should match /^OTEL_METRICS_EXPORTER=none$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_custom_preload_node_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_preload_node_instrumentation/test.rb
@@ -41,6 +41,8 @@ describe file('/etc/splunk/zeroconfig/node.conf') do
   its('content') { should match /^SPLUNK_PROFILER_MEMORY_ENABLED=true$/ }
   its('content') { should match /^SPLUNK_METRICS_ENABLED=true$/ }
   its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
+  its('content') { should match /^OTEL_EXPORTER_OTLP_PROTOCOL=grpc$/ }
+  its('content') { should match /^OTEL_METRICS_EXPORTER=none$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_custom_systemd_dotnet_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_systemd_dotnet_instrumentation/test.rb
@@ -48,6 +48,8 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should match /^DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED=true"$/ }
   its('content') { should match /^DefaultEnvironment="SPLUNK_METRICS_ENABLED=true"$/ }
   its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}"$/ }
+  its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL=grpc"$/ }
+  its('content') { should match /^DefaultEnvironment="OTEL_METRICS_EXPORTER=none"$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_custom_systemd_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_systemd_instrumentation/test.rb
@@ -50,6 +50,8 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should match /^DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED=true"$/ }
   its('content') { should match /^DefaultEnvironment="SPLUNK_METRICS_ENABLED=true"$/ }
   its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}"$/ }
+  its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL=grpc"$/ }
+  its('content') { should match /^DefaultEnvironment="OTEL_METRICS_EXPORTER=none"$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_custom_systemd_java_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_systemd_java_instrumentation/test.rb
@@ -48,6 +48,8 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should match /^DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED=true"$/ }
   its('content') { should match /^DefaultEnvironment="SPLUNK_METRICS_ENABLED=true"$/ }
   its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}"$/ }
+  its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL=grpc"$/ }
+  its('content') { should match /^DefaultEnvironment="OTEL_METRICS_EXPORTER=none"$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_custom_systemd_node_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_systemd_node_instrumentation/test.rb
@@ -48,6 +48,8 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should match /^DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED=true"$/ }
   its('content') { should match /^DefaultEnvironment="SPLUNK_METRICS_ENABLED=true"$/ }
   its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}"$/ }
+  its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL=grpc"$/ }
+  its('content') { should match /^DefaultEnvironment="OTEL_METRICS_EXPORTER=none"$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_preload_dotnet_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_dotnet_instrumentation/test.rb
@@ -1,6 +1,5 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+'
-otlp_endpoint = 'http://127.0.0.1:4317'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'
 
 describe package('splunk-otel-auto-instrumentation') do
@@ -45,7 +44,9 @@ describe file('/etc/splunk/zeroconfig/dotnet.conf') do
   its('content') { should match /^SPLUNK_PROFILER_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_PROFILER_MEMORY_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_METRICS_ENABLED=false$/ }
-  its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
+  its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_preload_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_instrumentation/test.rb
@@ -2,7 +2,6 @@ libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
 node_options = '-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument'
 resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+'
-otlp_endpoint = 'http://127.0.0.1:4317'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'
 
 describe package('splunk-otel-auto-instrumentation') do
@@ -32,7 +31,9 @@ describe file('/etc/splunk/zeroconfig/java.conf') do
   its('content') { should match /^SPLUNK_PROFILER_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_PROFILER_MEMORY_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_METRICS_ENABLED=false$/ }
-  its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
+  its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
 end
 
 describe file('/etc/splunk/zeroconfig/node.conf') do
@@ -42,7 +43,9 @@ describe file('/etc/splunk/zeroconfig/node.conf') do
   its('content') { should match /^SPLUNK_PROFILER_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_PROFILER_MEMORY_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_METRICS_ENABLED=false$/ }
-  its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
+  its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
 end
 
 describe file('/etc/splunk/zeroconfig/dotnet.conf') do
@@ -59,7 +62,9 @@ describe file('/etc/splunk/zeroconfig/dotnet.conf') do
   its('content') { should match /^SPLUNK_PROFILER_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_PROFILER_MEMORY_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_METRICS_ENABLED=false$/ }
-  its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
+  its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_preload_instrumentation_without_npm/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_instrumentation_without_npm/test.rb
@@ -1,7 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
 resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+'
-otlp_endpoint = 'http://127.0.0.1:4317'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'
 
 describe package('splunk-otel-auto-instrumentation') do
@@ -35,7 +34,9 @@ describe file('/etc/splunk/zeroconfig/java.conf') do
   its('content') { should match /^SPLUNK_PROFILER_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_PROFILER_MEMORY_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_METRICS_ENABLED=false$/ }
-  its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
+  its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
 end
 
 describe file('/etc/splunk/zeroconfig/dotnet.conf') do
@@ -52,7 +53,9 @@ describe file('/etc/splunk/zeroconfig/dotnet.conf') do
   its('content') { should match /^SPLUNK_PROFILER_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_PROFILER_MEMORY_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_METRICS_ENABLED=false$/ }
-  its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
+  its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_preload_java_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_java_instrumentation/test.rb
@@ -1,7 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
 resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+'
-otlp_endpoint = 'http://127.0.0.1:4317'
 
 describe package('splunk-otel-auto-instrumentation') do
   it { should be_installed }
@@ -38,7 +37,9 @@ describe file('/etc/splunk/zeroconfig/java.conf') do
   its('content') { should match /^SPLUNK_PROFILER_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_PROFILER_MEMORY_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_METRICS_ENABLED=false$/ }
-  its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
+  its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_preload_node_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_node_instrumentation/test.rb
@@ -1,7 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 node_options = '-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument'
 resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+'
-otlp_endpoint = 'http://127.0.0.1:4317'
 
 describe package('splunk-otel-auto-instrumentation') do
   it { should be_installed }
@@ -38,7 +37,9 @@ describe file('/etc/splunk/zeroconfig/node.conf') do
   its('content') { should match /^SPLUNK_PROFILER_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_PROFILER_MEMORY_ENABLED=false$/ }
   its('content') { should match /^SPLUNK_METRICS_ENABLED=false$/ }
-  its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
+  its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_systemd_dotnet_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_dotnet_instrumentation/test.rb
@@ -1,6 +1,5 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+-systemd'
-otlp_endpoint = 'http://127.0.0.1:4317'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'
 
 describe package('splunk-otel-auto-instrumentation') do
@@ -47,7 +46,9 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should match /^DefaultEnvironment="SPLUNK_PROFILER_ENABLED=false"$/ }
   its('content') { should match /^DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED=false"$/ }
   its('content') { should match /^DefaultEnvironment="SPLUNK_METRICS_ENABLED=false"$/ }
-  its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}"$/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
+  its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_systemd_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_instrumentation/test.rb
@@ -2,7 +2,6 @@ libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
 node_options = '-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument'
 resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+-systemd'
-otlp_endpoint = 'http://127.0.0.1:4317'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'
 
 describe package('splunk-otel-auto-instrumentation') do
@@ -49,7 +48,9 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should match /^DefaultEnvironment="SPLUNK_PROFILER_ENABLED=false"$/ }
   its('content') { should match /^DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED=false"$/ }
   its('content') { should match /^DefaultEnvironment="SPLUNK_METRICS_ENABLED=false"$/ }
-  its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}"$/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
+  its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_systemd_instrumentation_without_npm/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_instrumentation_without_npm/test.rb
@@ -1,7 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
 resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+-systemd'
-otlp_endpoint = 'http://127.0.0.1:4317'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'
 
 describe package('splunk-otel-auto-instrumentation') do
@@ -48,7 +47,9 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should match /^DefaultEnvironment="SPLUNK_PROFILER_ENABLED=false"$/ }
   its('content') { should match /^DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED=false"$/ }
   its('content') { should match /^DefaultEnvironment="SPLUNK_METRICS_ENABLED=false"$/ }
-  its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}"$/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
+  its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_systemd_java_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_java_instrumentation/test.rb
@@ -1,7 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
 resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+-systemd'
-otlp_endpoint = 'http://127.0.0.1:4317'
 
 describe package('splunk-otel-auto-instrumentation') do
   it { should be_installed }
@@ -47,7 +46,9 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should match /^DefaultEnvironment="SPLUNK_PROFILER_ENABLED=false"$/ }
   its('content') { should match /^DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED=false"$/ }
   its('content') { should match /^DefaultEnvironment="SPLUNK_METRICS_ENABLED=false"$/ }
-  its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}"$/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
+  its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_systemd_node_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_node_instrumentation/test.rb
@@ -1,7 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 node_options = '-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument'
 resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+-systemd'
-otlp_endpoint = 'http://127.0.0.1:4317'
 
 describe package('splunk-otel-auto-instrumentation') do
   it { should be_installed }
@@ -47,7 +46,9 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should match /^DefaultEnvironment="SPLUNK_PROFILER_ENABLED=false"$/ }
   its('content') { should match /^DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED=false"$/ }
   its('content') { should match /^DefaultEnvironment="SPLUNK_METRICS_ENABLED=false"$/ }
-  its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}"$/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
+  its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
+  its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do


### PR DESCRIPTION
Similar to the installer script changes in https://github.com/signalfx/splunk-otel-collector/pull/5029:
- change the default for `auto_instrumentation_otlp_endpoint` from `http://127.0.0.1:4317` to empty
- add new `auto_instrumentation_metrics_exporter` and `auto_instrumentation_otlp_endpoint_protocol` options