### PR TITLE
Deprecate collectd/mysql monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - (Splunk) Deprecate windowslegacy monitor ([#5518](https://github.com/signalfx/splunk-otel-collector/pull/5518))
 - (Splunk) Deprecate statsd monitor. Use the [statsd receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver) instead. ([#5513](https://github.com/signalfx/splunk-otel-collector/pull/5513))
 - (Splunk) Deprecate the collectd/consul monitor. Please use the statsd or prometheus receiver instead. See https://developer.hashicorp.com/consul/docs/agent/monitor/telemetry for more information. ([#5521](https://github.com/signalfx/splunk-otel-collector/pull/5521))
+- (Splunk) Deprecate collectd/mysql monitor. Use the [mysql receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/mysqlreceiver) instead. ([#5538](https://github.com/signalfx/splunk-otel-collector/pull/5538))
+
 
 ## v0.111.0
 

--- a/internal/signalfx-agent/pkg/monitors/collectd/mysql/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/collectd/mysql/metadata.yaml
@@ -1,6 +1,8 @@
 monitors:
 - dimensions:
   doc: |
+    **The MySQL monitor is deprecated. Please use the mysqlreceiver instead.**
+    
     Monitors a MySQL database server using collectd's [MySQL
     plugin](https://collectd.org/wiki/index.php/Plugin:MySQL). It supports
     MySQL versions 5.x or later.

--- a/internal/signalfx-agent/pkg/monitors/collectd/mysql/mysql.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/mysql/mysql.go
@@ -70,5 +70,5 @@ type Monitor struct {
 
 // Configure configures and runs the plugin in collectd
 func (am *Monitor) Configure(conf *Config) error {
-	return am.SetConfigurationAndRun(conf)
+	return am.SetConfigurationAndRun(conf, collectd.WithDeprecationWarningLog("mysqlreceiver"))
 }


### PR DESCRIPTION
**Description:**
Deprecate collectd/mysql monitor. Use the [mysql receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/mysqlreceiver) instead.