### PR TITLE
Fix an invalid doc reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ In addition, the following components can be configured:
   - Information about migrating from the SignalFx Smart Agent can be found
     [here](docs/signalfx-smart-agent-migration.md)
 
-By default the Splunk OpenTelemetry Collector provides a sensitive value-redacting, local config server listening at
-`http://localhost:55554/debug/configz/effective` that is helpful in troubleshooting. To disable this feature please
-set the `SPLUNK_DEBUG_CONFIG_SERVER` environment variable to any value other than `true`. To set the desired port to
+The Splunk OpenTelemetry Collector provides a sensitive value-redacting, local config server listening at
+`http://localhost:55554/debug/configz/effective` that is helpful in troubleshooting. To enable this feature please
+set the `SPLUNK_DEBUG_CONFIG_SERVER` environment variable to `true`. To set the desired port to
 listen to configure the `SPLUNK_DEBUG_CONFIG_SERVER_PORT` environment variable.
 
 You can use the environment variable `SPLUNK_LISTEN_INTERFACE` and associated installer option to configure the network


### PR DESCRIPTION
**Description:**
Fix a doc comment that is invalid. See https://github.com/signalfx/splunk-otel-collector/blob/80c54cdf0e9e7c15cfac0138069af99a5cdcd5bf/internal/configconverter/config_server.go#L134 for the algorithm.