### PR TITLE
[discovery] Move continuous discovery config parts to static files

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -92,6 +92,7 @@ receivers:
     #access_token_passthrough: true
   zipkin:
     endpoint: "${SPLUNK_LISTEN_INTERFACE}:9411"
+  nop:
 
 processors:
   batch:
@@ -137,6 +138,11 @@ exporters:
     #ingest_url: http://${SPLUNK_GATEWAY_URL}:9943
     sync_host_metadata: true
     correlation:
+  # Entities (applicable only if discovery mode is enabled)
+  otlphttp/entities:
+    logs_endpoint: "${SPLUNK_INGEST_URL}/v3/event"
+    headers:
+      "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"
   # Logs
   splunk_hec:
     token: "${SPLUNK_HEC_TOKEN}"
@@ -190,6 +196,11 @@ service:
       receivers: [signalfx, smartagent/processlist]
       processors: [memory_limiter, batch, resourcedetection]
       exporters: [signalfx]
+    logs/entities:
+      # Receivers are dynamically added if discovery mode is enabled
+      receivers: [nop]
+      processors: [memory_limiter, batch, resourcedetection]
+      exporters: [otlphttp/entities]
     logs:
       receivers: [fluentforward, otlp]
       processors:

--- a/cmd/otelcol/config/collector/upstream_agent_config.yaml
+++ b/cmd/otelcol/config/collector/upstream_agent_config.yaml
@@ -86,6 +86,7 @@ receivers:
     endpoint: 0.0.0.0:9943
   zipkin:
     endpoint: 0.0.0.0:9411
+  nop:
 
 processors:
   batch:
@@ -132,6 +133,11 @@ exporters:
     #ingest_url: http://${SPLUNK_GATEWAY_URL}:9943
     sync_host_metadata: true
     correlation:
+  # Entities (applicable only if discovery mode is enabled)
+  otlphttp/entities:
+    logs_endpoint: "${SPLUNK_INGEST_URL}/v3/event"
+    headers:
+      "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"
   splunk_hec/profiling:
     token: "${SPLUNK_ACCESS_TOKEN}"
     endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com/v1/log"
@@ -180,6 +186,11 @@ service:
       exporters: [signalfx]
       # Use instead when sending to gateway
       #exporters: [otlp]
+    logs/entities:
+      # Receivers are dynamically added if discovery mode is enabled
+      receivers: [nop]
+      processors: [memory_limiter, batch, resourcedetection]
+      exporters: [otlphttp/entities]
     # Required for profiling
     logs:
       receivers: [otlp]

--- a/internal/confmapprovider/discovery/discoverer.go
+++ b/internal/confmapprovider/discovery/discoverer.go
@@ -352,24 +352,9 @@ func (d *discoverer) continuousDiscoveryConfig(cfg *Config, discoveryReceiversCo
 	dCfg := map[string]any{
 		"extensions": extensions,
 		"receivers":  discoveryReceiversConfigs,
-		"exporters": map[string]any{
-			"otlphttp/entities": map[string]any{
-				"logs_endpoint": "https://ingest.${SPLUNK_REALM}.signalfx.com/v3/event",
-				"headers": map[string]any{
-					"X-SF-Token": "${SPLUNK_ACCESS_TOKEN}",
-				},
-			},
-		},
 		"service": map[string]any{
 			discovery.DiscoReceiversKey:  receiverIDs,
 			discovery.DiscoExtensionsKey: observerIDs,
-			"pipelines": map[string]any{
-				"logs/entities": map[string]any{
-					"receivers": receiverIDs,
-					// TODO: add processors dynamically in the converter: memory_limiter, resource (in k8s only).
-					"exporters": []string{"otlphttp/entities"},
-				},
-			},
 		},
 	}
 	d.logger.Debug("determined continuous discovery config", zap.Any("config", dCfg))

--- a/internal/confmapprovider/discovery/testdata/base-config.yaml
+++ b/internal/confmapprovider/discovery/testdata/base-config.yaml
@@ -1,0 +1,9 @@
+exporters:
+  otlphttp/entities:
+    logs_endpoint: "${SPLUNK_INGEST_URL}/v3/event"
+    headers:
+      "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"
+service:
+  pipelines:
+    logs/entities:
+      exporters: [otlphttp/entities]

--- a/tests/general/default_config_test.go
+++ b/tests/general/default_config_test.go
@@ -274,6 +274,12 @@ func TestDefaultAgentConfig(t *testing.T) {
 						"token":            "<redacted>",
 						"log_data_enabled": false,
 					},
+					"otlphttp/entities": map[string]any{
+						"logs_endpoint": "https://ingest.not.real.signalfx.com/v3/event",
+						"headers": map[string]any{
+							"X-SF-Token": "<redacted>",
+						},
+					},
 				},
 				"extensions": map[string]any{
 					"health_check": map[string]any{"endpoint": fmt.Sprintf("%s:13133", ip)},
@@ -362,7 +368,8 @@ func TestDefaultAgentConfig(t *testing.T) {
 					},
 					"signalfx":               map[string]any{"endpoint": fmt.Sprintf("%s:9943", ip)},
 					"smartagent/processlist": map[string]any{"type": "processlist"},
-					"zipkin":                 map[string]any{"endpoint": fmt.Sprintf("%s:9411", ip)}},
+					"zipkin":                 map[string]any{"endpoint": fmt.Sprintf("%s:9411", ip)},
+					"nop":                    nil},
 				"service": map[string]any{
 					"telemetry":  map[string]any{"metrics": map[string]any{"address": fmt.Sprintf("%s:8888", ip)}},
 					"extensions": []any{"health_check", "http_forwarder", "zpages", "smartagent"},
@@ -387,6 +394,11 @@ func TestDefaultAgentConfig(t *testing.T) {
 							"exporters":  []any{"sapm", "signalfx"},
 							"processors": []any{"memory_limiter", "batch", "resourcedetection"},
 							"receivers":  []any{"jaeger", "otlp", "zipkin"},
+						},
+						"logs/entities": map[string]any{
+							"receivers":  []any{"nop"},
+							"processors": []any{"memory_limiter", "batch", "resourcedetection"},
+							"exporters":  []any{"otlphttp/entities"},
 						},
 					},
 				},


### PR DESCRIPTION
We cannot assume that ${SPLUNK_ACCESS_TOKEN} and ${SPLUNK_REALM} are aways set. It's not the case for the helm chart. We should move static config part of continuous discovery from discoverer to the config files. Having it in the `agent_config.yaml` has no overhead until the continuous discovery is enabled.
