### PR TITLE
Deprecate windowslegacy monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - (Splunk) Deprecate the heroku observer. Use the [resource detection observer with heroku detector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#heroku) instead. ([#5496](https://github.com/signalfx/splunk-otel-collector/pull/5496))
 - (Splunk) Deprecate mongodb atlas monitor. [Please use the mongodbatlasreceiver instead](https://docs.splunk.com/observability/en/gdi/opentelemetry/components/mongodb-atlas-receiver.html) ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
 - (Splunk) Deprecate python-monitor monitor ([#5501](https://github.com/signalfx/splunk-otel-collector/pull/5501))
-- (Splunk) Deprecate windowslegacy monitor ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
+- (Splunk) Deprecate windowslegacy monitor ([#5518](https://github.com/signalfx/splunk-otel-collector/pull/5518))
 
 ## v0.111.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - (Splunk) Deprecate the heroku observer. Use the [resource detection observer with heroku detector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#heroku) instead. ([#5496](https://github.com/signalfx/splunk-otel-collector/pull/5496))
 - (Splunk) Deprecate mongodb atlas monitor. [Please use the mongodbatlasreceiver instead](https://docs.splunk.com/observability/en/gdi/opentelemetry/components/mongodb-atlas-receiver.html) ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
 - (Splunk) Deprecate python-monitor monitor ([#5501](https://github.com/signalfx/splunk-otel-collector/pull/5501))
+- (Splunk) Deprecate windowslegacy monitor ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
 
 ## v0.111.0
 

--- a/internal/signalfx-agent/pkg/monitors/windowslegacy/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/windowslegacy/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated and will be removed in a future release. Use the windowsperfcounters receiver instead.**
     (Windows Only) This monitor reports metrics for Windows system Performance Counters.
     The metric names are intended to match what was originally reported by
     the SignalFx [PerfCounterReporter](https://github.com/signalfx/PerfCounterReporter)

--- a/internal/signalfx-agent/pkg/monitors/windowslegacy/windowslegacy_windows.go
+++ b/internal/signalfx-agent/pkg/monitors/windowslegacy/windowslegacy_windows.go
@@ -20,6 +20,7 @@ var logger = logrus.WithField("monitorType", monitorType)
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) error {
 	m.logger = logger.WithField("monitorID", conf.MonitorID)
+	m.logger.Warn("[NOTICE] The windowslegacy monitor is deprecated and will be removed in a future release. Use the windowsperfcounters receiver instead.")
 	perfcounterConf := &winperfcounters.Config{
 		CountersRefreshInterval: conf.CountersRefreshInterval,
 		PrintValid:              conf.PrintValid,


### PR DESCRIPTION
Deprecate the windowslegacy monitor. A replacement for the monitor is the windowsperfcounters receiver.