### PR TITLE
[discovery/receiver] Emit metrics from discovered services

### DIFF
--- a/internal/common/sharedcomponent/package_test.go
+++ b/internal/common/sharedcomponent/package_test.go
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Copied from https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/internal/sharedcomponent
+
+package sharedcomponent
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/common/sharedcomponent/sharedcomponent.go
+++ b/internal/common/sharedcomponent/sharedcomponent.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Copied from https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/internal/sharedcomponent
+
+// Package sharedcomponent exposes util functionality for receivers and exporters
+// that need to share state between different signal types instances such as net.Listener or os.File.
+package sharedcomponent
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+// SharedComponents a map that keeps reference of all created instances for a given configuration,
+// and ensures that the shared state is started and stopped only once.
+type SharedComponents struct {
+	comps map[any]*SharedComponent
+}
+
+// NewSharedComponents returns a new empty SharedComponents.
+func NewSharedComponents() *SharedComponents {
+	return &SharedComponents{
+		comps: make(map[any]*SharedComponent),
+	}
+}
+
+// GetOrAdd returns the already created instance if exists, otherwise creates a new instance
+// and adds it to the map of references.
+func (scs *SharedComponents) GetOrAdd(key any, create func() component.Component) *SharedComponent {
+	if c, ok := scs.comps[key]; ok {
+		return c
+	}
+	newComp := &SharedComponent{
+		Component: create(),
+		removeFunc: func() {
+			delete(scs.comps, key)
+		},
+	}
+	scs.comps[key] = newComp
+	return newComp
+}
+
+// SharedComponent ensures that the wrapped component is started and stopped only once.
+// When stopped it is removed from the SharedComponents map.
+type SharedComponent struct {
+	component.Component
+	removeFunc func()
+	startOnce  sync.Once
+	stopOnce   sync.Once
+}
+
+// Unwrap returns the original component.
+func (r *SharedComponent) Unwrap() component.Component {
+	return r.Component
+}
+
+// Start implements component.Component.
+func (r *SharedComponent) Start(ctx context.Context, host component.Host) error {
+	var err error
+	r.startOnce.Do(func() {
+		err = r.Component.Start(ctx, host)
+	})
+	return err
+}
+
+// Shutdown implements component.Component.
+func (r *SharedComponent) Shutdown(ctx context.Context) error {
+	var err error
+	r.stopOnce.Do(func() {
+		err = r.Component.Shutdown(ctx)
+		r.removeFunc()
+	})
+	return err
+}

--- a/internal/common/sharedcomponent/sharedcomponent_test.go
+++ b/internal/common/sharedcomponent/sharedcomponent_test.go
@@ -1,0 +1,74 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Copied from https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/internal/sharedcomponent
+
+package sharedcomponent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+)
+
+var id = component.MustNewID("test")
+
+func TestNewSharedComponents(t *testing.T) {
+	comps := NewSharedComponents()
+	assert.Len(t, comps.comps, 0)
+}
+
+type mockComponent struct {
+	component.StartFunc
+	component.ShutdownFunc
+}
+
+func TestSharedComponents_GetOrAdd(t *testing.T) {
+	nop := &mockComponent{}
+	createNop := func() component.Component { return nop }
+
+	comps := NewSharedComponents()
+	got := comps.GetOrAdd(id, createNop)
+	assert.Len(t, comps.comps, 1)
+	assert.Same(t, nop, got.Unwrap())
+	assert.Same(t, got, comps.GetOrAdd(id, createNop))
+
+	// Shutdown nop will remove
+	assert.NoError(t, got.Shutdown(context.Background()))
+	assert.Len(t, comps.comps, 0)
+	assert.NotSame(t, got, comps.GetOrAdd(id, createNop))
+}
+
+func TestSharedComponent(t *testing.T) {
+	wantErr := errors.New("my error")
+	calledStart := 0
+	calledStop := 0
+	comp := &mockComponent{
+		StartFunc: func(_ context.Context, _ component.Host) error {
+			calledStart++
+			return wantErr
+		},
+		ShutdownFunc: func(_ context.Context) error {
+			calledStop++
+			return wantErr
+		},
+	}
+	createComp := func() component.Component { return comp }
+
+	comps := NewSharedComponents()
+	got := comps.GetOrAdd(id, createComp)
+	assert.Equal(t, wantErr, got.Start(context.Background(), componenttest.NewNopHost()))
+	assert.Equal(t, 1, calledStart)
+	// Second time is not called anymore.
+	assert.NoError(t, got.Start(context.Background(), componenttest.NewNopHost()))
+	assert.Equal(t, 1, calledStart)
+	assert.Equal(t, wantErr, got.Shutdown(context.Background()))
+	assert.Equal(t, 1, calledStop)
+	// Second time is not called anymore.
+	assert.NoError(t, got.Shutdown(context.Background()))
+	assert.Equal(t, 1, calledStop)
+}

--- a/internal/receiver/discoveryreceiver/factory_test.go
+++ b/internal/receiver/discoveryreceiver/factory_test.go
@@ -54,9 +54,8 @@ func TestCreateMetricsReceiver(t *testing.T) {
 
 	params := receivertest.NewNopSettings()
 	rcvr, err := factory.CreateMetricsReceiver(context.Background(), params, cfg, consumertest.NewNop())
-	require.Error(t, err)
-	assert.EqualError(t, err, "telemetry type is not supported")
-	assert.Nil(t, rcvr)
+	require.NoError(t, err)
+	assert.NotNil(t, rcvr)
 }
 
 func TestCreateTracesReceiver(t *testing.T) {

--- a/internal/receiver/discoveryreceiver/metric_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator_test.go
@@ -36,7 +36,7 @@ func TestMetricEvaluatorBaseMetricConsumer(t *testing.T) {
 	cfg := &Config{}
 	cStore := newCorrelationStore(logger, time.Hour)
 
-	me := newMetricEvaluator(logger, cfg, cStore)
+	me := newMetricsConsumer(logger, cfg, cStore, nil)
 	require.Equal(t, consumer.Capabilities{}, me.Capabilities())
 
 	md := pmetric.NewMetrics()
@@ -88,7 +88,7 @@ func TestMetricEvaluation(t *testing.T) {
 					endpointID := observer.EndpointID("endpoint.id")
 					cStore.UpdateEndpoint(observer.Endpoint{ID: endpointID}, receiverID, observerID)
 
-					me := newMetricEvaluator(logger, cfg, cStore)
+					me := newMetricsConsumer(logger, cfg, cStore, nil)
 
 					expectedRes := pcommon.NewResource()
 					expectedRes.Attributes().PutStr("discovery.receiver.type", "a_receiver")

--- a/internal/receiver/discoveryreceiver/receiver_test.go
+++ b/internal/receiver/discoveryreceiver/receiver_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/extension"
 	otelcolreceiver "go.opentelemetry.io/collector/receiver"
 	mnoop "go.opentelemetry.io/otel/metric/noop"
@@ -38,7 +37,7 @@ func TestNewDiscoveryReceiver(t *testing.T) {
 		},
 	}
 	cfg := &Config{}
-	receiver, err := newDiscoveryReceiver(rcs, cfg, consumertest.NewNop())
+	receiver, err := newDiscoveryReceiver(rcs, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, receiver)
 
@@ -109,7 +108,7 @@ func TestObservablesFromHost(t *testing.T) {
 			}
 			host := mockHost{extensions: test.extensions}
 			cfg := &Config{WatchObservers: test.watchObservers}
-			receiver, err := newDiscoveryReceiver(rcs, cfg, consumertest.NewNop())
+			receiver, err := newDiscoveryReceiver(rcs, cfg)
 			require.NoError(t, err)
 			require.NotNil(t, receiver)
 


### PR DESCRIPTION
This change will be used to convert the discovery receiver into long running receiver that would discover services and emit entity events along with the metrics without requiring the restart of the collector

I had to copy the sharedcomponent package from upstream to use the same instance of the discovery receiver work in both logs and metrics pipelines
