### PR TITLE
[chore] Update tidy comment

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,7 +65,7 @@ jobs:
           make install-tools
           make for-all CMD="make tidy"
           if ! git diff --exit-code; then
-            echo "One or more Go files are not tidied. Run 'make for-all CMD="make tidy"' and push the changes."
+            echo "One or more Go files are not tidied. Run 'make for-all CMD=\"make tidy\"' and push the changes."
             exit 1
           fi
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/signalfx/splunk-otel-collector
 go 1.21.0
 
 require (
-	github.com/alecthomas/participle/v2 v2.1.1
 	github.com/antonmedv/expr v1.15.5
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/expr-lang/expr v1.16.9

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/signalfx/splunk-otel-collector
 go 1.21.0
 
 require (
+	github.com/alecthomas/participle/v2 v2.1.1
 	github.com/antonmedv/expr v1.15.5
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/expr-lang/expr v1.16.9


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
When the tidy step fails, the message printed out is actually:
```
One or more Go files are not tidied. Run 'make for-all CMD=make tidy' and push the changes.
```
The `"` around `make tidy` get dropped, which means you can't copy-paste to your local terminal and run.

**Testing:**
I made this PR fail tidy on purpose, output of failure:
```
 require (
+	github.com/alecthomas/participle/v2 v2.1.1
 	github.com/antonmedv/expr v1.15.5
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/expr-lang/expr v1.16.9
One or more Go files are not tidied. Run 'make for-all CMD="make tidy"' and push the changes.
```