### PR TITLE
Deprecate the collectd/chrony monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - (Splunk) Deprecate windowslegacy monitor ([#5518](https://github.com/signalfx/splunk-otel-collector/pull/5518))
 - (Splunk) Deprecate statsd monitor. Use the [statsd receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver) instead. ([#5513](https://github.com/signalfx/splunk-otel-collector/pull/5513))
 - (Splunk) Deprecate the collectd/consul monitor. Please use the statsd or prometheus receiver instead. See https://developer.hashicorp.com/consul/docs/agent/monitor/telemetry for more information. ([#5521](https://github.com/signalfx/splunk-otel-collector/pull/5521))
+- (Splunk) Deprecate the collectd/chrony monitor. Please use the [chronyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/chronyreceiver) instead. ([#5536](https://github.com/signalfx/splunk-otel-collector/pull/5536))
 
 ## v0.111.0
 

--- a/internal/signalfx-agent/pkg/monitors/collectd/chrony/chrony.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/chrony/chrony.go
@@ -42,5 +42,5 @@ type Monitor struct {
 
 // Configure configures and runs the plugin in collectd
 func (m *Monitor) Configure(conf *Config) error {
-	return m.SetConfigurationAndRun(conf)
+	return m.SetConfigurationAndRun(conf, collectd.WithDeprecationWarningLog("chronyreceiver"))
 }

--- a/internal/signalfx-agent/pkg/monitors/collectd/chrony/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/collectd/chrony/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - dimensions:
   doc: |
+    **The collectd/chrony monitor is deprecated. Use the chronyreceiver instead.**
     Collectd NTP data from a chronyd instance
 
     See https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_chrony


### PR DESCRIPTION
**Description:**
Deprecate the collectd/chrony monitor. Please use the [chronyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/chronyreceiver) instead.