### PR TITLE
Deprecate heroku observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## Unreleased
 
+- (Splunk) Deprecate the heroku observer. Use the [resource detection observer with heroku detector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#heroku) instead. ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
+
 ## v0.111.0
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## Unreleased
 
-- (Splunk) Deprecate the heroku observer. Use the [resource detection observer with heroku detector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#heroku) instead. ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
+- (Splunk) Deprecate the heroku observer. Use the [resource detection observer with heroku detector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#heroku) instead. ([#5496](https://github.com/signalfx/splunk-otel-collector/pull/5496))
 
 ## v0.111.0
 

--- a/internal/signalfx-agent/pkg/monitors/heroku/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/heroku/metadata.yaml
@@ -1,6 +1,9 @@
 monitors:
   - dimensions:
     doc: |
+      This monitor is deprecated and will be removed soon.
+      Please use https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#heroku instead.
+      
       This monitor collects metadata from a Heroku dyno and syncs them as properties
       to `dyno_id` dimension, which is synced by datapoints emitted by the
       [Heroku SignalFx Collector (https://github.com/signalfx/heroku-signalfx-collector).

--- a/internal/signalfx-agent/pkg/monitors/heroku/monitor.go
+++ b/internal/signalfx-agent/pkg/monitors/heroku/monitor.go
@@ -33,6 +33,7 @@ func init() {
 // Configure monitor
 func (m *Monitor) Configure(c *Config) error {
 	m.logger = utils.NewThrottledLogger(log.WithFields(log.Fields{"monitorType": "heroku-metadata", "monitorID": c.MonitorID}), 20*time.Second)
+	m.logger.Warn("The heroku monitor is deprecated. Use the resourcedetectionprocessor with the heroku source instead.")
 	m.ctx, m.cancel = context.WithCancel(context.Background())
 
 	go func() {


### PR DESCRIPTION
Deprecate the heroku observer. Use the [resource detection observer with heroku detector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#heroku) instead.