### PR TITLE
Deprecate haproxy monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - (Splunk) Deprecate the collectd/nginx monitor. Please use the [nginx receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/nginxreceiver/) instead. ([#5537](https://github.com/signalfx/splunk-otel-collector/pull/5537))
 - (Splunk) Deprecate the collectd/chrony monitor. Please use the [chronyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/chronyreceiver) instead. ([#5536](https://github.com/signalfx/splunk-otel-collector/pull/5536))
 - (Splunk) Deprecate the ecs-metadata monitor ([#5541](https://github.com/signalfx/splunk-otel-collector/pull/5541))
-- (Splunk) Deprecate the haproxy monitor. Please use the [haproxyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/haproxyreceiver) instead. ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
+- (Splunk) Deprecate the haproxy monitor. Please use the [haproxyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/haproxyreceiver) instead. ([#5543](https://github.com/signalfx/splunk-otel-collector/pull/5543))
 
 ### 🚀 New components 🚀
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - (Splunk) Deprecate the collectd/nginx monitor. Please use the [nginx receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/nginxreceiver/) instead. ([#5537](https://github.com/signalfx/splunk-otel-collector/pull/5537))
 - (Splunk) Deprecate the collectd/chrony monitor. Please use the [chronyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/chronyreceiver) instead. ([#5536](https://github.com/signalfx/splunk-otel-collector/pull/5536))
 - (Splunk) Deprecate the ecs-metadata monitor ([#5541](https://github.com/signalfx/splunk-otel-collector/pull/5541))
+- (Splunk) Deprecate the haproxy monitor. Please use the [haproxyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/haproxyreceiver) instead. ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
 
 ### 🚀 New components 🚀
 

--- a/internal/signalfx-agent/pkg/monitors/haproxy/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/haproxy/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
   - monitorType: haproxy
     doc: |
+      **This monitor is deprecated and will be removed in a future release. Please use the haproxyreceiver instead.**
       This monitor scrapes [HAProxy](http://www.haproxy.org/) statistics (i.e. metrics) from a configured
       HTTP endpoint or UNIX socket. It requires HAProxy 1.8+ and supports scraping metrics for HAProxy running in
       multi-process mode. In multi-process mode, HAProxy must be configured to enable stats on different URLs/socket

--- a/internal/signalfx-agent/pkg/monitors/haproxy/monitor.go
+++ b/internal/signalfx-agent/pkg/monitors/haproxy/monitor.go
@@ -34,7 +34,7 @@ type proxies map[string]bool
 // Config for this monitor
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
-	m.logger.Warn("[NOTICE] The haproxy monitor is deprecated and will be removed in a future release. Please use the haproxy receiver instead.")
+	m.logger.Warn("[NOTICE] The haproxy monitor is deprecated and will be removed in a future release. Please use the haproxyreceiver instead.")
 	m.ctx, m.cancel = context.WithCancel(context.Background())
 	url, err := url.Parse(conf.ScrapeURL())
 	if err != nil {

--- a/internal/signalfx-agent/pkg/monitors/haproxy/monitor.go
+++ b/internal/signalfx-agent/pkg/monitors/haproxy/monitor.go
@@ -34,6 +34,7 @@ type proxies map[string]bool
 // Config for this monitor
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
+	m.logger.Warn("[NOTICE] The haproxy monitor is deprecated and will be removed in a future release. Please use the haproxy receiver instead.")
 	m.ctx, m.cancel = context.WithCancel(context.Background())
 	url, err := url.Parse(conf.ScrapeURL())
 	if err != nil {


### PR DESCRIPTION
**Description:**
Deprecate the haproxy monitor. Please use the [haproxyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/haproxyreceiver) instead