### PR TITLE
Fix telegraf integration tests

### DIFF
--- a/tests/receivers/smartagent/telegraf-exec/testdata/exec/Dockerfile
+++ b/tests/receivers/smartagent/telegraf-exec/testdata/exec/Dockerfile
@@ -6,4 +6,5 @@ COPY telegraf-exec.go /opt/telegraf-exec.go
 RUN go build -o /opt/telegraf-exec /opt/telegraf-exec.go
 
 FROM ${SPLUNK_OTEL_COLLECTOR_IMAGE}
+COPY config.yaml /etc/config.yaml
 COPY --from=golang /opt/telegraf-exec /opt/telegraf-exec


### PR DESCRIPTION
This line was accidentally removed in https://github.com/signalfx/splunk-otel-collector/pull/5664. Fixes https://github.com/signalfx/splunk-otel-collector/actions/runs/12152054403/job/33888059096