### PR TITLE
[chore] switch to v0.111.0 for release

### DIFF
--- a/packaging/technical-addon/Makefile
+++ b/packaging/technical-addon/Makefile
@@ -1,7 +1,7 @@
 # Used for building
 SOURCE_DIR?=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 BUILD_DIR?=./build
-OTEL_COLLECTOR_VERSION?=0.110.0
+OTEL_COLLECTOR_VERSION?=0.111.0
 SPLUNK_OTELCOL_DOWNLOAD_BASE?=https://github.com/signalfx/splunk-otel-collector/releases/download
 PLATFORM?=linux
 ARCH?=amd64


### PR DESCRIPTION
We didn't release `v0.110.0` due to some memory issues in that version