### PR TITLE
Fix TestConfigServer flakiness on Windows and mac

### DIFF
--- a/internal/configconverter/config_server.go
+++ b/internal/configconverter/config_server.go
@@ -168,8 +168,6 @@ func (cs *ConfigServer) start() {
 				cs.wg.Wait()
 				if cs.server != nil {
 					_ = cs.server.Close()
-					// If launched wait for Serve goroutine exit.
-					<-cs.doneCh
 				}
 
 			}()

--- a/internal/configconverter/config_server_test.go
+++ b/internal/configconverter/config_server_test.go
@@ -95,7 +95,13 @@ func TestConfigServer_EnvVar(t *testing.T) {
 			cs.OnNew()
 
 			require.NoError(t, cs.Convert(context.Background(), confmap.NewFromStringMap(initial)))
-			defer cs.OnShutdown()
+			defer func() {
+				cs.OnShutdown() // Call shutdown even if the server is not up.
+				if !tt.serverDown {
+					// Wait for the server to shutdown. Otherwise the port might be still in use.
+					<-cs.doneCh
+				}
+			}()
 
 			endpoint := tt.endpoint
 			if endpoint == "" {


### PR DESCRIPTION
It seems that some change either on the runner or the actual OS is exposing a race in which the previous test case didn't release the port yet.