### PR TITLE
Remove kong collectd plugin

### DIFF
--- a/packaging/bundle/collectd-plugins.yaml
+++ b/packaging/bundle/collectd-plugins.yaml
@@ -25,10 +25,6 @@
   version: v2.7.0
   repo: signalfx/collectd-jenkins
 
-- name: kong
-  version: v0.0.4
-  repo: signalfx/collectd-kong
-
 - name: openstack
   version: v4.2.0
   repo: signalfx/collectd-openstack


### PR DESCRIPTION
This plugin was removed but the python dependency was still being added. Removing it now.