### PR TITLE
Properly use run_state token

### DIFF
--- a/deployments/chef/recipes/collector_win_config_options.rb
+++ b/deployments/chef/recipes/collector_win_config_options.rb
@@ -2,7 +2,7 @@
 # Recipe:: collector_win_config_options
 
 collector_env_vars = [
-  { name: 'SPLUNK_ACCESS_TOKEN', type: :string, data: node['splunk_otel_collector']['splunk_access_token'].to_s },
+  { name: 'SPLUNK_ACCESS_TOKEN', type: :string, data: (node['splunk_otel_collector']['splunk_access_token'] || node.run_state['splunk_otel_collector']['splunk_access_token']).to_s },
   { name: 'SPLUNK_API_URL', type: :string, data: node['splunk_otel_collector']['splunk_api_url'].to_s },
   { name: 'SPLUNK_BUNDLE_DIR', type: :string, data: node['splunk_otel_collector']['splunk_bundle_dir'].to_s },
   { name: 'SPLUNK_COLLECTD_DIR', type: :string, data: node['splunk_otel_collector']['splunk_collectd_dir'].to_s },

--- a/deployments/chef/recipes/default.rb
+++ b/deployments/chef/recipes/default.rb
@@ -5,7 +5,7 @@ ruby_block 'splunk-access-token-unset' do
   block do
     raise "Set ['splunk_otel_collector']['splunk_access_token'] as an attribute or on the node's run_state."
   end
-  only_if { node['splunk_otel_collector']['splunk_access_token'].nil? }
+  only_if { node['splunk_otel_collector']['splunk_access_token'].nil? && node.run_state['splunk_otel_collector']['splunk_access_token'].nil? }
 end
 
 if platform_family?('windows')

--- a/deployments/chef/templates/splunk-otel-collector.conf.erb
+++ b/deployments/chef/templates/splunk-otel-collector.conf.erb
@@ -2,7 +2,7 @@
 SPLUNK_CONFIG=<%= node['splunk_otel_collector']['collector_config_dest'] %>
 
 # Access token to authenticate requests.
-SPLUNK_ACCESS_TOKEN=<%= node['splunk_otel_collector']['splunk_access_token'] %>
+SPLUNK_ACCESS_TOKEN=<%= node['splunk_otel_collector']['splunk_access_token'] || node.run_state['splunk_otel_collector']['splunk_access_token'] %>
 
 # Which realm to send the data to.
 SPLUNK_REALM=<%= node['splunk_otel_collector']['splunk_realm'] %>


### PR DESCRIPTION
**Description:** 
Chef does not explicitly merge node.default and node.run_state data.

The complicated bit here is the hec_token https://github.com/signalfx/splunk-otel-collector/blob/main/deployments/chef/attributes/default.rb#L21

I cannot use run_state in attributes as it is empty at that point.
My solution is to have this line after I set the token but not sure if that needs to be specified somewhere
```
node.default['splunk_otel_collector']['splunk_hec_token'] = "#{node['splunk_otel_collector']['splunk_access_token']}"
```

**Testing:** 

Tested on our internal node, Linux only

**Documentation:** 
This option was already documented but not actually working
