### PR TITLE
salt: support java v2

### DIFF
--- a/deployments/salt/README.md
+++ b/deployments/salt/README.md
@@ -232,6 +232,32 @@ after installation/configuration in order for any changes to take effect.
 - `auto_instrumentation_enable_metrics`: Enable or disable exporting
   instrumentation metrics. (**default**: `False`)
 
-- `auto_instrumentation_otlp_endpoint`: Set the OTLP gRPC endpoint for captured
-  traces. Only applicable if `auto_instrumentation_version` is `latest` or >=
-  `0.87.0`. (**default:** `http://127.0.0.1:4317`)
+- `auto_instrumentation_otlp_endpoint`: Set the OTLP endpoint for captured
+  traces, metrics, and logs. The value will be set to the
+  `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable. Only applicable if
+  `auto_instrumentation_version` is `latest` or >= `0.87.0`. (**default:**
+  `""`, i.e. defer to the default `OTEL_EXPORTER_OTLP_ENDPOINT` value for
+  each activated SDK)
+
+- `auto_instrumentation_otlp_endpoint_protocol`: Set the protocol for the OTLP
+  endpoint, for example `grpc` or `http/protobuf`. The value will be set to the
+  `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable. Only applicable if
+  `auto_instrumentation_version` is `latest` or >= `0.104.0`. (**default:**
+  `""`, i.e. defer to the default `OTEL_EXPORTER_OTLP_PROTOCOL` value for
+  each activated SDK)
+
+- `auto_instrumentation_metrics_exporter`: Comma-separated list of exporters
+  for collected metrics by all activated SDKs, for example `otlp,prometheus`.
+  Set the value to `none` to disable collection and export of metrics. The
+  value will be set to the `OTEL_METRICS_EXPORTER` environment variable. Only
+  applicable if `auto_instrumentation_version` is `latest` or >= `0.104.0`.
+  (**default:** `""`, i.e. defer to the default `OTEL_METRICS_EXPORTER`
+  value for each activated SDK)
+
+- `auto_instrumentation_logs_exporter`: Set the exporter for collected logs by
+  all activated SDKs, for example `otlp`. Set the value to `none` to disable
+  collection and export of logs. The value will be set to the
+  `OTEL_LOGS_EXPORTER` environment variable. Only applicable if
+  `auto_instrumentation_version` is `latest` or >= `0.108.0`. (**default:**
+  `""`, i.e. defer to the default `OTEL_LOGS_EXPORTER` value for each
+  activated SDK)

--- a/deployments/salt/splunk-otel-collector/auto_instrumentation.sls
+++ b/deployments/salt/splunk-otel-collector/auto_instrumentation.sls
@@ -11,7 +11,10 @@
 {% set auto_instrumentation_enable_profiler = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_enable_profiler', False) | to_bool %}
 {% set auto_instrumentation_enable_profiler_memory = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_enable_profiler_memory', False) | to_bool %}
 {% set auto_instrumentation_enable_metrics = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_enable_metrics', False) | to_bool %}
-{% set auto_instrumentation_otlp_endpoint = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_otlp_endpoint', 'http://127.0.0.1:4317') %}
+{% set auto_instrumentation_otlp_endpoint = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_otlp_endpoint') %}
+{% set auto_instrumentation_otlp_endpoint_protocol = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_otlp_endpoint_protocol') %}
+{% set auto_instrumentation_metrics_exporter = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_metrics_exporter') %}
+{% set auto_instrumentation_logs_exporter = salt['pillar.get']('splunk-otel-collector:auto_instrumentation_logs_exporter') %}
 {% set with_new_instrumentation = auto_instrumentation_version == 'latest' or salt['pkg.version_cmp'](auto_instrumentation_version, '0.87.0') >= 0 %}
 {% set dotnet_supported = (auto_instrumentation_version == 'latest' or salt['pkg.version_cmp'](auto_instrumentation_version, '0.99.0') >= 0) and grains['cpuarch'] in ['amd64', 'x86_64'] %}
 {% set systemd_config_path = '/usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf' %}
@@ -89,7 +92,18 @@ Install splunk-otel-js:
         - DefaultEnvironment="SPLUNK_PROFILER_ENABLED={{ auto_instrumentation_enable_profiler | string | lower }}"
         - DefaultEnvironment="SPLUNK_PROFILER_MEMORY_ENABLED={{ auto_instrumentation_enable_profiler_memory | string | lower }}"
         - DefaultEnvironment="SPLUNK_METRICS_ENABLED={{ auto_instrumentation_enable_metrics | string | lower }}"
+        {% if auto_instrumentation_otlp_endpoint != "" %}
         - DefaultEnvironment="OTEL_EXPORTER_OTLP_ENDPOINT={{ auto_instrumentation_otlp_endpoint }}"
+        {% endif %}
+        {% if auto_instrumentation_otlp_endpoint_protocol != "" %}
+        - DefaultEnvironment="OTEL_EXPORTER_OTLP_PROTOCOL={{ auto_instrumentation_otlp_endpoint_protocol }}"
+        {% endif %}
+        {% if auto_instrumentation_metrics_exporter != "" %}
+        - DefaultEnvironment="OTEL_METRICS_EXPORTER={{ auto_instrumentation_metrics_exporter }}"
+        {% endif %}
+        {% if auto_instrumentation_logs_exporter != "" %}
+        - DefaultEnvironment="OTEL_LOGS_EXPORTER={{ auto_instrumentation_logs_exporter }}"
+        {% endif %}
     - makedirs: True
     - require:
       - pkg: splunk-otel-auto-instrumentation
@@ -123,7 +137,18 @@ Delete auto instrumentation systemd config:
         - SPLUNK_PROFILER_ENABLED={{ auto_instrumentation_enable_profiler | string | lower }}
         - SPLUNK_PROFILER_MEMORY_ENABLED={{ auto_instrumentation_enable_profiler_memory | string | lower }}
         - SPLUNK_METRICS_ENABLED={{ auto_instrumentation_enable_metrics | string | lower }}
+        {% if auto_instrumentation_otlp_endpoint != "" %}
         - OTEL_EXPORTER_OTLP_ENDPOINT={{ auto_instrumentation_otlp_endpoint }}
+        {% endif %}
+        {% if auto_instrumentation_otlp_endpoint_protocol != "" %}
+        - OTEL_EXPORTER_OTLP_PROTOCOL={{ auto_instrumentation_otlp_endpoint_protocol }}
+        {% endif %}
+        {% if auto_instrumentation_metrics_exporter != "" %}
+        - OTEL_METRICS_EXPORTER={{ auto_instrumentation_metrics_exporter }}
+        {% endif %}
+        {% if auto_instrumentation_logs_exporter != "" %}
+        - OTEL_LOGS_EXPORTER={{ auto_instrumentation_logs_exporter }}
+        {% endif %}
     - makedirs: True
     - require:
       - pkg: splunk-otel-auto-instrumentation
@@ -150,7 +175,18 @@ Delete {{ java_config_path }}:
         - SPLUNK_PROFILER_ENABLED={{ auto_instrumentation_enable_profiler | string | lower }}
         - SPLUNK_PROFILER_MEMORY_ENABLED={{ auto_instrumentation_enable_profiler_memory | string | lower }}
         - SPLUNK_METRICS_ENABLED={{ auto_instrumentation_enable_metrics | string | lower }}
+        {% if auto_instrumentation_otlp_endpoint != "" %}
         - OTEL_EXPORTER_OTLP_ENDPOINT={{ auto_instrumentation_otlp_endpoint }}
+        {% endif %}
+        {% if auto_instrumentation_otlp_endpoint_protocol != "" %}
+        - OTEL_EXPORTER_OTLP_PROTOCOL={{ auto_instrumentation_otlp_endpoint_protocol }}
+        {% endif %}
+        {% if auto_instrumentation_metrics_exporter != "" %}
+        - OTEL_METRICS_EXPORTER={{ auto_instrumentation_metrics_exporter }}
+        {% endif %}
+        {% if auto_instrumentation_logs_exporter != "" %}
+        - OTEL_LOGS_EXPORTER={{ auto_instrumentation_logs_exporter }}
+        {% endif %}
     - makedirs: True
     - require:
       - pkg: splunk-otel-auto-instrumentation
@@ -184,7 +220,18 @@ Delete {{ nodejs_config_path }}:
         - SPLUNK_PROFILER_ENABLED={{ auto_instrumentation_enable_profiler | string | lower }}
         - SPLUNK_PROFILER_MEMORY_ENABLED={{ auto_instrumentation_enable_profiler_memory | string | lower }}
         - SPLUNK_METRICS_ENABLED={{ auto_instrumentation_enable_metrics | string | lower }}
+        {% if auto_instrumentation_otlp_endpoint != "" %}
         - OTEL_EXPORTER_OTLP_ENDPOINT={{ auto_instrumentation_otlp_endpoint }}
+        {% endif %}
+        {% if auto_instrumentation_otlp_endpoint_protocol != "" %}
+        - OTEL_EXPORTER_OTLP_PROTOCOL={{ auto_instrumentation_otlp_endpoint_protocol }}
+        {% endif %}
+        {% if auto_instrumentation_metrics_exporter != "" %}
+        - OTEL_METRICS_EXPORTER={{ auto_instrumentation_metrics_exporter }}
+        {% endif %}
+        {% if auto_instrumentation_logs_exporter != "" %}
+        - OTEL_LOGS_EXPORTER={{ auto_instrumentation_logs_exporter }}
+        {% endif %}
     - makedirs: True
     - require:
       - pkg: splunk-otel-auto-instrumentation

--- a/internal/buildscripts/packaging/tests/deployments/salt/salt_test.py
+++ b/internal/buildscripts/packaging/tests/deployments/salt/salt_test.py
@@ -284,7 +284,10 @@ def test_salt_default_instrumentation(distro, version, with_systemd):
             verify_config_file(container, SYSTEMD_CONFIG_PATH, "SPLUNK_PROFILER_ENABLED", "false")
             verify_config_file(container, SYSTEMD_CONFIG_PATH, "SPLUNK_PROFILER_MEMORY_ENABLED", "false")
             verify_config_file(container, SYSTEMD_CONFIG_PATH, "SPLUNK_METRICS_ENABLED", "false")
-            verify_config_file(container, SYSTEMD_CONFIG_PATH, "OTEL_EXPORTER_OTLP_ENDPOINT", r"http://127.0.0.1:4317")
+            verify_config_file(container, SYSTEMD_CONFIG_PATH, "OTEL_EXPORTER_OTLP_ENDPOINT", ".*", exists=False)
+            verify_config_file(container, SYSTEMD_CONFIG_PATH, "OTEL_EXPORTER_OTLP_PROTOCOL", ".*", exists=False)
+            verify_config_file(container, SYSTEMD_CONFIG_PATH, "OTEL_METRICS_EXPORTER", ".*", exists=False)
+            verify_config_file(container, SYSTEMD_CONFIG_PATH, "OTEL_LOGS_EXPORTER", ".*", exists=False)
             if version == "latest":
                 verify_config_file(container, SYSTEMD_CONFIG_PATH, "NODE_OPTIONS", NODE_OPTIONS)
                 verify_dotnet_config(container, SYSTEMD_CONFIG_PATH)
@@ -302,7 +305,10 @@ def test_salt_default_instrumentation(distro, version, with_systemd):
                 verify_config_file(container, config_path, "SPLUNK_PROFILER_ENABLED", "false")
                 verify_config_file(container, config_path, "SPLUNK_PROFILER_MEMORY_ENABLED", "false")
                 verify_config_file(container, config_path, "SPLUNK_METRICS_ENABLED", "false")
-                verify_config_file(container, config_path, "OTEL_EXPORTER_OTLP_ENDPOINT", r"http://127.0.0.1:4317")
+                verify_config_file(container, config_path, "OTEL_EXPORTER_OTLP_ENDPOINT", ".*", exists=False)
+                verify_config_file(container, config_path, "OTEL_EXPORTER_OTLP_PROTOCOL", ".*", exists=False)
+                verify_config_file(container, config_path, "OTEL_METRICS_EXPORTER", ".*", exists=False)
+                verify_config_file(container, config_path, "OTEL_LOGS_EXPORTER", ".*", exists=False)
         else:
             for config_path in [JAVA_CONFIG_PATH, NODE_CONFIG_PATH, DOTNET_CONFIG_PATH, SYSTEMD_CONFIG_PATH]:
                 assert not container_file_exists(container, config_path)
@@ -335,6 +341,9 @@ splunk-otel-collector:
   auto_instrumentation_enable_profiler_memory: True
   auto_instrumentation_enable_metrics: True
   auto_instrumentation_otlp_endpoint: 'http://0.0.0.0:4317'
+  auto_instrumentation_otlp_endpoint_protocol: 'grpc'
+  auto_instrumentation_metrics_exporter: 'none'
+  auto_instrumentation_logs_exporter: 'none'
   """
 )
 
@@ -382,6 +391,9 @@ def test_salt_custom_instrumentation(distro, version, with_systemd):
             verify_config_file(container, SYSTEMD_CONFIG_PATH, "SPLUNK_PROFILER_MEMORY_ENABLED", "true")
             verify_config_file(container, SYSTEMD_CONFIG_PATH, "SPLUNK_METRICS_ENABLED", "true")
             verify_config_file(container, SYSTEMD_CONFIG_PATH, "OTEL_EXPORTER_OTLP_ENDPOINT", r"http://0.0.0.0:4317")
+            verify_config_file(container, SYSTEMD_CONFIG_PATH, "OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+            verify_config_file(container, SYSTEMD_CONFIG_PATH, "OTEL_METRICS_EXPORTER", "none")
+            verify_config_file(container, SYSTEMD_CONFIG_PATH, "OTEL_LOGS_EXPORTER", "none")
             if version == "latest":
                 verify_config_file(container, SYSTEMD_CONFIG_PATH, "NODE_OPTIONS", NODE_OPTIONS)
                 verify_dotnet_config(container, SYSTEMD_CONFIG_PATH)
@@ -401,6 +413,9 @@ def test_salt_custom_instrumentation(distro, version, with_systemd):
                 verify_config_file(container, config_path, "SPLUNK_PROFILER_MEMORY_ENABLED", "true")
                 verify_config_file(container, config_path, "SPLUNK_METRICS_ENABLED", "true")
                 verify_config_file(container, config_path, "OTEL_EXPORTER_OTLP_ENDPOINT", r"http://0.0.0.0:4317")
+                verify_config_file(container, config_path, "OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+                verify_config_file(container, config_path, "OTEL_METRICS_EXPORTER", "none")
+                verify_config_file(container, config_path, "OTEL_LOGS_EXPORTER", "none")
         else:
             for config_path in [JAVA_CONFIG_PATH, NODE_CONFIG_PATH, DOTNET_CONFIG_PATH, SYSTEMD_CONFIG_PATH]:
                 assert not container_file_exists(container, config_path)


### PR DESCRIPTION
- Change default for `auto_instrumentation_otlp_endpoint` to empty
- Add `auto_instrumentation_otlp_endpoint_protocol`, `auto_instrumentation_metrics_exporter`, and `auto_instrumentation_logs_exporter` options