### PR TITLE
[chore] Running lint on Windows

### DIFF
--- a/pkg/extension/smartagentextension/config_windows_test.go
+++ b/pkg/extension/smartagentextension/config_windows_test.go
@@ -40,6 +40,7 @@ func TestBundleDirDefault(t *testing.T) {
 	err = cm.Unmarshal(&emptyConfig)
 	require.NoError(t, err)
 
+	factory := NewFactory()
 	ext, err := factory.Create(context.Background(), extension.Settings{}, emptyConfig)
 	require.NoError(t, err)
 	require.NotNil(t, ext)

--- a/tests/internal/discoverytest/discoverytest.go
+++ b/tests/internal/discoverytest/discoverytest.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
+
 package discoverytest
 
 import (

--- a/tests/msi/msi_test.go
+++ b/tests/msi/msi_test.go
@@ -166,9 +166,9 @@ func runMsiTest(t *testing.T, test msiTest, msiInstallerPath string) {
 			// Uninstall the MSI
 			uninstallCmd := exec.Command("msiexec")
 			uninstallCmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: "msiexec /x " + msiInstallerPath + " /qn"}
-			err := uninstallCmd.Run()
+			errUninstallCmd := uninstallCmd.Run()
 			t.Logf("Uninstall command: %s", uninstallCmd.SysProcAttr.CmdLine)
-			require.NoError(t, err, "Failed to uninstall the MSI: %v", err)
+			require.NoError(t, errUninstallCmd, "Failed to uninstall the MSI: %v", errUninstallCmd)
 		}()
 	}
 


### PR DESCRIPTION
Nothing serious here, but, indication that there is no CI running pkg/extension/smartagentextension tests on Windows. Anyway, just detected issues on test code.