### PR TITLE
[chore] Free GitHub runner space before docker integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -183,6 +183,8 @@ jobs:
     env:
       TEST_OUTPUT: ${{ github.job }}-${{ matrix.PROFILE }}-${{ matrix.ARCH }}.out
     steps:
+      # Multiarch images require more disk space
+      - uses: jlumbroso/free-disk-space@v1.3.1
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Intended to resolve out of space errors seen [here](https://github.com/signalfx/splunk-otel-collector/actions/runs/10374366437/job/28723529340?pr=5225). This simply copies what we're currently doing for the `docker-otelcol` action.

[Action reference here.](https://github.com/jlumbroso/free-disk-space)