### PR TITLE
[CI] Stabilize lychee links validation

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -23,6 +23,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2.1.0
         with:
+          lycheeVersion: nightly # TODO: Change to stable once v0.17.1 is released, the version that includes a retry fix
           args: -v -n --config .lychee.toml './*.md' './**/*.md'
           fail: true
         env:

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,9 +1,7 @@
-max-concurrency = 20
-accept = [
-    200,
-    429,
-]
+max_concurrency = 20
 timeout = 30
+max_retires = 5
+retry_wait_time = 30
 exclude = [
     "my.host",
     "file://*",
@@ -24,4 +22,5 @@ exclude = [
     "https://self-service.isv.ci", # Failing with timeouts, not stable and still current according to https://github.com/cf-platform-eng/selfservice/blame/main/README.md#L3
     "https://github.com/signalfx/splunk-otel-collector/tree/main/internal/exporter/httpsinkexporter", # exporter was deleted
     "https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter", # exporter was deleted
+    "https://github.com/.*/(pull|issues)/[0-9]+", # We have too many PR and issues links in CHANGELOG.md that we allways run out of the rate limit
 ]


### PR DESCRIPTION
- Exclude checking PRs and issues. There are too many of them in CHANGELOG.md, so we always run into the rate limits.
- Use the latest lychee build that has fixed retries https://github.com/lycheeverse/lychee/pull/1573
- Increase the number of retries and retry timeout to workaround [secondary Github rate limiting](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-secondary-rate-limits)
- Do not consider 429 successful

There is one failing link left which is fixed in https://github.com/signalfx/splunk-otel-collector/pull/5667