### PR TITLE
Deprecate the cloudfoundry monitor in favor of the cloudfoundry receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### 🚩Deprecations 🚩
 
 
-- (Splunk) Deprecate cloudfoundry monitor ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
+- (Splunk) Deprecate cloudfoundry monitor ([#5495](https://github.com/signalfx/splunk-otel-collector/pull/5495))
 
 ## v0.111.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 ## Unreleased
 
+### 🚩Deprecations 🚩
+
+
+- (Splunk) Deprecate cloudfoundry monitor ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
+
 ## v0.111.0
 
 

--- a/internal/signalfx-agent/pkg/monitors/cloudfoundry/README.md
+++ b/internal/signalfx-agent/pkg/monitors/cloudfoundry/README.md
@@ -1,5 +1,7 @@
 # cloudfoundry-firehose-nozzle
 
+**The cloudfoundry monitor is deprecated and will be removed in a future release. Please use https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/cloudfoundryreceiver**
+
 ## Developer Resources
 
 - <https://github.com/cf-platform-eng/firehose-nozzle-v2/tree/master/gateway>

--- a/internal/signalfx-agent/pkg/monitors/cloudfoundry/monitor.go
+++ b/internal/signalfx-agent/pkg/monitors/cloudfoundry/monitor.go
@@ -65,6 +65,7 @@ type Monitor struct {
 // on a varied interval
 func (m *Monitor) Configure(conf *Config) error {
 	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
+	m.logger.Warn("The cloudfoundry monitor is deprecated and will be removed in a future release. Please use https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/cloudfoundryreceiver")
 
 	// create contexts for managing the plugin loop
 	var ctx context.Context


### PR DESCRIPTION
**Description:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/cloudfoundryreceiver is now the preferred approach to integrate with Tanzu. See https://docs.splunk.com/observability/en/gdi/opentelemetry/deployments/deployments-pivotal-cloudfoundry.html for more information.