### PR TITLE
Deprecate the collectd/statsd monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - (Splunk) Deprecate the collectd/nginx monitor. Please use the [nginx receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/nginxreceiver/) instead. ([#5537](https://github.com/signalfx/splunk-otel-collector/pull/5537))
 - (Splunk) Deprecate the collectd/chrony monitor. Please use the [chronyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/chronyreceiver) instead. ([#5536](https://github.com/signalfx/splunk-otel-collector/pull/5536))
 - (Splunk) Deprecate the ecs-metadata monitor ([#5541](https://github.com/signalfx/splunk-otel-collector/pull/5541))
+- (Splunk) Deprecate the collectd/statsd monitor. Please use the [statsdreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver) instead. ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
 
 ### 🚀 New components 🚀
 

--- a/internal/signalfx-agent/pkg/monitors/collectd/statsd/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/collectd/statsd/metadata.yaml
@@ -1,6 +1,9 @@
 monitors:
 - dimensions:
   doc: |
+    The statsd monitor is deprecated and will be removed in a future release.
+    Use the statsd receiver instead.
+    
     The StatsD plugin for collectd listens for StatsD
     events, aggregates them and transmits them according to collectd's
     configuration. Use this plugin to send data from StatsD to SignalFx [statsd

--- a/internal/signalfx-agent/pkg/monitors/collectd/statsd/statsd.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/statsd/statsd.go
@@ -47,5 +47,5 @@ type Monitor struct {
 
 // Configure configures and runs the plugin in collectd
 func (am *Monitor) Configure(conf *Config) error {
-	return am.SetConfigurationAndRun(conf)
+	return am.SetConfigurationAndRun(conf, collectd.WithDeprecationWarningLog("statsdreceiver"))
 }


### PR DESCRIPTION
**Description:**
Deprecate the collectd/statsd monitor. Use the statsd receiver instead.