### PR TITLE
Swap linters to use copyloopvar after exitloopref was deprecated

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,7 +94,7 @@ linters:
   disable:
     - errcheck
   enable:
-    - exportloopref
+    - copyloopvar
     - gocritic
     - gofmt
     - goimports

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -319,7 +319,6 @@ func TestSetDefaultEnvVarsSetsInterfaceFromConfigOption(t *testing.T) {
 		{"some-other-config.yaml", "0.0.0.0"},
 		{"file:some-other-config.yaml", "0.0.0.0"},
 	} {
-		tc := tc
 		t.Run(fmt.Sprintf("%v->%v", tc.config, tc.expectedIP), func(t *testing.T) {
 			t.Cleanup(clearEnv(t))
 			os.Setenv("SPLUNK_REALM", "noop")

--- a/internal/signalfx-agent/pkg/monitors/ecs/ecs_test.go
+++ b/internal/signalfx-agent/pkg/monitors/ecs/ecs_test.go
@@ -57,7 +57,6 @@ func TestDimensionToUpdate(t *testing.T) {
 			expectedError: "unsupported `dimensionToUpdate` \"invalid\". Must be one of \"container_name\" or \"container_id\"",
 		},
 	} {
-		test := test
 		t.Run(test.configValue, func(t *testing.T) {
 			cfg := &Config{
 				MetadataEndpoint: "http://localhost:0/not/real",

--- a/internal/signalfx-agent/pkg/monitors/haproxy/monitor.go
+++ b/internal/signalfx-agent/pkg/monitors/haproxy/monitor.go
@@ -67,7 +67,6 @@ func (m *Monitor) Configure(conf *Config) (err error) {
 		var wg sync.WaitGroup
 		chs := make([]chan []*datapoint.Datapoint, 0)
 		for _, fn := range fetchFuncs {
-			fn := fn
 			ch := make(chan []*datapoint.Datapoint, 1)
 			wg.Add(1)
 			go func() {

--- a/internal/signalfx-agent/pkg/utils/timeutil/duration_test.go
+++ b/internal/signalfx-agent/pkg/utils/timeutil/duration_test.go
@@ -27,7 +27,6 @@ func TestSecondsOrDuration_UnmarshalYAML(t *testing.T) {
 		{name: "empty string", d: 0, args: args{"time:''"}, wantErr: true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var out map[string]Duration
 			if err := yaml.Unmarshal([]byte(tt.args.yml), &out); (err != nil) != tt.wantErr {
@@ -53,7 +52,6 @@ func TestSecondsOrDuration_Defaults(t *testing.T) {
 		{name: "5 seconds as integer", d: 5 * time.Second, args: args{"{}"}, wantErr: false},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var out struct {
 				Interval Duration `yaml:"interval" default:"5s"`
@@ -88,7 +86,6 @@ func TestDuration_UnmarshalJSON(t *testing.T) {
 		{name: "empty string", d: 0, args: args{"time:''"}, wantErr: true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var out map[string]Duration
 			if err := json.Unmarshal([]byte(tt.args.json), &out); (err != nil) != tt.wantErr {


### PR DESCRIPTION
Follow up on linter change as per https://github.com/signalfx/splunk-otel-collector/pull/5268