### PR TITLE
[chore] Make Apache discovery test more meaningful

### DIFF
--- a/tests/receivers/apachewebserver/testdata/docker_observer_apachewebserver_config.yaml
+++ b/tests/receivers/apachewebserver/testdata/docker_observer_apachewebserver_config.yaml
@@ -1,5 +1,6 @@
 extensions:
   docker_observer:
+    use_host_bindings: true
 
 receivers:
   discovery:
@@ -7,7 +8,7 @@ receivers:
     receivers:
       apache:
         config:
-          endpoint: "http://localhost:8080/server-status?auto"
+          endpoint: http://`host`:`port`/server-status?auto
         rule: type == "container" and any([name, image, command], {# matches "(?i)httpd"}) and not (command matches "splunk.discovery")
         status:
           metrics:


### PR DESCRIPTION
This is done by really using the data obtained by the observer instead of hardcoding the endpoint. This makes it more realistic and also an example that we can refer to.
