### PR TITLE
[chore] Add a replace statement for an unavailable module version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -680,5 +680,5 @@ replace (
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.53.1
 )
 
-// github.com/veraison/go-cose v1.2.0 doesn't exists but requered by github.com/Microsoft/hcsshim
+// github.com/veraison/go-cose v1.2.0 doesn't exists but required by the latest github.com/Microsoft/hcsshim
 replace github.com/veraison/go-cose v1.2.0 => github.com/veraison/go-cose v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -679,3 +679,6 @@ replace (
 	github.com/docker/docker => github.com/docker/docker v26.1.5+incompatible
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.53.1
 )
+
+// github.com/veraison/go-cose v1.2.0 doesn't exists but requered by github.com/Microsoft/hcsshim
+replace github.com/veraison/go-cose v1.2.0 => github.com/veraison/go-cose v1.1.1


### PR DESCRIPTION
I'm getting "go: github.com/veraison/go-cose@v1.2.0: invalid version: unknown revision v1.2.0" trying to build the distro locally.

Apparently, github.com/veraison/go-cose v1.2.0 doesn't exist (likely removed) but is required by the latest github.com/Microsoft/hcsshim