### PR TITLE
[chore] Splunk_TA_otel break out copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,4 +274,4 @@ endif
 
 
 .PHONY: package-technical-addon
-package-technical-addon: bundle.d otelcol generate-technical-addon package-ta smoketest-ta
+package-technical-addon: bundle.d otelcol generate-technical-addon copy-local-build-to-ta package-ta smoketest-ta

--- a/packaging/technical-addon/Makefile
+++ b/packaging/technical-addon/Makefile
@@ -22,12 +22,19 @@ generate-technical-addon: env-guard-all
 	BUILD_DIR="$(BUILD_DIR)" \
 	SOURCE_DIR="$(SOURCE_DIR)" \
 	$(SOURCE_DIR)/packaging-scripts/make-buildspace.sh
+
+.PHONY: copy-local-build-to-ta
+copy-local-build-to-ta: env-guard-ta
 	# Should only have affect if otelcol or download make targets were run first
 	# Running make download-otelcol will overwrite anything locally created
 	mkdir -p $(BUILD_DIR)/out/bin/
 	cp -Rv bin/* $(BUILD_DIR)/out/bin/
-	mkdir -p $(BUILD_DIR)/out/smart-agent
-	cp ./dist/agent-bundle_linux_amd64.tar.gz $(BUILD_DIR)/out/smart-agent
+	BUILD_DIR="$(BUILD_DIR)" \
+	PLATFORM="$(PLATFORM)" \
+	ARCH="$(ARCH)" \
+	SPLUNK_OTELCOL_DOWNLOAD_BASE="$(SPLUNK_OTELCOL_DOWNLOAD_BASE)" \
+	OTEL_COLLECTOR_VERSION="$(OTEL_COLLECTOR_VERSION)" \
+	$(SOURCE_DIR)/packaging-scripts/download-agent-bundle.sh
 
 .PHONY: env-guard-all
 env-guard-all:
@@ -49,15 +56,23 @@ env-guard-verify: env-guard-ta
 	UF_VERSION="$(UF_VERSION)" \
 	$(SOURCE_DIR)/packaging-scripts/env/verify.sh
 
-.PHONY: download-otelcol
-download-otelcol: env-guard-ta
+.PHONY: download-release
+download-release: env-guard-ta
 	BUILD_DIR="$(BUILD_DIR)" \
 	SOURCE_DIR="$(SOURCE_DIR)" \
 	OTEL_COLLECTOR_VERSION="$(OTEL_COLLECTOR_VERSION)" \
 	SPLUNK_OTELCOL_DOWNLOAD_BASE="$(SPLUNK_OTELCOL_DOWNLOAD_BASE)" \
 	PLATFORM="$(PLATFORM)" \
 	ARCH="$(ARCH)" \
-	$(SOURCE_DIR)/packaging-scripts/download-release.sh
+	$(SOURCE_DIR)/packaging-scripts/download-otelcol.sh
+	
+	BUILD_DIR="$(BUILD_DIR)" \
+	SOURCE_DIR="$(SOURCE_DIR)" \
+	OTEL_COLLECTOR_VERSION="$(OTEL_COLLECTOR_VERSION)" \
+	SPLUNK_OTELCOL_DOWNLOAD_BASE="$(SPLUNK_OTELCOL_DOWNLOAD_BASE)" \
+	PLATFORM="$(PLATFORM)" \
+	ARCH="$(ARCH)" \
+	$(SOURCE_DIR)/packaging-scripts/download-agent-bundle.sh
 
 
 .PHONY: package-ta
@@ -70,7 +85,7 @@ package-ta: env-guard-ta
 	$(SOURCE_DIR)/packaging-scripts/package-ta.sh
 
 .PHONY: distribute-ta
-distribute-ta: generate-technical-addon download-otelcol package-ta
+distribute-ta: generate-technical-addon download-release package-ta
 
 .PHONY: verify-ta
 verify-ta: env-guard-verify

--- a/packaging/technical-addon/packaging-scripts/download-agent-bundle.sh
+++ b/packaging/technical-addon/packaging-scripts/download-agent-bundle.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+set -o pipefail
+
+[[ -z "$SPLUNK_OTELCOL_DOWNLOAD_BASE" ]] && echo "SPLUNK_OTELCOL_DOWNLOAD_BASE not set" && exit 1
+
+# Download  smart agent
+if [ "$PLATFORM" == "windows" ] || [ "$PLATFORM" == "all" ]; then
+    SMART_AGENT_BUNDLE="agent-bundle_${OTEL_COLLECTOR_VERSION}_windows_${ARCH}.zip" 
+    URL="$SPLUNK_OTELCOL_DOWNLOAD_BASE/v$OTEL_COLLECTOR_VERSION/$SMART_AGENT_BUNDLE"
+    mkdir -p "$BUILD_DIR/out/smart-agent/"
+    OUTPUT_PATH="$BUILD_DIR/out/smart-agent/$SMART_AGENT_BUNDLE"
+    if ! [ -f "$OUTPUT_PATH" ]; then
+        wget "$URL" --output-document "$OUTPUT_PATH"
+    fi
+    echo "SAVED $SMART_AGENT_BUNDLE TO $OUTPUT_PATH"
+fi
+if [ "$PLATFORM" == "linux" ] || [ "$PLATFORM" == "all" ]; then
+    SMART_AGENT_BUNDLE="agent-bundle_${OTEL_COLLECTOR_VERSION}_linux_${ARCH}.tar.gz"
+    URL="$SPLUNK_OTELCOL_DOWNLOAD_BASE/v$OTEL_COLLECTOR_VERSION/$SMART_AGENT_BUNDLE"
+    mkdir -p "$BUILD_DIR/out/smart-agent/"
+    OUTPUT_PATH="$BUILD_DIR/out/smart-agent/$SMART_AGENT_BUNDLE"
+    if ! [ -f "$OUTPUT_PATH" ]; then
+        wget "$URL" --output-document "$OUTPUT_PATH"
+    fi
+    echo "SAVED $SMART_AGENT_BUNDLE TO $OUTPUT_PATH"
+fi

--- a/packaging/technical-addon/packaging-scripts/download-release.sh
+++ b/packaging/technical-addon/packaging-scripts/download-release.sh
@@ -26,26 +26,3 @@ if [ "$PLATFORM" == "linux" ] || [ "$PLATFORM" == "all" ]; then
     chmod +x "$OUTPUT_PATH"
     echo "SAVED $COLLECTOR_BINARY TO $OUTPUT_PATH"
 fi
-
-
-# Download  smart agent
-if [ "$PLATFORM" == "windows" ] || [ "$PLATFORM" == "all" ]; then
-    SMART_AGENT_BUNDLE="agent-bundle_${OTEL_COLLECTOR_VERSION}_windows_${ARCH}.zip" 
-    URL="$SPLUNK_OTELCOL_DOWNLOAD_BASE/v$OTEL_COLLECTOR_VERSION/$SMART_AGENT_BUNDLE"
-    mkdir -p "$BUILD_DIR/out/smart-agent/"
-    OUTPUT_PATH="$BUILD_DIR/out/smart-agent/$SMART_AGENT_BUNDLE"
-    if ! [ -f "$OUTPUT_PATH" ]; then
-        wget "$URL" --output-document "$OUTPUT_PATH"
-    fi
-    echo "SAVED $SMART_AGENT_BUNDLE TO $OUTPUT_PATH"
-fi
-if [ "$PLATFORM" == "linux" ] || [ "$PLATFORM" == "all" ]; then
-    SMART_AGENT_BUNDLE="agent-bundle_${OTEL_COLLECTOR_VERSION}_linux_${ARCH}.tar.gz"
-    URL="$SPLUNK_OTELCOL_DOWNLOAD_BASE/v$OTEL_COLLECTOR_VERSION/$SMART_AGENT_BUNDLE"
-    mkdir -p "$BUILD_DIR/out/smart-agent/"
-    OUTPUT_PATH="$BUILD_DIR/out/smart-agent/$SMART_AGENT_BUNDLE"
-    if ! [ -f "$OUTPUT_PATH" ]; then
-        wget "$URL" --output-document "$OUTPUT_PATH"
-    fi
-    echo "SAVED $SMART_AGENT_BUNDLE TO $OUTPUT_PATH"
-fi

--- a/packaging/technical-addon/packaging-scripts/package-ta.sh
+++ b/packaging/technical-addon/packaging-scripts/package-ta.sh
@@ -38,7 +38,7 @@ fi
 
 # Copy smart agent bundle into addon package directory
 version=""
-if [ "$OTEL_COLLECTOR_VERSION" == "" ]; then 
+if [ "$OTEL_COLLECTOR_VERSION" != "" ]; then 
     version="${OTEL_COLLECTOR_VERSION}_"
 fi
 if [ "$PLATFORM" == "windows" ] || [ "$PLATFORM" == "all" ] ; then


### PR DESCRIPTION
Sometimes we want to grab the signed binaries instead of the locally built ones, so separate the copy step