### PR TITLE
[package-test] Update test access token type

### DIFF
--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -351,7 +351,7 @@ jobs:
       - name: Run docker image
         run: |
           # ensure the collector can start with the default config file
-          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
+          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=\"12345\" -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
           sleep 10
           if [ -z "$( docker ps --filter=status=running --filter=name=otelcol -q )" ]; then
             docker logs otelcol
@@ -371,7 +371,7 @@ jobs:
             exit 1
           fi
           for config in $configs; do
-            docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_CONFIG=/etc/otel/collector/${config} -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
+            docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_CONFIG=/etc/otel/collector/${config} -e SPLUNK_ACCESS_TOKEN=\"12345\" -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
             sleep 10
             if [ -z "$( docker ps --filter=status=running --filter=name=otelcol -q )" ]; then
               docker logs otelcol
@@ -384,7 +384,7 @@ jobs:
       - name: Check journalctl
         run: |
           # ensure journalctl can run with the collected libraries
-          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
+          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=\"12345\" -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
           docker exec otelcol /bin/journalctl
           docker rm -f otelcol
 
@@ -392,7 +392,7 @@ jobs:
         if: ${{ matrix.ARCH != 'ppc64le' }}
         run: |
           # ensure python and java can run with the collected libraries
-          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
+          docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_ACCESS_TOKEN=\"12345\" -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest
           docker exec otelcol /usr/lib/splunk-otel-collector/agent-bundle/bin/python --version
           docker exec otelcol /usr/lib/splunk-otel-collector/agent-bundle/jre/bin/java -version
           # ensure collectd-python plugins were installed

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -128,9 +128,9 @@ jobs:
           until nc -w 10 127.0.0.1 4646; do sleep 1; done
       - name: Prepare deployment
         run: |
-          sed -i 's/<SPLUNK_ACCESS_TOKEN>/12345/g' otel-agent.nomad
+          sed -i 's/<SPLUNK_ACCESS_TOKEN>/\"12345\"/g' otel-agent.nomad
           sed -i 's/<SPLUNK_REALM>/test/g' otel-agent.nomad
-          sed -i 's/<SPLUNK_ACCESS_TOKEN>/12345/g' otel-gateway.nomad
+          sed -i 's/<SPLUNK_ACCESS_TOKEN>/\"12345\"/g' otel-gateway.nomad
           sed -i 's/<SPLUNK_REALM>/test/g' otel-gateway.nomad
 
       - name: Deploy gateway with Nomad

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -363,7 +363,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           Set-PSDebug -Trace 1
           $choco_file_name = Resolve-Path .\dist\splunk-otel-collector*.nupkg
-          $params = "/SPLUNK_ACCESS_TOKEN=${{ env.token }} /SPLUNK_REALM=${{ env.realm }} /SPLUNK_MEMORY_TOTAL_MIB=${{ env.memory }} /MODE:${{ matrix.MODE }} /WITH_FLUENTD:${{ matrix.WITH_FLUENTD }}"
+          $params = "/SPLUNK_ACCESS_TOKEN=\"${{ env.token }}\" /SPLUNK_REALM=${{ env.realm }} /SPLUNK_MEMORY_TOTAL_MIB=${{ env.memory }} /MODE:${{ matrix.MODE }} /WITH_FLUENTD:${{ matrix.WITH_FLUENTD }}"
           if ("${{ matrix.SCENARIO }}" -eq "install") {
             write-host "Installing $choco_file_name ..."
             choco install splunk-otel-collector -s=".\dist" --params="'$params'" -y
@@ -440,7 +440,7 @@ jobs:
       - name: Run docker image
         run: |
           $ErrorActionPreference = 'Stop'
-          docker run -d -e SPLUNK_ACCESS_TOKEN=12345 -e SPLUNK_REALM=fake-realm --name otelcol otelcol-windows:latest
+          docker run -d -e SPLUNK_ACCESS_TOKEN=\"12345\" -e SPLUNK_REALM=fake-realm --name otelcol otelcol-windows:latest
           Start-Sleep 10
           $DockerOutput=$(docker ps --filter=status=running --filter=name=otelcol -q)
           if ( $DockerOutput -eq $null ) {

--- a/deployments/chef/templates/splunk-otel-collector.conf.erb
+++ b/deployments/chef/templates/splunk-otel-collector.conf.erb
@@ -2,6 +2,7 @@
 SPLUNK_CONFIG=<%= node['splunk_otel_collector']['collector_config_dest'] %>
 
 # Access token to authenticate requests.
+# TODO: This opens us to a potential parsing error, maybe it needs quotes around it?
 SPLUNK_ACCESS_TOKEN=<%= node['splunk_otel_collector']['splunk_access_token'] %>
 
 # Which realm to send the data to.

--- a/internal/buildscripts/packaging/fpm/etc/otel/collector/splunk-otel-collector.conf.example
+++ b/internal/buildscripts/packaging/fpm/etc/otel/collector/splunk-otel-collector.conf.example
@@ -24,7 +24,7 @@ SPLUNK_CONFIG=/etc/otel/collector/agent_config.yaml
 # The following environment variables are referenced in the default /etc/otel/collector/agent_config.yaml config file.
 
 # Access token to authenticate requests.
-SPLUNK_ACCESS_TOKEN=12345
+SPLUNK_ACCESS_TOKEN=\"12345\"
 
 # Which realm to send the data to.
 SPLUNK_REALM=us0


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
With the introduction of strict type parsing for config parsing, tests using an int as the access token are now failing, as it's no longer parsed as a string. Before the upstream change, `12345` could successfully be parsed as a string. After, it will be parsed as an int no matter what. We need to make it clear in testing that `12345` should be considered a string.

Note: This is likely not yet complete, it's a WIP.