### PR TITLE
Upgrade journald client built in the docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
+
 ## Unreleased
+
+### 🧰 Bug fixes 🧰
+
+- (Splunk) `receiver/journald`: Upgrade journald client libraries in the Collector docker image by taking them from latest Debian image. 
+  This fixes journald receiver on kubernetes nodes with recent versions of systemd ([#5664](https://github.com/signalfx/splunk-otel-collector/pull/5664)).
 
 ## v0.113.0
 

--- a/cmd/otelcol/Dockerfile
+++ b/cmd/otelcol/Dockerfile
@@ -39,7 +39,7 @@ RUN JMX_METRICS_JAR=opentelemetry-jmx-metrics.jar && \
     URL=https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/${JMX_METRIC_GATHERER_RELEASE}/${JMX_METRICS_JAR} && \
     cd /tmp && wget "$URL";
 
-FROM ${DOCKER_REPO}/debian:11.5 as journalctl
+FROM ${DOCKER_REPO}/debian:12.8 as journalctl
 RUN apt update
 RUN apt install -y systemd
 COPY dist/collect-libs.sh /collect-libs.sh

--- a/tests/receivers/smartagent/telegraf-exec/testdata/exec/Dockerfile
+++ b/tests/receivers/smartagent/telegraf-exec/testdata/exec/Dockerfile
@@ -1,16 +1,9 @@
 ARG SPLUNK_OTEL_COLLECTOR_IMAGE
 ARG IMAGE_PLATFORM
-FROM --platform=${IMAGE_PLATFORM} golang:1.19 as golang
 
-RUN mkdir -p /some/path
+FROM --platform=${IMAGE_PLATFORM} golang:1.23 as golang
+COPY telegraf-exec.go /opt/telegraf-exec.go
+RUN go build -o /opt/telegraf-exec /opt/telegraf-exec.go
 
 FROM ${SPLUNK_OTEL_COLLECTOR_IMAGE}
-
-ENV PATH=/some/path/go/bin:$PATH
-ENV GOROOT=/some/path/go
-ENV GOCACHE=/some/path/go/.cache/go-build
-
-COPY telegraf-exec.go /opt/telegraf-exec.go
-COPY config.yaml /etc/config.yaml
-COPY --from=golang --chown=999 /some/path /some/path
-COPY --from=golang --chown=999 /usr/local/go /some/path/go
+COPY --from=golang /opt/telegraf-exec /opt/telegraf-exec

--- a/tests/receivers/smartagent/telegraf-exec/testdata/exec/config.yaml
+++ b/tests/receivers/smartagent/telegraf-exec/testdata/exec/config.yaml
@@ -1,7 +1,7 @@
 receivers:
   smartagent/exec:
     type: telegraf/exec
-    command: 'go run /opt/telegraf-exec.go'
+    command: /opt/telegraf-exec
     intervalSeconds: 1
     telegrafParser:
       metricName: some.metric


### PR DESCRIPTION
Use the latest debian image to build the journald client with the latest libraries. Otherwise, journald receiver doesn't work on nodes with latests OSs like Amazon Linux 2023.
