### PR TITLE
Deprecate Apache monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - (Splunk) Add ElasticSearch receiver ([#5165](https://github.com/signalfx/splunk-otel-collector/pull/5165/))
 
+### 🚩Deprecations 🚩
+
+- (Splunk) Deprecate the Apache monitor ([#5166](https://github.com/signalfx/splunk-otel-collector/pull/5166))
+
 ## v0.105.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.105.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.105.0) and the [opentelemetry-collector-contrib v0.105.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.105.0) releases where appropriate.

--- a/internal/signalfx-agent/pkg/monitors/collectd/apache/apache.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/apache/apache.go
@@ -46,5 +46,5 @@ type Monitor struct {
 
 // Configure configures and runs the plugin in collectd
 func (am *Monitor) Configure(conf *Config) error {
-	return am.SetConfigurationAndRun(conf)
+	return am.SetConfigurationAndRun(conf, collectd.WithWarning("[NOTICE] The collectd/apache plugin is deprecated and will be removed in a future release. Please migrate to the apache receiver."))
 }

--- a/internal/signalfx-agent/pkg/monitors/collectd/apache/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/collectd/apache/metadata.yaml
@@ -3,6 +3,8 @@ monitors:
     plugin_instance:
       description: Set to whatever you set in the `name` config option.
   doc: |
+    This monitor is deprecated and will be removed in a future release. Use the apache receiver instead.
+    
     Monitors Apache webservice instances using the information provided by
     `mod_status`.
 

--- a/internal/signalfx-agent/pkg/monitors/collectd/apache/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/collectd/apache/metadata.yaml
@@ -3,7 +3,7 @@ monitors:
     plugin_instance:
       description: Set to whatever you set in the `name` config option.
   doc: |
-    This monitor is deprecated and will be removed in a future release. Use the apache receiver instead.
+    This monitor is deprecated and will be removed in a future release. Use the [OpenTelemetry Apache Web Server Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/apachereceiver) instead.
     
     Monitors Apache webservice instances using the information provided by
     `mod_status`.

--- a/internal/signalfx-agent/pkg/monitors/collectd/monitorcore.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/monitorcore.go
@@ -71,6 +71,12 @@ func WithDeprecationWarningLog(replacement string) ConfigurationOption {
 	}
 }
 
+func WithWarning(log string) ConfigurationOption {
+	return func(mc *MonitorCore) {
+		mc.logger.Warn(log)
+	}
+}
+
 // SetConfigurationAndRun sets the configuration to be used when rendering
 // templates, and writes config before queueing a collectd restart.
 func (mc *MonitorCore) SetConfigurationAndRun(conf config.MonitorCustomConfig, opts ...ConfigurationOption) error {


### PR DESCRIPTION
**Description:**
Mark the apache monitor deprecated and to be removed in a future release. The apache receiver should be used instead.