### PR TITLE
Remove processlist from the default configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### 🚩Deprecations 🚩
 
 - (Splunk) Deprecate the collectd/health-checker plugin ([#5167](https://github.com/signalfx/splunk-otel-collector/pull/5167))
+- (Splunk) Remove `smartagent/processlist` from the default configuration ([#]()).
+  You can re-enable this configuration by uncommenting the processlist monitor in the configuration.
 
 ## v0.105.0
 

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -83,8 +83,8 @@ receivers:
           - source_labels: [ __name__ ]
             regex: 'otelcol_processor_batch_.*'
             action: drop
-  smartagent/processlist:
-    type: processlist
+#  smartagent/processlist:
+#    type: processlist
   signalfx:
     endpoint: "${SPLUNK_LISTEN_INTERFACE}:9943"
     # Whether to preserve incoming access token and use instead of exporter token
@@ -187,7 +187,9 @@ service:
       # to use signalfx exporter so host metadata gets emitted
       exporters: [signalfx]
     logs/signalfx:
-      receivers: [signalfx, smartagent/processlist]
+      receivers:
+      - signalfx
+      # - smartagent/processlist
       processors: [memory_limiter, batch, resourcedetection]
       exporters: [signalfx]
     logs:


### PR DESCRIPTION
**Description:**
Remove smartagent/processlist from the default configuration of the collector.

This can be re-enabled by uncommenting the instructions in the agent configuration.