### PR TITLE
Remove golang lint suppression for int overflow

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,8 +111,5 @@ issues:
     - text: "SA1019: \"github.com/signalfx/splunk-otel-collector/internal/exporter/httpsinkexporter"
       linters:
         - staticcheck
-    - linters:
-        - gosec
-      text: "G115: "
 
   exclude-dirs-use-default: false

--- a/internal/confmapprovider/discovery/properties/property.go
+++ b/internal/confmapprovider/discovery/properties/property.go
@@ -222,7 +222,7 @@ func unwordify(text string) (string, error) {
 		for len(decoded) < 4 {
 			decoded = append([]byte{0}, decoded...)
 		}
-		r := int32(binary.BigEndian.Uint32(decoded))
+		r := binary.BigEndian.Uint32(decoded)
 		return fmt.Sprintf("%c", r)
 	})
 	if err != nil {

--- a/internal/receiver/signalfxgatewayprometheusremotewritereceiver/mock_reporter_test.go
+++ b/internal/receiver/signalfxgatewayprometheusremotewritereceiver/mock_reporter_test.go
@@ -73,7 +73,7 @@ func (m *mockReporter) OnError(_ context.Context, errorLocation string, err erro
 }
 
 func (m *mockReporter) OnMetricsProcessed(_ context.Context, numReceivedMessages int, _ error) {
-	m.TotalSuccessMetrics.Add(int32(numReceivedMessages))
+	m.TotalSuccessMetrics.Add(int32(numReceivedMessages)) //nolint:gosec
 	m.OpsSuccess.Done()
 }
 

--- a/internal/signalfx-agent/pkg/monitors/cadvisor/converter/converter.go
+++ b/internal/signalfx-agent/pkg/monitors/cadvisor/converter/converter.go
@@ -110,7 +110,7 @@ func getContainerMetrics() []containerMetric {
 			help:      "Cumulative user cpu time consumed in nanoseconds.",
 			valueType: datapoint.Counter,
 			getValues: func(s *info.ContainerStats) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.Usage.User))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.Usage.User))}} //nolint:gosec
 			},
 		},
 		{
@@ -118,7 +118,7 @@ func getContainerMetrics() []containerMetric {
 			help:      "Cumulative system cpu time consumed in nanoseconds.",
 			valueType: datapoint.Counter,
 			getValues: func(s *info.ContainerStats) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.Usage.System))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.Usage.System))}} //nolint:gosec
 			},
 		},
 		{
@@ -126,7 +126,7 @@ func getContainerMetrics() []containerMetric {
 			help:      "Cumulative cpu time consumed per cpu in nanoseconds.",
 			valueType: datapoint.Counter,
 			getValues: func(s *info.ContainerStats) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.Usage.Total))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.Usage.Total))}} //nolint:gosec
 			},
 		},
 		{
@@ -134,7 +134,7 @@ func getContainerMetrics() []containerMetric {
 			help:      "Cumulative cpu utilization in percentages.",
 			valueType: datapoint.Counter,
 			getValues: func(s *info.ContainerStats) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.Usage.Total / 10000000))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.Usage.Total / 10000000))}} //nolint:gosec
 			},
 		},
 		{
@@ -143,7 +143,7 @@ func getContainerMetrics() []containerMetric {
 			valueType: datapoint.Counter,
 			getValues: func(s *info.ContainerStats) metricValues {
 				cpuCount := utils.MaxInt(len(s.Cpu.Usage.PerCpu), 1)
-				return metricValues{{value: datapoint.NewIntValue(int64(int(s.Cpu.Usage.Total) / (10000000 * cpuCount)))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(int(s.Cpu.Usage.Total) / (10000000 * cpuCount)))}} //nolint:gosec
 			},
 		},
 		{
@@ -155,7 +155,7 @@ func getContainerMetrics() []containerMetric {
 				mv := make(metricValues, len(s.Cpu.Usage.PerCpu))
 				for index, coreUsage := range s.Cpu.Usage.PerCpu {
 					if coreUsage > 0 {
-						mv[index] = metricValue{value: datapoint.NewIntValue(int64(coreUsage / 10000000)), labels: []string{"cpu" + strconv.Itoa(index)}}
+						mv[index] = metricValue{value: datapoint.NewIntValue(int64(coreUsage / 10000000)), labels: []string{"cpu" + strconv.Itoa(index)}} //nolint:gosec
 					} else {
 						mv[index] = metricValue{value: datapoint.NewIntValue(int64(0)), labels: []string{strconv.Itoa(index)}}
 					}
@@ -168,7 +168,7 @@ func getContainerMetrics() []containerMetric {
 			help:      "Total number of elapsed CFS enforcement intervals.",
 			valueType: datapoint.Counter,
 			getValues: func(s *info.ContainerStats) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.CFS.Periods))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.CFS.Periods))}} //nolint:gosec
 			},
 		},
 		{
@@ -176,7 +176,7 @@ func getContainerMetrics() []containerMetric {
 			help:      "Total number of times tasks in the cgroup have been throttled",
 			valueType: datapoint.Counter,
 			getValues: func(s *info.ContainerStats) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.CFS.ThrottledPeriods))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.CFS.ThrottledPeriods))}} //nolint:gosec
 			},
 		},
 		{
@@ -184,7 +184,7 @@ func getContainerMetrics() []containerMetric {
 			help:      "Total time duration, in nanoseconds, for which tasks in the cgroup have been throttled.",
 			valueType: datapoint.Counter,
 			getValues: func(s *info.ContainerStats) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.CFS.ThrottledTime))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.CFS.ThrottledTime))}} //nolint:gosec
 			},
 		},
 		{
@@ -192,7 +192,7 @@ func getContainerMetrics() []containerMetric {
 			help:      "RSS memory used by the container",
 			valueType: datapoint.Gauge,
 			getValues: func(s *info.ContainerStats) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(s.Memory.RSS))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(s.Memory.RSS))}} //nolint:gosec
 			},
 		},
 		{
@@ -200,7 +200,7 @@ func getContainerMetrics() []containerMetric {
 			help:      "Number of memory usage hits limits",
 			valueType: datapoint.Counter,
 			getValues: func(s *info.ContainerStats) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(s.Memory.Failcnt))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(s.Memory.Failcnt))}} //nolint:gosec
 			},
 		},
 		{
@@ -208,7 +208,7 @@ func getContainerMetrics() []containerMetric {
 			help:      "Current memory usage in bytes.",
 			valueType: datapoint.Gauge,
 			getValues: func(s *info.ContainerStats) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(s.Memory.Usage))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(s.Memory.Usage))}} //nolint:gosec
 			},
 		},
 		{
@@ -216,7 +216,7 @@ func getContainerMetrics() []containerMetric {
 			help:      "Current working set in bytes.",
 			valueType: datapoint.Gauge,
 			getValues: func(s *info.ContainerStats) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(s.Memory.WorkingSet))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(s.Memory.WorkingSet))}} //nolint:gosec
 			},
 		},
 		{
@@ -227,19 +227,19 @@ func getContainerMetrics() []containerMetric {
 			getValues: func(s *info.ContainerStats) metricValues {
 				return metricValues{
 					{
-						value:  datapoint.NewIntValue(int64(s.Memory.ContainerData.Pgfault)),
+						value:  datapoint.NewIntValue(int64(s.Memory.ContainerData.Pgfault)), //nolint:gosec
 						labels: []string{"pgfault", "container"},
 					},
 					{
-						value:  datapoint.NewIntValue(int64(s.Memory.ContainerData.Pgmajfault)),
+						value:  datapoint.NewIntValue(int64(s.Memory.ContainerData.Pgmajfault)), //nolint:gosec
 						labels: []string{"pgmajfault", "container"},
 					},
 					{
-						value:  datapoint.NewIntValue(int64(s.Memory.HierarchicalData.Pgfault)),
+						value:  datapoint.NewIntValue(int64(s.Memory.HierarchicalData.Pgfault)), //nolint:gosec
 						labels: []string{"pgfault", "hierarchy"},
 					},
 					{
-						value:  datapoint.NewIntValue(int64(s.Memory.HierarchicalData.Pgmajfault)),
+						value:  datapoint.NewIntValue(int64(s.Memory.HierarchicalData.Pgmajfault)), //nolint:gosec
 						labels: []string{"pgmajfault", "hierarchy"},
 					},
 				}
@@ -252,7 +252,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"device"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return fsValues(s.Filesystem, func(fs *info.FsStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(fs.Limit))
+					return datapoint.NewIntValue(int64(fs.Limit)) //nolint:gosec
 				})
 			},
 		},
@@ -263,7 +263,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"device"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return fsValues(s.Filesystem, func(fs *info.FsStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(fs.Usage))
+					return datapoint.NewIntValue(int64(fs.Usage)) //nolint:gosec
 				})
 			},
 		},
@@ -274,7 +274,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"device"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return fsValues(s.Filesystem, func(fs *info.FsStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(fs.ReadsCompleted))
+					return datapoint.NewIntValue(int64(fs.ReadsCompleted)) //nolint:gosec
 				})
 			},
 		},
@@ -285,7 +285,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"device"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return fsValues(s.Filesystem, func(fs *info.FsStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(fs.SectorsRead))
+					return datapoint.NewIntValue(int64(fs.SectorsRead)) //nolint:gosec
 				})
 			},
 		},
@@ -296,7 +296,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"device"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return fsValues(s.Filesystem, func(fs *info.FsStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(fs.ReadsMerged))
+					return datapoint.NewIntValue(int64(fs.ReadsMerged)) //nolint:gosec
 				})
 			},
 		},
@@ -307,7 +307,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"device"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return fsValues(s.Filesystem, func(fs *info.FsStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(fs.ReadTime / uint64(time.Second)))
+					return datapoint.NewIntValue(int64(fs.ReadTime / uint64(time.Second))) //nolint:gosec
 				})
 			},
 		},
@@ -318,7 +318,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"device"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return fsValues(s.Filesystem, func(fs *info.FsStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(fs.WritesCompleted))
+					return datapoint.NewIntValue(int64(fs.WritesCompleted)) //nolint:gosec
 				})
 			},
 		},
@@ -329,7 +329,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"device"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return fsValues(s.Filesystem, func(fs *info.FsStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(fs.SectorsWritten))
+					return datapoint.NewIntValue(int64(fs.SectorsWritten)) //nolint:gosec
 				})
 			},
 		},
@@ -340,7 +340,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"device"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return fsValues(s.Filesystem, func(fs *info.FsStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(fs.WritesMerged))
+					return datapoint.NewIntValue(int64(fs.WritesMerged)) //nolint:gosec
 				})
 			},
 		},
@@ -351,7 +351,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"device"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return fsValues(s.Filesystem, func(fs *info.FsStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(fs.WriteTime / uint64(time.Second)))
+					return datapoint.NewIntValue(int64(fs.WriteTime / uint64(time.Second))) //nolint:gosec
 				})
 			},
 		},
@@ -362,7 +362,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"device"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return fsValues(s.Filesystem, func(fs *info.FsStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(fs.IoInProgress))
+					return datapoint.NewIntValue(int64(fs.IoInProgress)) //nolint:gosec
 				})
 			},
 		},
@@ -373,7 +373,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"device"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return fsValues(s.Filesystem, func(fs *info.FsStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(fs.IoTime / uint64(time.Second)))
+					return datapoint.NewIntValue(int64(fs.IoTime / uint64(time.Second))) //nolint:gosec
 				})
 			},
 		},
@@ -384,7 +384,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"device"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return fsValues(s.Filesystem, func(fs *info.FsStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(fs.WeightedIoTime / uint64(time.Second)))
+					return datapoint.NewIntValue(int64(fs.WeightedIoTime / uint64(time.Second))) //nolint:gosec
 				})
 			},
 		},
@@ -395,7 +395,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"interface"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return networkValues(s.Network.Interfaces, func(is *info.InterfaceStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(is.RxBytes))
+					return datapoint.NewIntValue(int64(is.RxBytes)) //nolint:gosec
 				})
 			},
 		},
@@ -406,7 +406,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"interface"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return networkValues(s.Network.Interfaces, func(is *info.InterfaceStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(is.RxPackets))
+					return datapoint.NewIntValue(int64(is.RxPackets)) //nolint:gosec
 				})
 			},
 		},
@@ -417,7 +417,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"interface"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return networkValues(s.Network.Interfaces, func(is *info.InterfaceStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(is.RxDropped))
+					return datapoint.NewIntValue(int64(is.RxDropped)) //nolint:gosec
 				})
 			},
 		},
@@ -428,7 +428,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"interface"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return networkValues(s.Network.Interfaces, func(is *info.InterfaceStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(is.RxErrors))
+					return datapoint.NewIntValue(int64(is.RxErrors)) //nolint:gosec
 				})
 			},
 		},
@@ -439,7 +439,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"interface"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return networkValues(s.Network.Interfaces, func(is *info.InterfaceStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(is.TxBytes))
+					return datapoint.NewIntValue(int64(is.TxBytes)) //nolint:gosec
 				})
 			},
 		},
@@ -450,7 +450,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"interface"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return networkValues(s.Network.Interfaces, func(is *info.InterfaceStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(is.TxPackets))
+					return datapoint.NewIntValue(int64(is.TxPackets)) //nolint:gosec
 				})
 			},
 		},
@@ -461,7 +461,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"interface"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return networkValues(s.Network.Interfaces, func(is *info.InterfaceStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(is.TxDropped))
+					return datapoint.NewIntValue(int64(is.TxDropped)) //nolint:gosec
 				})
 			},
 		},
@@ -472,7 +472,7 @@ func getContainerMetrics() []containerMetric {
 			extraLabels: []string{"interface"},
 			getValues: func(s *info.ContainerStats) metricValues {
 				return networkValues(s.Network.Interfaces, func(is *info.InterfaceStats) datapoint.Value {
-					return datapoint.NewIntValue(int64(is.TxErrors))
+					return datapoint.NewIntValue(int64(is.TxErrors)) //nolint:gosec
 				})
 			},
 		},
@@ -484,23 +484,23 @@ func getContainerMetrics() []containerMetric {
 			getValues: func(s *info.ContainerStats) metricValues {
 				return metricValues{
 					{
-						value:  datapoint.NewIntValue(int64(s.TaskStats.NrSleeping)),
+						value:  datapoint.NewIntValue(int64(s.TaskStats.NrSleeping)), //nolint:gosec
 						labels: []string{"sleeping"},
 					},
 					{
-						value:  datapoint.NewIntValue(int64(s.TaskStats.NrRunning)),
+						value:  datapoint.NewIntValue(int64(s.TaskStats.NrRunning)), //nolint:gosec
 						labels: []string{"running"},
 					},
 					{
-						value:  datapoint.NewIntValue(int64(s.TaskStats.NrStopped)),
+						value:  datapoint.NewIntValue(int64(s.TaskStats.NrStopped)), //nolint:gosec
 						labels: []string{"stopped"},
 					},
 					{
-						value:  datapoint.NewIntValue(int64(s.TaskStats.NrUninterruptible)),
+						value:  datapoint.NewIntValue(int64(s.TaskStats.NrUninterruptible)), //nolint:gosec
 						labels: []string{"uninterruptible"},
 					},
 					{
-						value:  datapoint.NewIntValue(int64(s.TaskStats.NrIoWait)),
+						value:  datapoint.NewIntValue(int64(s.TaskStats.NrIoWait)), //nolint:gosec
 						labels: []string{"iowaiting"},
 					},
 				}
@@ -521,7 +521,7 @@ func getContainerSpecCPUMetrics() []containerSpecMetric {
 				extraLabels: []string{},
 			},
 			getValues: func(container *info.ContainerInfo) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(container.Spec.Cpu.Limit))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(container.Spec.Cpu.Limit))}} //nolint:gosec
 			},
 		},
 		{
@@ -532,7 +532,7 @@ func getContainerSpecCPUMetrics() []containerSpecMetric {
 				extraLabels: []string{},
 			},
 			getValues: func(container *info.ContainerInfo) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(container.Spec.Cpu.Quota))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(container.Spec.Cpu.Quota))}} //nolint:gosec
 			},
 		},
 		{
@@ -543,7 +543,7 @@ func getContainerSpecCPUMetrics() []containerSpecMetric {
 				extraLabels: []string{},
 			},
 			getValues: func(container *info.ContainerInfo) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(container.Spec.Cpu.Period))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(container.Spec.Cpu.Period))}} //nolint:gosec
 			},
 		},
 	}
@@ -561,7 +561,7 @@ func getContainerSpecMemMetrics() []containerSpecMetric {
 				extraLabels: []string{},
 			},
 			getValues: func(container *info.ContainerInfo) metricValues {
-				limit := int64(container.Spec.Memory.Limit)
+				limit := int64(container.Spec.Memory.Limit) //nolint:gosec
 				// Workaround a strange issue where cadvisor reports
 				// ridiculously high memory values in older k8s versions.
 				if limit >= math.MaxUint64/3 {
@@ -579,7 +579,7 @@ func getContainerSpecMemMetrics() []containerSpecMetric {
 				extraLabels: []string{},
 			},
 			getValues: func(container *info.ContainerInfo) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(container.Spec.Memory.SwapLimit))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(container.Spec.Memory.SwapLimit))}} //nolint:gosec
 			},
 		},
 	}
@@ -597,7 +597,7 @@ func getMachineInfoMetrics() []machineInfoMetric {
 				extraLabels: []string{},
 			},
 			getValues: func(machineInfo *info.MachineInfo) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(machineInfo.CpuFrequency))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(machineInfo.CpuFrequency))}} //nolint:gosec
 			},
 		},
 		{
@@ -619,7 +619,7 @@ func getMachineInfoMetrics() []machineInfoMetric {
 				extraLabels: []string{},
 			},
 			getValues: func(machineInfo *info.MachineInfo) metricValues {
-				return metricValues{{value: datapoint.NewIntValue(int64(machineInfo.MemoryCapacity))}}
+				return metricValues{{value: datapoint.NewIntValue(int64(machineInfo.MemoryCapacity))}} //nolint:gosec
 			},
 		},
 	}
@@ -651,7 +651,7 @@ func getPodEphemeralStorageMetrics() []podStatusMetric {
 			valueType: datapoint.Gauge,
 			getValues: func(es *stats.FsStats) metricValues {
 				if es.CapacityBytes != nil {
-					return metricValues{{value: datapoint.NewIntValue(int64(*es.CapacityBytes))}}
+					return metricValues{{value: datapoint.NewIntValue(int64(*es.CapacityBytes))}} //nolint:gosec
 				}
 				return metricValues{}
 			},
@@ -661,7 +661,7 @@ func getPodEphemeralStorageMetrics() []podStatusMetric {
 			valueType: datapoint.Counter,
 			getValues: func(es *stats.FsStats) metricValues {
 				if es.UsedBytes != nil {
-					return metricValues{{value: datapoint.NewIntValue(int64(*es.UsedBytes))}}
+					return metricValues{{value: datapoint.NewIntValue(int64(*es.UsedBytes))}} //nolint:gosec
 				}
 				return metricValues{}
 

--- a/internal/signalfx-agent/pkg/monitors/collectd/collectd.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/collectd.go
@@ -203,7 +203,7 @@ func (cm *Manager) RequestRestart() {
 func (cm *Manager) WriteServerURL() string {
 	// Just reuse the config struct's method for making a URL
 	conf := *cm.conf
-	conf.WriteServerPort = uint16(cm.writeServerPort)
+	conf.WriteServerPort = uint16(cm.writeServerPort) //nolint:gosec
 	return conf.WriteServerURL()
 }
 
@@ -464,7 +464,7 @@ func (cm *Manager) rerenderConf(writeHTTPPort int) error {
 	// Copy so that hash of config struct is consistent
 	conf := *cm.conf
 	conf.HasGenericJMXMonitor = len(cm.genericJMXUsers) > 0
-	conf.WriteServerPort = uint16(writeHTTPPort)
+	conf.WriteServerPort = uint16(writeHTTPPort) //nolint:gosec
 
 	if err := CollectdTemplate.Execute(&output, &conf); err != nil {
 		return fmt.Errorf("failed to render collectd template: %w", err)

--- a/internal/signalfx-agent/pkg/monitors/diskio/diskio_others.go
+++ b/internal/signalfx-agent/pkg/monitors/diskio/diskio_others.go
@@ -33,15 +33,15 @@ type Monitor struct {
 
 func (m *Monitor) makeLinuxDatapoints(disk disk.IOCountersStat, dimensions map[string]string) []*datapoint.Datapoint {
 	return []*datapoint.Datapoint{
-		datapoint.New("disk_ops.read", dimensions, datapoint.NewIntValue(int64(disk.ReadCount)), datapoint.Counter, time.Time{}),
-		datapoint.New("disk_ops.write", dimensions, datapoint.NewIntValue(int64(disk.WriteCount)), datapoint.Counter, time.Time{}),
-		datapoint.New("disk_octets.read", dimensions, datapoint.NewIntValue(int64(disk.ReadBytes)), datapoint.Counter, time.Time{}),
-		datapoint.New("disk_octets.write", dimensions, datapoint.NewIntValue(int64(disk.WriteBytes)), datapoint.Counter, time.Time{}),
-		datapoint.New("disk_merged.read", dimensions, datapoint.NewIntValue(int64(disk.MergedReadCount)), datapoint.Counter, time.Time{}),
-		datapoint.New("disk_merged.write", dimensions, datapoint.NewIntValue(int64(disk.MergedWriteCount)), datapoint.Counter, time.Time{}),
-		datapoint.New("disk_time.read", dimensions, datapoint.NewIntValue(int64(disk.ReadTime)), datapoint.Counter, time.Time{}),
-		datapoint.New("disk_time.write", dimensions, datapoint.NewIntValue(int64(disk.WriteTime)), datapoint.Counter, time.Time{}),
-		datapoint.New(diskOpsPending, dimensions, datapoint.NewIntValue(int64(disk.IopsInProgress)), datapoint.Gauge, time.Time{}),
+		datapoint.New("disk_ops.read", dimensions, datapoint.NewIntValue(int64(disk.ReadCount)), datapoint.Counter, time.Time{}),            //nolint:gosec
+		datapoint.New("disk_ops.write", dimensions, datapoint.NewIntValue(int64(disk.WriteCount)), datapoint.Counter, time.Time{}),          //nolint:gosec
+		datapoint.New("disk_octets.read", dimensions, datapoint.NewIntValue(int64(disk.ReadBytes)), datapoint.Counter, time.Time{}),         //nolint:gosec
+		datapoint.New("disk_octets.write", dimensions, datapoint.NewIntValue(int64(disk.WriteBytes)), datapoint.Counter, time.Time{}),       //nolint:gosec
+		datapoint.New("disk_merged.read", dimensions, datapoint.NewIntValue(int64(disk.MergedReadCount)), datapoint.Counter, time.Time{}),   //nolint:gosec
+		datapoint.New("disk_merged.write", dimensions, datapoint.NewIntValue(int64(disk.MergedWriteCount)), datapoint.Counter, time.Time{}), //nolint:gosec
+		datapoint.New("disk_time.read", dimensions, datapoint.NewIntValue(int64(disk.ReadTime)), datapoint.Counter, time.Time{}),            //nolint:gosec
+		datapoint.New("disk_time.write", dimensions, datapoint.NewIntValue(int64(disk.WriteTime)), datapoint.Counter, time.Time{}),          //nolint:gosec
+		datapoint.New(diskOpsPending, dimensions, datapoint.NewIntValue(int64(disk.IopsInProgress)), datapoint.Gauge, time.Time{}),          //nolint:gosec
 	}
 }
 
@@ -67,7 +67,7 @@ func (m *Monitor) emitDatapoints() {
 
 		dps = append(dps, m.makeLinuxDatapoints(disk, map[string]string{"disk": diskName})...)
 
-		opCount += int64(disk.ReadCount) + int64(disk.WriteCount)
+		opCount += int64(disk.ReadCount) + int64(disk.WriteCount) //nolint:gosec
 	}
 
 	dps = append(dps, sfxclient.Gauge("disk_ops.total", nil, opCount-m.lastOpCount))

--- a/internal/signalfx-agent/pkg/monitors/docker/conversion.go
+++ b/internal/signalfx-agent/pkg/monitors/docker/conversion.go
@@ -80,7 +80,7 @@ func convertBlkioStats(stats *dtypes.BlkioStats, enhancedMetrics bool) []*datapo
 					"device_major": strconv.FormatUint(bs.Major, 10),
 					"device_minor": strconv.FormatUint(bs.Minor, 10),
 				}
-				out = append(out, sfxclient.Cumulative("blkio."+k+"."+strings.ToLower(bs.Op), dims, int64(bs.Value)))
+				out = append(out, sfxclient.Cumulative("blkio."+k+"."+strings.ToLower(bs.Op), dims, int64(bs.Value))) //nolint:gosec
 			}
 		}
 	}
@@ -92,28 +92,28 @@ func convertCPUStats(stats *dtypes.CPUStats, prior *dtypes.CPUStats, enhancedMet
 	var out []*datapoint.Datapoint
 
 	out = append(out, []*datapoint.Datapoint{
-		sfxclient.Cumulative("cpu.usage.total", nil, int64(stats.CPUUsage.TotalUsage)),
-		sfxclient.Cumulative("cpu.usage.system", nil, int64(stats.SystemUsage)),
+		sfxclient.Cumulative("cpu.usage.total", nil, int64(stats.CPUUsage.TotalUsage)), //nolint:gosec
+		sfxclient.Cumulative("cpu.usage.system", nil, int64(stats.SystemUsage)),        //nolint:gosec
 	}...)
 
 	// Except two metrics above, everything else will be added only when enhnacedMetrics is enabled
 	if enhancedMetrics {
 		out = append(out, []*datapoint.Datapoint{
-			sfxclient.Cumulative("cpu.usage.kernelmode", nil, int64(stats.CPUUsage.UsageInKernelmode)),
-			sfxclient.Cumulative("cpu.usage.usermode", nil, int64(stats.CPUUsage.UsageInUsermode)),
+			sfxclient.Cumulative("cpu.usage.kernelmode", nil, int64(stats.CPUUsage.UsageInKernelmode)), //nolint:gosec
+			sfxclient.Cumulative("cpu.usage.usermode", nil, int64(stats.CPUUsage.UsageInUsermode)),     //nolint:gosec
 		}...)
 
 		for i, v := range stats.CPUUsage.PercpuUsage {
 			dims := map[string]string{
 				"core": "cpu" + strconv.Itoa(i),
 			}
-			out = append(out, sfxclient.Cumulative("cpu.percpu.usage", dims, int64(v)))
+			out = append(out, sfxclient.Cumulative("cpu.percpu.usage", dims, int64(v))) //nolint:gosec
 		}
 
 		out = append(out, []*datapoint.Datapoint{
-			sfxclient.Cumulative("cpu.throttling_data.periods", nil, int64(stats.ThrottlingData.Periods)),
-			sfxclient.Cumulative("cpu.throttling_data.throttled_periods", nil, int64(stats.ThrottlingData.ThrottledPeriods)),
-			sfxclient.Cumulative("cpu.throttling_data.throttled_time", nil, int64(stats.ThrottlingData.ThrottledTime)),
+			sfxclient.Cumulative("cpu.throttling_data.periods", nil, int64(stats.ThrottlingData.Periods)),                    //nolint:gosec
+			sfxclient.Cumulative("cpu.throttling_data.throttled_periods", nil, int64(stats.ThrottlingData.ThrottledPeriods)), //nolint:gosec
+			sfxclient.Cumulative("cpu.throttling_data.throttled_time", nil, int64(stats.ThrottlingData.ThrottledTime)),       //nolint:gosec
 		}...)
 
 		out = append(out, sfxclient.GaugeF("cpu.percent", nil, calculateCPUPercent(prior, stats)))
@@ -149,19 +149,19 @@ func convertMemoryStats(stats *dtypes.MemoryStats, enhancedMetrics bool) []*data
 	// If not present, default value will be 0.
 	bufferCacheUsage := stats.Stats["total_cache"]
 
-	out = append(out, sfxclient.Gauge("memory.usage.limit", nil, int64(stats.Limit)))
+	out = append(out, sfxclient.Gauge("memory.usage.limit", nil, int64(stats.Limit))) //nolint:gosec
 	if stats.PrivateWorkingSet == 0 {
 		// See discussion at https://github.com/signalfx/signalfx-agent/issues/1009
-		out = append(out, sfxclient.Gauge("memory.usage.total", nil, int64(stats.Usage-bufferCacheUsage)))
+		out = append(out, sfxclient.Gauge("memory.usage.total", nil, int64(stats.Usage-bufferCacheUsage))) //nolint:gosec
 	} else {
 		// This is used for Windows containers
-		out = append(out, sfxclient.Gauge("memory.usage.total", nil, int64(stats.PrivateWorkingSet)))
+		out = append(out, sfxclient.Gauge("memory.usage.total", nil, int64(stats.PrivateWorkingSet))) //nolint:gosec
 	}
 
 	// Except two metrics above, everything else will be added only when enhnacedMetrics is enabled
 	if enhancedMetrics {
 		out = append(out, []*datapoint.Datapoint{
-			sfxclient.Gauge("memory.usage.max", nil, int64(stats.MaxUsage)),
+			sfxclient.Gauge("memory.usage.max", nil, int64(stats.MaxUsage)), //nolint:gosec
 			sfxclient.GaugeF("memory.percent", nil,
 				// If cache is not present it will use the default value of 0
 				100.0*(float64(stats.Usage)-float64(stats.Stats["cache"]))/float64(stats.Limit)),
@@ -169,9 +169,9 @@ func convertMemoryStats(stats *dtypes.MemoryStats, enhancedMetrics bool) []*data
 
 		for k, v := range stats.Stats {
 			if _, exists := memoryStatCounters[k]; exists {
-				out = append(out, sfxclient.Cumulative("memory.stats."+k, nil, int64(v)))
+				out = append(out, sfxclient.Cumulative("memory.stats."+k, nil, int64(v))) //nolint:gosec
 			} else {
-				out = append(out, sfxclient.Gauge("memory.stats."+k, nil, int64(v)))
+				out = append(out, sfxclient.Gauge("memory.stats."+k, nil, int64(v))) //nolint:gosec
 			}
 		}
 	}
@@ -190,18 +190,18 @@ func convertNetworkStats(stats *map[string]dtypes.NetworkStats, enhancedMetrics 
 		}
 
 		out = append(out, []*datapoint.Datapoint{
-			sfxclient.Cumulative("network.usage.rx_bytes", dims, int64(s.RxBytes)),
-			sfxclient.Cumulative("network.usage.tx_bytes", dims, int64(s.TxBytes)),
+			sfxclient.Cumulative("network.usage.rx_bytes", dims, int64(s.RxBytes)), //nolint:gosec
+			sfxclient.Cumulative("network.usage.tx_bytes", dims, int64(s.TxBytes)), //nolint:gosec
 		}...)
 
 		if enhancedMetrics {
 			out = append(out, []*datapoint.Datapoint{
-				sfxclient.Cumulative("network.usage.rx_dropped", dims, int64(s.RxDropped)),
-				sfxclient.Cumulative("network.usage.rx_errors", dims, int64(s.RxErrors)),
-				sfxclient.Cumulative("network.usage.rx_packets", dims, int64(s.RxPackets)),
-				sfxclient.Cumulative("network.usage.tx_dropped", dims, int64(s.TxDropped)),
-				sfxclient.Cumulative("network.usage.tx_errors", dims, int64(s.TxErrors)),
-				sfxclient.Cumulative("network.usage.tx_packets", dims, int64(s.TxPackets)),
+				sfxclient.Cumulative("network.usage.rx_dropped", dims, int64(s.RxDropped)), //nolint:gosec
+				sfxclient.Cumulative("network.usage.rx_errors", dims, int64(s.RxErrors)),   //nolint:gosec
+				sfxclient.Cumulative("network.usage.rx_packets", dims, int64(s.RxPackets)), //nolint:gosec
+				sfxclient.Cumulative("network.usage.tx_dropped", dims, int64(s.TxDropped)), //nolint:gosec
+				sfxclient.Cumulative("network.usage.tx_errors", dims, int64(s.TxErrors)),   //nolint:gosec
+				sfxclient.Cumulative("network.usage.tx_packets", dims, int64(s.TxPackets)), //nolint:gosec
 			}...)
 		}
 	}

--- a/internal/signalfx-agent/pkg/monitors/filesystems/filesystems.go
+++ b/internal/signalfx-agent/pkg/monitors/filesystems/filesystems.go
@@ -98,8 +98,8 @@ func (m *Monitor) getCommonDimensions(partition *gopsutil.PartitionStat) map[str
 
 func (m *Monitor) makeInodeDatapoints(dimensions map[string]string, disk *gopsutil.UsageStat) []*datapoint.Datapoint {
 	return []*datapoint.Datapoint{
-		datapoint.New(dfInodesFree, dimensions, datapoint.NewIntValue(int64(disk.InodesFree)), datapoint.Gauge, time.Time{}),
-		datapoint.New(dfInodesUsed, dimensions, datapoint.NewIntValue(int64(disk.InodesUsed)), datapoint.Gauge, time.Time{}),
+		datapoint.New(dfInodesFree, dimensions, datapoint.NewIntValue(int64(disk.InodesFree)), datapoint.Gauge, time.Time{}), //nolint:gosec
+		datapoint.New(dfInodesUsed, dimensions, datapoint.NewIntValue(int64(disk.InodesUsed)), datapoint.Gauge, time.Time{}), //nolint:gosec
 		datapoint.New(percentInodesFree, dimensions, datapoint.NewIntValue(int64(100-disk.InodesUsedPercent)), datapoint.Gauge, time.Time{}),
 		datapoint.New(percentInodesUsed, dimensions, datapoint.NewIntValue(int64(disk.InodesUsedPercent)), datapoint.Gauge, time.Time{}),
 		// TODO: implement percent_inodes.reserved and df_inodes.reserved.
@@ -112,9 +112,9 @@ func (m *Monitor) makeInodeDatapoints(dimensions map[string]string, disk *gopsut
 
 func (m *Monitor) makeDFComplex(dimensions map[string]string, disk *gopsutil.UsageStat) []*datapoint.Datapoint {
 	return []*datapoint.Datapoint{
-		datapoint.New(dfComplexFree, dimensions, datapoint.NewIntValue(int64(disk.Free)), datapoint.Gauge, time.Time{}),
-		datapoint.New(dfComplexUsed, dimensions, datapoint.NewIntValue(int64(disk.Used)), datapoint.Gauge, time.Time{}),
-		datapoint.New(dfComplexReserved, dimensions, datapoint.NewIntValue(int64(disk.Total-disk.Used-disk.Free)), datapoint.Gauge, time.Time{}),
+		datapoint.New(dfComplexFree, dimensions, datapoint.NewIntValue(int64(disk.Free)), datapoint.Gauge, time.Time{}),                          //nolint:gosec
+		datapoint.New(dfComplexUsed, dimensions, datapoint.NewIntValue(int64(disk.Used)), datapoint.Gauge, time.Time{}),                          //nolint:gosec
+		datapoint.New(dfComplexReserved, dimensions, datapoint.NewIntValue(int64(disk.Total-disk.Used-disk.Free)), datapoint.Gauge, time.Time{}), //nolint:gosec
 	}
 }
 

--- a/internal/signalfx-agent/pkg/monitors/filesystems/partitions_windows.go
+++ b/internal/signalfx-agent/pkg/monitors/filesystems/partitions_windows.go
@@ -150,12 +150,12 @@ func getFsNameAndFlags(rootPath string, fsNameBuf []uint16, fsFlags *uint32) err
 	return windows.GetVolumeInformation(
 		rootPathPtr,
 		&volNameBuf[0],
-		uint32(len(volNameBuf)),
+		uint32(len(volNameBuf)), //nolint:gosec
 		&volSerialNum,
 		&maxComponentLen,
 		fsFlags,
 		&fsNameBuf[0],
-		uint32(len(fsNameBuf)))
+		uint32(len(fsNameBuf))) //nolint:gosec
 }
 
 // getPartitionStats returns partition stats for the given volume paths.

--- a/internal/signalfx-agent/pkg/monitors/filesystems/partitions_windows_test.go
+++ b/internal/signalfx-agent/pkg/monitors/filesystems/partitions_windows_test.go
@@ -192,14 +192,14 @@ func (v *volumesMock) findFirstVolumeMock(volumeNamePtr *uint16) (windows.Handle
 	start := uintptr(unsafe.Pointer(volumeNamePtr))
 	size := unsafe.Sizeof(*volumeNamePtr)
 	for i := range volumeName {
-		*(*uint16)(unsafe.Pointer(start + size*uintptr(i))) = volumeName[i]
+		*(*uint16)(unsafe.Pointer(start + size*uintptr(i))) = volumeName[i] //nolint:gosec
 	}
 
 	return windows.Handle(unsafe.Pointer(&v.handle)), nil
 }
 
 func (v *volumesMock) findNextVolumeMock(volumeIndexHandle windows.Handle, volumeNamePtr *uint16) error {
-	volumeIndex := *(*int)(unsafe.Pointer(volumeIndexHandle))
+	volumeIndex := *(*int)(unsafe.Pointer(volumeIndexHandle)) //nolint:gosec
 	if volumeIndex == uninitialized {
 		return windows.ERROR_NO_MORE_FILES
 	}
@@ -208,7 +208,7 @@ func (v *volumesMock) findNextVolumeMock(volumeIndexHandle windows.Handle, volum
 	if nextVolumeIndex >= len(v.volumes) {
 		return windows.ERROR_NO_MORE_FILES
 	}
-	*(*int)(unsafe.Pointer(volumeIndexHandle)) = nextVolumeIndex
+	*(*int)(unsafe.Pointer(volumeIndexHandle)) = nextVolumeIndex //nolint:gosec
 
 	nextVolume := v.volumes[nextVolumeIndex]
 	if nextVolume.err != nil {
@@ -223,16 +223,16 @@ func (v *volumesMock) findNextVolumeMock(volumeIndexHandle windows.Handle, volum
 	start := uintptr(unsafe.Pointer(volumeNamePtr))
 	size := unsafe.Sizeof(*volumeNamePtr)
 	for i := range volumeName {
-		*(*uint16)(unsafe.Pointer(start + size*uintptr(i))) = volumeName[i]
+		*(*uint16)(unsafe.Pointer(start + size*uintptr(i))) = volumeName[i] //nolint:gosec
 	}
 
 	return err
 }
 
 func (v *volumesMock) findVolumeCloseMock(volumeIndexHandle windows.Handle) error {
-	volumeIndex := *(*int)(unsafe.Pointer(volumeIndexHandle))
+	volumeIndex := *(*int)(unsafe.Pointer(volumeIndexHandle)) //nolint:gosec
 	if volumeIndex != uninitialized {
-		*(*int)(unsafe.Pointer(volumeIndexHandle)) = closed
+		*(*int)(unsafe.Pointer(volumeIndexHandle)) = closed //nolint:gosec
 	}
 	return nil
 }

--- a/internal/signalfx-agent/pkg/monitors/jaegergrpc/jaegerprotobuf/trace_jaeger.go
+++ b/internal/signalfx-agent/pkg/monitors/jaegergrpc/jaegerprotobuf/trace_jaeger.go
@@ -82,7 +82,7 @@ func convertPeerIPv4(tag *model.KeyValue) string {
 		}
 	case model.ValueType_INT64:
 		localIP := make(net.IP, 4)
-		binary.BigEndian.PutUint32(localIP, uint32(tag.GetVInt64()))
+		binary.BigEndian.PutUint32(localIP, uint32(tag.GetVInt64())) //nolint:gosec
 		return localIP.String()
 	}
 	return ""
@@ -92,10 +92,10 @@ func convertPeerPort(tag *model.KeyValue) int32 {
 	switch tag.VType {
 	case model.ValueType_STRING:
 		if port, err := strconv.ParseUint(tag.GetVStr(), 10, 16); err == nil {
-			return int32(port)
+			return int32(port) //nolint:gosec
 		}
 	case model.ValueType_INT64:
-		return int32(tag.GetVInt64())
+		return int32(tag.GetVInt64()) //nolint:gosec
 	}
 	return 0
 }

--- a/internal/signalfx-agent/pkg/monitors/kubernetes/kubeletmetrics/metrics.go
+++ b/internal/signalfx-agent/pkg/monitors/kubernetes/kubeletmetrics/metrics.go
@@ -25,22 +25,22 @@ func convertContainerMetrics(c *v1alpha1.ContainerStats, status *v1.ContainerSta
 
 	if c.Memory != nil {
 		if c.Memory.AvailableBytes != nil {
-			dps = append(dps, sfxclient.Gauge(containerMemoryAvailableBytes, dims, int64(*c.Memory.AvailableBytes)))
+			dps = append(dps, sfxclient.Gauge(containerMemoryAvailableBytes, dims, int64(*c.Memory.AvailableBytes))) //nolint:gosec
 		}
 		if c.Memory.UsageBytes != nil {
-			dps = append(dps, sfxclient.Gauge(containerMemoryUsageBytes, dims, int64(*c.Memory.UsageBytes)))
+			dps = append(dps, sfxclient.Gauge(containerMemoryUsageBytes, dims, int64(*c.Memory.UsageBytes))) //nolint:gosec
 		}
 		if c.Memory.WorkingSetBytes != nil {
-			dps = append(dps, sfxclient.Gauge(containerMemoryWorkingSetBytes, dims, int64(*c.Memory.WorkingSetBytes)))
+			dps = append(dps, sfxclient.Gauge(containerMemoryWorkingSetBytes, dims, int64(*c.Memory.WorkingSetBytes))) //nolint:gosec
 		}
 		if c.Memory.RSSBytes != nil {
-			dps = append(dps, sfxclient.Gauge(containerMemoryRssBytes, dims, int64(*c.Memory.RSSBytes)))
+			dps = append(dps, sfxclient.Gauge(containerMemoryRssBytes, dims, int64(*c.Memory.RSSBytes))) //nolint:gosec
 		}
 		if c.Memory.PageFaults != nil {
-			dps = append(dps, sfxclient.Cumulative(containerMemoryPageFaults, dims, int64(*c.Memory.PageFaults)))
+			dps = append(dps, sfxclient.Cumulative(containerMemoryPageFaults, dims, int64(*c.Memory.PageFaults))) //nolint:gosec
 		}
 		if c.Memory.MajorPageFaults != nil {
-			dps = append(dps, sfxclient.Cumulative(containerMemoryMajorPageFaults, dims, int64(*c.Memory.MajorPageFaults)))
+			dps = append(dps, sfxclient.Cumulative(containerMemoryMajorPageFaults, dims, int64(*c.Memory.MajorPageFaults))) //nolint:gosec
 		}
 	}
 
@@ -48,13 +48,13 @@ func convertContainerMetrics(c *v1alpha1.ContainerStats, status *v1.ContainerSta
 		if c.Rootfs.AvailableBytes != nil {
 			// uint64 -> int64 conversion should be safe since disk sizes
 			// aren't going to get that big for a long time.
-			dps = append(dps, sfxclient.Gauge(containerFsAvailableBytes, dims, int64(*c.Rootfs.AvailableBytes)))
+			dps = append(dps, sfxclient.Gauge(containerFsAvailableBytes, dims, int64(*c.Rootfs.AvailableBytes))) //nolint:gosec
 		}
 		if c.Rootfs.CapacityBytes != nil {
-			dps = append(dps, sfxclient.Gauge(containerFsCapacityBytes, dims, int64(*c.Rootfs.CapacityBytes)))
+			dps = append(dps, sfxclient.Gauge(containerFsCapacityBytes, dims, int64(*c.Rootfs.CapacityBytes))) //nolint:gosec
 		}
 		if c.Rootfs.UsedBytes != nil {
-			dps = append(dps, sfxclient.Gauge(containerFsUsageBytes, dims, int64(*c.Rootfs.UsedBytes)))
+			dps = append(dps, sfxclient.Gauge(containerFsUsageBytes, dims, int64(*c.Rootfs.UsedBytes))) //nolint:gosec
 		}
 	}
 

--- a/internal/signalfx-agent/pkg/monitors/kubernetes/kubeletmetrics/monitor.go
+++ b/internal/signalfx-agent/pkg/monitors/kubernetes/kubeletmetrics/monitor.go
@@ -106,10 +106,10 @@ func (m *Monitor) getSummaryMetrics(usePodsEndpoint bool) ([]*datapoint.Datapoin
 
 		if p.EphemeralStorage != nil {
 			if p.EphemeralStorage.CapacityBytes != nil {
-				dps = append(dps, sfxclient.Gauge(podEphemeralStorageCapacityBytes, dims, int64(*p.EphemeralStorage.CapacityBytes)))
+				dps = append(dps, sfxclient.Gauge(podEphemeralStorageCapacityBytes, dims, int64(*p.EphemeralStorage.CapacityBytes))) //nolint:gosec
 			}
 			if p.EphemeralStorage.UsedBytes != nil {
-				dps = append(dps, sfxclient.Gauge(podEphemeralStorageUsedBytes, dims, int64(*p.EphemeralStorage.UsedBytes)))
+				dps = append(dps, sfxclient.Gauge(podEphemeralStorageUsedBytes, dims, int64(*p.EphemeralStorage.UsedBytes))) //nolint:gosec
 			}
 		}
 
@@ -120,16 +120,16 @@ func (m *Monitor) getSummaryMetrics(usePodsEndpoint bool) ([]*datapoint.Datapoin
 				intfDims["interface"] = i.Name
 
 				if i.RxBytes != nil {
-					dps = append(dps, sfxclient.Cumulative(podNetworkReceiveBytesTotal, intfDims, int64(*i.RxBytes)))
+					dps = append(dps, sfxclient.Cumulative(podNetworkReceiveBytesTotal, intfDims, int64(*i.RxBytes))) //nolint:gosec
 				}
 				if i.TxBytes != nil {
-					dps = append(dps, sfxclient.Cumulative(podNetworkTransmitBytesTotal, intfDims, int64(*i.TxBytes)))
+					dps = append(dps, sfxclient.Cumulative(podNetworkTransmitBytesTotal, intfDims, int64(*i.TxBytes))) //nolint:gosec
 				}
 				if i.RxErrors != nil {
-					dps = append(dps, sfxclient.Cumulative(podNetworkReceiveErrorsTotal, intfDims, int64(*i.RxErrors)))
+					dps = append(dps, sfxclient.Cumulative(podNetworkReceiveErrorsTotal, intfDims, int64(*i.RxErrors))) //nolint:gosec
 				}
 				if i.TxErrors != nil {
-					dps = append(dps, sfxclient.Cumulative(podNetworkTransmitErrorsTotal, intfDims, int64(*i.TxErrors)))
+					dps = append(dps, sfxclient.Cumulative(podNetworkTransmitErrorsTotal, intfDims, int64(*i.TxErrors))) //nolint:gosec
 				}
 			}
 		}

--- a/internal/signalfx-agent/pkg/monitors/kubernetes/volumes/volumes.go
+++ b/internal/signalfx-agent/pkg/monitors/kubernetes/volumes/volumes.go
@@ -108,19 +108,19 @@ func (m *Monitor) getVolumeMetrics() ([]*datapoint.Datapoint, error) {
 			if v.AvailableBytes != nil {
 				// uint64 -> int64 conversion should be safe since disk sizes
 				// aren't going to get that big for a long time.
-				dps = append(dps, sfxclient.Gauge(kubernetesVolumeAvailableBytes, dims, int64(*v.AvailableBytes)))
+				dps = append(dps, sfxclient.Gauge(kubernetesVolumeAvailableBytes, dims, int64(*v.AvailableBytes))) //nolint:gosec
 			}
 			if v.CapacityBytes != nil {
-				dps = append(dps, sfxclient.Gauge(kubernetesVolumeCapacityBytes, dims, int64(*v.CapacityBytes)))
+				dps = append(dps, sfxclient.Gauge(kubernetesVolumeCapacityBytes, dims, int64(*v.CapacityBytes))) //nolint:gosec
 			}
 			if v.Inodes != nil {
-				dps = append(dps, sfxclient.Gauge(kubernetesVolumeInodes, dims, int64(*v.Inodes)))
+				dps = append(dps, sfxclient.Gauge(kubernetesVolumeInodes, dims, int64(*v.Inodes))) //nolint:gosec
 			}
 			if v.InodesFree != nil {
-				dps = append(dps, sfxclient.Gauge(kubernetesVolumeInodesFree, dims, int64(*v.InodesFree)))
+				dps = append(dps, sfxclient.Gauge(kubernetesVolumeInodesFree, dims, int64(*v.InodesFree))) //nolint:gosec
 			}
 			if v.InodesUsed != nil {
-				dps = append(dps, sfxclient.Gauge(kubernetesVolumeInodesUsed, dims, int64(*v.InodesUsed)))
+				dps = append(dps, sfxclient.Gauge(kubernetesVolumeInodesUsed, dims, int64(*v.InodesUsed))) //nolint:gosec
 			}
 		}
 	}

--- a/internal/signalfx-agent/pkg/monitors/memory/memory_darwin.go
+++ b/internal/signalfx-agent/pkg/monitors/memory/memory_darwin.go
@@ -10,14 +10,14 @@ import (
 func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, swapInfo *mem.SwapMemoryStat, dimensions map[string]string) []*datapoint.Datapoint {
 	return []*datapoint.Datapoint{
 		datapoint.New("memory.utilization", dimensions, datapoint.NewFloatValue(memInfo.UsedPercent), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.used", dimensions, datapoint.NewIntValue(int64(memInfo.Used)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.active", dimensions, datapoint.NewIntValue(int64(memInfo.Active)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.inactive", dimensions, datapoint.NewIntValue(int64(memInfo.Inactive)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.wired", dimensions, datapoint.NewIntValue(int64(memInfo.Wired)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.free", dimensions, datapoint.NewIntValue(int64(memInfo.Free)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.total", dimensions, datapoint.NewIntValue(int64(memInfo.Total)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.swap_total", dimensions, datapoint.NewIntValue(int64(swapInfo.Total)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.swap_free", dimensions, datapoint.NewIntValue(int64(swapInfo.Free)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.swap_used", dimensions, datapoint.NewIntValue(int64(swapInfo.Used)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.used", dimensions, datapoint.NewIntValue(int64(memInfo.Used)), datapoint.Gauge, time.Time{}),         //nolint:gosec
+		datapoint.New("memory.active", dimensions, datapoint.NewIntValue(int64(memInfo.Active)), datapoint.Gauge, time.Time{}),     //nolint:gosec
+		datapoint.New("memory.inactive", dimensions, datapoint.NewIntValue(int64(memInfo.Inactive)), datapoint.Gauge, time.Time{}), //nolint:gosec
+		datapoint.New("memory.wired", dimensions, datapoint.NewIntValue(int64(memInfo.Wired)), datapoint.Gauge, time.Time{}),       //nolint:gosec
+		datapoint.New("memory.free", dimensions, datapoint.NewIntValue(int64(memInfo.Free)), datapoint.Gauge, time.Time{}),         //nolint:gosec
+		datapoint.New("memory.total", dimensions, datapoint.NewIntValue(int64(memInfo.Total)), datapoint.Gauge, time.Time{}),       //nolint:gosec
+		datapoint.New("memory.swap_total", dimensions, datapoint.NewIntValue(int64(swapInfo.Total)), datapoint.Gauge, time.Time{}), //nolint:gosec
+		datapoint.New("memory.swap_free", dimensions, datapoint.NewIntValue(int64(swapInfo.Free)), datapoint.Gauge, time.Time{}),   //nolint:gosec
+		datapoint.New("memory.swap_used", dimensions, datapoint.NewIntValue(int64(swapInfo.Used)), datapoint.Gauge, time.Time{}),   //nolint:gosec
 	}
 }

--- a/internal/signalfx-agent/pkg/monitors/memory/memory_linux.go
+++ b/internal/signalfx-agent/pkg/monitors/memory/memory_linux.go
@@ -12,16 +12,16 @@ func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, swapInfo 
 
 	return []*datapoint.Datapoint{
 		datapoint.New("memory.utilization", dimensions, datapoint.NewFloatValue(float64(used)/float64(memInfo.Total)*100), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.used", dimensions, datapoint.NewIntValue(int64(used)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.buffered", dimensions, datapoint.NewIntValue(int64(memInfo.Buffers)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.used", dimensions, datapoint.NewIntValue(int64(used)), datapoint.Gauge, time.Time{}),                //nolint:gosec
+		datapoint.New("memory.buffered", dimensions, datapoint.NewIntValue(int64(memInfo.Buffers)), datapoint.Gauge, time.Time{}), //nolint:gosec
 		// for some reason gopsutil decided to add slab_reclaimable to cached which collectd does not
-		datapoint.New("memory.cached", dimensions, datapoint.NewIntValue(int64(memInfo.Cached-memInfo.Sreclaimable)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.slab_recl", dimensions, datapoint.NewIntValue(int64(memInfo.Sreclaimable)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.slab_unrecl", dimensions, datapoint.NewIntValue(int64(memInfo.Slab-memInfo.Sreclaimable)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.free", dimensions, datapoint.NewIntValue(int64(memInfo.Free)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.total", dimensions, datapoint.NewIntValue(int64(memInfo.Total)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.swap_total", dimensions, datapoint.NewIntValue(int64(swapInfo.Total)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.swap_free", dimensions, datapoint.NewIntValue(int64(swapInfo.Free)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.swap_used", dimensions, datapoint.NewIntValue(int64(swapInfo.Used)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.cached", dimensions, datapoint.NewIntValue(int64(memInfo.Cached-memInfo.Sreclaimable)), datapoint.Gauge, time.Time{}),    //nolint:gosec
+		datapoint.New("memory.slab_recl", dimensions, datapoint.NewIntValue(int64(memInfo.Sreclaimable)), datapoint.Gauge, time.Time{}),                //nolint:gosec
+		datapoint.New("memory.slab_unrecl", dimensions, datapoint.NewIntValue(int64(memInfo.Slab-memInfo.Sreclaimable)), datapoint.Gauge, time.Time{}), //nolint:gosec
+		datapoint.New("memory.free", dimensions, datapoint.NewIntValue(int64(memInfo.Free)), datapoint.Gauge, time.Time{}),                             //nolint:gosec
+		datapoint.New("memory.total", dimensions, datapoint.NewIntValue(int64(memInfo.Total)), datapoint.Gauge, time.Time{}),                           //nolint:gosec
+		datapoint.New("memory.swap_total", dimensions, datapoint.NewIntValue(int64(swapInfo.Total)), datapoint.Gauge, time.Time{}),                     //nolint:gosec
+		datapoint.New("memory.swap_free", dimensions, datapoint.NewIntValue(int64(swapInfo.Free)), datapoint.Gauge, time.Time{}),                       //nolint:gosec
+		datapoint.New("memory.swap_used", dimensions, datapoint.NewIntValue(int64(swapInfo.Used)), datapoint.Gauge, time.Time{}),                       //nolint:gosec
 	}
 }

--- a/internal/signalfx-agent/pkg/monitors/memory/memory_windows.go
+++ b/internal/signalfx-agent/pkg/monitors/memory/memory_windows.go
@@ -10,11 +10,11 @@ import (
 func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, swapInfo *mem.SwapMemoryStat, dimensions map[string]string) []*datapoint.Datapoint {
 	return []*datapoint.Datapoint{
 		datapoint.New("memory.utilization", dimensions, datapoint.NewFloatValue(memInfo.UsedPercent), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.used", dimensions, datapoint.NewIntValue(int64(memInfo.Used)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.available", dimensions, datapoint.NewIntValue(int64(memInfo.Available)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.total", dimensions, datapoint.NewIntValue(int64(memInfo.Total)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.swap_total", dimensions, datapoint.NewIntValue(int64(swapInfo.Total)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.swap_free", dimensions, datapoint.NewIntValue(int64(swapInfo.Free)), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.swap_used", dimensions, datapoint.NewIntValue(int64(swapInfo.Used)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.used", dimensions, datapoint.NewIntValue(int64(memInfo.Used)), datapoint.Gauge, time.Time{}),           //nolint:gosec
+		datapoint.New("memory.available", dimensions, datapoint.NewIntValue(int64(memInfo.Available)), datapoint.Gauge, time.Time{}), //nolint:gosec
+		datapoint.New("memory.total", dimensions, datapoint.NewIntValue(int64(memInfo.Total)), datapoint.Gauge, time.Time{}),         //nolint:gosec
+		datapoint.New("memory.swap_total", dimensions, datapoint.NewIntValue(int64(swapInfo.Total)), datapoint.Gauge, time.Time{}),   //nolint:gosec
+		datapoint.New("memory.swap_free", dimensions, datapoint.NewIntValue(int64(swapInfo.Free)), datapoint.Gauge, time.Time{}),     //nolint:gosec
+		datapoint.New("memory.swap_used", dimensions, datapoint.NewIntValue(int64(swapInfo.Used)), datapoint.Gauge, time.Time{}),     //nolint:gosec
 	}
 }

--- a/internal/signalfx-agent/pkg/monitors/netio/netio.go
+++ b/internal/signalfx-agent/pkg/monitors/netio/netio.go
@@ -94,19 +94,19 @@ func (m *Monitor) EmitDatapoints() {
 		dimensions := map[string]string{"interface": ifaceName}
 
 		dps = append(dps,
-			datapoint.New("if_errors.rx", dimensions, datapoint.NewIntValue(int64(intf.Errin)), datapoint.Counter, time.Time{}),
-			datapoint.New("if_errors.tx", dimensions, datapoint.NewIntValue(int64(intf.Errout)), datapoint.Counter, time.Time{}),
-			datapoint.New("if_octets.rx", dimensions, datapoint.NewIntValue(int64(intf.BytesRecv)), datapoint.Counter, time.Time{}),
-			datapoint.New("if_octets.tx", dimensions, datapoint.NewIntValue(int64(intf.BytesSent)), datapoint.Counter, time.Time{}),
-			datapoint.New("if_packets.rx", dimensions, datapoint.NewIntValue(int64(intf.PacketsRecv)), datapoint.Counter, time.Time{}),
-			datapoint.New("if_packets.tx", dimensions, datapoint.NewIntValue(int64(intf.PacketsSent)), datapoint.Counter, time.Time{}),
-			datapoint.New("if_dropped.rx", dimensions, datapoint.NewIntValue(int64(intf.Dropin)), datapoint.Counter, time.Time{}),
-			datapoint.New("if_dropped.tx", dimensions, datapoint.NewIntValue(int64(intf.Dropout)), datapoint.Counter, time.Time{}),
+			datapoint.New("if_errors.rx", dimensions, datapoint.NewIntValue(int64(intf.Errin)), datapoint.Counter, time.Time{}),        //nolint:gosec
+			datapoint.New("if_errors.tx", dimensions, datapoint.NewIntValue(int64(intf.Errout)), datapoint.Counter, time.Time{}),       //nolint:gosec
+			datapoint.New("if_octets.rx", dimensions, datapoint.NewIntValue(int64(intf.BytesRecv)), datapoint.Counter, time.Time{}),    //nolint:gosec
+			datapoint.New("if_octets.tx", dimensions, datapoint.NewIntValue(int64(intf.BytesSent)), datapoint.Counter, time.Time{}),    //nolint:gosec
+			datapoint.New("if_packets.rx", dimensions, datapoint.NewIntValue(int64(intf.PacketsRecv)), datapoint.Counter, time.Time{}), //nolint:gosec
+			datapoint.New("if_packets.tx", dimensions, datapoint.NewIntValue(int64(intf.PacketsSent)), datapoint.Counter, time.Time{}), //nolint:gosec
+			datapoint.New("if_dropped.rx", dimensions, datapoint.NewIntValue(int64(intf.Dropin)), datapoint.Counter, time.Time{}),      //nolint:gosec
+			datapoint.New("if_dropped.tx", dimensions, datapoint.NewIntValue(int64(intf.Dropout)), datapoint.Counter, time.Time{}),     //nolint:gosec
 		)
 	}
 
 	// network.total
-	dps = append(dps, datapoint.New("network.total", map[string]string{}, datapoint.NewIntValue(int64(m.networkTotal)), datapoint.Counter, time.Time{}))
+	dps = append(dps, datapoint.New("network.total", map[string]string{}, datapoint.NewIntValue(int64(m.networkTotal)), datapoint.Counter, time.Time{})) //nolint:gosec
 
 	m.Output.SendDatapoints(dps...)
 }

--- a/internal/signalfx-agent/pkg/monitors/processlist/processlist_windows.go
+++ b/internal/signalfx-agent/pkg/monitors/processlist/processlist_windows.go
@@ -76,7 +76,7 @@ func getProcessesWithNonWaitingThreads() (map[uint32]struct{}, error) {
 	for _, nonWaitingThread := range nonWaitingThreads {
 		val, err := strconv.ParseUint(nonWaitingThread.ProcessHandle, 10, 32)
 		if err == nil {
-			pid := uint32(val)
+			pid := uint32(val) //nolint:gosec
 			if _, ok := processWithNonWaitingThreads[pid]; !ok {
 				processWithNonWaitingThreads[pid] = struct{}{}
 			}

--- a/internal/signalfx-agent/pkg/monitors/prometheusexporter/conversion.go
+++ b/internal/signalfx-agent/pkg/monitors/prometheusexporter/conversion.go
@@ -66,7 +66,7 @@ func makeSummaryDatapoints(name string, ms []*dto.Metric) []*datapoint.Datapoint
 
 		//nolint:protogetter
 		if s.SampleCount != nil {
-			dps = append(dps, sfxclient.Cumulative(name+"_count", dims, int64(s.GetSampleCount())))
+			dps = append(dps, sfxclient.Cumulative(name+"_count", dims, int64(s.GetSampleCount()))) //nolint:gosec
 		}
 
 		//nolint:protogetter
@@ -96,7 +96,7 @@ func makeHistogramDatapoints(name string, ms []*dto.Metric) []*datapoint.Datapoi
 
 		//nolint:protogetter
 		if h.SampleCount != nil {
-			dps = append(dps, sfxclient.Cumulative(name+"_count", dims, int64(h.GetSampleCount())))
+			dps = append(dps, sfxclient.Cumulative(name+"_count", dims, int64(h.GetSampleCount()))) //nolint:gosec
 		}
 
 		//nolint:protogetter
@@ -109,7 +109,7 @@ func makeHistogramDatapoints(name string, ms []*dto.Metric) []*datapoint.Datapoi
 			bucketDims := utils.MergeStringMaps(dims, map[string]string{
 				"upper_bound": strconv.FormatFloat(buckets[i].GetUpperBound(), 'f', 6, 64),
 			})
-			dps = append(dps, sfxclient.Cumulative(name+"_bucket", bucketDims, int64(buckets[i].GetCumulativeCount())))
+			dps = append(dps, sfxclient.Cumulative(name+"_bucket", bucketDims, int64(buckets[i].GetCumulativeCount()))) //nolint:gosec
 		}
 	}
 	return dps

--- a/internal/signalfx-agent/pkg/monitors/subproc/messages.go
+++ b/internal/signalfx-agent/pkg/monitors/subproc/messages.go
@@ -77,7 +77,7 @@ func (m *messageReadWriter) SendMessage(msgType MessageType, payload []byte) err
 		return err
 	}
 
-	binary.BigEndian.PutUint32(buf[:], uint32(len(payload)))
+	binary.BigEndian.PutUint32(buf[:], uint32(len(payload))) //nolint:gosec
 	if _, err := m.Writer.Write(buf[:]); err != nil {
 		return err
 	}

--- a/tests/testutils/endpoint.go
+++ b/tests/testutils/endpoint.go
@@ -16,6 +16,7 @@
 package testutils
 
 import (
+	"math"
 	"net"
 	"os/exec"
 	"runtime"
@@ -78,8 +79,9 @@ func GetAvailablePort(t testing.TB) uint16 {
 
 	portInt, err := strconv.Atoi(port)
 	require.NoError(t, err)
-
-	return uint16(portInt)
+	require.Greater(t, portInt, -1)
+	require.Less(t, portInt, math.MaxUint16+1)
+	return uint16(portInt) //nolint:gosec
 }
 
 // Get excluded ports on Windows from the command: netsh interface ipv4 show excludedportrange protocol=tcp


### PR DESCRIPTION
Removing lint suppression for G115: int overflow.

Fixed or suppressed the 3 locations outside `internal/signalfx-agent/pkg/monitors`, I will call these out via PR comments. For the `internal/signalfx-agent/pkg/monitors` I'm suppressing them line by line per Slack conversation, see https://splunk.slack.com/archives/G01L5S7BKLY/p1724431826011759?thread_ts=1724358192.342099&cid=G01L5S7BKLY