### PR TITLE
Make TestConfigServer_RequireEnvVar environment consistent

### DIFF
--- a/internal/configconverter/config_server_test.go
+++ b/internal/configconverter/config_server_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestConfigServer_RequireEnvVar(t *testing.T) {
-	 // Ensure that the env var is unset as required by this test.
+	// Ensure that the env var is unset as required by this test.
 	os.Unsetenv(configServerEnabledEnvVar)
 	initial := map[string]any{
 		"minimal": "config",

--- a/internal/configconverter/config_server_test.go
+++ b/internal/configconverter/config_server_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 func TestConfigServer_RequireEnvVar(t *testing.T) {
+	 // Ensure that the env var is unset as required by this test.
+	os.Unsetenv(configServerEnabledEnvVar)
 	initial := map[string]any{
 		"minimal": "config",
 	}
@@ -49,7 +51,7 @@ func TestConfigServer_RequireEnvVar(t *testing.T) {
 	client := &http.Client{}
 	path := "/debug/configz/initial"
 	_, err := client.Get("http://" + defaultConfigServerEndpoint + path)
-	assert.Error(t, err)
+	assert.Error(t, err, "SPLUNK_DEBUG_CONFIG_SERVER=%s", os.Getenv(configServerEnabledEnvVar))
 }
 
 func TestConfigServer_EnvVar(t *testing.T) {


### PR DESCRIPTION
It seems that somehow the `TestConfigServer_RequireEnvVar` is being launched with the environment variable `SPLUNK_DEBUG_CONFIG_SERVER` set to `true`. This seems to happen when `go test -v -cover ./...` is launched on a GH runner. I can't reproduce it locally, in light of that, I'm opting to enforce the condition required by the test at its own status.