### PR TITLE
[chore] Fix RunMetricsCollectionTest helper to avoid false positives

### DIFF
--- a/tests/testutils/golden.go
+++ b/tests/testutils/golden.go
@@ -125,11 +125,7 @@ func RunMetricsCollectionTest(t *testing.T, configFile string, expectedFilePath 
 
 	index := 0
 	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
-		if len(sink.AllMetrics()) == 0 {
-			assert.Fail(tt, "No metrics collected")
-			return
-		}
-		var err error
+		err := fmt.Errorf("no matching metrics found, %d collected", index)
 		newIndex := len(sink.AllMetrics())
 		for i := index; i < newIndex; i++ {
 			m := sink.AllMetrics()[i]


### PR DESCRIPTION
Currently, the test passes if there are no new metrics between the `assert.EventuallyWithT` tries because the for loop isn't executed, and the `err` is left to the initiated `nil.`
