### PR TITLE
[chore] Remove redundant CI comments

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -221,7 +221,6 @@ jobs:
       - run: docker load -i ./docker-otelcol/${{ matrix.ARCH }}/image.tar
       - run: ln -sf otelcol_linux_${{ matrix.ARCH }} ./bin/otelcol
       - run: chmod a+x ./bin/*
-      # Pin the version until https://github.com/shogo82148/actions-setup-redis/issues/958 is resolved
       - uses: shogo82148/actions-setup-redis@v1.35.1
         if: matrix.PROFILE == 'integration'
         with:
@@ -299,7 +298,6 @@ jobs:
           path: ./bin
       - run: ln -sf otelcol_linux_amd64 ./bin/otelcol
       - run: chmod a+x ./bin/*
-      # Pin the version until https://github.com/shogo82148/actions-setup-redis/issues/958 is resolved
       - uses: shogo82148/actions-setup-redis@v1.35.1
         if: matrix.PROFILE == 'integration'
         with:


### PR DESCRIPTION
https://github.com/shogo82148/actions-setup-redis/issues/958 is fixed now. Keeping the version pinned since it's tracked by the dependabot anyway. That way, it's easier to pinpoint any issue during explicit upgrades.
