### PR TITLE
update golang to 1.22.7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -101,13 +101,6 @@ updates:
     directory: "/internal/signalfx-agent/bundle/python"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/internal/signalfx-agent/bundle/scripts"
-    ignore:
-      - dependency-name: "urllib3"
-        versions: [">=2"]
-    schedule:
-      interval: "weekly"
   - package-ecosystem: "docker"
     directory: "/cmd/otelcol"
     schedule:
@@ -118,6 +111,10 @@ updates:
       interval: "weekly"
   - package-ecosystem: "docker"
     directory: "/docker/apache"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/docker/apachespark"
     schedule:
       interval: "weekly"
   - package-ecosystem: "docker"

--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -20,7 +20,7 @@ env:
   PYTHON_VERSION: '3.11'
   PIP_VERSION: '22.0.4'
   REQUIREMENTS_PATH: "internal/buildscripts/packaging/tests/requirements.txt"
-  GO_VERSION: 1.22.6
+  GO_VERSION: 1.22.7
 
 jobs:
   cross-compile:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.22.6
+  GO_VERSION: 1.22.7
 
 jobs:
   setup-environment:

--- a/.github/workflows/darwin-test.yml
+++ b/.github/workflows/darwin-test.yml
@@ -19,7 +19,7 @@ on:
       - '!internal/buildscripts/**'
 
 env:
-  GO_VERSION: '1.22.6'
+  GO_VERSION: '1.22.7'
 
 concurrency:
   group: darwin-test-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/gendependabot.yml
+++ b/.github/workflows/gendependabot.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/scripts/gendependabot.sh'
 
 env:
-  GO_VERSION: 1.22.6
+  GO_VERSION: 1.22.7
 
 jobs:
   gendependabot:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.22.6"
+  GO_VERSION: "1.22.7"
 jobs:
   agent-bundle-linux:
     runs-on: ${{ fromJSON('["ubuntu-20.04", "otel-arm64"]')[matrix.ARCH == 'arm64'] }}

--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.22.6
+  GO_VERSION: 1.22.7
 
 jobs:
   lint:

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -21,7 +21,7 @@ env:
   PYTHON_VERSION: '3.11'
   PIP_VERSION: '22.0.4'
   REQUIREMENTS_PATH: "internal/buildscripts/packaging/tests/requirements.txt"
-  GO_VERSION: 1.22.6
+  GO_VERSION: 1.22.7
 
 jobs:
   setup-environment:

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -14,7 +14,7 @@ on:
     - cron: '0 0 * * 1-5' # Every weekday at midnight UTC
 
 env:
-  GO_VERSION: '1.22.6'
+  GO_VERSION: '1.22.7'
 
 concurrency:
   group: vuln-scans-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.22.6
+  GO_VERSION: 1.22.7
 
 jobs:
   setup-environment:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -18,7 +18,7 @@ on:
       - '!internal/buildscripts/**'
 
 env:
-  GO_VERSION: '1.22.6'
+  GO_VERSION: '1.22.7'
 
 concurrency:
   group: windows-test-${{ github.event.pull_request.number || github.ref }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,7 +150,7 @@ fossa:
       fi
 
 .go-cache:
-  image: '${DOCKER_HUB_REPO}/golang:1.22.6'
+  image: '${DOCKER_HUB_REPO}/golang:1.22.7'
   variables:
     GOPATH: "$CI_PROJECT_DIR/.go"
   before_script:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/signalfx/splunk-otel-collector
 
 go 1.22.5
 
-toolchain go1.22.6
+toolchain go1.22.7
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.1

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/signalfx/splunk-otel-collector/internal/tools
 
 go 1.22.1
 
-toolchain go1.22.6
+toolchain go1.22.7
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/pkg/extension/smartagentextension/go.mod
+++ b/pkg/extension/smartagentextension/go.mod
@@ -2,7 +2,7 @@ module github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextensi
 
 go 1.22.0
 
-toolchain go1.22.6
+toolchain go1.22.7
 
 require (
 	github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657

--- a/pkg/processor/timestampprocessor/go.mod
+++ b/pkg/processor/timestampprocessor/go.mod
@@ -2,7 +2,7 @@ module github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocesso
 
 go 1.22.0
 
-toolchain go1.22.6
+toolchain go1.22.7
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/pkg/receiver/smartagentreceiver/go.mod
+++ b/pkg/receiver/smartagentreceiver/go.mod
@@ -2,7 +2,7 @@ module github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver
 
 go 1.22.0
 
-toolchain go1.22.6
+toolchain go1.22.7
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.108.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -2,7 +2,7 @@ module github.com/signalfx/splunk-otel-collector/tests
 
 go 1.22.0
 
-toolchain go1.22.6
+toolchain go1.22.7
 
 require (
 	github.com/docker/docker v26.1.5+incompatible


### PR DESCRIPTION
For [GO-2024-3105](https://pkg.go.dev/vuln/GO-2024-3105), [GO-2024-3106](https://pkg.go.dev/vuln/GO-2024-3106), [GO-2024-3107](https://pkg.go.dev/vuln/GO-2024-3107)