### PR TITLE
Fix includeconfigsource handling of multiple file writes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -705,5 +705,3 @@ replace github.com/pires/go-proxyproto v1.0.0 => github.com/peteski22/go-proxypr
 
 // github.com/veraison/go-cose v1.2.0 doesn't exists but required by the latest github.com/Microsoft/hcsshim
 replace github.com/veraison/go-cose v1.2.0 => github.com/veraison/go-cose v1.1.1
-
-replace github.com/fsnotify/fsnotify v1.8.0 => github.com/fsnotify/fsnotify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -494,8 +494,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
-github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=

--- a/internal/configsource/includeconfigsource/package_test.go
+++ b/internal/configsource/includeconfigsource/package_test.go
@@ -1,0 +1,25 @@
+// Copyright  Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package includeconfigsource
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/configsource/includeconfigsource/source.go
+++ b/internal/configsource/includeconfigsource/source.go
@@ -109,7 +109,6 @@ func (is *includeConfigSource) watchFile(file string, watcherFunc confmap.Watche
 					}
 					if event.Op&fsnotify.Write == fsnotify.Write {
 						watcherFunc(&confmap.ChangeEvent{Error: nil})
-						return
 					}
 				case watcherErr, ok := <-is.watcher.Errors:
 					if !ok {


### PR DESCRIPTION
**Description:**
This was noticed while investigating failures to upgrade fsnotify, see https://splunk.atlassian.net/browse/OTL-3177

The `TestIncludeConfigSource_WatchFileUpdate` was deadlocking because a goroutine that empties the fsnotify event channel was bailing out on first write operation. The test deadlocked on trying to write another file event. The fixes on fsnotify for Windows file watching made surfaced the issue because prior to that it was really not listening to changes on the file.

In practice, the deadlock was an artifact from the test, on production, depending on the config source usage it meant that only the first file change was notified.

Test deadlock, for the record:
```terminal
=== RUN   TestIncludeConfigSource_WatchFileUpdate
panic: test timed out after 30s
        running tests:
                TestIncludeConfigSource_WatchFileUpdate (30s)

goroutine 18 [running]:
testing.(*M).startAlarm.func1()
        C:/Program Files/Go/src/testing/testing.go:2373 +0x385
created by time.goFunc
        C:/Program Files/Go/src/time/sleep.go:215 +0x2d

goroutine 1 [chan receive]:
testing.(*T).Run(0xc0000fd6c0, {0x111991c?, 0x7ffe42a30e70?}, 0x114a648)
        C:/Program Files/Go/src/testing/testing.go:1751 +0x392
testing.runTests.func1(0xc0000fd6c0)
        C:/Program Files/Go/src/testing/testing.go:2168 +0x37
testing.tRunner(0xc0000fd6c0, 0xc0001d1c70)
        C:/Program Files/Go/src/testing/testing.go:1690 +0xcb
testing.runTests(0xc000008828, {0x169af60, 0x7, 0x7}, {0x9f3070?, 0x9f2cda?, 0x16a9040?})
        C:/Program Files/Go/src/testing/testing.go:2166 +0x43d
testing.(*M).Run(0xc0001acbe0)
        C:/Program Files/Go/src/testing/testing.go:2034 +0x64a
main.main()
        _testmain.go:57 +0x9b

goroutine 7 [chan receive]:
github.com/fsnotify/fsnotify.(*readDirChangesW).Remove(0xc0000a3600, {0xc00003aa80, 0x6a})
        C:/Users/pjanotti/go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/backend_windows.go:162 +0x20e
github.com/fsnotify/fsnotify.(*Watcher).Remove(...)
        C:/Users/pjanotti/go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/fsnotify.go:332
github.com/signalfx/splunk-otel-collector/internal/configsource/includeconfigsource.(*includeConfigSource).watchFile.func2({0x11f97c0?, 0xc0000fd860?})
        c:/src/sfx/splunk-otel-collector/internal/configsource/includeconfigsource/source.go:133 +0x30
go.opentelemetry.io/collector/confmap.(*Retrieved).Close(...)
        C:/Users/pjanotti/go/pkg/mod/go.opentelemetry.io/collector/confmap@v1.23.0/provider.go:228
github.com/signalfx/splunk-otel-collector/internal/configsource/includeconfigsource.TestIncludeConfigSource_WatchFileUpdate(0xc0000fd860)
        c:/src/sfx/splunk-otel-collector/internal/configsource/includeconfigsource/source_test.go:145 +0x409
testing.tRunner(0xc0000fd860, 0x114a648)
        C:/Program Files/Go/src/testing/testing.go:1690 +0xcb
created by testing.(*T).Run in goroutine 1
        C:/Program Files/Go/src/testing/testing.go:1743 +0x377

goroutine 8 [select, locked to thread]:
github.com/fsnotify/fsnotify.(*readDirChangesW).sendEvent(0xc0000a3600, {0xc000112180?, 0xc000114030?}, {0x0?, 0xffffffff?}, 0x0?)
        C:/Users/pjanotti/go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/backend_windows.go:72 +0x176
github.com/fsnotify/fsnotify.(*readDirChangesW).readEvents(0xc0000a3600)
        C:/Users/pjanotti/go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/backend_windows.go:612 +0xb96
created by github.com/fsnotify/fsnotify.newBufferedBackend in goroutine 7
        C:/Users/pjanotti/go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/backend_windows.go:55 +0x198
FAIL    github.com/signalfx/splunk-otel-collector/internal/configsource/includeconfigsource     30.854s
```