### PR TITLE
[chore] Upgrade CI workers for ansible tests

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -36,8 +36,7 @@ jobs:
 
   lint:
     name: Lint
-    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v4
@@ -56,8 +55,8 @@ jobs:
   linux-test:
     name: Linux Test
     needs: lint
-    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
-    runs-on: ubuntu-20.04
+    # Use ubuntu-20.04.5 for containers with cgroups v1. Otherwise, use ubuntu-24.04 (cgroups v2).
+    runs-on: ${{ fromJSON('["ubuntu-24.04", "ubuntu-20.04"]')[contains(fromJSON('["amazonlinux2", "centos9", "opensuse12", "ubuntu1604"]'), matrix.distro)] }}
     strategy:
       fail-fast: false
       matrix:
@@ -196,8 +195,7 @@ jobs:
   push-release-tag:
     name: Push Release Tag
     needs: lint
-    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/main' 
     steps:
       - name: Checkout

--- a/deployments/ansible/molecule/config/docker.yml
+++ b/deployments/ansible/molecule/config/docker.yml
@@ -14,7 +14,7 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
-    cgroupns: host
+    cgroupns_mode: host
     pre_build_image: false
 
 provisioner:


### PR DESCRIPTION
Migrating CI runners from Ubuntu 20.04 to Ubuntu 24.04 means that the host VM for Ansible tests is switched from cgroups v1 to cgroups v2. This is a significant difference because we use docker containers to run Ansible Molecule tests connected to cgroups on the host VM. Making cgroups v1 OSs work in docker containers on a host with groups v2 appeared to be not possible based on my trials. 

I also tried to migrate to the full VM virtualization, from Docker to Vagrant. This made some particular VM boxes fail and increased test run time by 50%.

Eventually, I kept the old Ubuntu 20.04 workers to test OSs with groups v1 and the latest Ubuntu 24.04 to test OSs with groups v2. Once the old VMs are EOL'd, we can drop Ubuntu 20.04 workers.