### PR TITLE
[chore] update macos runner versions in tests

### DIFF
--- a/.github/workflows/darwin-test.yml
+++ b/.github/workflows/darwin-test.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         # The "macos-13-xlarge" runner is arm64: https://github.com/actions/runner-images/issues/8439
-        OS: [ "macos-12", "macos-13", "macos-13-xlarge", "macos-14" ]
+        OS: [ "macos-13", "macos-13-xlarge", "macos-14", "macos-15" ]
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v4


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Removes `macos-12` since the runner image will be removed start of December. Introduce newer `macos-15` to darwin test grid. 

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
