### PR TITLE
Revert "Bump cassandra from 4.1 to 5.0 in /docker/cassandra (#5333)"

### DIFF
--- a/docker/cassandra/Dockerfile
+++ b/docker/cassandra/Dockerfile
@@ -1,4 +1,4 @@
-FROM cassandra:5.0
+FROM cassandra:4.1
 
 # Configures Cassandra with remote JMX with username/password of
 # cassandra/cassandra


### PR DESCRIPTION
This reverts commit d8c510c43c3f0f92ca868192ed8bfb00be431b6b.
