### PR TITLE
Continuous service discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,7 @@ require (
 	go.etcd.io/etcd/client/v2 v2.305.15
 	go.opentelemetry.io/collector/component/componentstatus v0.109.0
 	go.opentelemetry.io/collector/config/confighttp v0.109.0
+	go.opentelemetry.io/collector/config/configopaque v1.15.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.109.0
 	go.opentelemetry.io/collector/confmap v1.15.0
 	go.opentelemetry.io/collector/confmap/provider/envprovider v1.15.0
@@ -350,7 +351,6 @@ require (
 	go.opentelemetry.io/collector/config/configcompression v1.15.0 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.109.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.109.0 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.15.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.15.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.15.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.109.0 // indirect
@@ -625,7 +625,7 @@ require (
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector/component v0.109.0
 	go.opentelemetry.io/collector/consumer v0.109.0
-	go.opentelemetry.io/collector/featuregate v1.15.0 // indirect
+	go.opentelemetry.io/collector/featuregate v1.15.0
 	go.opentelemetry.io/collector/semconv v0.109.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.55.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.55.0 // indirect

--- a/internal/confmapprovider/discovery/discoverer_test.go
+++ b/internal/confmapprovider/discovery/discoverer_test.go
@@ -15,146 +15,18 @@
 package discovery
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
-	otelcolextension "go.opentelemetry.io/collector/extension"
-	otelcolreceiver "go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/signalfx/splunk-otel-collector/internal/common/discovery"
 )
-
-func TestInnerDiscoveryExecution(t *testing.T) {
-	tests := []struct {
-		observers map[component.ID]otelcolextension.Extension
-		receivers map[component.ID]otelcolreceiver.Logs
-		name      string
-	}{
-		{
-			name: "happy_path",
-			observers: map[component.ID]otelcolextension.Extension{
-				component.MustNewID("observer00"): &mockExtension{},
-				component.MustNewID("observer01"): &mockExtension{},
-				component.MustNewID("observer02"): &mockExtension{},
-			},
-			receivers: map[component.ID]otelcolreceiver.Logs{
-				component.MustNewID("receiver00"): &mockReceiverLogs{},
-				component.MustNewID("receiver01"): &mockReceiverLogs{},
-			},
-		},
-		{
-			name: "fail_start_extension",
-			observers: map[component.ID]otelcolextension.Extension{
-				component.MustNewID("observer00"): &mockExtension{},
-				component.MustNewID("observer01"): &mockExtension{mockComponent{startErr: fmt.Errorf("extension_start_error")}},
-				component.MustNewID("observer02"): &mockExtension{},
-			},
-			receivers: map[component.ID]otelcolreceiver.Logs{
-				component.MustNewID("receiver00"): &mockReceiverLogs{},
-			},
-		},
-		{
-			name: "fail_start_receiver",
-			observers: map[component.ID]otelcolextension.Extension{
-				component.MustNewID("observer00"): &mockExtension{},
-				component.MustNewID("observer01"): &mockExtension{},
-			},
-			receivers: map[component.ID]otelcolreceiver.Logs{
-				component.MustNewID("receiver00"): &mockReceiverLogs{},
-				component.MustNewID("receiver01"): &mockReceiverLogs{mockComponent{startErr: fmt.Errorf("receiver_start_error")}},
-				component.MustNewID("receiver02"): &mockReceiverLogs{},
-			},
-		},
-		{
-			name: "fail_shutdown_no_crash",
-			observers: map[component.ID]otelcolextension.Extension{
-				component.MustNewID("observer00"): &mockExtension{},
-				component.MustNewID("observer01"): &mockExtension{},
-			},
-			receivers: map[component.ID]otelcolreceiver.Logs{
-				component.MustNewID("receiver00"): &mockReceiverLogs{},
-				component.MustNewID("receiver01"): &mockReceiverLogs{mockComponent{shutdownErr: fmt.Errorf("receiver_shutdown_error")}},
-				component.MustNewID("receiver02"): &mockReceiverLogs{},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			d, err := newDiscoverer(zap.NewNop())
-			require.NoError(t, err)
-			require.NotNil(t, d)
-
-			d.duration = 1 * time.Second
-			d.performDiscovery(tt.receivers, tt.observers)
-
-			for id, observer := range tt.observers {
-				mockExtension := observer.(*mockExtension)
-				if mockExtension.started {
-					assert.True(t, mockExtension.shutdown)
-				} else {
-					assert.False(t, mockExtension.shutdown)
-					assert.NotContains(t, d.operationalObservers, id)
-				}
-			}
-
-			for _, receiver := range tt.receivers {
-				mockReceiver := receiver.(*mockReceiverLogs)
-				if mockReceiver.started {
-					assert.True(t, mockReceiver.shutdown)
-				} else {
-					assert.False(t, mockReceiver.shutdown)
-				}
-			}
-		})
-	}
-}
-
-type mockExtension struct {
-	mockComponent
-}
-
-var _ otelcolextension.Extension = (*mockExtension)(nil)
-
-type mockReceiverLogs struct {
-	mockComponent
-}
-
-var _ otelcolreceiver.Logs = (*mockReceiverLogs)(nil)
-
-type mockComponent struct {
-	startErr    error
-	shutdownErr error
-	started     bool
-	shutdown    bool
-}
-
-var _ component.Component = (*mockComponent)(nil)
-
-func (m *mockComponent) Start(context.Context, component.Host) error {
-	if m.startErr != nil {
-		return m.startErr
-	}
-	m.started = true
-	return nil
-}
-
-func (m *mockComponent) Shutdown(context.Context) error {
-	m.shutdown = true
-	if m.shutdownErr != nil {
-		return m.shutdownErr
-	}
-	return nil
-}
 
 func TestDiscovererDurationFromEnv(t *testing.T) {
 	t.Cleanup(func() func() {

--- a/internal/confmapprovider/discovery/provider_test.go
+++ b/internal/confmapprovider/discovery/provider_test.go
@@ -20,9 +20,20 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/confmap/provider/envprovider"
+	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
+	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/otelcol"
+
+	"github.com/signalfx/splunk-otel-collector/internal/components"
+	"github.com/signalfx/splunk-otel-collector/internal/configconverter"
+	"github.com/signalfx/splunk-otel-collector/internal/receiver/discoveryreceiver"
 )
 
 func TestConfigDProviderHappyPath(t *testing.T) {
@@ -95,4 +106,66 @@ func TestConfigDProviderInvalidURIs(t *testing.T) {
 	retrieved, err = configD.Retrieve(context.Background(), fmt.Sprintf("%s:not.a.path", discoveryModeScheme), nil)
 	assert.EqualError(t, err, `uri "splunk.discovery:not.a.path" is not supported by splunk.configd provider`)
 	assert.Nil(t, retrieved)
+}
+
+func TestDiscoveryProvider_ContinuousDiscoveryConfig(t *testing.T) {
+	require.NoError(t, featuregate.GlobalRegistry().Set(continuousDiscoveryFGKey, true))
+	t.Setenv("SPLUNK_REALM", "fake-realm")
+	t.Setenv("SPLUNK_ACCESS_TOKEN", "fake-token")
+
+	confmapProvider, err := New()
+	require.NoError(t, err)
+
+	cfgDir, err := filepath.Abs(filepath.Join(".", "testdata", "config.d"))
+	require.NoError(t, err)
+	provider, err := otelcol.NewConfigProvider(otelcol.ConfigProviderSettings{
+		ResolverSettings: confmap.ResolverSettings{
+			URIs: []string{fmt.Sprintf("%s:%s", discoveryModeScheme, cfgDir)},
+			ProviderFactories: []confmap.ProviderFactory{
+				confmapProvider.DiscoveryModeProviderFactory(),
+				envprovider.NewFactory(),
+			},
+			ConverterFactories: []confmap.ConverterFactory{configconverter.ConverterFactoryFromFunc(configconverter.SetupDiscovery)},
+			DefaultScheme:      "env",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	factories, err := components.Get()
+	require.NoError(t, err)
+
+	conf, err := provider.Get(context.Background(), factories)
+	require.NoError(t, err)
+	assert.NotNil(t, conf)
+
+	assert.Equal(t, 1, len(conf.Receivers))
+	drc, ok := conf.Receivers[component.MustNewIDWithName("discovery", "host_observer")].(*discoveryreceiver.Config)
+	require.True(t, ok)
+	assert.NotNil(t, drc)
+
+	assert.Equal(t, 1, len(conf.Exporters))
+	oec, ok := conf.Exporters[component.MustNewIDWithName("otlphttp", "entities")].(*otlphttpexporter.Config)
+	require.True(t, ok)
+	expectedOtlpExporterConfig := otlphttpexporter.NewFactory().CreateDefaultConfig().(*otlphttpexporter.Config)
+	expectedOtlpExporterConfig.LogsEndpoint = "https://ingest.fake-realm.signalfx.com/v3/event"
+	expectedOtlpExporterConfig.ClientConfig.Headers = map[string]configopaque.String{
+		"X-SF-Token": "fake-token",
+	}
+	assert.Equal(t, expectedOtlpExporterConfig, oec)
+
+	assert.Equal(t, 1, len(conf.Extensions))
+	hoc, ok := conf.Extensions[component.MustNewID("host_observer")].(*hostobserver.Config)
+	require.True(t, ok)
+	assert.Equal(t, hostobserver.NewFactory().CreateDefaultConfig(), hoc)
+
+	assert.EqualValues(t, []component.ID{component.MustNewID("host_observer")}, conf.Service.Extensions)
+	pipelines := conf.Service.Pipelines
+	assert.Equal(t, 2, len(pipelines))
+	assert.Equal(t, []component.ID{component.MustNewIDWithName("discovery", "host_observer")},
+		pipelines[component.MustNewID("metrics")].Receivers)
+	assert.Equal(t, []component.ID{component.MustNewIDWithName("discovery", "host_observer")},
+		pipelines[component.MustNewIDWithName("logs", "entities")].Receivers)
+	assert.Equal(t, []component.ID{component.MustNewIDWithName("otlphttp", "entities")},
+		pipelines[component.MustNewIDWithName("logs", "entities")].Exporters)
 }


### PR DESCRIPTION
This change introduces a new way of how the discovery mechanism works. Instead of observing data for the first 10 seconds and creating a static `receiver_cretor` config from that, it'll be running discovery receiver watching for all supported receivers. Once a new endpoint for any supported service is available, the collector will try to fetch metrics from it. If the collector cannot get metrics from a new service right away, it'll send detailed information about what can be done to enable it to the backend, which will be reflected in the newly discovered services UI. Any services that are successfully discovered will also be reflected in the UI. The collector sends entity events as OTLP logs to deliver information about the discovered services.

The new functionality can be enabled with "splunk.continuousDiscovery" feature gate by adding `--feature-gates=splunk.continuousDiscovery` argument to the `otecol` command.
