### PR TITLE
Discovery observers Start failures should not stop nor crash the collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - (Splunk) Deprecate the nagios monitor ([#5172](https://github.com/signalfx/splunk-otel-collector/pull/5172))
 
+### 🧰 Bug fixes 🧰
+
+- (Splunk) Discovery observers start failures should not stop the collector ([#5299](https://github.com/signalfx/splunk-otel-collector/pull/5299))
+
 ## v0.108.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.108.1](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.108.1) and the [opentelemetry-collector-contrib v0.108.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.108.0) releases where appropriate.

--- a/internal/confmapprovider/discovery/discoverer.go
+++ b/internal/confmapprovider/discovery/discoverer.go
@@ -623,6 +623,7 @@ func (d *discoverer) GetFactory(kind component.Kind, componentType component.Typ
 }
 
 // GetExtensions is a component.Host method used to forward discovery observers.
+// This method only returns operational extensions, i.e., those that have been successfully started.
 func (d *discoverer) GetExtensions() map[component.ID]otelcolextension.Extension {
 	return d.operationalObservers
 }

--- a/internal/confmapprovider/discovery/discoverer.go
+++ b/internal/confmapprovider/discovery/discoverer.go
@@ -67,7 +67,7 @@ type discoverer struct {
 	factories otelcol.Factories
 	// receiverID -> observerID -> config
 	unexpandedReceiverEntries map[component.ID]map[component.ID]map[string]any
-	extensions                map[component.ID]otelcolextension.Extension
+	operationalObservers      map[component.ID]otelcolextension.Extension // Only extensions successfully started should be added to this map.
 	logger                    *zap.Logger
 	discoveredReceivers       map[component.ID]discovery.StatusType
 	configs                   map[string]*Config
@@ -104,7 +104,6 @@ func newDiscoverer(logger *zap.Logger) (*discoverer, error) {
 		logger:                    logger,
 		info:                      info,
 		factories:                 factories,
-		extensions:                map[component.ID]otelcolextension.Extension{},
 		configs:                   map[string]*Config{},
 		duration:                  duration,
 		mu:                        sync.Mutex{},
@@ -182,10 +181,7 @@ func (d *discoverer) discover(cfg *Config) (map[string]any, error) {
 		return nil, nil
 	}
 
-	err = d.performDiscovery(discoveryReceivers, discoveryObservers)
-	if err != nil {
-		return nil, err
-	}
+	d.performDiscovery(discoveryReceivers, discoveryObservers)
 
 	discoveryConfig, err := d.discoveryConfig(cfg)
 	if err != nil {
@@ -194,7 +190,7 @@ func (d *discoverer) discover(cfg *Config) (map[string]any, error) {
 	return discoveryConfig, nil
 }
 
-func (d *discoverer) performDiscovery(discoveryReceivers map[component.ID]otelcolreceiver.Logs, discoveryObservers map[component.ID]otelcolextension.Extension) error {
+func (d *discoverer) performDiscovery(discoveryReceivers map[component.ID]otelcolreceiver.Logs, discoveryObservers map[component.ID]otelcolextension.Extension) {
 	var cancels []context.CancelFunc
 
 	defer func() {
@@ -202,6 +198,8 @@ func (d *discoverer) performDiscovery(discoveryReceivers map[component.ID]otelco
 			cancel()
 		}
 	}()
+
+	d.operationalObservers = make(map[component.ID]component.Component, len(discoveryObservers))
 
 	for observerID, observer := range discoveryObservers {
 		d.logger.Debug(fmt.Sprintf("starting observer %q", observerID))
@@ -212,7 +210,7 @@ func (d *discoverer) performDiscovery(discoveryReceivers map[component.ID]otelco
 				fmt.Sprintf("%q startup failed. Won't proceed with %q-based discovery", observerID, observerID.Type()),
 				zap.Error(e),
 			)
-			return e
+			continue
 		}
 		defer func(obsID component.ID, obsExt otelcolextension.Extension) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -221,6 +219,7 @@ func (d *discoverer) performDiscovery(discoveryReceivers map[component.ID]otelco
 				d.logger.Warn(fmt.Sprintf("error shutting down observer %q", obsID), zap.Error(e))
 			}
 		}(observerID, observer)
+		d.operationalObservers[observerID] = observer
 	}
 
 	for receiverID, receiver := range discoveryReceivers {
@@ -232,7 +231,7 @@ func (d *discoverer) performDiscovery(discoveryReceivers map[component.ID]otelco
 				fmt.Sprintf("%q startup failed.", receiverID),
 				zap.Error(err),
 			)
-			return err
+			continue
 		}
 		defer func(rcvID component.ID, rcv otelcolreceiver.Logs) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -249,8 +248,6 @@ func (d *discoverer) performDiscovery(discoveryReceivers map[component.ID]otelco
 	case <-context.Background().Done():
 	}
 	_, _ = fmt.Fprintf(os.Stderr, "Discovery complete.\n")
-
-	return nil
 }
 
 func (d *discoverer) createDiscoveryReceiversAndObservers(cfg *Config) (map[component.ID]otelcolreceiver.Logs, map[component.ID]otelcolextension.Extension, error) {
@@ -268,7 +265,6 @@ func (d *discoverer) createDiscoveryReceiversAndObservers(cfg *Config) (map[comp
 			// disabled by property
 			continue
 		}
-		d.extensions[observerID] = observer
 		discoveryObservers[observerID] = observer
 
 		discoveryReceiverDefaultConfig := discoveryReceiverFactory.CreateDefaultConfig()
@@ -628,7 +624,7 @@ func (d *discoverer) GetFactory(kind component.Kind, componentType component.Typ
 
 // GetExtensions is a component.Host method used to forward discovery observers.
 func (d *discoverer) GetExtensions() map[component.ID]otelcolextension.Extension {
-	return d.extensions
+	return d.operationalObservers
 }
 
 // GetExporters is a component.Host method.

--- a/internal/confmapprovider/discovery/discoverer_test.go
+++ b/internal/confmapprovider/discovery/discoverer_test.go
@@ -35,9 +35,9 @@ import (
 
 func TestInnerDiscoveryExecution(t *testing.T) {
 	tests := []struct {
-		name      string
 		observers map[component.ID]otelcolextension.Extension
 		receivers map[component.ID]otelcolreceiver.Logs
+		name      string
 	}{
 		{
 			name: "happy_path",


### PR DESCRIPTION
In #5202 the discovery code was changed so the collector ended its start up in case any observer failed to start - this behavior was agreed per [conversation](https://splunk.slack.com/archives/C02C8GVHL1Z/p1722025110851139). However, the docker observer had a behavior that if it failed to start on mac and Linux it didn't crash as in Windows. This cemented a behavior on the collector that was changed by #5202: the collector started successfully even if the docker observer failed. This change restores the previous behavior while not adding the risk of crashing in observers that failed to start (that's why it is not a simple reverse).

In the future we may want to consider if having a strict discovery mode is desirable. In this mode the user could enter an option to indicate that discovery should fail if any observer or receiver fails to be created or started.