### PR TITLE
try to match against metric received by the sink

### DIFF
--- a/tests/receivers/envoy/bundled_k8s_test.go
+++ b/tests/receivers/envoy/bundled_k8s_test.go
@@ -18,7 +18,6 @@ package tests
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -131,10 +130,10 @@ func TestEnvoyK8sObserver(t *testing.T) {
 			assert.Fail(tt, "No metrics collected")
 			return
 		}
-		var errs error
+		var err error
 		newIndex := len(sink.AllMetrics())
 		for i := index; i < newIndex; i++ {
-			err := pmetrictest.CompareMetrics(expected, m,
+			err = pmetrictest.CompareMetrics(expected, sink.AllMetrics()[i],
 				pmetrictest.IgnoreResourceAttributeValue("service.instance.id"),
 				pmetrictest.IgnoreResourceAttributeValue("net.host.port"),
 				pmetrictest.IgnoreResourceAttributeValue("net.host.name"),
@@ -162,9 +161,8 @@ func TestEnvoyK8sObserver(t *testing.T) {
 			if err == nil {
 				return
 			}
-			errs = errors.Join(errs, err)
 		}
 		index = newIndex
-		assert.NoError(tt, errs)
+		assert.NoError(tt, err)
 	}, 120*time.Second, 1*time.Second)
 }

--- a/tests/receivers/envoy/bundled_k8s_test.go
+++ b/tests/receivers/envoy/bundled_k8s_test.go
@@ -18,6 +18,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -124,39 +125,43 @@ func TestEnvoyK8sObserver(t *testing.T) {
 	expected, err := golden.ReadMetrics(filepath.Join("testdata", "expected_k8s.yaml"))
 	require.NoError(t, err)
 
-	i := 0
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
 		if len(sink.AllMetrics()) == 0 {
 			assert.Fail(tt, "No metrics collected")
 			return
 		}
-
-		i++
-		err := pmetrictest.CompareMetrics(expected, sink.AllMetrics()[len(sink.AllMetrics())-1],
-			pmetrictest.IgnoreResourceAttributeValue("service.instance.id"),
-			pmetrictest.IgnoreResourceAttributeValue("net.host.port"),
-			pmetrictest.IgnoreResourceAttributeValue("net.host.name"),
-			pmetrictest.IgnoreResourceAttributeValue("server.address"),
-			pmetrictest.IgnoreResourceAttributeValue("container.name"),
-			pmetrictest.IgnoreResourceAttributeValue("server.port"),
-			pmetrictest.IgnoreResourceAttributeValue("service.name"),
-			pmetrictest.IgnoreResourceAttributeValue("service_instance_id"),
-			pmetrictest.IgnoreResourceAttributeValue("service_version"),
-			pmetrictest.IgnoreResourceAttributeValue("discovery.endpoint.id"),
-			pmetrictest.IgnoreMetricAttributeValue("service_version"),
-			pmetrictest.IgnoreMetricAttributeValue("service_instance_id"),
-			pmetrictest.IgnoreResourceAttributeValue("server.address"),
-			pmetrictest.IgnoreResourceAttributeValue("k8s.pod.name"),
-			pmetrictest.IgnoreResourceAttributeValue("k8s.pod.uid"),
-			pmetrictest.IgnoreTimestamp(),
-			pmetrictest.IgnoreStartTimestamp(),
-			pmetrictest.IgnoreMetricDataPointsOrder(),
-			pmetrictest.IgnoreScopeMetricsOrder(),
-			pmetrictest.IgnoreScopeVersion(),
-			pmetrictest.IgnoreResourceMetricsOrder(),
-			pmetrictest.IgnoreMetricsOrder(),
-			pmetrictest.IgnoreMetricValues(),
-		)
-		assert.NoError(tt, err)
+		var errs error
+		for _, m := range sink.AllMetrics() {
+			err := pmetrictest.CompareMetrics(expected, m,
+				pmetrictest.IgnoreResourceAttributeValue("service.instance.id"),
+				pmetrictest.IgnoreResourceAttributeValue("net.host.port"),
+				pmetrictest.IgnoreResourceAttributeValue("net.host.name"),
+				pmetrictest.IgnoreResourceAttributeValue("server.address"),
+				pmetrictest.IgnoreResourceAttributeValue("container.name"),
+				pmetrictest.IgnoreResourceAttributeValue("server.port"),
+				pmetrictest.IgnoreResourceAttributeValue("service.name"),
+				pmetrictest.IgnoreResourceAttributeValue("service_instance_id"),
+				pmetrictest.IgnoreResourceAttributeValue("service_version"),
+				pmetrictest.IgnoreResourceAttributeValue("discovery.endpoint.id"),
+				pmetrictest.IgnoreMetricAttributeValue("service_version"),
+				pmetrictest.IgnoreMetricAttributeValue("service_instance_id"),
+				pmetrictest.IgnoreResourceAttributeValue("server.address"),
+				pmetrictest.IgnoreResourceAttributeValue("k8s.pod.name"),
+				pmetrictest.IgnoreResourceAttributeValue("k8s.pod.uid"),
+				pmetrictest.IgnoreTimestamp(),
+				pmetrictest.IgnoreStartTimestamp(),
+				pmetrictest.IgnoreMetricDataPointsOrder(),
+				pmetrictest.IgnoreScopeMetricsOrder(),
+				pmetrictest.IgnoreScopeVersion(),
+				pmetrictest.IgnoreResourceMetricsOrder(),
+				pmetrictest.IgnoreMetricsOrder(),
+				pmetrictest.IgnoreMetricValues(),
+			)
+			if err == nil {
+				return
+			}
+			errs = errors.Join(errs, err)
+		}
+		assert.NoError(tt, errs)
 	}, 120*time.Second, 1*time.Second)
 }

--- a/tests/receivers/envoy/bundled_k8s_test.go
+++ b/tests/receivers/envoy/bundled_k8s_test.go
@@ -125,13 +125,15 @@ func TestEnvoyK8sObserver(t *testing.T) {
 	expected, err := golden.ReadMetrics(filepath.Join("testdata", "expected_k8s.yaml"))
 	require.NoError(t, err)
 
+	index := 0
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
 		if len(sink.AllMetrics()) == 0 {
 			assert.Fail(tt, "No metrics collected")
 			return
 		}
 		var errs error
-		for _, m := range sink.AllMetrics() {
+		newIndex := len(sink.AllMetrics())
+		for i := index; i < newIndex; i++ {
 			err := pmetrictest.CompareMetrics(expected, m,
 				pmetrictest.IgnoreResourceAttributeValue("service.instance.id"),
 				pmetrictest.IgnoreResourceAttributeValue("net.host.port"),
@@ -162,6 +164,7 @@ func TestEnvoyK8sObserver(t *testing.T) {
 			}
 			errs = errors.Join(errs, err)
 		}
+		index = newIndex
 		assert.NoError(tt, errs)
 	}, 120*time.Second, 1*time.Second)
 }

--- a/tests/receivers/smartagent/postgresql/postgresql_test.go
+++ b/tests/receivers/smartagent/postgresql/postgresql_test.go
@@ -17,7 +17,6 @@
 package tests
 
 import (
-	"errors"
 	"path"
 	"path/filepath"
 	"testing"
@@ -61,12 +60,12 @@ func TestPostgresReceiverProvidesAllMetrics(t *testing.T) {
 			assert.Fail(tt, "No metrics collected")
 			return
 		}
-		var errs error
+		var err error
 		newIndex := len(tc.OTLPReceiverSink.AllMetrics()) - 1
 		for i := newIndex; i >= lastIndex; i-- {
 			m := tc.OTLPReceiverSink.AllMetrics()[i]
 			if m.MetricCount() == expected.MetricCount() {
-				err := pmetrictest.CompareMetrics(expected, m,
+				err = pmetrictest.CompareMetrics(expected, m,
 					pmetrictest.IgnoreResourceAttributeValue("service.instance.id"),
 					pmetrictest.IgnoreResourceAttributeValue("net.host.port"),
 					pmetrictest.IgnoreResourceAttributeValue("server.port"),
@@ -90,10 +89,9 @@ func TestPostgresReceiverProvidesAllMetrics(t *testing.T) {
 				if err == nil {
 					return
 				}
-				errs = errors.Join(errs, err)
 			}
 		}
 		lastIndex = newIndex
-		assert.NoError(tt, errs)
+		assert.NoError(tt, err)
 	}, 30*time.Second, 1*time.Second)
 }

--- a/tests/receivers/smartagent/postgresql/postgresql_test.go
+++ b/tests/receivers/smartagent/postgresql/postgresql_test.go
@@ -55,13 +55,15 @@ func TestPostgresReceiverProvidesAllMetrics(t *testing.T) {
 
 	expected, err := golden.ReadMetrics(filepath.Join("testdata", "expected", "all.yaml"))
 	require.NoError(t, err)
+	lastIndex := 0
 	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
 		if len(tc.OTLPReceiverSink.AllMetrics()) == 0 {
 			assert.Fail(tt, "No metrics collected")
 			return
 		}
 		var errs error
-		for i := len(tc.OTLPReceiverSink.AllMetrics()) - 1; i >= 0; i-- {
+		newIndex := len(tc.OTLPReceiverSink.AllMetrics()) - 1
+		for i := newIndex; i >= lastIndex; i-- {
 			m := tc.OTLPReceiverSink.AllMetrics()[i]
 			if m.MetricCount() == expected.MetricCount() {
 				err := pmetrictest.CompareMetrics(expected, m,
@@ -91,6 +93,7 @@ func TestPostgresReceiverProvidesAllMetrics(t *testing.T) {
 				errs = errors.Join(errs, err)
 			}
 		}
+		lastIndex = newIndex
 		assert.NoError(tt, errs)
 	}, 30*time.Second, 1*time.Second)
 }

--- a/tests/testutils/golden.go
+++ b/tests/testutils/golden.go
@@ -124,13 +124,16 @@ func RunMetricsCollectionTest(t *testing.T, configFile string, expectedFilePath 
 	expected, err := golden.ReadMetrics(filepath.Join("testdata", expectedFilePath))
 	require.NoError(t, err)
 
+	index := 0
 	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
 		if len(sink.AllMetrics()) == 0 {
 			assert.Fail(tt, "No metrics collected")
 			return
 		}
 		var errs error
-		for _, m := range sink.AllMetrics() {
+		newIndex := len(sink.AllMetrics())
+		for i := index; i < newIndex; i++ {
+			m := sink.AllMetrics()[i]
 			err := pmetrictest.CompareMetrics(expected, m,
 				opts.compareMetricsOptions...)
 			if err == nil {
@@ -138,6 +141,7 @@ func RunMetricsCollectionTest(t *testing.T, configFile string, expectedFilePath 
 			}
 			errs = errors.Join(errs, err)
 		}
+		index = newIndex
 		assert.NoError(tt, errs)
 	}, 30*time.Second, 1*time.Second)
 }

--- a/tests/testutils/golden.go
+++ b/tests/testutils/golden.go
@@ -17,7 +17,6 @@ package testutils
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -130,18 +129,17 @@ func RunMetricsCollectionTest(t *testing.T, configFile string, expectedFilePath 
 			assert.Fail(tt, "No metrics collected")
 			return
 		}
-		var errs error
+		var err error
 		newIndex := len(sink.AllMetrics())
 		for i := index; i < newIndex; i++ {
 			m := sink.AllMetrics()[i]
-			err := pmetrictest.CompareMetrics(expected, m,
+			err = pmetrictest.CompareMetrics(expected, m,
 				opts.compareMetricsOptions...)
 			if err == nil {
 				return
 			}
-			errs = errors.Join(errs, err)
 		}
 		index = newIndex
-		assert.NoError(tt, errs)
+		assert.NoError(tt, err)
 	}, 30*time.Second, 1*time.Second)
 }


### PR DESCRIPTION
Attempt to make testing catch any intermediate metrics that we may have received instead of the latest metrics in the sink.