### PR TITLE
[chore] Add an integration test to validate internal metrics

### DIFF
--- a/tests/general/internal_metrics_test.go
+++ b/tests/general/internal_metrics_test.go
@@ -1,0 +1,55 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
+
+	"github.com/signalfx/splunk-otel-collector/tests/testutils"
+)
+
+func TestDefaultInternalMetrics(t *testing.T) {
+	testutils.RunMetricsCollectionTest(t, "internal_metrics_config.yaml", "internal_metrics_expected.yaml",
+		testutils.WithCompareMetricsOptions(
+			pmetrictest.IgnoreStartTimestamp(),
+			pmetrictest.IgnoreTimestamp(),
+			pmetrictest.IgnoreMetricsOrder(),
+			pmetrictest.IgnoreScopeVersion(),
+			pmetrictest.IgnoreMetricValues(
+				"otelcol_exporter_sent_metric_points",
+				"otelcol_process_cpu_seconds",
+				"otelcol_process_memory_rss",
+				"otelcol_process_runtime_heap_alloc_bytes",
+				"otelcol_process_runtime_total_alloc_bytes",
+				"otelcol_process_runtime_total_sys_memory_bytes",
+				"otelcol_process_uptime",
+				"otelcol_receiver_accepted_metric_points",
+				"scrape_duration_seconds",
+				"scrape_samples_post_metric_relabeling",
+				"scrape_samples_scraped",
+				"scrape_series_added",
+				"up",
+			),
+			pmetrictest.IgnoreResourceAttributeValue("service_instance_id"),
+			pmetrictest.IgnoreResourceAttributeValue("service_version"),
+			pmetrictest.IgnoreMetricAttributeValue("service_instance_id"),
+			pmetrictest.IgnoreMetricAttributeValue("service_version"),
+		),
+	)
+}

--- a/tests/general/testdata/internal_metrics_config.yaml
+++ b/tests/general/testdata/internal_metrics_config.yaml
@@ -1,0 +1,22 @@
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "test"
+          scrape_interval: 1s
+          static_configs:
+            - targets: ["localhost:8888"]
+exporters:
+  otlp:
+    endpoint: "${OTLP_ENDPOINT}"
+    tls:
+      insecure: true
+
+service:
+  telemetry:
+    logs:
+      level: debug
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      exporters: [otlp]

--- a/tests/general/testdata/internal_metrics_expected.yaml
+++ b/tests/general/testdata/internal_metrics_expected.yaml
@@ -1,0 +1,374 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: http.scheme
+          value:
+            stringValue: http
+        - key: net.host.port
+          value:
+            stringValue: "8888"
+        - key: server.port
+          value:
+            stringValue: "8888"
+        - key: service.instance.id
+          value:
+            stringValue: localhost:8888
+        - key: service.name
+          value:
+            stringValue: test
+        - key: service_instance_id
+          value:
+            stringValue: 4109d2cd-6907-4e60-862b-b3ef85d76574
+        - key: service_name
+          value:
+            stringValue: otelcol
+        - key: service_version
+          value:
+            stringValue: v0.118.0-9-g261873a8c
+        - key: url.scheme
+          value:
+            stringValue: http
+    scopeMetrics:
+      - metrics:
+          - description: Fixed capacity of the retry queue (in batches)
+            gauge:
+              dataPoints:
+                - asDouble: 1000
+                  attributes:
+                    - key: exporter
+                      value:
+                        stringValue: otlp
+                    - key: service_instance_id
+                      value:
+                        stringValue: 4109d2cd-6907-4e60-862b-b3ef85d76574
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.118.0-9-g261873a8c
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: otelcol_exporter_queue_capacity
+          - description: Total physical memory (resident set size) [alpha]
+            gauge:
+              dataPoints:
+                - asDouble: 1.82636544e+08
+                  attributes:
+                    - key: service_instance_id
+                      value:
+                        stringValue: 4109d2cd-6907-4e60-862b-b3ef85d76574
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.118.0-9-g261873a8c
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: otelcol_process_memory_rss
+          - description: Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc') [alpha]
+            gauge:
+              dataPoints:
+                - asDouble: 2.5950552e+07
+                  attributes:
+                    - key: service_instance_id
+                      value:
+                        stringValue: 4109d2cd-6907-4e60-862b-b3ef85d76574
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.118.0-9-g261873a8c
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: otelcol_process_runtime_heap_alloc_bytes
+          - description: Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys') [alpha]
+            gauge:
+              dataPoints:
+                - asDouble: 4.1506056e+07
+                  attributes:
+                    - key: service_instance_id
+                      value:
+                        stringValue: 4109d2cd-6907-4e60-862b-b3ef85d76574
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.118.0-9-g261873a8c
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: otelcol_process_runtime_total_sys_memory_bytes
+          - description: Number of metric points successfully pushed into the pipeline. [alpha]
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: otelcol_receiver_accepted_metric_points
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 319
+                  attributes:
+                    - key: receiver
+                      value:
+                        stringValue: prometheus
+                    - key: service_instance_id
+                      value:
+                        stringValue: 4109d2cd-6907-4e60-862b-b3ef85d76574
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.118.0-9-g261873a8c
+                    - key: transport
+                      value:
+                        stringValue: http
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+          - description: The number of samples remaining after metric relabeling was applied
+            gauge:
+              dataPoints:
+                - asDouble: 13
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: scrape_samples_post_metric_relabeling
+          - description: Current size of the retry queue (in batches)
+            gauge:
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: data_type
+                      value:
+                        stringValue: metrics
+                    - key: exporter
+                      value:
+                        stringValue: otlp
+                    - key: service_instance_id
+                      value:
+                        stringValue: 4109d2cd-6907-4e60-862b-b3ef85d76574
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.118.0-9-g261873a8c
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: otelcol_exporter_queue_size
+          - description: Number of metric points in failed attempts to send to destination. [alpha]
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: otelcol_exporter_send_failed_metric_points
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: exporter
+                      value:
+                        stringValue: otlp
+                    - key: service_instance_id
+                      value:
+                        stringValue: 4109d2cd-6907-4e60-862b-b3ef85d76574
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.118.0-9-g261873a8c
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+          - description: Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc') [alpha]
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: otelcol_process_runtime_total_alloc_bytes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 3.8346408e+07
+                  attributes:
+                    - key: service_instance_id
+                      value:
+                        stringValue: 4109d2cd-6907-4e60-862b-b3ef85d76574
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.118.0-9-g261873a8c
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+          - description: The scraping was successful
+            gauge:
+              dataPoints:
+                - asDouble: 1
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: up
+          - description: The number of samples the target exposed
+            gauge:
+              dataPoints:
+                - asDouble: 13
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: scrape_samples_scraped
+          - description: Number of metric points successfully sent to destination. [alpha]
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: otelcol_exporter_sent_metric_points
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 319
+                  attributes:
+                    - key: exporter
+                      value:
+                        stringValue: otlp
+                    - key: service_instance_id
+                      value:
+                        stringValue: 4109d2cd-6907-4e60-862b-b3ef85d76574
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.118.0-9-g261873a8c
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+          - description: The approximate number of new series in this scrape
+            gauge:
+              dataPoints:
+                - asDouble: 13
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: scrape_series_added
+          - description: Total CPU user and system time in seconds [alpha]
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: otelcol_process_cpu_seconds
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 1.11
+                  attributes:
+                    - key: service_instance_id
+                      value:
+                        stringValue: 4109d2cd-6907-4e60-862b-b3ef85d76574
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.118.0-9-g261873a8c
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+          - description: Uptime of the process [alpha]
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: otelcol_process_uptime
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 24.295834539
+                  attributes:
+                    - key: service_instance_id
+                      value:
+                        stringValue: 4109d2cd-6907-4e60-862b-b3ef85d76574
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.118.0-9-g261873a8c
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+          - description: Number of metric points that could not be pushed into the pipeline. [alpha]
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: otelcol_receiver_refused_metric_points
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: receiver
+                      value:
+                        stringValue: prometheus
+                    - key: service_instance_id
+                      value:
+                        stringValue: 4109d2cd-6907-4e60-862b-b3ef85d76574
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.118.0-9-g261873a8c
+                    - key: transport
+                      value:
+                        stringValue: http
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+          - description: Duration of the scrape
+            gauge:
+              dataPoints:
+                - asDouble: 0.001270916
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: scrape_duration_seconds
+            unit: s
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
+          version: v0.118.0-9-g261873a8c


### PR DESCRIPTION
The test is needed for the 0.119.0 upgrade to validate that the output of the internal metrics isn't changed. There was a new unexpected metric added.