### PR TITLE
Do not ignore vulns reported in packaging code

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -13,5 +13,4 @@ targets:
 paths:
   exclude:
     - examples
-    - internal/buildscripts
     - tests


### PR DESCRIPTION
We ignored vulnerabilities in the packaging scripts. We no longer want to do that to reduce any misunderstanding about the standing of our code.