### PR TITLE
[chore] Build .exe files by default on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,13 +136,21 @@ generate-metrics:
 otelcol:
 	go generate ./...
 	GO111MODULE=on CGO_ENABLED=0 go build -trimpath -o ./bin/otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) $(BUILD_INFO) ./cmd/otelcol
-	ln -sf otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) ./bin/otelcol
+ifeq ($(OS), Windows_NT)
+	$(LINK_CMD) .\bin\otelcol$(EXTENSION) .\bin\otelcol_$(GOOS)_$(GOARCH)$(EXTENSION)
+else
+	$(LINK_CMD) otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) ./bin/otelcol$(EXTENSION)
+endif
 
 .PHONY: migratecheckpoint
 migratecheckpoint:
 	go generate ./...
 	GO111MODULE=on CGO_ENABLED=0 go build -trimpath -o ./bin/migratecheckpoint_$(GOOS)_$(GOARCH)$(EXTENSION) $(BUILD_INFO) ./cmd/migratecheckpoint
-	ln -sf migratecheckpoint_$(GOOS)_$(GOARCH)$(EXTENSION) ./bin/migratecheckpoint
+ifeq ($(OS), Windows_NT)
+	$(LINK_CMD) .\bin\migratecheckpoint$(EXTENSION) .\bin\migratecheckpoint_$(GOOS)_$(GOARCH)$(EXTENSION)
+else
+	$(LINK_CMD) migratecheckpoint_$(GOOS)_$(GOARCH)$(EXTENSION) ./bin/migratecheckpoint$(EXTENSION)
+endif
 
 .PHONY: bundle.d
 bundle.d:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -12,9 +12,12 @@ ifeq ($(UNIX_SHELL_ON_WINDOWS),true)
 	# The backslash needs to be doubled so its passed correctly to the shell. 
 	NORMALIZE_DIRS = sed -e 's/^/\\//' -e 's/://' -e 's/\\\\/\\//g' | sort
 	NUM_CORES := ${NUMBER_OF_PROCESSORS}
+	EXTENSION ?=.exe
+	LINK_CMD = cmd /c mklink /H
 else
 	NORMALIZE_DIRS = sort
 	NUM_CORES := $(shell getconf _NPROCESSORS_ONLN)
+	LINK_CMD = ln -sf
 endif
 
 # SRC_ROOT is the top of the source tree.


### PR DESCRIPTION
Making my life easier: a few times I ended losing time because I forgot to set the env var while building on Windows and kept testing an old build. While Windows can run executables without the `.exe` extension the terminal/shells don't like that in general and I have to manually rename or copy the result from the build.

Sorry about the link thing the `ln` from bash doesn't work at all on Windows so ...