### PR TITLE
Deprecate collectd/nginx monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - (Splunk) Deprecate windowslegacy monitor ([#5518](https://github.com/signalfx/splunk-otel-collector/pull/5518))
 - (Splunk) Deprecate statsd monitor. Use the [statsd receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver) instead. ([#5513](https://github.com/signalfx/splunk-otel-collector/pull/5513))
 - (Splunk) Deprecate the collectd/consul monitor. Please use the statsd or prometheus receiver instead. See https://developer.hashicorp.com/consul/docs/agent/monitor/telemetry for more information. ([#5521](https://github.com/signalfx/splunk-otel-collector/pull/5521))
+- (Splunk) Deprecate the collectd/nginx monitor. Please use the [nginx receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/nginxreceiver/) instead. ([#5537](https://github.com/signalfx/splunk-otel-collector/pull/5537))
 
 ## v0.111.0
 

--- a/internal/signalfx-agent/pkg/monitors/collectd/nginx/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/collectd/nginx/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - dimensions:
   doc: |
+    **The collectd/nginx monitor is deprecated. Please use nginx receiver instead.**
     Monitors an NGINX instance using our fork of the
     collectd nginx plugin based on the [collectd nginx
     plugin](https://collectd.org/wiki/index.php/Plugin:nginx).

--- a/internal/signalfx-agent/pkg/monitors/collectd/nginx/nginx.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/nginx/nginx.go
@@ -40,5 +40,5 @@ type Monitor struct {
 
 // Configure configures and runs the plugin in collectd
 func (m *Monitor) Configure(conf *Config) error {
-	return m.SetConfigurationAndRun(conf)
+	return m.SetConfigurationAndRun(conf, collectd.WithDeprecationWarningLog("nginxreceiver"))
 }


### PR DESCRIPTION
**Description:**
Deprecate the collectd/nginx monitor. Please use the [nginx receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/nginxreceiver/) instead.
