### PR TITLE
chef: add logs exporter option

### DIFF
--- a/deployments/chef/CHANGELOG.md
+++ b/deployments/chef/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## chef-v0.16.0
+
+- Add support for the ``auto_instrumentation_logs_exporter` option to configure the `OTEL_LOGS_EXPORTER` environment variable.
+
 ## chef-v0.15.0
 
 - Breaking Change: The default for the `auto_instrumentation_otlp_endpoint` option has been changed from

--- a/deployments/chef/CHANGELOG.md
+++ b/deployments/chef/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## chef-v0.16.0
 
-- Add support for the ``auto_instrumentation_logs_exporter` option to configure the `OTEL_LOGS_EXPORTER` environment variable.
+- Add support for the `auto_instrumentation_logs_exporter` option to configure the `OTEL_LOGS_EXPORTER` environment variable.
 
 ## chef-v0.15.0
 

--- a/deployments/chef/README.md
+++ b/deployments/chef/README.md
@@ -292,6 +292,14 @@ after installation/configuration in order for any change to take effect.
   `0.104.0`. (**default:** `''`, i.e. defer to the default
   `OTEL_METRICS_EXPORTER` value for each activated SDK)
 
+- `auto_instrumentation_logs_exporter` (Linux only): Set the exporter for
+  collected logs by all activated SDKs, for example `otlp`. Set the value to
+  `none` to disable collection and export of logs. The value will be set to the
+  `OTEL_LOGS_EXPORTER` environment variable. Only applicable if
+  `auto_instrumentation_version` is `latest` or >= `0.108.0`.
+  (**default:** `''`, i.e. defer to the default `OTEL_LOGS_EXPORTER` value for
+  each activated SDK)
+
 ### Auto Instrumentation for .NET on Windows
 
 ***Warning:*** The `Environment` property in the

--- a/deployments/chef/attributes/default.rb
+++ b/deployments/chef/attributes/default.rb
@@ -100,6 +100,7 @@ elsif platform_family?('debian', 'rhel', 'amazon', 'suse')
   default['splunk_otel_collector']['auto_instrumentation_enable_profiler_memory'] = false
   default['splunk_otel_collector']['auto_instrumentation_enable_metrics'] = false
   default['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] = ''
+  default['splunk_otel_collector']['auto_instrumentation_logs_exporter'] = ''
   default['splunk_otel_collector']['auto_instrumentation_otlp_endpoint'] = ''
   default['splunk_otel_collector']['auto_instrumentation_otlp_endpoint_protocol'] = ''
   default['splunk_otel_collector']['with_auto_instrumentation_sdks'] = %w(java nodejs dotnet)

--- a/deployments/chef/kitchen.yml
+++ b/deployments/chef/kitchen.yml
@@ -177,6 +177,7 @@ suites:
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
         auto_instrumentation_otlp_endpoint_protocol: grpc
         auto_instrumentation_metrics_exporter: none
+        auto_instrumentation_logs_exporter: none
 
   - name: with_default_systemd_instrumentation
     run_list:
@@ -212,6 +213,7 @@ suites:
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
         auto_instrumentation_otlp_endpoint_protocol: grpc
         auto_instrumentation_metrics_exporter: none
+        auto_instrumentation_logs_exporter: none
 
   - name: with_default_preload_java_instrumentation
     run_list:
@@ -243,6 +245,7 @@ suites:
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
         auto_instrumentation_otlp_endpoint_protocol: grpc
         auto_instrumentation_metrics_exporter: none
+        auto_instrumentation_logs_exporter: none
 
   - name: with_default_systemd_java_instrumentation
     run_list:
@@ -275,6 +278,7 @@ suites:
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
         auto_instrumentation_otlp_endpoint_protocol: grpc
         auto_instrumentation_metrics_exporter: none
+        auto_instrumentation_logs_exporter: none
 
   - name: with_default_preload_node_instrumentation
     run_list:
@@ -312,6 +316,7 @@ suites:
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
         auto_instrumentation_otlp_endpoint_protocol: grpc
         auto_instrumentation_metrics_exporter: none
+        auto_instrumentation_logs_exporter: none
 
   - name: with_default_systemd_node_instrumentation
     run_list:
@@ -350,6 +355,7 @@ suites:
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
         auto_instrumentation_otlp_endpoint_protocol: grpc
         auto_instrumentation_metrics_exporter: none
+        auto_instrumentation_logs_exporter: none
 
   - name: with_default_preload_dotnet_instrumentation
     run_list:
@@ -381,6 +387,7 @@ suites:
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
         auto_instrumentation_otlp_endpoint_protocol: grpc
         auto_instrumentation_metrics_exporter: none
+        auto_instrumentation_logs_exporter: none
 
   - name: with_default_systemd_dotnet_instrumentation
     run_list:
@@ -413,6 +420,7 @@ suites:
         auto_instrumentation_otlp_endpoint: http://0.0.0.0:4317
         auto_instrumentation_otlp_endpoint_protocol: grpc
         auto_instrumentation_metrics_exporter: none
+        auto_instrumentation_logs_exporter: none
 
   - name: with_default_preload_instrumentation_without_npm
     run_list:

--- a/deployments/chef/metadata.rb
+++ b/deployments/chef/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Splunk, Inc.'
 maintainer_email 'signalfx-support@splunk.com'
 license 'Apache-2.0'
 description 'Install/Configure the Splunk OpenTelemetry Collector'
-version '0.15.0'
+version '0.16.0'
 chef_version '>= 16.0'
 
 supports 'amazon'

--- a/deployments/chef/templates/00-splunk-otel-auto-instrumentation.conf.erb
+++ b/deployments/chef/templates/00-splunk-otel-auto-instrumentation.conf.erb
@@ -35,3 +35,6 @@ DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL=<%= node['splunk_otel_collector'
 <% if defined?(node['splunk_otel_collector']['auto_instrumentation_metrics_exporter']) && node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] != "" -%>
 DefaultEnvironment="OTEL_METRICS_EXPORTER=<%= node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] %>"
 <% end -%>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_logs_exporter']) && node['splunk_otel_collector']['auto_instrumentation_logs_exporter'] != "" -%>
+DefaultEnvironment="OTEL_LOGS_EXPORTER=<%= node['splunk_otel_collector']['auto_instrumentation_logs_exporter'] %>"
+<% end -%>

--- a/deployments/chef/templates/dotnet.conf.erb
+++ b/deployments/chef/templates/dotnet.conf.erb
@@ -26,3 +26,6 @@ OTEL_EXPORTER_OTLP_PROTOCOL=<%= node['splunk_otel_collector']['auto_instrumentat
 <% if defined?(node['splunk_otel_collector']['auto_instrumentation_metrics_exporter']) && node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] != "" -%>
 OTEL_METRICS_EXPORTER=<%= node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] %>
 <% end -%>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_logs_exporter']) && node['splunk_otel_collector']['auto_instrumentation_logs_exporter'] != "" -%>
+OTEL_LOGS_EXPORTER=<%= node['splunk_otel_collector']['auto_instrumentation_logs_exporter'] %>
+<% end -%>

--- a/deployments/chef/templates/java.conf.erb
+++ b/deployments/chef/templates/java.conf.erb
@@ -19,3 +19,6 @@ OTEL_EXPORTER_OTLP_PROTOCOL=<%= node['splunk_otel_collector']['auto_instrumentat
 <% if defined?(node['splunk_otel_collector']['auto_instrumentation_metrics_exporter']) && node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] != "" -%>
 OTEL_METRICS_EXPORTER=<%= node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] %>
 <% end -%>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_logs_exporter']) && node['splunk_otel_collector']['auto_instrumentation_logs_exporter'] != "" -%>
+OTEL_LOGS_EXPORTER=<%= node['splunk_otel_collector']['auto_instrumentation_logs_exporter'] %>
+<% end -%>

--- a/deployments/chef/templates/node.conf.erb
+++ b/deployments/chef/templates/node.conf.erb
@@ -19,3 +19,6 @@ OTEL_EXPORTER_OTLP_PROTOCOL=<%= node['splunk_otel_collector']['auto_instrumentat
 <% if defined?(node['splunk_otel_collector']['auto_instrumentation_metrics_exporter']) && node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] != "" -%>
 OTEL_METRICS_EXPORTER=<%= node['splunk_otel_collector']['auto_instrumentation_metrics_exporter'] %>
 <% end -%>
+<% if defined?(node['splunk_otel_collector']['auto_instrumentation_logs_exporter']) && node['splunk_otel_collector']['auto_instrumentation_logs_exporter'] != "" -%>
+OTEL_LOGS_EXPORTER=<%= node['splunk_otel_collector']['auto_instrumentation_logs_exporter'] %>
+<% end -%>

--- a/deployments/chef/test/integration/with_custom_preload_dotnet_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_preload_dotnet_instrumentation/test.rb
@@ -50,6 +50,7 @@ describe file('/etc/splunk/zeroconfig/dotnet.conf') do
   its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
   its('content') { should match /^OTEL_EXPORTER_OTLP_PROTOCOL=grpc$/ }
   its('content') { should match /^OTEL_METRICS_EXPORTER=none$/ }
+  its('content') { should match /^OTEL_LOGS_EXPORTER=none$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_custom_preload_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_preload_instrumentation/test.rb
@@ -68,6 +68,7 @@ describe file('/etc/splunk/zeroconfig/dotnet.conf') do
   its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
   its('content') { should match /^OTEL_EXPORTER_OTLP_PROTOCOL=grpc$/ }
   its('content') { should match /^OTEL_METRICS_EXPORTER=none$/ }
+  its('content') { should match /^OTEL_LOGS_EXPORTER=none$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_custom_preload_java_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_preload_java_instrumentation/test.rb
@@ -43,6 +43,7 @@ describe file('/etc/splunk/zeroconfig/java.conf') do
   its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
   its('content') { should match /^OTEL_EXPORTER_OTLP_PROTOCOL=grpc$/ }
   its('content') { should match /^OTEL_METRICS_EXPORTER=none$/ }
+  its('content') { should match /^OTEL_LOGS_EXPORTER=none$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_custom_preload_node_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_preload_node_instrumentation/test.rb
@@ -43,6 +43,7 @@ describe file('/etc/splunk/zeroconfig/node.conf') do
   its('content') { should match /^OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}$/ }
   its('content') { should match /^OTEL_EXPORTER_OTLP_PROTOCOL=grpc$/ }
   its('content') { should match /^OTEL_METRICS_EXPORTER=none$/ }
+  its('content') { should match /^OTEL_LOGS_EXPORTER=none$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_custom_systemd_dotnet_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_systemd_dotnet_instrumentation/test.rb
@@ -50,6 +50,7 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}"$/ }
   its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL=grpc"$/ }
   its('content') { should match /^DefaultEnvironment="OTEL_METRICS_EXPORTER=none"$/ }
+  its('content') { should match /^DefaultEnvironment="OTEL_LOGS_EXPORTER=none"$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_custom_systemd_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_systemd_instrumentation/test.rb
@@ -52,6 +52,7 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}"$/ }
   its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL=grpc"$/ }
   its('content') { should match /^DefaultEnvironment="OTEL_METRICS_EXPORTER=none"$/ }
+  its('content') { should match /^DefaultEnvironment="OTEL_LOGS_EXPORTER=none"$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_custom_systemd_java_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_systemd_java_instrumentation/test.rb
@@ -50,6 +50,7 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}"$/ }
   its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL=grpc"$/ }
   its('content') { should match /^DefaultEnvironment="OTEL_METRICS_EXPORTER=none"$/ }
+  its('content') { should match /^DefaultEnvironment="OTEL_LOGS_EXPORTER=none"$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_custom_systemd_node_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_systemd_node_instrumentation/test.rb
@@ -50,6 +50,7 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT=#{otlp_endpoint}"$/ }
   its('content') { should match /^DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL=grpc"$/ }
   its('content') { should match /^DefaultEnvironment="OTEL_METRICS_EXPORTER=none"$/ }
+  its('content') { should match /^DefaultEnvironment="OTEL_LOGS_EXPORTER=none"$/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_preload_dotnet_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_dotnet_instrumentation/test.rb
@@ -47,6 +47,7 @@ describe file('/etc/splunk/zeroconfig/dotnet.conf') do
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
   its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
+  its('content') { should_not match /.*OTEL_LOGS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_preload_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_instrumentation/test.rb
@@ -65,6 +65,7 @@ describe file('/etc/splunk/zeroconfig/dotnet.conf') do
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
   its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
+  its('content') { should_not match /.*OTEL_LOGS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_preload_instrumentation_without_npm/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_instrumentation_without_npm/test.rb
@@ -56,6 +56,7 @@ describe file('/etc/splunk/zeroconfig/dotnet.conf') do
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
   its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
+  its('content') { should_not match /.*OTEL_LOGS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_preload_java_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_java_instrumentation/test.rb
@@ -40,6 +40,7 @@ describe file('/etc/splunk/zeroconfig/java.conf') do
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
   its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
+  its('content') { should_not match /.*OTEL_LOGS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_preload_node_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_node_instrumentation/test.rb
@@ -40,6 +40,7 @@ describe file('/etc/splunk/zeroconfig/node.conf') do
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
   its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
+  its('content') { should_not match /.*OTEL_LOGS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_systemd_dotnet_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_dotnet_instrumentation/test.rb
@@ -49,6 +49,7 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
   its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
+  its('content') { should_not match /.*OTEL_LOGS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_systemd_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_instrumentation/test.rb
@@ -51,6 +51,7 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
   its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
+  its('content') { should_not match /.*OTEL_LOGS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_systemd_instrumentation_without_npm/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_instrumentation_without_npm/test.rb
@@ -50,6 +50,7 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
   its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
+  its('content') { should_not match /.*OTEL_LOGS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_systemd_java_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_java_instrumentation/test.rb
@@ -49,6 +49,7 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
   its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
+  its('content') { should_not match /.*OTEL_LOGS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do

--- a/deployments/chef/test/integration/with_default_systemd_node_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_node_instrumentation/test.rb
@@ -49,6 +49,7 @@ describe file('/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentatio
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_ENDPOINT.*/ }
   its('content') { should_not match /.*OTEL_EXPORTER_OTLP_PROTOCOL.*/ }
   its('content') { should_not match /.*OTEL_METRICS_EXPORTER.*/ }
+  its('content') { should_not match /.*OTEL_LOGS_EXPORTER.*/ }
 end
 
 describe service('splunk-otel-collector') do


### PR DESCRIPTION
Support configuration of `OTEL_LOGS_EXPORTER`. Follow up to https://github.com/signalfx/splunk-otel-collector/pull/5160.
