### PR TITLE
Added new dimension to internal metrics to identify mode

### DIFF
--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -124,6 +124,13 @@ processors:
         #value: staging/production/...
         #key: deployment.environment
 
+  # The following processor is used to add "otelcol.service.mode" attribute to the internal metrics
+  resource/add_mode:
+    attributes:
+      - action: insert
+        value: "agent"
+        key: otelcol.service.mode
+
 exporters:
   # Traces
   sapm:
@@ -186,7 +193,7 @@ service:
       #exporters: [otlp]
     metrics/internal:
       receivers: [prometheus/internal]
-      processors: [memory_limiter, batch, resourcedetection]
+      processors: [memory_limiter, batch, resourcedetection, resource/add_mode]
       # When sending to gateway, at least one metrics pipeline needs
       # to use signalfx exporter so host metadata gets emitted
       exporters: [signalfx]

--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -82,6 +82,13 @@ processors:
         #value: staging/production/...
         #key: deployment.environment
 
+  # The following processor is used to add "otelcol.service.mode" attribute to the internal metrics
+  resource/add_mode:
+    attributes:
+      - action: insert
+        value: "gateway"
+        key: otelcol.service.mode
+
   # Detect if the collector is running on a cloud system. Overrides resource attributes set by receivers.
   # Detector order is important: the `system` detector goes last so it can't preclude cloud detectors from setting host/os info.
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#ordering
@@ -142,7 +149,7 @@ service:
       exporters: [signalfx]
     metrics/internal:
       receivers: [prometheus/internal]
-      processors: [memory_limiter, batch, resourcedetection/internal]
+      processors: [memory_limiter, batch, resourcedetection/internal, resource/add_mode]
       exporters: [signalfx/internal]
     logs/signalfx:
       receivers: [signalfx]

--- a/tests/general/default_config_test.go
+++ b/tests/general/default_config_test.go
@@ -118,6 +118,15 @@ func TestDefaultGatewayConfig(t *testing.T) {
 						"detectors": []any{"gcp", "ecs", "ec2", "azure", "system"},
 						"override":  true,
 					},
+					"resource/add_mode": map[string]any{
+						"attributes": []any{
+							map[string]any{
+								"action": "insert",
+								"value":  "gateway",
+								"key":    "otelcol.service.mode",
+							},
+						},
+					},
 				},
 				"receivers": map[string]any{
 					"jaeger": map[string]any{
@@ -196,7 +205,7 @@ func TestDefaultGatewayConfig(t *testing.T) {
 						},
 						"metrics/internal": map[string]any{
 							"exporters":  []any{"signalfx/internal"},
-							"processors": []any{"memory_limiter", "batch", "resourcedetection/internal"},
+							"processors": []any{"memory_limiter", "batch", "resourcedetection/internal", "resource/add_mode"},
 							"receivers":  []any{"prometheus/internal"},
 						},
 						"traces": map[string]any{
@@ -313,6 +322,15 @@ func TestDefaultAgentConfig(t *testing.T) {
 						"detectors": []any{"gcp", "ecs", "ec2", "azure", "system"},
 						"override":  true,
 					},
+					"resource/add_mode": map[string]any{
+						"attributes": []any{
+							map[string]any{
+								"action": "insert",
+								"value":  "agent",
+								"key":    "otelcol.service.mode",
+							},
+						},
+					},
 				},
 				"receivers": map[string]any{
 					"fluentforward": map[string]any{"endpoint": fmt.Sprintf("%s:8006", ip)},
@@ -400,7 +418,7 @@ func TestDefaultAgentConfig(t *testing.T) {
 						},
 						"metrics/internal": map[string]any{
 							"exporters":  []any{"signalfx"},
-							"processors": []any{"memory_limiter", "batch", "resourcedetection"},
+							"processors": []any{"memory_limiter", "batch", "resourcedetection", "resource/add_mode"},
 							"receivers":  []any{"prometheus/internal"},
 						},
 						"traces": map[string]any{


### PR DESCRIPTION
**Description:**
To easily filter between agent and gateway deployments of the collector in dashboards a proposed new dimension `otelcol.service.mode` to be added to the `metrics/internal` pipeline.

**Link to Splunk idea:**
N/A

**Testing:**
N/A - new PR for verified commits

**Documentation:**
N/A
