### PR TITLE
fix choco package upgrades

### DIFF
--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -371,14 +371,12 @@ jobs:
               throw "choco install failed!"
             }
           } else {
-            write-host "Installing splunk-otel-collector 0.74.0 ..."
+            write-host "Installing splunk-otel-collector ..."
             choco feature enable -n=useRememberedArgumentsForUpgrades
-            choco install splunk-otel-collector --no-progress --version=0.74.0 --params="'$params'" -y
+            choco install splunk-otel-collector --no-progress --params="'$params'" -y
             if ($LASTEXITCODE -ne 0) {
               throw "choco install failed!"
             }
-            stop-service splunk-otel-collector
-            rm "$env:PROGRAMDATA\Splunk\OpenTelemetry Collector\*_config.yaml"
             Start-Sleep 30
             write-host "Upgrading $choco_file_name ..."
             choco upgrade splunk-otel-collector -s=".\dist" -y

--- a/internal/buildscripts/packaging/choco/splunk-otel-collector/tools/chocolateyinstall.ps1
+++ b/internal/buildscripts/packaging/choco/splunk-otel-collector/tools/chocolateyinstall.ps1
@@ -73,7 +73,7 @@ if ($installed_collector) {
 $reg_path = Join-Path "HKLM:\SYSTEM\CurrentControlSet\Services" $service_name
 if (Test-Path $reg_path) {
     Write-Host "Service registry entry key found: $reg_path"
-    $previous_environment = Get-ItemProperty $reg_path -Name "Environment" -ErrorAction SilentlyContinue
+    $previous_environment = Get-ItemPropertyValue $reg_path -Name "Environment" -ErrorAction SilentlyContinue
     if ($previous_environment) {
         Write-Host "Found previous environment variables for the $service_name service."
         foreach ($entry in $previous_environment) {


### PR DESCRIPTION
choco upgrades currently fail:
```
PS C:\Windows\system32> choco upgrade -y splunk-otel-collector
Chocolatey v1.3.1
Upgrading the following packages:
splunk-otel-collector
By upgrading, you accept licenses for the packages.

You have splunk-otel-collector v0.106.0 installed. Version 0.106.1 is available based on your source(s).
Progress: Downloading splunk-otel-collector 0.106.1... 100%

splunk-otel-collector v0.106.1 [Approved]
splunk-otel-collector package files upgrade completed. Performing other installation steps.
Checking configuration parameters ...
Checking for previous installation...
Found a previous installation...
Service registry entry key found: HKLM:\SYSTEM\CurrentControlSet\Services\splunk-otel-collector
Found previous environment variables for the splunk-otel-collector service.
ERROR: Method invocation failed because [System.Management.Automation.PSCustomObject] does not contain a method named 'Split'.
The upgrade of splunk-otel-collector was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\splunk-otel-collector\tools\chocolateyinstall.ps1'.
 See log for details.

Chocolatey upgraded 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - splunk-otel-collector (exited -1) - Error while running 'C:\ProgramData\chocolatey\lib\splunk-otel-collector\tools\chocolateyinstall.ps1'.
 See log for details.
```