### PR TITLE
Fix update otel version script

### DIFF
--- a/packaging/technical-addon/Makefile
+++ b/packaging/technical-addon/Makefile
@@ -119,7 +119,6 @@ discovery-test-ta:
 .PHONY: update-ta-deps
 update-ta-deps:
 	SOURCE_DIR="$(SOURCE_DIR)" \
-	SPLUNK_OTEL_VERSION="$(SPLUNK_OTEL_VERSION)" \
 	$(SOURCE_DIR)/packaging-scripts/update-otel-version.sh
 	
 	SOURCE_DIR="$(SOURCE_DIR)" \

--- a/packaging/technical-addon/packaging-scripts/update-otel-version.sh
+++ b/packaging/technical-addon/packaging-scripts/update-otel-version.sh
@@ -19,7 +19,7 @@
 #SPLUNK_OTEL_VERSION="v0.88.0"
 SPLUNK_OTEL_VERSION="${SPLUNK_OTEL_VERSION:-}"
 if [ -z "$SPLUNK_OTEL_VERSION" ]; then
-    SPLUNK_OTEL_VERSION="$(curl "https://api.github.com/repos/signalfx/splunk-otel-collector/tags" | jq -r '.[0].name')"
+    SPLUNK_OTEL_VERSION="$(curl "https://api.github.com/repos/signalfx/splunk-otel-collector/tags" | jq -r '[.[].name | select(test("v[0-9]+\\.[0-9]+\\.[0-9]+")) | sub("^v"; "")] | sort_by(split(".") | map(tonumber)) | last | "v" + .')"
 fi
 echo "updating otel to version $SPLUNK_OTEL_VERSION"
 sed -i'.old' "s/^OTEL_COLLECTOR_VERSION?=.*$/OTEL_COLLECTOR_VERSION?=${SPLUNK_OTEL_VERSION#v}/g" "$SOURCE_DIR/Makefile" && rm "$SOURCE_DIR/Makefile.old"


### PR DESCRIPTION
During testing, I accidentally uploaded an invalid tag we cannot delete (`v$1.$2.3`)

This adds a filter on the tags to get around such, and more resiliently grabs the latest version

Testing:

ran `TA_VERSION=1.4.0 make update-and-release` and this was the result:

https://github.com/signalfx/splunk-otel-collector/compare/release/technical-addon/v1.4.0?expand=1