### PR TITLE
Turn on `splunk.continuousDiscovery` feature gate by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Enhancements 💡
 
-- (Splunk) Turn on `splunk.continuousDiscovery` feature gate be default ([#5833](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5832))
+- (Splunk) Turn on `splunk.continuousDiscovery` feature gate by default ([#5833](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5832))
   This enables new way to discover third-party components and collect metrics from them:
   - It allows discovering services that were not available at the time of the collector startup but were started later.
   - Information about discovered services will be sent to Splunk Observability Cloud that can be found in "Discovered services" page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
   - `$include:file_path` must be replaced with `${include:file_path}`. The same applied for any other config source.
     More information can be found in ([the upgrade guidelines](https://github.com/signalfx/splunk-otel-collector?tab=readme-ov-file#from-01170-to-01180)).
 
+### 💡 Enhancements 💡
+
+- (Splunk) Turn on `splunk.continuousDiscovery` feature gate be default ([#5833](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5832))
+  This enables new way to discover third-party components and collect metrics from them:
+  - It allows discovering services that were not available at the time of the collector startup but were started later.
+  - Information about discovered services will be sent to Splunk Observability Cloud that can be found in "Discovered services" page.
+  If you want to disable this feature and bring back the old behavior, add `--feature-gates=-splunk.continuousDiscovery` command line flag.
+
 ## v0.117.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.117.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.117.0) and the [opentelemetry-collector-contrib v0.117.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.117.0) releases where appropriate.

--- a/internal/confmapprovider/discovery/discoverer.go
+++ b/internal/confmapprovider/discovery/discoverer.go
@@ -62,7 +62,7 @@ const continuousDiscoveryFGKey = "splunk.continuousDiscovery"
 
 var continuousDiscoveryFG = featuregate.GlobalRegistry().MustRegister(
 	continuousDiscoveryFGKey,
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("When enabled, service discovery will continuously run and collect metrics from discovered services."),
 	featuregate.WithRegisterFromVersion("v0.109.0"),
 )

--- a/tests/general/discoverymode/docker_observer_discovery_test.go
+++ b/tests/general/discoverymode/docker_observer_discovery_test.go
@@ -81,7 +81,7 @@ func TestDockerObserver(t *testing.T) {
 				"SPLUNK_DISCOVERY_RECEIVERS_prometheus_x5f_simple_CONFIG_labels_x3a__x3a_label_x5f_three": "overwritten by --set property",
 				"SPLUNK_DISCOVERY_RECEIVERS_prometheus_x5f_simple_CONFIG_labels_x3a__x3a_label_x5f_four":  "actual.label.four.value",
 			}).WithArgs(
-				"--discovery", "--config-dir", "/opt/config.d",
+				"--discovery", "--feature-gates=-splunk.continuousDiscovery", "--config-dir", "/opt/config.d",
 				"--set", `splunk.discovery.extensions.k8s_observer.enabled=false`,
 				"--set", `splunk.discovery.extensions.docker_observer.enabled=true`,
 				"--set", `splunk.discovery.extensions.docker_observer.config.endpoint=${DOCKER_DOMAIN_SOCKET}`,
@@ -282,7 +282,7 @@ SPLUNK_DISCOVERY_EXTENSIONS_docker_observer_CONFIG_endpoint=\${DOCKER_DOMAIN_SOC
 SPLUNK_DISCOVERY_RECEIVERS_prometheus_x5f_simple_ENABLED=true \
 SPLUNK_DISCOVERY_RECEIVERS_prometheus_x5f_simple_CONFIG_labels_x3a__x3a_label_x5f_three=="overwritten by --set property" \
 SPLUNK_DISCOVERY_RECEIVERS_prometheus_x5f_simple_CONFIG_labels_x3a__x3a_label_x5f_four="actual.label.four.value" \
-/otelcol --config-dir /opt/config.d --discovery --dry-run \
+/otelcol --config-dir /opt/config.d --discovery --feature-gates=-splunk.continuousDiscovery --dry-run \
 --set splunk.discovery.receivers.prometheus_simple.config.labels::label_three=actual.label.three.value \
 --discovery-properties /opt/properties.yaml
 `)

--- a/tests/general/discoverymode/host_observer_discovery_test.go
+++ b/tests/general/discoverymode/host_observer_discovery_test.go
@@ -86,7 +86,7 @@ func TestHostObserver(t *testing.T) {
 				"LABEL_ONE_VALUE":            "actual.label.one.value.from.env.var",
 				"LABEL_TWO_VALUE":            "actual.label.two.value.from.env.var",
 			}).WithArgs(
-				"--discovery",
+				"--discovery", "--feature-gates=-splunk.continuousDiscovery",
 				"--config-dir", "/opt/config.d",
 				"--set", "splunk.discovery.receivers.prometheus_simple.config.labels::label_three=actual.label.three.value.from.cmdline.property",
 				"--set", "splunk.discovery.extensions.k8s_observer.enabled=false",
@@ -302,7 +302,7 @@ SPLUNK_DISCOVERY_DURATION=9s \
 SPLUNK_DISCOVERY_RECEIVERS_prometheus_simple_CONFIG_labels_x3a__x3a_label_three=actual.label.three.value.from.env.var.property \
 SPLUNK_DISCOVERY_EXTENSIONS_k8s_observer_ENABLED=false \
 SPLUNK_DISCOVERY_EXTENSIONS_host_observer_CONFIG_refresh_interval=\${REFRESH_INTERVAL} \
-/otelcol --config-dir /opt/config.d --discovery --dry-run`)
+/otelcol --config-dir /opt/config.d --discovery --feature-gates=-splunk.continuousDiscovery --dry-run`)
 
 	errorContent := fmt.Sprintf("unexpected --dry-run: %s", stderr)
 	require.Equal(t, `exporters:

--- a/tests/receivers/envoy/bundled_k8s_test.go
+++ b/tests/receivers/envoy/bundled_k8s_test.go
@@ -142,6 +142,7 @@ func TestEnvoyK8sObserver(t *testing.T) {
 			pmetrictest.IgnoreResourceAttributeValue("service.name"),
 			pmetrictest.IgnoreResourceAttributeValue("service_instance_id"),
 			pmetrictest.IgnoreResourceAttributeValue("service_version"),
+			pmetrictest.IgnoreResourceAttributeValue("discovery.endpoint.id"),
 			pmetrictest.IgnoreMetricAttributeValue("service_version"),
 			pmetrictest.IgnoreMetricAttributeValue("service_instance_id"),
 			pmetrictest.IgnoreResourceAttributeValue("server.address"),

--- a/tests/receivers/envoy/bundled_test.go
+++ b/tests/receivers/envoy/bundled_test.go
@@ -44,7 +44,6 @@ func TestEnvoyDockerObserver(t *testing.T) {
 	_, shutdown := tc.SplunkOtelCollectorContainer("otlp_exporter.yaml", func(collector testutils.Collector) testutils.Collector {
 		cc := collector.(*testutils.CollectorContainer)
 		return cc.WithEnv(map[string]string{
-			"SPLUNK_DISCOVERY_DURATION":  "20s",
 			"SPLUNK_DISCOVERY_LOG_LEVEL": "debug",
 		}).WithArgs(
 			"--discovery",
@@ -72,6 +71,7 @@ func TestEnvoyDockerObserver(t *testing.T) {
 			pmetrictest.IgnoreResourceAttributeValue("service.name"),
 			pmetrictest.IgnoreResourceAttributeValue("service_instance_id"),
 			pmetrictest.IgnoreResourceAttributeValue("service_version"),
+			pmetrictest.IgnoreResourceAttributeValue("discovery.endpoint.id"),
 			pmetrictest.IgnoreMetricAttributeValue("service_version"),
 			pmetrictest.IgnoreMetricAttributeValue("service_instance_id"),
 			pmetrictest.IgnoreResourceAttributeValue("server.address"),

--- a/tests/receivers/mysql/bundled_test.go
+++ b/tests/receivers/mysql/bundled_test.go
@@ -44,12 +44,11 @@ func TestMysqlDockerObserver(t *testing.T) {
 
 	_, shutdown := tc.SplunkOtelCollectorContainer("otlp_exporter.yaml", func(c testutils.Collector) testutils.Collector {
 		cc := c.(*testutils.CollectorContainer)
-		cc.Container = cc.Container.WillWaitForLogs("Discovering for next")
+		cc.Container = cc.Container.WillWaitForLogs("Everything is ready")
 		return cc
 	},
 		func(collector testutils.Collector) testutils.Collector {
 			return collector.WithEnv(map[string]string{
-				"SPLUNK_DISCOVERY_DURATION":  "60s",
 				"SPLUNK_DISCOVERY_LOG_LEVEL": "debug",
 			}).WithArgs(
 				"--discovery",
@@ -79,6 +78,7 @@ func TestMysqlDockerObserver(t *testing.T) {
 			pmetrictest.IgnoreResourceAttributeValue("service.name"),
 			pmetrictest.IgnoreResourceAttributeValue("service_instance_id"),
 			pmetrictest.IgnoreResourceAttributeValue("service_version"),
+			pmetrictest.IgnoreResourceAttributeValue("discovery.endpoint.id"),
 			pmetrictest.IgnoreMetricAttributeValue("service_version"),
 			pmetrictest.IgnoreMetricAttributeValue("service_instance_id"),
 			pmetrictest.IgnoreResourceAttributeValue("mysql.instance.endpoint"),

--- a/tests/receivers/oracledb/bundled_test.go
+++ b/tests/receivers/oracledb/bundled_test.go
@@ -41,12 +41,11 @@ func TestOracledbDockerObserver(t *testing.T) {
 
 	_, shutdown := tc.SplunkOtelCollectorContainer("otlp_exporter.yaml", func(c testutils.Collector) testutils.Collector {
 		cc := c.(*testutils.CollectorContainer)
-		cc.Container = cc.Container.WillWaitForLogs("Discovering for next")
+		cc.Container = cc.Container.WillWaitForLogs("Everything is ready")
 		return cc
 	},
 		func(collector testutils.Collector) testutils.Collector {
 			return collector.WithEnv(map[string]string{
-				"SPLUNK_DISCOVERY_DURATION": "20s",
 				// confirm that debug logging doesn't affect runtime
 				"SPLUNK_DISCOVERY_LOG_LEVEL": "debug",
 				"ORACLE_PASSWORD":            "password",

--- a/tests/receivers/redis/bundled_test.go
+++ b/tests/receivers/redis/bundled_test.go
@@ -44,7 +44,7 @@ func TestRedisDockerObserver(t *testing.T) {
 
 	_, shutdown := tc.SplunkOtelCollectorContainer("otlp_exporter.yaml", func(c testutils.Collector) testutils.Collector {
 		cc := c.(*testutils.CollectorContainer)
-		cc.Container = cc.Container.WillWaitForLogs("Discovering for next")
+		cc.Container = cc.Container.WillWaitForLogs("Everything is ready")
 		return cc
 	},
 		func(collector testutils.Collector) testutils.Collector {
@@ -53,7 +53,6 @@ func TestRedisDockerObserver(t *testing.T) {
 				"REDIS_USERNAME": "otel",
 				// confirm that debug logging doesn't affect runtime
 				"SPLUNK_DISCOVERY_LOG_LEVEL": "debug",
-				"SPLUNK_DISCOVERY_DURATION":  "20s",
 			}).WithArgs(
 				"--discovery",
 				"--set", "splunk.discovery.receivers.redis.config.password=${REDIS_PASSWORD}",
@@ -81,6 +80,7 @@ func TestRedisDockerObserver(t *testing.T) {
 			pmetrictest.IgnoreResourceAttributeValue("service.name"),
 			pmetrictest.IgnoreResourceAttributeValue("service_instance_id"),
 			pmetrictest.IgnoreResourceAttributeValue("service_version"),
+			pmetrictest.IgnoreResourceAttributeValue("discovery.endpoint.id"),
 			pmetrictest.IgnoreMetricAttributeValue("service_version"),
 			pmetrictest.IgnoreMetricAttributeValue("service_instance_id"),
 			pmetrictest.IgnoreTimestamp(),


### PR DESCRIPTION
This enables new way to discover third-party components and collect metrics from them:
  - It allows discovering services that were not available at the time of the collector startup but were started later.
  - Information about discovered services will be sent to Splunk Observability Cloud that can be found in "Discovered services" page. If you want to disable this feature and bring back the old behavior, add `--feature-gates=-splunk.continuousDiscovery` command line flag.
