### PR TITLE
[chore] Skip flaky mongodb discovery tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -340,7 +340,8 @@ jobs:
           for service in "apache" "mongodb" "kafkametrics" "jmx/cassandra"; do
             for arch in "amd64" "arm64"; do
               if [ "$service" = "mongodb" ]; then
-                for mongodb_version in "4.0" "4.4" "5.0" "6.0" "7.0"; do
+                # tests for mongo "6.0" and "7.0" are flaky, skipping for now
+                for mongodb_version in "4.0" "4.4" "5.0"; do
                   includes="${includes},{\"SERVICE\": \"${service}\", \"ARCH\": \"${arch}\", \"MONGODB_VERSION\": \"${mongodb_version}\"}"
                 done
               elif [[ "$service" != "jmx/cassandra" || "arm64" != "$arch" ]]; then


### PR DESCRIPTION
Tests for mongo 6 and 7 are flaky. Skipping for now. Reported a ticket to fix later