### PR TITLE
Deprecate collectd/consul monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - (Splunk) Deprecate python-monitor monitor ([#5501](https://github.com/signalfx/splunk-otel-collector/pull/5501))
 - (Splunk) Deprecate windowslegacy monitor ([#5518](https://github.com/signalfx/splunk-otel-collector/pull/5518))
 - (Splunk) Deprecate statsd monitor. Use the [statsd receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver) instead. ([#5513](https://github.com/signalfx/splunk-otel-collector/pull/5513))
-- (Splunk) Deprecate the collectd/consul monitor. Please use the statsd or prometheus receiver instead. See https://developer.hashicorp.com/consul/docs/agent/monitor/telemetry for more information. ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
+- (Splunk) Deprecate the collectd/consul monitor. Please use the statsd or prometheus receiver instead. See https://developer.hashicorp.com/consul/docs/agent/monitor/telemetry for more information. ([#5521](https://github.com/signalfx/splunk-otel-collector/pull/5521))
 
 ## v0.111.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - (Splunk) Deprecate python-monitor monitor ([#5501](https://github.com/signalfx/splunk-otel-collector/pull/5501))
 - (Splunk) Deprecate windowslegacy monitor ([#5518](https://github.com/signalfx/splunk-otel-collector/pull/5518))
 - (Splunk) Deprecate statsd monitor. Use the [statsd receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver) instead. ([#5513](https://github.com/signalfx/splunk-otel-collector/pull/5513))
+- (Splunk) Deprecate the collectd/consul monitor. Please use the statsd or prometheus receiver instead. See https://developer.hashicorp.com/consul/docs/agent/monitor/telemetry for more information. ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
 
 ## v0.111.0
 

--- a/internal/signalfx-agent/pkg/monitors/collectd/consul/consul.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/consul/consul.go
@@ -69,7 +69,7 @@ type Monitor struct {
 
 // Configure configures and runs the plugin in collectd
 func (m *Monitor) Configure(conf *Config) error {
-	m.Logger().Warn("The collectd/consul plugin is deprecated. Please use the statsd or prometheus receiver instead. See https://developer.hashicorp.com/consul/docs/agent/monitor/telemetry for more information. This plugin will be removed in a future release.")
+	m.Logger().Warn("[NOTICE] The collectd/consul plugin is deprecated. Please use the statsd or prometheus receiver instead. See https://developer.hashicorp.com/consul/docs/agent/monitor/telemetry for more information. This plugin will be removed in a future release.")
 	conf.pyConf = &python.Config{
 		MonitorConfig: conf.MonitorConfig,
 		Host:          conf.Host,

--- a/internal/signalfx-agent/pkg/monitors/collectd/consul/consul.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/consul/consul.go
@@ -69,6 +69,7 @@ type Monitor struct {
 
 // Configure configures and runs the plugin in collectd
 func (m *Monitor) Configure(conf *Config) error {
+	m.Logger().Warn("The collectd/consul plugin is deprecated. Please use the statsd or prometheus receiver instead. See https://developer.hashicorp.com/consul/docs/agent/monitor/telemetry for more information. This plugin will be removed in a future release.")
 	conf.pyConf = &python.Config{
 		MonitorConfig: conf.MonitorConfig,
 		Host:          conf.Host,

--- a/internal/signalfx-agent/pkg/monitors/collectd/consul/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/collectd/consul/metadata.yaml
@@ -7,6 +7,7 @@ monitors:
     datacenter:
       description: The name of the consul datacenter
   doc: |
+    **This plugin is deprecated and will be removed in a future release. Please follow the documentation at https://developer.hashicorp.com/consul/docs/agent/monitor/telemetry to set up with statsd or prometheus receivers.**
     Monitors the Consul data store by using the
     [Consul collectd Python
     plugin](https://github.com/signalfx/collectd-consul), which collects metrics


### PR DESCRIPTION
**Description:**
Deprecate the collectd/consul monitor. Please use the statsd or prometheus receiver instead. See https://developer.hashicorp.com/consul/docs/agent/monitor/telemetry for more information.