### PR TITLE
Add the purefa receiver from contrib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🚀 New components 🚀
 
 - (Splunk) Add `snowflake` receiver ([#5724](https://github.com/signalfx/splunk-otel-collector/pull/5724))
+- (Splunk) Add `purefa` receiver ([#5731](https://github.com/signalfx/splunk-otel-collector/pull/5731))
 
 ## v0.115.0
 
@@ -24,7 +25,6 @@
 - (Splunk) Add `filestats` receiver ([#5229](https://github.com/signalfx/splunk-otel-collector/pull/5229))
 - (Splunk) Add `iis` receiver ([#5717](https://github.com/signalfx/splunk-otel-collector/pull/5717))
 - (Splunk) Add `bearertokenauth` extension ([#5727](https://github.com/signalfx/splunk-otel-collector/pull/5727))
-- (Splunk) Add `purefa` receiver ([#5731](https://github.com/signalfx/splunk-otel-collector/pull/5731))
 
 ### 💡 Enhancements 💡
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - (Splunk) Add `filestats` receiver ([#5229](https://github.com/signalfx/splunk-otel-collector/pull/5229))
 - (Splunk) Add `iis` receiver ([#5717](https://github.com/signalfx/splunk-otel-collector/pull/5717))
 - (Splunk) Add `bearertokenauth` extension ([#5727](https://github.com/signalfx/splunk-otel-collector/pull/5727))
+- (Splunk) Add `purefa` receiver ([#5731](https://github.com/signalfx/splunk-otel-collector/pull/5731))
 
 ### 💡 Enhancements 💡
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -55,6 +55,7 @@ The distribution offers support for the following components.
 | [postgresql](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/postgresqlreceiver)                                              | [beta]           |
 | [prometheus](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)                                              | [beta]           |
 | [prometheus_simple](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/simpleprometheusreceiver)                                 | [beta]           |
+| [purefa](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/purefareceiver)                                                      | [alpha]           |
 | [rabbitmq](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/rabbitmqreceiver)                                                  | [beta]           |
 | [receiver_creator](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/receivercreator)                                           | [beta]           |
 | [redis](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/redisreceiver)                                                        | [beta]           |

--- a/docs/components.md
+++ b/docs/components.md
@@ -55,7 +55,7 @@ The distribution offers support for the following components.
 | [postgresql](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/postgresqlreceiver)                                              | [beta]           |
 | [prometheus](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)                                              | [beta]           |
 | [prometheus_simple](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/simpleprometheusreceiver)                                 | [beta]           |
-| [purefa](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/purefareceiver)                                                      | [alpha]           |
+| [purefa](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/purefareceiver)                                                      | [alpha]          |
 | [rabbitmq](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/rabbitmqreceiver)                                                  | [beta]           |
 | [receiver_creator](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/receivercreator)                                           | [beta]           |
 | [redis](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/redisreceiver)                                                        | [beta]           |

--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver v0.115.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.115.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.115.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver v0.115.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver v0.115.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator v0.115.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver v0.115.0

--- a/go.sum
+++ b/go.sum
@@ -1475,6 +1475,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlrec
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.115.0/go.mod h1:Hm48Djy2wSY2f7/MiO1Pqx+z2PgBtTkratthdCo9Keg=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.115.0 h1:GIyMUiud3T8nyCJP9KVhxVKvfcNQRBCde5uTCl6K/i0=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.115.0/go.mod h1:x4hCznyUolxGt5cE/uXWRCckdIDrUYqH5hJddvdKZd4=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver v0.115.0 h1:zm9t0eh0re28NdIugHWWeikPnYHALtIYm/NtWNJ69pw=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver v0.115.0/go.mod h1:LIN46f0w8Qq1zepf8/HCMIFNjxMqIWbrDamTbeqeE6I=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver v0.115.0 h1:Z/oZB+2i6yhFVJfdfwHLRtmu1gwnPPDLR2S2D9amklc=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver v0.115.0/go.mod h1:HHG6YOBUjzg4BRHpWXMDsFFvxDG9PpnoNBnZrSMBCy4=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator v0.115.0 h1:Di0uc2QvwEVrq1PEReZ34FpPuo1z5QhHmT0bvdTe0DU=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -93,6 +93,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver"
@@ -208,6 +209,7 @@ func Get() (otelcol.Factories, error) {
 		otlpreceiver.NewFactory(),
 		postgresqlreceiver.NewFactory(),
 		prometheusreceiver.NewFactory(),
+		purefareceiver.NewFactory(),
 		rabbitmqreceiver.NewFactory(),
 		receivercreator.NewFactory(),
 		redisreceiver.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -86,6 +86,7 @@ func TestDefaultComponents(t *testing.T) {
 		"postgresql",
 		"prometheus",
 		"prometheus_simple",
+		"purefa",
 		"rabbitmq",
 		"receiver_creator",
 		"redis",


### PR DESCRIPTION
HI!

This PR is to add the purefa receiver from contrib.

Pure Storage is a Splunk Partner with mutual customers who are looking to get their Pure Storage FlashArray Data into Splunk IM using the Splunk OTel Collector.