### PR TITLE
[draft] [chef] Upgrade CI workers for chef tests

### DIFF
--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -32,8 +32,7 @@ env:
 jobs:
   chef-lint-spec-test:
     name: chef-lint-spec-test
-    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v4
@@ -46,7 +45,7 @@ jobs:
           make rake-spec
 
   chef-kitchen-matrix:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -80,8 +79,7 @@ jobs:
       win-matrix: ${{ steps.get-win-matrix.outputs.matrix }}
 
   chef-kitchen-linux:
-    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [chef-lint-spec-test, chef-kitchen-matrix]
     strategy:
       matrix: ${{ fromJSON(needs.chef-kitchen-matrix.outputs.linux-matrix) }}

--- a/.github/workflows/chef.yml
+++ b/.github/workflows/chef.yml
@@ -17,8 +17,7 @@ permissions:
 jobs:
   push-release-tag:
     name: Push Release Tag
-    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout

--- a/deployments/chef/kitchen.yml
+++ b/deployments/chef/kitchen.yml
@@ -21,11 +21,6 @@ verifier:
   name: inspec
 
 platforms:
-  - name: amazonlinux-2
-    driver:
-      image: dokken/amazonlinux-2
-      pid_one_command: /usr/lib/systemd/systemd
-
   - name: centos-9
     driver:
       image: dokken/centos-stream-9
@@ -51,33 +46,9 @@ platforms:
       image: dokken/debian-12
       pid_one_command: /bin/systemd
 
-  - name: opensuse-12
-    driver:
-      image: opensuse/leap:42
-      intermediate_instructions: |
-        ENV container docker
-        RUN sed -i 's|download.opensuse.org|ftp5.gwdg.de/pub/opensuse/discontinued|' /etc/zypp/repos.d/*.repo
-        RUN zypper -n clean && zypper -n refresh
-        RUN zypper -n install -l curl procps dbus-1 systemd-sysvinit tar wget hostname sudo
-        RUN (cd /usr/lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
-            "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
-            rm -f /usr/lib/systemd/system/multi-user.target.wants/*;\
-            rm -f /usr/lib/systemd/system/local-fs.target.wants/*; \
-            rm -f /usr/lib/systemd/system/sockets.target.wants/*udev*; \
-            rm -f /usr/lib/systemd/system/sockets.target.wants/*initctl*; \
-            rm -f /usr/lib/systemd/system/basic.target.wants/*;\
-            rm -f /usr/lib/systemd/system/anaconda.target.wants/*;
-        ENV init /sbin/init
-      pid_one_command: /sbin/init
-
   - name: opensuse-15
     driver:
       image: dokken/opensuse-leap-15
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: oraclelinux-7
-    driver:
-      image: dokken/oraclelinux-7
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: oraclelinux-8


### PR DESCRIPTION
The tests for old systems (amazonlinux-2, opensuse-12, oraclelinux-7) are removed. Newer versions of Chef v18.x+ come with ruby 3.1, which requires glibc 2.28. The removed systems go with glibc 2.26. We could've tested them with an old Chef version 17.x, but it has reached EOL.
