### PR TITLE
[chore] Fix deprecation warning for multiline config source calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - (Splunk) Add a new discovery bundle for Envoy proxy metrics ([#5780](https://github.com/signalfx/splunk-otel-collector/pull/5780))
 
+### 🧰 Bug fixes 🧰
+
+- (Splunk) Fix deprecation warning for multiline config source calls ([#5829](https://github.com/signalfx/splunk-otel-collector/pull/5829))
+
 ## v0.116.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.116.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.116.0) and the [opentelemetry-collector-contrib v0.116.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.116.0) releases where appropriate.

--- a/internal/configsource/source.go
+++ b/internal/configsource/source.go
@@ -368,10 +368,18 @@ func resolveStringValue(ctx context.Context, configSources map[string]ConfigSour
 					}
 				default:
 					if deprecatedFormUsed {
-						printDeprecationWarningOnce(fmt.Sprintf(
-							"[WARNING] Config source expansion formatted as $uri:selector has been deprecated, "+
-								"use ${uri:selector[?params]} instead. Please replace $%s with ${%s} in your configuration",
-							expandableContent, expandableContent))
+						if strings.Contains(expandableContent, "\n") {
+							printDeprecationWarningOnce(fmt.Sprintf(
+								"[WARNING] Calling config sources in multiline format is deprecated. "+
+									"Please convert the following call to the one-line format ${uri:selector?param1"+
+									"=value1,param2=value2}:\n %s",
+								expandableContent))
+						} else {
+							printDeprecationWarningOnce(fmt.Sprintf(
+								"[WARNING] Config source expansion formatted as $uri:selector has been deprecated, "+
+									"use ${uri:selector[?params]} instead. Please replace $%s with ${%s} in your configuration",
+								expandableContent, expandableContent))
+						}
 					}
 				}
 			}


### PR DESCRIPTION
There is a deprecation for bare config source calls. `${source:value[?params]}` should be used instead of `$source:value[?params]`. 

It's also applied to multiline config source calls. One-line format like `${source:value?param1=val1,param2=val2}` should be used instead of multiline calls with a bare reference to a config source like the following DEPRECATED call:
```
config_field: |
  $source: value
  param1: val1
  param2: val2
```

 However, the deprecation warning is broken. This change fixes that. So instead of 
```
[WARNING] Config source expansion formatted as $uri:selector has been deprecated, use ${uri:selector[?params]} instead. Please replace $include: /Users/danoshin/Projects/otel-configs/memory-limiter.yaml
watch_files: true
 with ${include: /Users/danoshin/Projects/otel-configs/memory-limiter.yaml
watch_files: true
} in your configuration
```

users will see 
```
[WARNING] Calling config sources in multiline format is deprecated. Please convert the following call to the one-line format ${uri:selector?param1=value1,param2=value2}:
 include: /Users/danoshin/Projects/otel-configs/memory-limiter.yaml
watch_files: true
```

One-line deprecation warnings stay as is.