### PR TITLE
Fix installer tests

### DIFF
--- a/packaging/tests/instrumentation/config.yaml
+++ b/packaging/tests/instrumentation/config.yaml
@@ -9,17 +9,17 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 exporters:
-  debug:
-    verbosity: detailed
+  file:
+    path: /tmp/out
 
 service:
   pipelines:
     metrics:
       receivers: [signalfx, otlp]
-      exporters: [debug]
+      exporters: [file]
     logs:
       receivers: [otlp]
-      exporters: [debug]
+      exporters: [file]
     traces:
       receivers: [otlp]
-      exporters: [debug]
+      exporters: [file]


### PR DESCRIPTION
The installer tests were changed to use the debug exporter. The test installs a very old version of the collector, which doesn't have the debug exporter yet, then upgrades the collector. This change makes the collector use the file exporter.