### PR TITLE
Build Windows image for FIPS use cases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -933,12 +933,12 @@ build-push-windows-image:
   parallel:
     matrix:
       - WIN_VERSION: ["2019", "2022"]
-      - FIPS: ["-fips", ""]
+        FIPS: ["-fips", ""]
   dependencies:
     - sign-exe
     - agent-bundle-windows
   tags:
-    - splunk-otel-collector-windows${WIN_VERSION}${FIPS}
+    - splunk-otel-collector-windows${WIN_VERSION}
   retry: 2
   variables:
     ErrorActionPreference: stop

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,7 +110,7 @@ fossa:
 .trigger-filter:
   only:
     variables:
-      - $CI_COMMIT_BRANCH == "main"
+      - $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "fips_windows_image"
       - $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
   except:
     - schedules
@@ -931,16 +931,17 @@ build-push-windows-image:
   parallel:
     matrix:
       - WIN_VERSION: ["2019", "2022"]
+      - FIPS: ["-fips", ""]
   dependencies:
     - sign-exe
     - agent-bundle-windows
   tags:
-    - splunk-otel-collector-windows${WIN_VERSION}
+    - splunk-otel-collector-windows${WIN_VERSION}${FIPS}
   retry: 2
   variables:
     ErrorActionPreference: stop
   before_script:
-    - Copy-Item .\dist\signed\otelcol_windows_amd64.exe .\cmd\otelcol\otelcol.exe
+    - Copy-Item .\dist\signed\otelcol${FIPS}_windows_amd64.exe .\cmd\otelcol\otelcol.exe
     - Copy-Item .\dist\agent-bundle_windows_amd64.zip .\cmd\otelcol\agent-bundle_windows_amd64.zip
     - &get-base-image |
       if ($env:WIN_VERSION -eq "2019") {
@@ -967,13 +968,13 @@ build-push-windows-image:
     - |
       # Set env vars
       if ($env:CI_COMMIT_TAG) {
-        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector"
-        $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows"
+        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector${FIPS}"
+        $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector${FIPS}-windows"
         $tagNumber = $env:CI_COMMIT_TAG.TrimStart("v")
         $IMAGE_TAG = "${tagNumber}-${env:WIN_VERSION}"
       } else {
-        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-dev"
-        $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows-dev"
+        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector${FIPS}-dev"
+        $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector${FIPS}-windows-dev"
         $IMAGE_TAG = "${env:CI_COMMIT_SHA}-${env:WIN_VERSION}"
       }
       $LATEST_TAG = ""
@@ -1056,7 +1057,7 @@ build-push-windows-image:
       }
     - echo "${IMAGE_NAME}:${IMAGE_TAG}" > tags
     - echo "${OLD_IMAGE_NAME}:${IMAGE_TAG}" >> tags
-    - (Get-Content -Raw -Path tags) -replace "`r`n", "`n"| Set-Content -NoNewline tags_to_sign_${env:WIN_VERSION}
+    - (Get-Content -Raw -Path tags) -replace "`r`n", "`n"| Set-Content -NoNewline tags_to_sign_${env:WIN_VERSION}${env:FIPS}
   after_script:
     - *get-base-image
     - *delete-all-images-except-base
@@ -1067,7 +1068,7 @@ build-push-windows-image:
       }
   artifacts:
     paths:
-      - tags_to_sign_${WIN_VERSION}
+      - tags_to_sign_${WIN_VERSION}${FIPS}
 
 sign-windows-image:
   extends: .sign-docker
@@ -1075,10 +1076,11 @@ sign-windows-image:
   parallel:
     matrix:
       - WIN_VERSION: ["2019", "2022"]
+      - FIPS: ["-fips", ""]
   needs:
     - build-push-windows-image
   before_script:
-    - mv tags_to_sign_${WIN_VERSION} tags_to_sign
+    - mv tags_to_sign_${WIN_VERSION}${FIPS} tags_to_sign
 
 release-debs:
   extends:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1078,7 +1078,7 @@ sign-windows-image:
   parallel:
     matrix:
       - WIN_VERSION: ["2019", "2022"]
-      - FIPS: ["-fips", ""]
+        FIPS: ["-fips", ""]
   needs:
     - build-push-windows-image
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1201,7 +1201,7 @@ build-push-windows-fips-image:
       }
     - echo "${IMAGE_NAME}:${IMAGE_TAG}" > tags
     - echo "${OLD_IMAGE_NAME}:${IMAGE_TAG}" >> tags
-    - (Get-Content -Raw -Path tags) -replace "`r`n", "`n"| Set-Content -NoNewline tags_to_sign_${env:WIN_VERSION}fips
+    - (Get-Content -Raw -Path tags) -replace "`r`n", "`n"| Set-Content -NoNewline tags_to_sign_${env:WIN_VERSION}-fips
   after_script:
     - *get-base-image
     - *delete-all-images-except-base

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1391,6 +1391,7 @@ push-multiarch-manifest:
   parallel:
     matrix:
       - MANIFEST: [multiarch, windows_multiarch]
+        FIPS: ["-fips",""]
   needs:
     - sign-linux-image
     - sign-windows-image
@@ -1403,12 +1404,12 @@ push-multiarch-manifest:
     - |
       # Set env vars
       if [[ -n "${CI_COMMIT_TAG:-}" ]]; then
-        MANIFEST_NAME="quay.io/signalfx/splunk-otel-collector"
-        WIN_MANIFEST_NAME="quay.io/signalfx/splunk-otel-collector-windows"
+        MANIFEST_NAME="quay.io/signalfx/splunk-otel-collector${FIPS}"
+        WIN_MANIFEST_NAME="quay.io/signalfx/splunk-otel-collector${FIPS}-windows"
         MANIFEST_TAG=${CI_COMMIT_TAG#v}
       else
-        MANIFEST_NAME="quay.io/signalfx/splunk-otel-collector-dev"
-        WIN_MANIFEST_NAME="quay.io/signalfx/splunk-otel-collector-windows-dev"
+        MANIFEST_NAME="quay.io/signalfx/splunk-otel-collector${FIPS}-dev"
+        WIN_MANIFEST_NAME="quay.io/signalfx/splunk-otel-collector${FIPS}-windows-dev"
         MANIFEST_TAG=${CI_COMMIT_SHA}
       fi
       LATEST_TAG=""

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1085,7 +1085,7 @@ build-push-windows-fips-image:
   variables:
     ErrorActionPreference: stop
   before_script:
-    - Copy-Item .\dist\signed\otelcol-fips_windows_amd64.exe .\cmd\otelcol\otelcol.exe
+    - Copy-Item .\dist\signed\otelcol-fips_windows_amd64.exe .\cmd\otelcol\fips\dist\otelcol-fips_windows_amd64.exe
     - &get-base-image |
       if ($env:WIN_VERSION -eq "2019") {
         $BASE_IMAGE = $env:WIN_2019_BASE_IMAGE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1451,7 +1451,9 @@ push-multiarch-manifest:
         echo "$json"
         # Check number of images in the manifest
         count=$( echo "$json" | jq -r ".manifests | length" )
-        if [[ "$MANIFEST" = "multiarch" && $count -ne 5 ]]; then
+        if [[ "$MANIFEST" = "multiarch" && "$FIPS" == "" && $count -ne 5 ]]; then
+          exit 1
+        elif [[ "$MANIFEST" = "multiarch" && "$FIPS" == "-fips" && $count -ne 4 ]]; then
           exit 1
         elif [[ "$MANIFEST" = "windows_multiarch" && $count -ne 2 ]]; then
           exit 1
@@ -1459,6 +1461,9 @@ push-multiarch-manifest:
         # Check the manifest for the linux images
         if [[ "$MANIFEST" != "windows_multiarch" ]]; then
           for arch in "amd64" "arm64" "ppc64le"; do
+            if [[ "$FIPS" != "" && "$arch" == "ppc64le" ]]; then
+              continue
+            fi
             found=$( echo "$json" | jq -r ".manifests[] | select(.platform.architecture == \"${arch}\" and .platform.os == \"linux\")" )
             if [[ -z "$found" ]]; then
               echo "linux/${arch} not found in ${MANIFEST_NAME}:${tag}"
@@ -1490,7 +1495,7 @@ push-multiarch-manifest:
       fi
     - mkdir -p dist
     - echo "[${MANIFEST_NAME}@${digest}]" | tee dist/${MANIFEST}_digest.txt
-    - echo "${MANIFEST_NAME}:${MANIFEST_TAG}" > tags_to_sign_${MANIFEST}
+    - echo "${MANIFEST_NAME}:${MANIFEST_TAG}" > tags_to_sign_${MANIFEST}${FIPS}
     - if [[ "$CI_COMMIT_BRANCH" != "main" || "$MANIFEST" != "multiarch" ]]; then exit 0; fi
     # Push the multiarch manifest for the main branch to the docker-test artifactory repo for xray scanning
     # TODO: Add new job to trigger xray scanning for the manifest whenever it is supported
@@ -1502,7 +1507,7 @@ push-multiarch-manifest:
   artifacts:
     paths:
       - dist/${MANIFEST}_digest.txt
-      - tags_to_sign_${MANIFEST}
+      - tags_to_sign_${MANIFEST}${FIPS}
 
 sign-multiarch-manifest:
   extends: .sign-docker
@@ -1510,10 +1515,11 @@ sign-multiarch-manifest:
   parallel:
     matrix:
       - MANIFEST: [multiarch, windows_multiarch]
+        FIPS: ["-fips",""]
   needs:
     - push-multiarch-manifest
   before_script:
-    - mv tags_to_sign_${MANIFEST} tags_to_sign
+    - mv tags_to_sign_${MANIFEST}${FIPS} tags_to_sign
 
 xray-scan-docker:
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -367,6 +367,7 @@ libsplunk:
 agent-bundle-linux:
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_BRANCH == "fips_windows_image"
     - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
     - if: $CI_PIPELINE_SOURCE == "schedule"
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,7 +111,6 @@ fossa:
   only:
     variables:
       - $CI_COMMIT_BRANCH == "main"
-      - $CI_COMMIT_BRANCH == "fips_windows_image"
       - $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
   except:
     - schedules
@@ -367,7 +366,6 @@ libsplunk:
 agent-bundle-linux:
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
-    - if: $CI_COMMIT_BRANCH == "fips_windows_image"
     - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
     - if: $CI_PIPELINE_SOURCE == "schedule"
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1223,6 +1223,7 @@ sign-windows-image:
         FIPS: ["-fips", ""]
   needs:
     - build-push-windows-image
+    - build-push-windows-fips-image
   before_script:
     - mv tags_to_sign_${WIN_VERSION}${FIPS} tags_to_sign
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1129,7 +1129,7 @@ build-push-windows-fips-image:
     - $JMX_METRIC_GATHERER_RELEASE = $(Get-Content packaging\jmx-metric-gatherer-release.txt)
     - |
       echo "Building ${IMAGE_NAME}:${IMAGE_TAG}"
-      docker build -t ${IMAGE_NAME}:${IMAGE_TAG} --build-arg BASE_IMAGE=${BASE_IMAGE} --build-arg JMX_METRIC_GATHERER_RELEASE=${JMX_METRIC_GATHERER_RELEASE} -f .\cmd\otelcol\fips\Dockerfile.windows .\cmd\otelcol\
+      docker build -t ${IMAGE_NAME}:${IMAGE_TAG} --build-arg BASE_IMAGE=${BASE_IMAGE} --build-arg JMX_METRIC_GATHERER_RELEASE=${JMX_METRIC_GATHERER_RELEASE} -f .\cmd\otelcol\fips\Dockerfile.windows .\cmd\otelcol\fips
       if ($LASTEXITCODE -ne 0) { exit 1 }
     - |
       echo "Pushing ${IMAGE_NAME}:${IMAGE_TAG}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1085,6 +1085,7 @@ build-push-windows-fips-image:
   variables:
     ErrorActionPreference: stop
   before_script:
+    - New-Item -Type dir .\cmd\otelcol\fips\dist
     - Copy-Item .\dist\signed\otelcol-fips_windows_amd64.exe .\cmd\otelcol\fips\dist\otelcol-fips_windows_amd64.exe
     - &get-base-image |
       if ($env:WIN_VERSION -eq "2019") {

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,7 +110,8 @@ fossa:
 .trigger-filter:
   only:
     variables:
-      - $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "fips_windows_image"
+      - $CI_COMMIT_BRANCH == "main"
+      - $CI_COMMIT_BRANCH == "fips_windows_image"
       - $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
   except:
     - schedules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -933,7 +933,6 @@ build-push-windows-image:
   parallel:
     matrix:
       - WIN_VERSION: ["2019", "2022"]
-        FIPS: ["-fips", ""]
   dependencies:
     - sign-exe
     - agent-bundle-windows
@@ -943,7 +942,7 @@ build-push-windows-image:
   variables:
     ErrorActionPreference: stop
   before_script:
-    - Copy-Item .\dist\signed\otelcol${FIPS}_windows_amd64.exe .\cmd\otelcol\otelcol.exe
+    - Copy-Item .\dist\signed\otelcol_windows_amd64.exe .\cmd\otelcol\otelcol.exe
     - Copy-Item .\dist\agent-bundle_windows_amd64.zip .\cmd\otelcol\agent-bundle_windows_amd64.zip
     - &get-base-image |
       if ($env:WIN_VERSION -eq "2019") {
@@ -970,13 +969,13 @@ build-push-windows-image:
     - |
       # Set env vars
       if ($env:CI_COMMIT_TAG) {
-        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector${FIPS}"
-        $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector${FIPS}-windows"
+        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector"
+        $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows"
         $tagNumber = $env:CI_COMMIT_TAG.TrimStart("v")
         $IMAGE_TAG = "${tagNumber}-${env:WIN_VERSION}"
       } else {
-        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector${FIPS}-dev"
-        $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector${FIPS}-windows-dev"
+        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-dev"
+        $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows-dev"
         $IMAGE_TAG = "${env:CI_COMMIT_SHA}-${env:WIN_VERSION}"
       }
       $LATEST_TAG = ""
@@ -1059,7 +1058,7 @@ build-push-windows-image:
       }
     - echo "${IMAGE_NAME}:${IMAGE_TAG}" > tags
     - echo "${OLD_IMAGE_NAME}:${IMAGE_TAG}" >> tags
-    - (Get-Content -Raw -Path tags) -replace "`r`n", "`n"| Set-Content -NoNewline tags_to_sign_${env:WIN_VERSION}${env:FIPS}
+    - (Get-Content -Raw -Path tags) -replace "`r`n", "`n"| Set-Content -NoNewline tags_to_sign_${env:WIN_VERSION}
   after_script:
     - *get-base-image
     - *delete-all-images-except-base
@@ -1070,7 +1069,149 @@ build-push-windows-image:
       }
   artifacts:
     paths:
-      - tags_to_sign_${WIN_VERSION}${FIPS}
+      - tags_to_sign_${WIN_VERSION}
+
+build-push-windows-fips-image:
+  extends: .trigger-filter
+  stage: release
+  parallel:
+    matrix:
+      - WIN_VERSION: ["2019", "2022"]
+  dependencies:
+    - sign-exe
+  tags:
+    - splunk-otel-collector-windows${WIN_VERSION}
+  retry: 2
+  variables:
+    ErrorActionPreference: stop
+  before_script:
+    - Copy-Item .\dist\signed\otelcol-fips_windows_amd64.exe .\cmd\otelcol\otelcol.exe
+    - &get-base-image |
+      if ($env:WIN_VERSION -eq "2019") {
+        $BASE_IMAGE = $env:WIN_2019_BASE_IMAGE
+      } else {
+        $BASE_IMAGE = $env:WIN_2022_BASE_IMAGE
+      }
+    - |
+      docker pull $BASE_IMAGE
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - &delete-all-images-except-base |
+      # Delete all images except the base image
+      $base_id = $(docker images -q $BASE_IMAGE)
+      foreach ($id in $(docker images -a -q | Get-Unique)) {
+        if ($id -ne $base_id) {
+          docker rmi -f $id
+        }
+      }
+    - docker system prune --force
+  script:
+    - |
+      docker login -u $env:CIRCLECI_QUAY_USERNAME -p $env:CIRCLECI_QUAY_PASSWORD quay.io
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - |
+      # Set env vars
+      if ($env:CI_COMMIT_TAG) {
+        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-fips"
+        $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-fips-windows"
+        $tagNumber = $env:CI_COMMIT_TAG.TrimStart("v")
+        $IMAGE_TAG = "${tagNumber}-${env:WIN_VERSION}"
+      } else {
+        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-fips-dev"
+        $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-fips-windows-dev"
+        $IMAGE_TAG = "${env:CI_COMMIT_SHA}-${env:WIN_VERSION}"
+      }
+      $LATEST_TAG = ""
+      if ($env:CI_COMMIT_BRANCH -eq "main" -or $env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$') {
+        # Only push latest tag for main and stable releases
+        $LATEST_TAG = "latest-${env:WIN_VERSION}"
+      }
+    - $JMX_METRIC_GATHERER_RELEASE = $(Get-Content packaging\jmx-metric-gatherer-release.txt)
+    - |
+      echo "Building ${IMAGE_NAME}:${IMAGE_TAG}"
+      docker build -t ${IMAGE_NAME}:${IMAGE_TAG} --build-arg BASE_IMAGE=${BASE_IMAGE} --build-arg JMX_METRIC_GATHERER_RELEASE=${JMX_METRIC_GATHERER_RELEASE} -f .\cmd\otelcol\fips\Dockerfile.windows .\cmd\otelcol\
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - |
+      echo "Pushing ${IMAGE_NAME}:${IMAGE_TAG}"
+      docker push ${IMAGE_NAME}:${IMAGE_TAG}
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - |
+      # DEPRECATED: Push image to the windows repo
+      echo "Tagging and pushing ${OLD_IMAGE_NAME}:${IMAGE_TAG}"
+      docker tag ${IMAGE_NAME}:${IMAGE_TAG} ${OLD_IMAGE_NAME}:${IMAGE_TAG}
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+      docker push ${OLD_IMAGE_NAME}:${IMAGE_TAG}
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - |
+      echo "Getting os.version from ${BASE_IMAGE}"
+      $os_version = (docker manifest inspect $BASE_IMAGE | ConvertFrom-Json).manifests[0].platform."os.version"
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+      echo "$os_version"
+    - |
+      echo "Creating and pushing ${IMAGE_NAME}:${IMAGE_TAG} manifest"
+      docker manifest rm ${IMAGE_NAME}:${IMAGE_TAG}
+      docker manifest create ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:${IMAGE_TAG}
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+      docker manifest annotate --os "windows" --arch "amd64" --os-version ${os_version} ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:${IMAGE_TAG}
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+      docker manifest push ${IMAGE_NAME}:${IMAGE_TAG} --purge
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - |
+      # DEPRECATED: Push manifest to the windows repo
+      echo "Creating and pushing ${OLD_IMAGE_NAME}:${IMAGE_TAG} manifest"
+      docker manifest rm ${OLD_IMAGE_NAME}:${IMAGE_TAG}
+      docker manifest create ${OLD_IMAGE_NAME}:${IMAGE_TAG} ${OLD_IMAGE_NAME}:${IMAGE_TAG}
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+      docker manifest annotate --os "windows" --arch "amd64" --os-version ${os_version} ${OLD_IMAGE_NAME}:${IMAGE_TAG} ${OLD_IMAGE_NAME}:${IMAGE_TAG}
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+      docker manifest push ${OLD_IMAGE_NAME}:${IMAGE_TAG} --purge
+      if ($LASTEXITCODE -ne 0) { exit 1 }
+    - |
+      if ($LATEST_TAG) {
+        echo "Tagging and pushing ${IMAGE_NAME}:${LATEST_TAG}"
+        docker tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        docker push ${IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        echo "Creating and pushing ${IMAGE_NAME}:${LATEST_TAG} manifest"
+        docker manifest rm ${IMAGE_NAME}:${LATEST_TAG}
+        docker manifest create ${IMAGE_NAME}:${LATEST_TAG} ${IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        docker manifest annotate --os "windows" --arch "amd64" --os-version ${os_version} ${IMAGE_NAME}:${LATEST_TAG} ${IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        docker manifest push ${IMAGE_NAME}:${LATEST_TAG} --purge
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+      }
+    - |
+      # DEPRECATED: Push latest tag to the windows repo
+      if ($LATEST_TAG) {
+        echo "Tagging and pushing ${OLD_IMAGE_NAME}:${LATEST_TAG}"
+        docker tag ${OLD_IMAGE_NAME}:${IMAGE_TAG} ${OLD_IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        docker push ${OLD_IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        echo "Creating and pushing ${OLD_IMAGE_NAME}:${LATEST_TAG} manifest"
+        docker manifest rm ${OLD_IMAGE_NAME}:${LATEST_TAG}
+        docker manifest create ${OLD_IMAGE_NAME}:${LATEST_TAG} ${OLD_IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        docker manifest annotate --os "windows" --arch "amd64" --os-version ${os_version} ${OLD_IMAGE_NAME}:${LATEST_TAG} ${OLD_IMAGE_NAME}:${LATEST_TAG}
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        docker manifest push ${OLD_IMAGE_NAME}:${LATEST_TAG} --purge
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+      }
+    - echo "${IMAGE_NAME}:${IMAGE_TAG}" > tags
+    - echo "${OLD_IMAGE_NAME}:${IMAGE_TAG}" >> tags
+    - (Get-Content -Raw -Path tags) -replace "`r`n", "`n"| Set-Content -NoNewline tags_to_sign_${env:WIN_VERSION}fips
+  after_script:
+    - *get-base-image
+    - *delete-all-images-except-base
+    - docker system prune --force
+    - |
+      if (Test-Path -Path C:\Users\Administrator\Desktop\ops-scripts\docker-leak-check.exe) {
+        C:\Users\Administrator\Desktop\ops-scripts\docker-leak-check.exe -remove
+      }
+  artifacts:
+    paths:
+      - tags_to_sign_${WIN_VERSION}-fips
 
 sign-windows-image:
   extends: .sign-docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
                   port: 8888
   ```
   This also removes a warning about deprecated `service::telemetry::metrics::address`.
+- (Splunk) Publish a FIPS-140 compliant Docker [images](https://quay.io/repository/signalfx/splunk-otel-collector-fips?tab=tags) and binaries for Linux and Windows. ([#5725](https://github.com/signalfx/splunk-otel-collector/pull/5725))
 - (Core) `exporterqueue`: Introduce a feature gate exporter.UsePullingBasedExporterQueueBatcher to use the new pulling model in exporter queue batching. ([#8122](https://github.com/open-telemetry/opentelemetry-collector/pull/8122), [#10368](https://github.com/open-telemetry/opentelemetry-collector/pull/10368))
   If both queuing and batching is enabled for exporter, we now use a pulling model instead of a
   pushing model. num_consumer in queue configuration is now used to specify the maximum number of


### PR DESCRIPTION
This PR changes the way we build internally to produce a Windows FIPS docker image, signed and combined with the Linux FIPS images with a multiarch tag.

Here is the result of the run:
* Windows FIPS image: https://quay.io/repository/signalfx/splunk-otel-collector-fips-windows-dev/manifest/sha256:fba0c70c4b1fb743ec319cf5d871464d0d8de84b506fd2f646161ff6ebc41cb1
* Linux FIPS image: https://quay.io/repository/signalfx/splunk-otel-collector-fips-dev/manifest/sha256:1f3a69d1dda9de055d8250d6a15e127080f595874a2b3fd311f6d032497be1c8
