### PR TITLE
[Tanzu Tile] Add host.name resource attribute

### DIFF
--- a/deployments/cloudfoundry/bosh/DEVELOPMENT.md
+++ b/deployments/cloudfoundry/bosh/DEVELOPMENT.md
@@ -81,6 +81,7 @@ If no configuration file is provided, a template file will be populated using th
 
 Required Properties:
 
+- `cloudfoundry.deployment.hostname`
 - `cloudfoundry.rlp_gateway.endpoint`
 - `cloudfoundry.uaa.endpoint`
 - `cloudfoundry.uaa.password`

--- a/deployments/cloudfoundry/bosh/jobs/splunk-otel-collector/spec
+++ b/deployments/cloudfoundry/bosh/jobs/splunk-otel-collector/spec
@@ -82,6 +82,9 @@ properties:
         description: "The Splunk realm in which your organization resides -- used to derive splunk.ingest_url and splunk.api_url if those are not provided"
         required: false
 
+    cloudfoundry.director.hostname:
+        description: "The hostname of the Cloud Foundry BOSH director"
+
     cloudfoundry.rlp_gateway.endpoint:
         description: "The URL of the RLP Gateway that acts as a proxy for the firehose"
 

--- a/deployments/cloudfoundry/bosh/jobs/splunk-otel-collector/templates/otel-collector-config.yaml.erb
+++ b/deployments/cloudfoundry/bosh/jobs/splunk-otel-collector/templates/otel-collector-config.yaml.erb
@@ -23,8 +23,11 @@ receivers:
         <% end %>
 
 processors:
-  resourcedetection:
-    detectors: [system]
+  resource:
+    attributes:
+    - key: host.name
+      value: <%= p('cloudfoundry.director.hostname') %>
+      action: upsert
 
 exporters:
   signalfx:
@@ -43,6 +46,6 @@ service:
   pipelines:
     metrics:
       receivers: [cloudfoundry]
-      processors: [resourcedetection]
+      processors: [resource]
       exporters: [signalfx]
 <% end %>

--- a/deployments/cloudfoundry/tile/tile.yml
+++ b/deployments/cloudfoundry/tile/tile.yml
@@ -33,6 +33,8 @@ packages:
             release: splunk-otel-collector
         properties:
           cloudfoundry:
+            director:
+              hostname: (( $director.hostname ))
             rlp_gateway:
               endpoint: https://log-stream.(( ..cf.cloud_controller.system_domain.value ))
               shard_id: (( .properties.cloudfoundry_rlp_gateway_shard_id.value ))


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The `host.name` resource attribute should come from the Tanzu environment, not the environment in which the collector itself is running.

**Note:**
No changelog here because this won't have any impact until a new Tanzu Tile release is created.

**Testing:** <Describe what testing was performed and which tests were added.>
Tested on TAS 10.0 and TAS 6.0. Working as expected. The `host.name` is populated as the IP address of the BOSH director.