### PR TITLE
Don't expand config provider invocations

### DIFF
--- a/internal/configsource/source.go
+++ b/internal/configsource/source.go
@@ -472,6 +472,10 @@ func retrieveConfigSourceData(ctx context.Context, configSources map[string]Conf
 	var provider confmap.Provider
 	var providerFound bool
 	if !ok {
+		if confmapProviders == nil {
+			// Don't need to expand. Let the upstream handle it.
+			return cfgSrcInvocation, nil, nil
+		}
 		if provider, providerFound = confmapProviders[cfgSrcName]; !providerFound {
 			return nil, nil, newErrUnknownConfigSource(cfgSrcName)
 		}

--- a/internal/confmapprovider/configsource/provider.go
+++ b/internal/confmapprovider/configsource/provider.go
@@ -174,7 +174,7 @@ func (pw *ProviderWrapper) ResolveForWrapped(ctx context.Context, uri string, on
 		return nil, fmt.Errorf("failed resolving latestConf: %w", err)
 	}
 
-	resolved, closeFunc, err := configsource.ResolveWithConfigSources(ctx, configSources, providers, confToResolve, onChange)
+	resolved, closeFunc, err := configsource.ResolveWithConfigSources(ctx, configSources, nil, confToResolve, onChange)
 	if err != nil {
 		return nil, fmt.Errorf("failed resolving with config sources: %w", err)
 	}


### PR DESCRIPTION
Leave it to upstream. Only expand them if they are found in the config_sources section.
