### PR TITLE
Fix error message when splunk_access_token is not set

### DIFF
--- a/deployments/chef/recipes/default.rb
+++ b/deployments/chef/recipes/default.rb
@@ -3,7 +3,7 @@
 
 ruby_block 'splunk-access-token-unset' do
   block do
-    raise "Set ['splunk_access_token']['splunk_access_token'] as an attribute or on the node's run_state."
+    raise "Set ['splunk_otel_collector']['splunk_access_token'] as an attribute or on the node's run_state."
   end
   only_if { node['splunk_otel_collector']['splunk_access_token'].nil? }
 end


### PR DESCRIPTION
**Description:** Fixing the error message displayed on error

Just changing the attribute to match the one actually expected.