### PR TITLE
[chore] Simplify Apache container discovery test config

### DIFF
--- a/tests/receivers/apachewebserver/testdata/docker_observer_apachewebserver_config.yaml
+++ b/tests/receivers/apachewebserver/testdata/docker_observer_apachewebserver_config.yaml
@@ -8,7 +8,7 @@ receivers:
     receivers:
       apache:
         config:
-          endpoint: http://`host`:`port`/server-status?auto
+          endpoint: http://`endpoint`/server-status?auto
         rule: type == "container" and any([name, image, command], {# matches "(?i)httpd"}) and not (command matches "splunk.discovery")
         status:
           metrics:


### PR DESCRIPTION
Using the `endpoint` directly instead of building it from `host` and `port`. Follow-up to #5325