### PR TITLE
ansible: add logs exporter option

### DIFF
--- a/deployments/ansible/CHANGELOG.md
+++ b/deployments/ansible/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## ansible-v0.30.0
+
+### 💡 Enhancements 💡
+
+- Add support for the `splunk_otel_auto_instrumentation_logs_exporter` option to configure the `OTEL_LOGS_EXPORTER` environment variable.
+
 ## ansible-v0.29.0
 
 ### 🛑 Breaking changes 🛑

--- a/deployments/ansible/galaxy.yml
+++ b/deployments/ansible/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: signalfx
 name: splunk_otel_collector
 description: Ansible collection for Splunk OpenTelemetry Collector
-version: 0.29.0
+version: 0.30.0
 readme: README.md
 authors:
   - Splunk Inc.

--- a/deployments/ansible/molecule/with_instrumentation_preload_custom/converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_custom/converge.yml
@@ -13,6 +13,7 @@
     splunk_otel_auto_instrumentation_enable_profiler_memory: true
     splunk_otel_auto_instrumentation_enable_metrics: true
     splunk_otel_auto_instrumentation_metrics_exporter: none
+    splunk_otel_auto_instrumentation_logs_exporter: none
     splunk_otel_auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
     splunk_otel_auto_instrumentation_otlp_endpoint_protocol: grpc
   tasks:

--- a/deployments/ansible/molecule/with_instrumentation_preload_custom/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_custom/verify.yml
@@ -199,3 +199,16 @@
         - java.conf
         - node.conf
         - dotnet.conf
+
+    - name: Assert instrumentation config contains OTEL_LOGS_EXPORTER
+      ansible.builtin.lineinfile:
+        line: OTEL_LOGS_EXPORTER=none
+        dest: "/etc/splunk/zeroconfig/{{ item }}"
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+      loop:
+        - java.conf
+        - node.conf
+        - dotnet.conf

--- a/deployments/ansible/molecule/with_instrumentation_preload_default/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_default/verify.yml
@@ -189,3 +189,16 @@
         - java.conf
         - node.conf
         - dotnet.conf
+
+    - name: Assert instrumentation config does not contain OTEL_LOGS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_LOGS_EXPORTER.*'
+        dest: "/etc/splunk/zeroconfig/{{ item }}"
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+      loop:
+        - java.conf
+        - node.conf
+        - dotnet.conf

--- a/deployments/ansible/molecule/with_instrumentation_preload_dotnet/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_dotnet/verify.yml
@@ -159,3 +159,12 @@
       check_mode: yes
       register: config
       failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_LOGS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_LOGS_EXPORTER.*'
+        dest: /etc/splunk/zeroconfig/dotnet.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_preload_java/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_java/verify.yml
@@ -150,3 +150,12 @@
       check_mode: yes
       register: config
       failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_LOGS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_LOGS_EXPORTER.*'
+        dest: /etc/splunk/zeroconfig/java.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_preload_nodejs/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_nodejs/verify.yml
@@ -148,3 +148,12 @@
       check_mode: yes
       register: config
       failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_LOGS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_LOGS_EXPORTER.*'
+        dest: /etc/splunk/zeroconfig/node.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_preload_without_npm/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_preload_without_npm/verify.yml
@@ -174,3 +174,15 @@
       loop:
         - java.conf
         - dotnet.conf
+
+    - name: Assert instrumentation config does not contain OTEL_LOGS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_LOGS_EXPORTER.*'
+        dest: "/etc/splunk/zeroconfig/{{ item }}"
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed
+      loop:
+        - java.conf
+        - dotnet.conf

--- a/deployments/ansible/molecule/with_instrumentation_systemd_custom/converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_custom/converge.yml
@@ -13,6 +13,7 @@
     splunk_otel_auto_instrumentation_enable_profiler_memory: true
     splunk_otel_auto_instrumentation_enable_metrics: true
     splunk_otel_auto_instrumentation_metrics_exporter: none
+    splunk_otel_auto_instrumentation_logs_exporter: none
     splunk_otel_auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
     splunk_otel_auto_instrumentation_otlp_endpoint_protocol: grpc
   tasks:

--- a/deployments/ansible/molecule/with_instrumentation_systemd_custom/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_custom/verify.yml
@@ -155,3 +155,12 @@
       check_mode: yes
       register: config
       failed_when: config is changed
+
+    - name: Assert instrumentation config contains OTEL_LOGS_EXPORTER
+      ansible.builtin.lineinfile:
+        line: DefaultEnvironment="OTEL_LOGS_EXPORTER=none"
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: present
+      check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_systemd_default/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_default/verify.yml
@@ -156,3 +156,12 @@
       check_mode: yes
       register: config
       failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_LOGS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_LOGS_EXPORTER.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_systemd_dotnet/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_dotnet/verify.yml
@@ -156,3 +156,12 @@
       check_mode: yes
       register: config
       failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_LOGS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_LOGS_EXPORTER.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_systemd_java/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_java/verify.yml
@@ -157,3 +157,12 @@
       check_mode: yes
       register: config
       failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_LOGS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_LOGS_EXPORTER.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_systemd_nodejs/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_nodejs/verify.yml
@@ -155,3 +155,12 @@
       check_mode: yes
       register: config
       failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_LOGS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_LOGS_EXPORTER.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/molecule/with_instrumentation_systemd_without_npm/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation_systemd_without_npm/verify.yml
@@ -157,3 +157,12 @@
       check_mode: yes
       register: config
       failed_when: config is changed
+
+    - name: Assert instrumentation config does not contain OTEL_LOGS_EXPORTER
+      ansible.builtin.lineinfile:
+        regexp: '.*OTEL_LOGS_EXPORTER.*'
+        dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
+        state: absent
+      check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -315,6 +315,15 @@ to take effect.
   (**default:** ```, i.e. defer to the default `OTEL_METRICS_EXPORTER` value
   for each activated SDK)
 
+- `splunk_otel_auto_instrumentation_logs_exporter` (Linux only):
+  Set the exporter for collected logs by all activated SDKs, for example
+  `otlp`. Set the value to `none` to disable collection and export of logs.
+  The value will be set to the `OTEL_LOGS_EXPORTER` environment variable. Only
+  applicable if `splunk_otel_auto_instrumentation_version` is `latest` or >=
+  `0.108.0`.
+  (**default:** ```, i.e. defer to the default `OTEL_LOGS_EXPORTER` value
+  for each activated SDK)
+
 ### Auto Instrumentation for .NET on Windows
 
 ***Warning:*** The `Environment` property in the

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -74,6 +74,7 @@ splunk_otel_auto_instrumentation_enable_profiler: false
 splunk_otel_auto_instrumentation_enable_profiler_memory: false
 splunk_otel_auto_instrumentation_enable_metrics: false
 splunk_otel_auto_instrumentation_metrics_exporter: ""
+splunk_otel_auto_instrumentation_logs_exporter: ""
 splunk_otel_auto_instrumentation_otlp_endpoint: ""
 splunk_otel_auto_instrumentation_otlp_endpoint_protocol: ""
 splunk_otel_auto_instrumentation_sdks:

--- a/deployments/ansible/roles/collector/templates/00-splunk-otel-auto-instrumentation.conf.j2
+++ b/deployments/ansible/roles/collector/templates/00-splunk-otel-auto-instrumentation.conf.j2
@@ -35,3 +35,6 @@ DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL={{ splunk_otel_auto_instrumentat
 {% if splunk_otel_auto_instrumentation_metrics_exporter is defined and splunk_otel_auto_instrumentation_metrics_exporter %}
 DefaultEnvironment="OTEL_METRICS_EXPORTER={{ splunk_otel_auto_instrumentation_metrics_exporter }}"
 {% endif %}
+{% if splunk_otel_auto_instrumentation_logs_exporter is defined and splunk_otel_auto_instrumentation_logs_exporter %}
+DefaultEnvironment="OTEL_LOGS_EXPORTER={{ splunk_otel_auto_instrumentation_logs_exporter }}"
+{% endif %}

--- a/deployments/ansible/roles/collector/templates/dotnet.conf.j2
+++ b/deployments/ansible/roles/collector/templates/dotnet.conf.j2
@@ -26,3 +26,6 @@ OTEL_EXPORTER_OTLP_PROTOCOL={{ splunk_otel_auto_instrumentation_otlp_endpoint_pr
 {% if splunk_otel_auto_instrumentation_metrics_exporter is defined and splunk_otel_auto_instrumentation_metrics_exporter %}
 OTEL_METRICS_EXPORTER={{ splunk_otel_auto_instrumentation_metrics_exporter }}
 {% endif %}
+{% if splunk_otel_auto_instrumentation_logs_exporter is defined and splunk_otel_auto_instrumentation_logs_exporter %}
+OTEL_LOGS_EXPORTER={{ splunk_otel_auto_instrumentation_logs_exporter }}
+{% endif %}

--- a/deployments/ansible/roles/collector/templates/java.conf.j2
+++ b/deployments/ansible/roles/collector/templates/java.conf.j2
@@ -19,3 +19,6 @@ OTEL_EXPORTER_OTLP_PROTOCOL={{ splunk_otel_auto_instrumentation_otlp_endpoint_pr
 {% if splunk_otel_auto_instrumentation_metrics_exporter is defined and splunk_otel_auto_instrumentation_metrics_exporter %}
 OTEL_METRICS_EXPORTER={{ splunk_otel_auto_instrumentation_metrics_exporter }}
 {% endif %}
+{% if splunk_otel_auto_instrumentation_logs_exporter is defined and splunk_otel_auto_instrumentation_logs_exporter %}
+OTEL_LOGS_EXPORTER={{ splunk_otel_auto_instrumentation_logs_exporter }}
+{% endif %}

--- a/deployments/ansible/roles/collector/templates/node.conf.j2
+++ b/deployments/ansible/roles/collector/templates/node.conf.j2
@@ -19,3 +19,6 @@ OTEL_EXPORTER_OTLP_PROTOCOL={{ splunk_otel_auto_instrumentation_otlp_endpoint_pr
 {% if splunk_otel_auto_instrumentation_metrics_exporter is defined and splunk_otel_auto_instrumentation_metrics_exporter %}
 OTEL_METRICS_EXPORTER={{ splunk_otel_auto_instrumentation_metrics_exporter }}
 {% endif %}
+{% if splunk_otel_auto_instrumentation_logs_exporter is defined and splunk_otel_auto_instrumentation_logs_exporter %}
+OTEL_LOGS_EXPORTER={{ splunk_otel_auto_instrumentation_logs_exporter }}
+{% endif %}


### PR DESCRIPTION
Support configuration of `OTEL_LOGS_EXPORTER`. Follow up to https://github.com/signalfx/splunk-otel-collector/pull/5133.