### PR TITLE
Discover Apache web server on Debian based distros

### DIFF
--- a/cmd/otelcol/config/collector/config.d.linux/receivers/apache.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/apache.discovery.yaml
@@ -9,9 +9,9 @@
 # apache:
 #   enabled: true
 #   rule:
-#     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)httpd.*"}) and not (command matches "splunk.discovery")
-#     host_observer: type == "hostport" and command matches "(?i)httpd.*" and not (command matches "splunk.discovery")
-#     k8s_observer: type == "port" and pod.name matches "(?i)httpd.*"
+#     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)(httpd|apache2).*"}) and not (command matches "splunk.discovery")
+#     host_observer: type == "hostport" and command matches "(?i)(httpd|apache2).*" and not (command matches "splunk.discovery")
+#     k8s_observer: type == "port" and pod.name matches "(?i)(httpd|apache2).*"
 #   config:
 #     default:
 #       endpoint: "http://`endpoint`/server-status?auto"

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/apache.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/apache.discovery.yaml
@@ -5,9 +5,9 @@
 apache:
   enabled: true
   rule:
-    docker_observer: type == "container" and any([name, image, command], {# matches "(?i)httpd.*"}) and not (command matches "splunk.discovery")
-    host_observer: type == "hostport" and command matches "(?i)httpd.*" and not (command matches "splunk.discovery")
-    k8s_observer: type == "port" and pod.name matches "(?i)httpd.*"
+    docker_observer: type == "container" and any([name, image, command], {# matches "(?i)(httpd|apache2).*"}) and not (command matches "splunk.discovery")
+    host_observer: type == "hostport" and command matches "(?i)(httpd|apache2).*" and not (command matches "splunk.discovery")
+    k8s_observer: type == "port" and pod.name matches "(?i)(httpd|apache2).*"
   config:
     default:
       endpoint: "http://`endpoint`/server-status?auto"

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/apache.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/apache.discovery.yaml.tmpl
@@ -1,9 +1,9 @@
 {{ receiver "apache" }}:
   enabled: true
   rule:
-    docker_observer: type == "container" and any([name, image, command], {# matches "(?i)httpd.*"}) and not (command matches "splunk.discovery")
-    host_observer: type == "hostport" and command matches "(?i)httpd.*" and not (command matches "splunk.discovery")
-    k8s_observer: type == "port" and pod.name matches "(?i)httpd.*"
+    docker_observer: type == "container" and any([name, image, command], {# matches "(?i)(httpd|apache2).*"}) and not (command matches "splunk.discovery")
+    host_observer: type == "hostport" and command matches "(?i)(httpd|apache2).*" and not (command matches "splunk.discovery")
+    k8s_observer: type == "port" and pod.name matches "(?i)(httpd|apache2).*"
   config:
     default:
       endpoint: "http://`endpoint`/server-status?auto"

--- a/tests/receivers/apache/testdata/docker_observer_apache_config.yaml
+++ b/tests/receivers/apache/testdata/docker_observer_apache_config.yaml
@@ -9,7 +9,7 @@ receivers:
       apache:
         config:
           endpoint: http://`endpoint`/server-status?auto
-        rule: type == "container" and any([name, image, command], {# matches "(?i)httpd"}) and not (command matches "splunk.discovery")
+        rule: type == "container" and any([name, image, command], {# matches "(?i)(httpd|apache2).*"}) and not (command matches "splunk.discovery")
         status:
           metrics:
             - status: successful


### PR DESCRIPTION
On Debian based distros the process is named `apache2` not `httpd` as in other distros. This change just adds `apache2` to the matching expression.

Reference: https://askubuntu.com/a/248412
