### PR TITLE
Update link checker to ingore deleted exporter links from CHANGELOG.md

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -22,5 +22,6 @@ exclude = [
     "https://superuser.com/a/980821", # failing with 403 Forbidden
     "https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/databricksreceiver", # databricsreceiver was deleted
     "https://self-service.isv.ci", # Failing with timeouts, not stable and still current according to https://github.com/cf-platform-eng/selfservice/blame/main/README.md#L3
-    "https://github.com/signalfx/splunk-otel-collector/tree/main/internal/exporter/httpsinkexporter" # exporter was deleted
+    "https://github.com/signalfx/splunk-otel-collector/tree/main/internal/exporter/httpsinkexporter", # exporter was deleted
+    "https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter", # exporter was deleted
 ]

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -22,4 +22,5 @@ exclude = [
     "https://superuser.com/a/980821", # failing with 403 Forbidden
     "https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/databricksreceiver", # databricsreceiver was deleted
     "https://self-service.isv.ci", # Failing with timeouts, not stable and still current according to https://github.com/cf-platform-eng/selfservice/blame/main/README.md#L3
+    "https://github.com/signalfx/splunk-otel-collector/tree/main/internal/exporter/httpsinkexporter" # exporter was deleted
 ]


### PR DESCRIPTION
**Description:** Ignore `httpsinkexporter` link in CHANGELOG.md from linter since the exporter was deleted.
