### PR TITLE
[chore] fix TestTelegrafSQLServerReceiverProvidesAllMetrics

### DIFF
--- a/tests/receivers/smartagent/telegraf-sqlserver/telegraf_sqlserver_test.go
+++ b/tests/receivers/smartagent/telegraf-sqlserver/telegraf_sqlserver_test.go
@@ -81,6 +81,7 @@ func TestTelegrafSQLServerReceiverProvidesAllMetrics(t *testing.T) {
 			pmetrictest.IgnoreResourceAttributeValue("service_version"),
 			pmetrictest.IgnoreMetricAttributeValue("service_version"),
 			pmetrictest.IgnoreMetricAttributeValue("service_instance_id"),
+			pmetrictest.IgnoreMetricAttributeValue("sql_version"),
 			pmetrictest.IgnoreMetricAttributeValue("sql_instance"),
 			pmetrictest.IgnoreMetricAttributeValue("instance"),
 			pmetrictest.IgnoreMetricAttributeValue("wait_type"),


### PR DESCRIPTION
Ignore `sql_version` attribute value since we don't pin the MySQL image version.

The latest go updated, and we are getting the `sql_version` attribute value mismatch errors:
```
-  resource "map[system.type:sqlserver]": scope "": metric "sqlserver_server_properties.cpu_count": missing expected datapoint: map[hardware_type: plugin:telegraf-sqlserver sku:Developer Edition (64-bit) sql_instance: sql_version:15.0.4415.2 telegraf_type:untyped]
-  resource "map[system.type:sqlserver]": scope "": metric "sqlserver_server_properties.cpu_count": unexpected datapoint: map[hardware_type: plugin:telegraf-sqlserver sku:Developer Edition (64-bit) sql_instance: sql_version:15.0.4420.2 telegraf_type:untyped]
```