### PR TITLE
Stop supporting deprecated syntax for config source expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- (Splunk) Stop supporting deprecated syntax for config source expansion ([#5832](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5832))
+  Use the following guidelines to update your configuration:
+  - `$ENV` must be replaced with `${env:ENV}`
+  - `$include:file_path` must be replaced with `${include:file_path}`. The same applied for any other config source.
+    More information can be found in ([the upgrade guidelines](https://github.com/signalfx/splunk-otel-collector?tab=readme-ov-file#from-01170-to-01180)).
+
 ## v0.117.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.117.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.117.0) and the [opentelemetry-collector-contrib v0.117.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.117.0) releases where appropriate.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,16 @@ manually before the backward compatibility is dropped. For every configuration u
 [the default agent config](https://github.com/signalfx/splunk-otel-collector/blob/main/cmd/otelcol/config/collector/agent_config.yaml)
 as a reference.
 
+### From 0.117.0 to 0.118.0
+
+- The deprecated syntax for config source expansion is no longer supported. 
+
+  Strings like `$ENV` or `$include:/path/to/file.yaml` will no longer be expanded. Instead, use the
+  `${env:ENV}` or `${include:/path/to/file.yaml}` syntax. There are only two symbols allowed after `$`: `{` and `$`.
+  The collector will log an error and fail to start if it encounters a bare config source.
+
+  Please update your configuration files to use the correct syntax.
+
 ### From 0.114.0 to 0.115.0
 
 -  The sapm exporter still works as before but has been deprecated. Use the otlphttp exporter instead

--- a/internal/configsource/includeconfigsource/README.md
+++ b/internal/configsource/includeconfigsource/README.md
@@ -99,10 +99,7 @@ components:
   # component_0 is built from the ./templates/component_template file
   # according to the template parameters and commands. The example below
   # defines a few parameters to be used by the template.
-  component_0: |
-    $include: ./templates/component_template
-    my_glob_pattern: /var/**/*.log
-    my_format: json
+  component_0: ${include:./templates/component_template?my_glob_pattern=/var/**/*.log&my_format=json}
 ```
 
 The effective configuration will be:

--- a/internal/configsource/testdata/arrays_and_maps.yaml
+++ b/internal/configsource/testdata/arrays_and_maps.yaml
@@ -1,12 +1,12 @@
 top0:
   array0:
-    - $tstcfgsrc:elem0
-    - $tstcfgsrc:elem1
+    - ${tstcfgsrc:elem0}
+    - ${tstcfgsrc:elem1}
   array1:
     - entry:
-        str: $tstcfgsrc:elem0
+        str: ${tstcfgsrc:elem0}
     - entry:
-        str: $tstcfgsrc:elem1
+        str: ${tstcfgsrc:elem1}
   map0:
-    k0: $tstcfgsrc:k0
-    k1: $tstcfgsrc:k1
+    k0: ${tstcfgsrc:k0}
+    k1: ${tstcfgsrc:k1}

--- a/internal/configsource/testdata/cfgsrc_load_use_cfgsrc.yaml
+++ b/internal/configsource/testdata/cfgsrc_load_use_cfgsrc.yaml
@@ -2,4 +2,4 @@ config_sources:
   tstcfgsrc:
   tstcfgsrc/named:
     # It is not valid to use a dynamic config source when defining other one.
-    endpoint: $tstcfgsrc:str_value
+    endpoint: ${tstcfgsrc:str_value}

--- a/internal/configsource/testdata/env_var_on_load.yaml
+++ b/internal/configsource/testdata/env_var_on_load.yaml
@@ -1,6 +1,6 @@
 config_sources:
   tstcfgsrc:
     endpoint: https://${ENV_VAR_ENDPOINT}:8200
-    token: $ENV_VAR_TOKEN
+    token: ${ENV_VAR_TOKEN}
 ignored_by_parser:
   some_field: $ENV_VAR_TOKEN

--- a/internal/configsource/testdata/params_handling.yaml
+++ b/internal/configsource/testdata/params_handling.yaml
@@ -1,13 +1,3 @@
 single_line:
-  ex0: $tstcfgsrc:elem0
-  ex1: $tstcfgsrc:elem1?p0=true&p1=a string with spaces&p3=42
-multi_line:
-  k0: |
-    $tstcfgsrc: k0
-  k1: |
-    $tstcfgsrc: k1
-    p0: true
-    p1: a string with spaces
-    p2:
-      p2_0: a nested map0
-      p2_1: true
+  ex0: ${tstcfgsrc:elem0}
+  ex1: ${tstcfgsrc:elem1?p0=true&p1=a string with spaces&p3=42}

--- a/internal/configsource/testdata/params_handling_expected.yaml
+++ b/internal/configsource/testdata/params_handling_expected.yaml
@@ -4,11 +4,3 @@ single_line:
     p0: true
     p1: a string with spaces
     p3: 42
-multi_line:
-  k0:
-  k1:
-    p0: true
-    p1: a string with spaces
-    p2:
-      p2_0: a nested map0
-      p2_1: true

--- a/internal/configsource/testdata/yaml_injection.yaml
+++ b/internal/configsource/testdata/yaml_injection.yaml
@@ -1,2 +1,2 @@
-yaml_00: $tstcfgsrc:valid_yaml_str
-yaml_01: $tstcfgsrc:invalid_yaml_str
+yaml_00: ${tstcfgsrc:valid_yaml_str}
+yaml_01: ${tstcfgsrc:invalid_yaml_str}

--- a/internal/confmapprovider/configsource/testdata/manager_resolve_error.yaml
+++ b/internal/confmapprovider/configsource/testdata/manager_resolve_error.yaml
@@ -1,4 +1,4 @@
 config_sources:
   tstcfgsrc:
 
-cfgsrc: $tstcfgsrc:selector?{invalid}
+cfgsrc: ${tstcfgsrc:selector?{invalid}}

--- a/tests/general/configsources/testdata/templated.yaml
+++ b/tests/general/configsources/testdata/templated.yaml
@@ -15,8 +15,4 @@ processors:
     detectors: [ system ]
 exporters:
   otlp: ${include:./testdata/exporter_component}
-service: |
-  $include: ./testdata/service_template_component
-  my_receivers: [ hostmetrics ]
-  my_processors: [ resourcedetection ]
-  my_exporters: [ otlp ]
+service: ${include:./testdata/service_template_component?my_receivers=[hostmetrics]&my_processors=[resourcedetection]&my_exporters=[otlp]}

--- a/tests/general/discoverymode/host_observer_discovery_test.go
+++ b/tests/general/discoverymode/host_observer_discovery_test.go
@@ -41,10 +41,10 @@ import (
 // launching two collector processes:
 // The first is the main collector process without internal prometheus metrics and `--discovery`
 // w/ a config dir containing a host discovery observer and simple prometheus discovery config whose
-// rule is for an "otelcol" process using a port of $INTERNAL_PROMETHEUS_PORT.
+// rule is for an "otelcol" process using a port of ${INTERNAL_PROMETHEUS_PORT}.
 // The second process is exec'ed after the first successfully starts and is a collector process using
 // a noop otlp receiver and logging exporter from another config.d with an internal prometheus server
-// bound to $INTERNAL_PROMETHEUS_PORT.
+// bound to ${INTERNAL_PROMETHEUS_PORT}.
 // The test verifies that the second collector process's internal metrics contain a logging exporter
 // one and that the first collector process's initial and effective configs from the config server
 // are as expected.

--- a/tests/general/testdata/env_config_source_labels.yaml
+++ b/tests/general/testdata/env_config_source_labels.yaml
@@ -23,62 +23,32 @@ processors:
             new_label: single-dollar
             new_value: ${env:AN_ENVVAR}-suffix
           - action: add_label
-            new_label: single-dollar-no-curly-braces
-            new_value: prefix-$env:AN_ENVVAR
-          - action: add_label
             new_label: double-dollar
             new_value: $${env:AN_ENVVAR}-suffix
-          - action: add_label
-            new_label: double-dollar-no-curly-braces
-            new_value: prefix-$$env:AN_ENVVAR
           - action: add_label
             new_label: triple-dollar
             new_value: $$${env:AN_ENVVAR}-suffix
           - action: add_label
-            new_label: triple-dollar-no-curly-braces
-            new_value: prefix-$$$env:AN_ENVVAR
-          - action: add_label
             new_label: quadruple-dollar
             new_value: $$$${env:AN_ENVVAR}-suffix
-          - action: add_label
-            new_label: quadruple-dollar-no-curly-braces
-            new_value: prefix-$$$$env:AN_ENVVAR
           - action: add_label
             new_label: quintuple-dollar
             new_value: $$$$${env:AN_ENVVAR}-suffix
           - action: add_label
-            new_label: quintuple-dollar-no-curly-braces
-            new_value: prefix-$$$$$env:AN_ENVVAR
-          - action: add_label
             new_label: sextuple-dollar
             new_value: $$$$$${env:AN_ENVVAR}-suffix
-          - action: add_label
-            new_label: sextuple-dollar-no-curly-braces
-            new_value: prefix-$$$$$$env:AN_ENVVAR
           - action: add_label
             new_label: septuple-dollar
             new_value: $$$$$$${env:AN_ENVVAR}-suffix
           - action: add_label
-            new_label: septuple-dollar-no-curly-braces
-            new_value: prefix-$$$$$$$env:AN_ENVVAR
-          - action: add_label
             new_label: octuple-dollar
             new_value: $$$$$$$${env:AN_ENVVAR}-suffix
-          - action: add_label
-            new_label: octuple-dollar-no-curly-braces
-            new_value: prefix-$$$$$$$$env:AN_ENVVAR
           - action: add_label
             new_label: nonuple-dollar
             new_value: $$$$$$$$${env:AN_ENVVAR}-suffix
           - action: add_label
-            new_label: nonuple-dollar-no-curly-braces
-            new_value: prefix-$$$$$$$$$env:AN_ENVVAR
-          - action: add_label
             new_label: decuple-dollar
             new_value: $$$$$$$$$${env:AN_ENVVAR}-suffix
-          - action: add_label
-            new_label: decuple-dollar-no-curly-braces
-            new_value: prefix-$$$$$$$$$$env:AN_ENVVAR
 
 exporters:
   otlp:

--- a/tests/general/testdata/env_config_source_labels_expected.yaml
+++ b/tests/general/testdata/env_config_source_labels_expected.yaml
@@ -13,66 +13,36 @@ resourceMetrics:
                     - key: decuple-dollar
                       value:
                         stringValue: $$$$${env:AN_ENVVAR}-suffix
-                    - key: decuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$$env:AN_ENVVAR
                     - key: double-dollar
                       value:
                         stringValue: ${env:AN_ENVVAR}-suffix
-                    - key: double-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$env:AN_ENVVAR
                     - key: nonuple-dollar
                       value:
                         stringValue: $$$$an-envvar-value-suffix
-                    - key: nonuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$an-envvar-value
                     - key: octuple-dollar
                       value:
                         stringValue: $$$${env:AN_ENVVAR}-suffix
-                    - key: octuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$env:AN_ENVVAR
                     - key: quadruple-dollar
                       value:
                         stringValue: $${env:AN_ENVVAR}-suffix
-                    - key: quadruple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$env:AN_ENVVAR
                     - key: quintuple-dollar
                       value:
                         stringValue: $$an-envvar-value-suffix
-                    - key: quintuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$an-envvar-value
                     - key: septuple-dollar
                       value:
                         stringValue: $$$an-envvar-value-suffix
-                    - key: septuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$an-envvar-value
                     - key: sextuple-dollar
                       value:
                         stringValue: $$${env:AN_ENVVAR}-suffix
-                    - key: sextuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$env:AN_ENVVAR
                     - key: single-dollar
                       value:
                         stringValue: an-envvar-value-suffix
-                    - key: single-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-an-envvar-value
                     - key: state
                       value:
                         stringValue: buffered
                     - key: triple-dollar
                       value:
                         stringValue: $an-envvar-value-suffix
-                    - key: triple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$an-envvar-value
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "4355174400"
@@ -80,66 +50,36 @@ resourceMetrics:
                     - key: decuple-dollar
                       value:
                         stringValue: $$$$${env:AN_ENVVAR}-suffix
-                    - key: decuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$$env:AN_ENVVAR
                     - key: double-dollar
                       value:
                         stringValue: ${env:AN_ENVVAR}-suffix
-                    - key: double-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$env:AN_ENVVAR
                     - key: nonuple-dollar
                       value:
                         stringValue: $$$$an-envvar-value-suffix
-                    - key: nonuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$an-envvar-value
                     - key: octuple-dollar
                       value:
                         stringValue: $$$${env:AN_ENVVAR}-suffix
-                    - key: octuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$env:AN_ENVVAR
                     - key: quadruple-dollar
                       value:
                         stringValue: $${env:AN_ENVVAR}-suffix
-                    - key: quadruple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$env:AN_ENVVAR
                     - key: quintuple-dollar
                       value:
                         stringValue: $$an-envvar-value-suffix
-                    - key: quintuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$an-envvar-value
                     - key: septuple-dollar
                       value:
                         stringValue: $$$an-envvar-value-suffix
-                    - key: septuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$an-envvar-value
                     - key: sextuple-dollar
                       value:
                         stringValue: $$${env:AN_ENVVAR}-suffix
-                    - key: sextuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$env:AN_ENVVAR
                     - key: single-dollar
                       value:
                         stringValue: an-envvar-value-suffix
-                    - key: single-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-an-envvar-value
                     - key: state
                       value:
                         stringValue: cached
                     - key: triple-dollar
                       value:
                         stringValue: $an-envvar-value-suffix
-                    - key: triple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$an-envvar-value
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "3182825472"
@@ -147,66 +87,36 @@ resourceMetrics:
                     - key: decuple-dollar
                       value:
                         stringValue: $$$$${env:AN_ENVVAR}-suffix
-                    - key: decuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$$env:AN_ENVVAR
                     - key: double-dollar
                       value:
                         stringValue: ${env:AN_ENVVAR}-suffix
-                    - key: double-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$env:AN_ENVVAR
                     - key: nonuple-dollar
                       value:
                         stringValue: $$$$an-envvar-value-suffix
-                    - key: nonuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$an-envvar-value
                     - key: octuple-dollar
                       value:
                         stringValue: $$$${env:AN_ENVVAR}-suffix
-                    - key: octuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$env:AN_ENVVAR
                     - key: quadruple-dollar
                       value:
                         stringValue: $${env:AN_ENVVAR}-suffix
-                    - key: quadruple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$env:AN_ENVVAR
                     - key: quintuple-dollar
                       value:
                         stringValue: $$an-envvar-value-suffix
-                    - key: quintuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$an-envvar-value
                     - key: septuple-dollar
                       value:
                         stringValue: $$$an-envvar-value-suffix
-                    - key: septuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$an-envvar-value
                     - key: sextuple-dollar
                       value:
                         stringValue: $$${env:AN_ENVVAR}-suffix
-                    - key: sextuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$env:AN_ENVVAR
                     - key: single-dollar
                       value:
                         stringValue: an-envvar-value-suffix
-                    - key: single-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-an-envvar-value
                     - key: state
                       value:
                         stringValue: free
                     - key: triple-dollar
                       value:
                         stringValue: $an-envvar-value-suffix
-                    - key: triple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$an-envvar-value
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "250474496"
@@ -214,66 +124,36 @@ resourceMetrics:
                     - key: decuple-dollar
                       value:
                         stringValue: $$$$${env:AN_ENVVAR}-suffix
-                    - key: decuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$$env:AN_ENVVAR
                     - key: double-dollar
                       value:
                         stringValue: ${env:AN_ENVVAR}-suffix
-                    - key: double-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$env:AN_ENVVAR
                     - key: nonuple-dollar
                       value:
                         stringValue: $$$$an-envvar-value-suffix
-                    - key: nonuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$an-envvar-value
                     - key: octuple-dollar
                       value:
                         stringValue: $$$${env:AN_ENVVAR}-suffix
-                    - key: octuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$env:AN_ENVVAR
                     - key: quadruple-dollar
                       value:
                         stringValue: $${env:AN_ENVVAR}-suffix
-                    - key: quadruple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$env:AN_ENVVAR
                     - key: quintuple-dollar
                       value:
                         stringValue: $$an-envvar-value-suffix
-                    - key: quintuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$an-envvar-value
                     - key: septuple-dollar
                       value:
                         stringValue: $$$an-envvar-value-suffix
-                    - key: septuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$an-envvar-value
                     - key: sextuple-dollar
                       value:
                         stringValue: $$${env:AN_ENVVAR}-suffix
-                    - key: sextuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$env:AN_ENVVAR
                     - key: single-dollar
                       value:
                         stringValue: an-envvar-value-suffix
-                    - key: single-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-an-envvar-value
                     - key: state
                       value:
                         stringValue: slab_reclaimable
                     - key: triple-dollar
                       value:
                         stringValue: $an-envvar-value-suffix
-                    - key: triple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$an-envvar-value
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "73023488"
@@ -281,66 +161,36 @@ resourceMetrics:
                     - key: decuple-dollar
                       value:
                         stringValue: $$$$${env:AN_ENVVAR}-suffix
-                    - key: decuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$$env:AN_ENVVAR
                     - key: double-dollar
                       value:
                         stringValue: ${env:AN_ENVVAR}-suffix
-                    - key: double-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$env:AN_ENVVAR
                     - key: nonuple-dollar
                       value:
                         stringValue: $$$$an-envvar-value-suffix
-                    - key: nonuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$an-envvar-value
                     - key: octuple-dollar
                       value:
                         stringValue: $$$${env:AN_ENVVAR}-suffix
-                    - key: octuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$env:AN_ENVVAR
                     - key: quadruple-dollar
                       value:
                         stringValue: $${env:AN_ENVVAR}-suffix
-                    - key: quadruple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$env:AN_ENVVAR
                     - key: quintuple-dollar
                       value:
                         stringValue: $$an-envvar-value-suffix
-                    - key: quintuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$an-envvar-value
                     - key: septuple-dollar
                       value:
                         stringValue: $$$an-envvar-value-suffix
-                    - key: septuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$an-envvar-value
                     - key: sextuple-dollar
                       value:
                         stringValue: $$${env:AN_ENVVAR}-suffix
-                    - key: sextuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$env:AN_ENVVAR
                     - key: single-dollar
                       value:
                         stringValue: an-envvar-value-suffix
-                    - key: single-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-an-envvar-value
                     - key: state
                       value:
                         stringValue: slab_unreclaimable
                     - key: triple-dollar
                       value:
                         stringValue: $an-envvar-value-suffix
-                    - key: triple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$an-envvar-value
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "4770893824"
@@ -348,66 +198,36 @@ resourceMetrics:
                     - key: decuple-dollar
                       value:
                         stringValue: $$$$${env:AN_ENVVAR}-suffix
-                    - key: decuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$$env:AN_ENVVAR
                     - key: double-dollar
                       value:
                         stringValue: ${env:AN_ENVVAR}-suffix
-                    - key: double-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$env:AN_ENVVAR
                     - key: nonuple-dollar
                       value:
                         stringValue: $$$$an-envvar-value-suffix
-                    - key: nonuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$an-envvar-value
                     - key: octuple-dollar
                       value:
                         stringValue: $$$${env:AN_ENVVAR}-suffix
-                    - key: octuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$$env:AN_ENVVAR
                     - key: quadruple-dollar
                       value:
                         stringValue: $${env:AN_ENVVAR}-suffix
-                    - key: quadruple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$env:AN_ENVVAR
                     - key: quintuple-dollar
                       value:
                         stringValue: $$an-envvar-value-suffix
-                    - key: quintuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$an-envvar-value
                     - key: septuple-dollar
                       value:
                         stringValue: $$$an-envvar-value-suffix
-                    - key: septuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$an-envvar-value
                     - key: sextuple-dollar
                       value:
                         stringValue: $$${env:AN_ENVVAR}-suffix
-                    - key: sextuple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$$$env:AN_ENVVAR
                     - key: single-dollar
                       value:
                         stringValue: an-envvar-value-suffix
-                    - key: single-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-an-envvar-value
                     - key: state
                       value:
                         stringValue: used
                     - key: triple-dollar
                       value:
                         stringValue: $an-envvar-value-suffix
-                    - key: triple-dollar-no-curly-braces
-                      value:
-                        stringValue: prefix-$an-envvar-value
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By

--- a/tests/general/testdata/envvar_labels.yaml
+++ b/tests/general/testdata/envvar_labels.yaml
@@ -17,65 +17,35 @@ processors:
         match_type: regexp
         operations:
           - action: add_label
-            new_label: single-dollar-no-curly-braces
-            new_value: $AN_ENVVAR-$nonenvvar-$-suffix $
-          - action: add_label
             new_label: single-dollar-curly-braces
-            new_value: ${AN_ENVVAR}-$nonenvvar-$-suffix $
-          - action: add_label
-            new_label: double-dollar-no-curly-braces
-            new_value: $$AN_ENVVAR-$$nonenvvar-$$-suffix $$
+            new_value: ${AN_ENVVAR}-$-suffix $
           - action: add_label
             new_label: double-dollar-curly-braces
-            new_value: $${AN_ENVVAR}-$$nonenvvar-$$-suffix $$
-          - action: add_label
-            new_label: triple-dollar-no-curly-braces
-            new_value: $$$AN_ENVVAR-$$$nonenvvar-$$$-suffix $$$
+            new_value: $${AN_ENVVAR}-$$-suffix $$
           - action: add_label
             new_label: triple-dollar-curly-braces
-            new_value: $$${AN_ENVVAR}-$$$nonenvvar-$$$-suffix $$$
-          - action: add_label
-            new_label: quadruple-dollar-no-curly-braces
-            new_value: $$$$AN_ENVVAR-$$$$nonenvvar-$$$$-suffix $$$$
+            new_value: $$${AN_ENVVAR}-$$$-suffix $$$
           - action: add_label
             new_label: quadruple-dollar-curly-braces
-            new_value: $$$${AN_ENVVAR}-$$$$nonenvvar-$$$$-suffix $$$$
-          - action: add_label
-            new_label: quintuple-dollar-no-curly-braces
-            new_value: $$$$$AN_ENVVAR-$$$$$nonenvvar-$$$$$-suffix $$$$$
+            new_value: $$$${AN_ENVVAR}-$$$$-suffix $$$$
           - action: add_label
             new_label: quintuple-dollar-curly-braces
-            new_value: $$$$${AN_ENVVAR}-$$$$$nonenvvar-$$$$$-suffix $$$$$
-          - action: add_label
-            new_label: sextuple-dollar-no-curly-braces
-            new_value: $$$$$$AN_ENVVAR-$$$$$$nonenvvar-$$$$$$-suffix $$$$$$
+            new_value: $$$$${AN_ENVVAR}-$$$$$-suffix $$$$$
           - action: add_label
             new_label: sextuple-dollar-curly-braces
-            new_value: $$$$$${AN_ENVVAR}-$$$$$$nonenvvar-$$$$$$-suffix $$$$$$
-          - action: add_label
-            new_label: septuple-dollar-no-curly-braces
-            new_value: $$$$$$$AN_ENVVAR-$$$$$$$nonenvvar-$$$$$$$-suffix $$$$$$$
+            new_value: $$$$$${AN_ENVVAR}-$$$$$$-suffix $$$$$$
           - action: add_label
             new_label: septuple-dollar-curly-braces
-            new_value: $$$$$$${AN_ENVVAR}-$$$$$$$nonenvvar-$$$$$$$-suffix $$$$$$$
-          - action: add_label
-            new_label: octuple-dollar-no-curly-braces
-            new_value: $$$$$$$$AN_ENVVAR-$$$$$$$$nonenvvar-$$$$$$$$-suffix $$$$$$$$
+            new_value: $$$$$$${AN_ENVVAR}-$$$$$$$-suffix $$$$$$$
           - action: add_label
             new_label: octuple-dollar-curly-braces
-            new_value: $$$$$$$${AN_ENVVAR}-$$$$$$$$nonenvvar-$$$$$$$$-suffix $$$$$$$$
-          - action: add_label
-            new_label: nonuple-dollar-no-curly-braces
-            new_value: $$$$$$$$$AN_ENVVAR-$$$$$$$$$nonenvvar-$$$$$$$$$-suffix $$$$$$$$$
+            new_value: $$$$$$$${AN_ENVVAR}-$$$$$$$$-suffix $$$$$$$$
           - action: add_label
             new_label: nonuple-dollar-curly-braces
-            new_value: $$$$$$$$${AN_ENVVAR}-$$$$$$$$$nonenvvar-$$$$$$$$$-suffix $$$$$$$$$
-          - action: add_label
-            new_label: decuple-dollar-no-curly-braces
-            new_value: $$$$$$$$$$AN_ENVVAR-$$$$$$$$$$nonenvvar-$$$$$$$$$$-suffix $$$$$$$$$$
+            new_value: $$$$$$$$${AN_ENVVAR}-$$$$$$$$$-suffix $$$$$$$$$
           - action: add_label
             new_label: decuple-dollar-curly-braces
-            new_value: $$$$$$$$$${AN_ENVVAR}-$$$$$$$$$$nonenvvar-$$$$$$$$$$-suffix $$$$$$$$$$
+            new_value: $$$$$$$$$${AN_ENVVAR}-$$$$$$$$$$-suffix $$$$$$$$$$
 
 exporters:
   otlp:

--- a/tests/general/testdata/envvar_labels_expected.yaml
+++ b/tests/general/testdata/envvar_labels_expected.yaml
@@ -12,402 +12,222 @@ resourceMetrics:
                   attributes:
                     - key: decuple-dollar-curly-braces
                       value:
-                        stringValue: $$$$${AN_ENVVAR}-$$$$$nonenvvar-$$$$$-suffix $$$$$
-                    - key: decuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$$AN_ENVVAR-$$$$$nonenvvar-$$$$$-suffix $$$$$
+                        stringValue: $$$$${AN_ENVVAR}-$$$$$-suffix $$$$$
                     - key: double-dollar-curly-braces
                       value:
-                        stringValue: ${AN_ENVVAR}-$nonenvvar-$-suffix $
-                    - key: double-dollar-no-curly-braces
-                      value:
-                        stringValue: $AN_ENVVAR-$nonenvvar-$-suffix $
+                        stringValue: ${AN_ENVVAR}-$-suffix $
                     - key: nonuple-dollar-curly-braces
                       value:
-                        stringValue: $$$$an-envvar-value-$$$$-$$$$$-suffix $$$$$
-                    - key: nonuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$an-envvar-value-$$$$-$$$$$-suffix $$$$$
+                        stringValue: $$$$an-envvar-value-$$$$$-suffix $$$$$
                     - key: octuple-dollar-curly-braces
                       value:
-                        stringValue: $$$${AN_ENVVAR}-$$$$nonenvvar-$$$$-suffix $$$$
-                    - key: octuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$AN_ENVVAR-$$$$nonenvvar-$$$$-suffix $$$$
+                        stringValue: $$$${AN_ENVVAR}-$$$$-suffix $$$$
                     - key: quadruple-dollar-curly-braces
                       value:
-                        stringValue: $${AN_ENVVAR}-$$nonenvvar-$$-suffix $$
-                    - key: quadruple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$AN_ENVVAR-$$nonenvvar-$$-suffix $$
+                        stringValue: $${AN_ENVVAR}-$$-suffix $$
                     - key: quintuple-dollar-curly-braces
                       value:
-                        stringValue: $$an-envvar-value-$$-$$$-suffix $$$
-                    - key: quintuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$an-envvar-value-$$-$$$-suffix $$$
+                        stringValue: $$an-envvar-value-$$$-suffix $$$
                     - key: septuple-dollar-curly-braces
                       value:
-                        stringValue: $$$an-envvar-value-$$$-$$$$-suffix $$$$
-                    - key: septuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$an-envvar-value-$$$-$$$$-suffix $$$$
+                        stringValue: $$$an-envvar-value-$$$$-suffix $$$$
                     - key: sextuple-dollar-curly-braces
                       value:
-                        stringValue: $$${AN_ENVVAR}-$$$nonenvvar-$$$-suffix $$$
-                    - key: sextuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$AN_ENVVAR-$$$nonenvvar-$$$-suffix $$$
+                        stringValue: $$${AN_ENVVAR}-$$$-suffix $$$
                     - key: single-dollar-curly-braces
                       value:
-                        stringValue: an-envvar-value--$-suffix $
-                    - key: single-dollar-no-curly-braces
-                      value:
-                        stringValue: an-envvar-value--$-suffix $
+                        stringValue: an-envvar-value-$-suffix $
                     - key: state
                       value:
                         stringValue: buffered
                     - key: triple-dollar-curly-braces
                       value:
-                        stringValue: $an-envvar-value-$-$$-suffix $$
-                    - key: triple-dollar-no-curly-braces
-                      value:
-                        stringValue: $an-envvar-value-$-$$-suffix $$
+                        stringValue: $an-envvar-value-$$-suffix $$
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "4355420160"
                   attributes:
                     - key: decuple-dollar-curly-braces
                       value:
-                        stringValue: $$$$${AN_ENVVAR}-$$$$$nonenvvar-$$$$$-suffix $$$$$
-                    - key: decuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$$AN_ENVVAR-$$$$$nonenvvar-$$$$$-suffix $$$$$
+                        stringValue: $$$$${AN_ENVVAR}-$$$$$-suffix $$$$$
                     - key: double-dollar-curly-braces
                       value:
-                        stringValue: ${AN_ENVVAR}-$nonenvvar-$-suffix $
-                    - key: double-dollar-no-curly-braces
-                      value:
-                        stringValue: $AN_ENVVAR-$nonenvvar-$-suffix $
+                        stringValue: ${AN_ENVVAR}-$-suffix $
                     - key: nonuple-dollar-curly-braces
                       value:
-                        stringValue: $$$$an-envvar-value-$$$$-$$$$$-suffix $$$$$
-                    - key: nonuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$an-envvar-value-$$$$-$$$$$-suffix $$$$$
+                        stringValue: $$$$an-envvar-value-$$$$$-suffix $$$$$
                     - key: octuple-dollar-curly-braces
                       value:
-                        stringValue: $$$${AN_ENVVAR}-$$$$nonenvvar-$$$$-suffix $$$$
-                    - key: octuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$AN_ENVVAR-$$$$nonenvvar-$$$$-suffix $$$$
+                        stringValue: $$$${AN_ENVVAR}-$$$$-suffix $$$$
                     - key: quadruple-dollar-curly-braces
                       value:
-                        stringValue: $${AN_ENVVAR}-$$nonenvvar-$$-suffix $$
-                    - key: quadruple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$AN_ENVVAR-$$nonenvvar-$$-suffix $$
+                        stringValue: $${AN_ENVVAR}-$$-suffix $$
                     - key: quintuple-dollar-curly-braces
                       value:
-                        stringValue: $$an-envvar-value-$$-$$$-suffix $$$
-                    - key: quintuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$an-envvar-value-$$-$$$-suffix $$$
+                        stringValue: $$an-envvar-value-$$$-suffix $$$
                     - key: septuple-dollar-curly-braces
                       value:
-                        stringValue: $$$an-envvar-value-$$$-$$$$-suffix $$$$
-                    - key: septuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$an-envvar-value-$$$-$$$$-suffix $$$$
+                        stringValue: $$$an-envvar-value-$$$$-suffix $$$$
                     - key: sextuple-dollar-curly-braces
                       value:
-                        stringValue: $$${AN_ENVVAR}-$$$nonenvvar-$$$-suffix $$$
-                    - key: sextuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$AN_ENVVAR-$$$nonenvvar-$$$-suffix $$$
+                        stringValue: $$${AN_ENVVAR}-$$$-suffix $$$
                     - key: single-dollar-curly-braces
                       value:
-                        stringValue: an-envvar-value--$-suffix $
-                    - key: single-dollar-no-curly-braces
-                      value:
-                        stringValue: an-envvar-value--$-suffix $
+                        stringValue: an-envvar-value-$-suffix $
                     - key: state
                       value:
                         stringValue: cached
                     - key: triple-dollar-curly-braces
                       value:
-                        stringValue: $an-envvar-value-$-$$-suffix $$
-                    - key: triple-dollar-no-curly-braces
-                      value:
-                        stringValue: $an-envvar-value-$-$$-suffix $$
+                        stringValue: $an-envvar-value-$$-suffix $$
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "3154911232"
                   attributes:
                     - key: decuple-dollar-curly-braces
                       value:
-                        stringValue: $$$$${AN_ENVVAR}-$$$$$nonenvvar-$$$$$-suffix $$$$$
-                    - key: decuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$$AN_ENVVAR-$$$$$nonenvvar-$$$$$-suffix $$$$$
+                        stringValue: $$$$${AN_ENVVAR}-$$$$$-suffix $$$$$
                     - key: double-dollar-curly-braces
                       value:
-                        stringValue: ${AN_ENVVAR}-$nonenvvar-$-suffix $
-                    - key: double-dollar-no-curly-braces
-                      value:
-                        stringValue: $AN_ENVVAR-$nonenvvar-$-suffix $
+                        stringValue: ${AN_ENVVAR}-$-suffix $
                     - key: nonuple-dollar-curly-braces
                       value:
-                        stringValue: $$$$an-envvar-value-$$$$-$$$$$-suffix $$$$$
-                    - key: nonuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$an-envvar-value-$$$$-$$$$$-suffix $$$$$
+                        stringValue: $$$$an-envvar-value-$$$$$-suffix $$$$$
                     - key: octuple-dollar-curly-braces
                       value:
-                        stringValue: $$$${AN_ENVVAR}-$$$$nonenvvar-$$$$-suffix $$$$
-                    - key: octuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$AN_ENVVAR-$$$$nonenvvar-$$$$-suffix $$$$
+                        stringValue: $$$${AN_ENVVAR}-$$$$-suffix $$$$
                     - key: quadruple-dollar-curly-braces
                       value:
-                        stringValue: $${AN_ENVVAR}-$$nonenvvar-$$-suffix $$
-                    - key: quadruple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$AN_ENVVAR-$$nonenvvar-$$-suffix $$
+                        stringValue: $${AN_ENVVAR}-$$-suffix $$
                     - key: quintuple-dollar-curly-braces
                       value:
-                        stringValue: $$an-envvar-value-$$-$$$-suffix $$$
-                    - key: quintuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$an-envvar-value-$$-$$$-suffix $$$
+                        stringValue: $$an-envvar-value-$$$-suffix $$$
                     - key: septuple-dollar-curly-braces
                       value:
-                        stringValue: $$$an-envvar-value-$$$-$$$$-suffix $$$$
-                    - key: septuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$an-envvar-value-$$$-$$$$-suffix $$$$
+                        stringValue: $$$an-envvar-value-$$$$-suffix $$$$
                     - key: sextuple-dollar-curly-braces
                       value:
-                        stringValue: $$${AN_ENVVAR}-$$$nonenvvar-$$$-suffix $$$
-                    - key: sextuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$AN_ENVVAR-$$$nonenvvar-$$$-suffix $$$
+                        stringValue: $$${AN_ENVVAR}-$$$-suffix $$$
                     - key: single-dollar-curly-braces
                       value:
-                        stringValue: an-envvar-value--$-suffix $
-                    - key: single-dollar-no-curly-braces
-                      value:
-                        stringValue: an-envvar-value--$-suffix $
+                        stringValue: an-envvar-value-$-suffix $
                     - key: state
                       value:
                         stringValue: free
                     - key: triple-dollar-curly-braces
                       value:
-                        stringValue: $an-envvar-value-$-$$-suffix $$
-                    - key: triple-dollar-no-curly-braces
-                      value:
-                        stringValue: $an-envvar-value-$-$$-suffix $$
+                        stringValue: $an-envvar-value-$$-suffix $$
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "251011072"
                   attributes:
                     - key: decuple-dollar-curly-braces
                       value:
-                        stringValue: $$$$${AN_ENVVAR}-$$$$$nonenvvar-$$$$$-suffix $$$$$
-                    - key: decuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$$AN_ENVVAR-$$$$$nonenvvar-$$$$$-suffix $$$$$
+                        stringValue: $$$$${AN_ENVVAR}-$$$$$-suffix $$$$$
                     - key: double-dollar-curly-braces
                       value:
-                        stringValue: ${AN_ENVVAR}-$nonenvvar-$-suffix $
-                    - key: double-dollar-no-curly-braces
-                      value:
-                        stringValue: $AN_ENVVAR-$nonenvvar-$-suffix $
+                        stringValue: ${AN_ENVVAR}-$-suffix $
                     - key: nonuple-dollar-curly-braces
                       value:
-                        stringValue: $$$$an-envvar-value-$$$$-$$$$$-suffix $$$$$
-                    - key: nonuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$an-envvar-value-$$$$-$$$$$-suffix $$$$$
+                        stringValue: $$$$an-envvar-value-$$$$$-suffix $$$$$
                     - key: octuple-dollar-curly-braces
                       value:
-                        stringValue: $$$${AN_ENVVAR}-$$$$nonenvvar-$$$$-suffix $$$$
-                    - key: octuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$AN_ENVVAR-$$$$nonenvvar-$$$$-suffix $$$$
+                        stringValue: $$$${AN_ENVVAR}-$$$$-suffix $$$$
                     - key: quadruple-dollar-curly-braces
                       value:
-                        stringValue: $${AN_ENVVAR}-$$nonenvvar-$$-suffix $$
-                    - key: quadruple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$AN_ENVVAR-$$nonenvvar-$$-suffix $$
+                        stringValue: $${AN_ENVVAR}-$$-suffix $$
                     - key: quintuple-dollar-curly-braces
                       value:
-                        stringValue: $$an-envvar-value-$$-$$$-suffix $$$
-                    - key: quintuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$an-envvar-value-$$-$$$-suffix $$$
+                        stringValue: $$an-envvar-value-$$$-suffix $$$
                     - key: septuple-dollar-curly-braces
                       value:
-                        stringValue: $$$an-envvar-value-$$$-$$$$-suffix $$$$
-                    - key: septuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$an-envvar-value-$$$-$$$$-suffix $$$$
+                        stringValue: $$$an-envvar-value-$$$$-suffix $$$$
                     - key: sextuple-dollar-curly-braces
                       value:
-                        stringValue: $$${AN_ENVVAR}-$$$nonenvvar-$$$-suffix $$$
-                    - key: sextuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$AN_ENVVAR-$$$nonenvvar-$$$-suffix $$$
+                        stringValue: $$${AN_ENVVAR}-$$$-suffix $$$
                     - key: single-dollar-curly-braces
                       value:
-                        stringValue: an-envvar-value--$-suffix $
-                    - key: single-dollar-no-curly-braces
-                      value:
-                        stringValue: an-envvar-value--$-suffix $
+                        stringValue: an-envvar-value-$-suffix $
                     - key: state
                       value:
                         stringValue: slab_reclaimable
                     - key: triple-dollar-curly-braces
                       value:
-                        stringValue: $an-envvar-value-$-$$-suffix $$
-                    - key: triple-dollar-no-curly-braces
-                      value:
-                        stringValue: $an-envvar-value-$-$$-suffix $$
+                        stringValue: $an-envvar-value-$$-suffix $$
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "73723904"
                   attributes:
                     - key: decuple-dollar-curly-braces
                       value:
-                        stringValue: $$$$${AN_ENVVAR}-$$$$$nonenvvar-$$$$$-suffix $$$$$
-                    - key: decuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$$AN_ENVVAR-$$$$$nonenvvar-$$$$$-suffix $$$$$
+                        stringValue: $$$$${AN_ENVVAR}-$$$$$-suffix $$$$$
                     - key: double-dollar-curly-braces
                       value:
-                        stringValue: ${AN_ENVVAR}-$nonenvvar-$-suffix $
-                    - key: double-dollar-no-curly-braces
-                      value:
-                        stringValue: $AN_ENVVAR-$nonenvvar-$-suffix $
+                        stringValue: ${AN_ENVVAR}-$-suffix $
                     - key: nonuple-dollar-curly-braces
                       value:
-                        stringValue: $$$$an-envvar-value-$$$$-$$$$$-suffix $$$$$
-                    - key: nonuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$an-envvar-value-$$$$-$$$$$-suffix $$$$$
+                        stringValue: $$$$an-envvar-value-$$$$$-suffix $$$$$
                     - key: octuple-dollar-curly-braces
                       value:
-                        stringValue: $$$${AN_ENVVAR}-$$$$nonenvvar-$$$$-suffix $$$$
-                    - key: octuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$AN_ENVVAR-$$$$nonenvvar-$$$$-suffix $$$$
+                        stringValue: $$$${AN_ENVVAR}-$$$$-suffix $$$$
                     - key: quadruple-dollar-curly-braces
                       value:
-                        stringValue: $${AN_ENVVAR}-$$nonenvvar-$$-suffix $$
-                    - key: quadruple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$AN_ENVVAR-$$nonenvvar-$$-suffix $$
+                        stringValue: $${AN_ENVVAR}-$$-suffix $$
                     - key: quintuple-dollar-curly-braces
                       value:
-                        stringValue: $$an-envvar-value-$$-$$$-suffix $$$
-                    - key: quintuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$an-envvar-value-$$-$$$-suffix $$$
+                        stringValue: $$an-envvar-value-$$$-suffix $$$
                     - key: septuple-dollar-curly-braces
                       value:
-                        stringValue: $$$an-envvar-value-$$$-$$$$-suffix $$$$
-                    - key: septuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$an-envvar-value-$$$-$$$$-suffix $$$$
+                        stringValue: $$$an-envvar-value-$$$$-suffix $$$$
                     - key: sextuple-dollar-curly-braces
                       value:
-                        stringValue: $$${AN_ENVVAR}-$$$nonenvvar-$$$-suffix $$$
-                    - key: sextuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$AN_ENVVAR-$$$nonenvvar-$$$-suffix $$$
+                        stringValue: $$${AN_ENVVAR}-$$$-suffix $$$
                     - key: single-dollar-curly-braces
                       value:
-                        stringValue: an-envvar-value--$-suffix $
-                    - key: single-dollar-no-curly-braces
-                      value:
-                        stringValue: an-envvar-value--$-suffix $
+                        stringValue: an-envvar-value-$-suffix $
                     - key: state
                       value:
                         stringValue: slab_unreclaimable
                     - key: triple-dollar-curly-braces
                       value:
-                        stringValue: $an-envvar-value-$-$$-suffix $$
-                    - key: triple-dollar-no-curly-braces
-                      value:
-                        stringValue: $an-envvar-value-$-$$-suffix $$
+                        stringValue: $an-envvar-value-$$-suffix $$
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "4796518400"
                   attributes:
                     - key: decuple-dollar-curly-braces
                       value:
-                        stringValue: $$$$${AN_ENVVAR}-$$$$$nonenvvar-$$$$$-suffix $$$$$
-                    - key: decuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$$AN_ENVVAR-$$$$$nonenvvar-$$$$$-suffix $$$$$
+                        stringValue: $$$$${AN_ENVVAR}-$$$$$-suffix $$$$$
                     - key: double-dollar-curly-braces
                       value:
-                        stringValue: ${AN_ENVVAR}-$nonenvvar-$-suffix $
-                    - key: double-dollar-no-curly-braces
-                      value:
-                        stringValue: $AN_ENVVAR-$nonenvvar-$-suffix $
+                        stringValue: ${AN_ENVVAR}-$-suffix $
                     - key: nonuple-dollar-curly-braces
                       value:
-                        stringValue: $$$$an-envvar-value-$$$$-$$$$$-suffix $$$$$
-                    - key: nonuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$an-envvar-value-$$$$-$$$$$-suffix $$$$$
+                        stringValue: $$$$an-envvar-value-$$$$$-suffix $$$$$
                     - key: octuple-dollar-curly-braces
                       value:
-                        stringValue: $$$${AN_ENVVAR}-$$$$nonenvvar-$$$$-suffix $$$$
-                    - key: octuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$$AN_ENVVAR-$$$$nonenvvar-$$$$-suffix $$$$
+                        stringValue: $$$${AN_ENVVAR}-$$$$-suffix $$$$
                     - key: quadruple-dollar-curly-braces
                       value:
-                        stringValue: $${AN_ENVVAR}-$$nonenvvar-$$-suffix $$
-                    - key: quadruple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$AN_ENVVAR-$$nonenvvar-$$-suffix $$
+                        stringValue: $${AN_ENVVAR}-$$-suffix $$
                     - key: quintuple-dollar-curly-braces
                       value:
-                        stringValue: $$an-envvar-value-$$-$$$-suffix $$$
-                    - key: quintuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$an-envvar-value-$$-$$$-suffix $$$
+                        stringValue: $$an-envvar-value-$$$-suffix $$$
                     - key: septuple-dollar-curly-braces
                       value:
-                        stringValue: $$$an-envvar-value-$$$-$$$$-suffix $$$$
-                    - key: septuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$an-envvar-value-$$$-$$$$-suffix $$$$
+                        stringValue: $$$an-envvar-value-$$$$-suffix $$$$
                     - key: sextuple-dollar-curly-braces
                       value:
-                        stringValue: $$${AN_ENVVAR}-$$$nonenvvar-$$$-suffix $$$
-                    - key: sextuple-dollar-no-curly-braces
-                      value:
-                        stringValue: $$$AN_ENVVAR-$$$nonenvvar-$$$-suffix $$$
+                        stringValue: $$${AN_ENVVAR}-$$$-suffix $$$
                     - key: single-dollar-curly-braces
                       value:
-                        stringValue: an-envvar-value--$-suffix $
-                    - key: single-dollar-no-curly-braces
-                      value:
-                        stringValue: an-envvar-value--$-suffix $
+                        stringValue: an-envvar-value-$-suffix $
                     - key: state
                       value:
                         stringValue: used
                     - key: triple-dollar-curly-braces
                       value:
-                        stringValue: $an-envvar-value-$-$$-suffix $$
-                    - key: triple-dollar-no-curly-braces
-                      value:
-                        stringValue: $an-envvar-value-$-$$-suffix $$
+                        stringValue: $an-envvar-value-$$-suffix $$
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By


### PR DESCRIPTION
The expansion of bare config sources is no longer supported.

Strings like `$ENV` or `$include:/path/to/file.yaml` will no longer be expanded. Instead, use the `${env:ENV}` or `${include:/path/to/file.yaml}` syntax. Only two symbols are allowed after `$`: `{` and `$`. The collector will log an error and fail to start if it encounters a bare config source expansion.

This syntax has been deprecated since [version 0.105.0](https://github.com/signalfx/splunk-otel-collector/blob/main/CHANGELOG.md#deprecations--6).

The reason for this change is aligning with OpenTelemetry Collector upstream, where this syntax has been removed in [0.104.0 version](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CHANGELOG.md#v1110v01040). Long term plan is to do not have [the custom config sources](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/configsource) in this repository, instead consolidate the functionality with [the upstream confmap providers](https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider).