### PR TITLE
Deprecate mongodb atlas monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - (Splunk) Deprecate cloudfoundry monitor ([#5495](https://github.com/signalfx/splunk-otel-collector/pull/5495))
 - (Splunk) Deprecate the heroku observer. Use the [resource detection observer with heroku detector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#heroku) instead. ([#5496](https://github.com/signalfx/splunk-otel-collector/pull/5496))
+- (Splunk) Deprecate mongodb atlas monitor. [Please use the mongodbatlasreceiver instead](https://docs.splunk.com/observability/en/gdi/opentelemetry/components/mongodb-atlas-receiver.html) ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
 
 ## v0.111.0
 

--- a/internal/signalfx-agent/pkg/monitors/mongodb/atlas/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/mongodb/atlas/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated. Please use the mongodbatlasreceiver instead. See https://docs.splunk.com/observability/en/gdi/opentelemetry/components/mongodb-atlas-receiver.html **
     MongoDB Atlas is a provider of MongoDB as an on-demand fully managed service. Atlas exposes MongoDB cluster
     monitoring and logging data through its [monitoring and logs](https://docs.atlas.mongodb.com/reference/api/monitoring-and-logs/)
     REST API endpoints. These Atlas monitoring API resources are grouped into measurements for MongoDB processes,

--- a/internal/signalfx-agent/pkg/monitors/mongodb/atlas/monitor.go
+++ b/internal/signalfx-agent/pkg/monitors/mongodb/atlas/monitor.go
@@ -58,6 +58,7 @@ type Monitor struct {
 // Configure monitor
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
+	m.logger.Warn("The mongodb-atlas monitor is deprecated. Please use the mongodbatlasreceiver instead. See https://docs.splunk.com/observability/en/gdi/opentelemetry/components/mongodb-atlas-receiver.html ")
 	var client *mongodbatlas.Client
 	var processMeasurements measurements.ProcessesMeasurements
 	var diskMeasurements measurements.DisksMeasurements


### PR DESCRIPTION
**Description:**
Deprecate mongodb atlas monitor. [Please use the mongodbatlasreceiver instead](https://docs.splunk.com/observability/en/gdi/opentelemetry/components/mongodb-atlas-receiver.html)