### PR TITLE
Add metricsgeneration processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🚀 New components 🚀
 
-- (Splunk) Add `metricsgeneration` processor ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
+- (Splunk) Add `metricsgeneration` processor ([#5769](https://github.com/signalfx/splunk-otel-collector/pull/5769))
 
 ## v0.116.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🚀 New components 🚀
+
+- (Splunk) Add `metricsgeneration` processor ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
+
 ## v0.116.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.116.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.116.0) and the [opentelemetry-collector-contrib v0.116.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.116.0) releases where appropriate.

--- a/docs/components.md
+++ b/docs/components.md
@@ -87,7 +87,7 @@ The distribution offers support for the following components.
 <div>
 
 | Processors                                                                                                                                   | Stability        |
-|:---------------------------------------------------------------------------------------------------------------------------------------------| :--------------- |
+|:---------------------------------------------------------------------------------------------------------------------------------------------|:-----------------|
 | [attributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor)                      | [alpha]          |
 | [batch](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor)                                        | [beta]           |
 | [cumulativetodelta](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor)        | [beta]           |
@@ -96,6 +96,7 @@ The distribution offers support for the following components.
 | [k8sattributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor)                | [beta]           |
 | [logstransform](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/logstransformprocessor)                | [in development] |
 | [memory_limiter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor)                       | [beta]           |
+| [metricsgeneration](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricsgenerationprocessor)        | [alpha]          |
 | [metricstransform](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)          | [beta]           |
 | [probabilistic_sampler](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/probabilisticsamplerprocessor) | [beta]           |
 | [redaction](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor)                        | [beta]           |

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor v0.117.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.117.0

--- a/go.sum
+++ b/go.sum
@@ -1379,6 +1379,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattribute
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.117.0/go.mod h1:vVVMWo0MjnkVkoeCFFVRPtwqtkklk+vRwkcO7dqzmFk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor v0.117.0 h1:zzHnjIZq84TToeraeEJf+l1fC7A4bcOGenrjpASvM/0=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor v0.117.0/go.mod h1:Nu/TVuBir6nX01bxXakiFvjOU2g93erDQxQYy9eZArs=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor v0.117.0 h1:ehBehcndmTdABReipk/1bJLWHFA0yh1Iwh4gzdJY8IA=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor v0.117.0/go.mod h1:fcZAQazyfeE3i/nLfN9uztjb2kzYDrX0HU5S6iidcTM=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.117.0 h1:d6UTgSQc34kEK6Hqf8IMSV5IQiXnwvXj4sbrDOfLGJw=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.117.0/go.mod h1:jW64G556FOb8iCXqgRFgtr/8EwA6b/6+BbzGO61Fva0=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.117.0 h1:dtZxvyO1/xLS4XNLoLX8/3M3j09dU6u6P8Glz5yBE1g=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -48,6 +48,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor"
@@ -268,6 +269,7 @@ func Get() (otelcol.Factories, error) {
 		k8sattributesprocessor.NewFactory(),
 		logstransformprocessor.NewFactory(),
 		memorylimiterprocessor.NewFactory(),
+		metricsgenerationprocessor.NewFactory(),
 		metricstransformprocessor.NewFactory(),
 		probabilisticsamplerprocessor.NewFactory(),
 		redactionprocessor.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -121,6 +121,7 @@ func TestDefaultComponents(t *testing.T) {
 		"k8sattributes",
 		"logstransform",
 		"memory_limiter",
+		"metricsgeneration",
 		"metricstransform",
 		"probabilistic_sampler",
 		"redaction",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This processor has functionality that is required to be able to remove the SignalFx exporter's translation rules