### PR TITLE
[docs] Update upstream troubleshooting link

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,7 +1,7 @@
 The official Splunk documentation for this page is [Troubleshoot issues when collecting data](https://docs.splunk.com/Observability/gdi/opentelemetry/troubleshooting.html). 
 
 You might review the [OpenTelemetry Collector troubleshooting
-documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md) as well.
+documentation](https://opentelemetry.io/docs/collector/troubleshooting/) as well.
 
 For instructions on how to contribute to the docs, see [Contribute to Splunk Observability Cloud documentation](https://docs.splunk.com/observability/en/get-started/contribute.html).
 


### PR DESCRIPTION
Documentation from the upstream repo was removed in https://github.com/open-telemetry/opentelemetry-collector/pull/11483