### PR TITLE
[chore] use newer trivy version with registry fallback feature

### DIFF
--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Run trivy filesystem scan
         uses: aquasecurity/trivy-action@0.28.0
         with:
+          version: v0.57.1
           scan-type: 'fs'
           scan-ref: '.'
           skip-dirs: 'deployments,examples,instrumentation/packaging,packaging,tests'
@@ -121,6 +122,7 @@ jobs:
       - name: Run trivy image scan
         uses: aquasecurity/trivy-action@0.28.0
         with:
+          version: v0.57.1
           scan-type: 'image'
           image-ref: "otelcol${{ matrix.FIPS == true && '-fips' || '' }}:latest"
           format: 'table'


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

We are seeing our trivy scans failing constantly due to github rate limits. This PR updates the trivy github action to run with a newer version of trivy (default in the action is `0.56`) which has a feature to try ECR repo as fallback https://github.com/aquasecurity/trivy/pull/7679

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
