### PR TITLE
[chore] Pin govuln check to latest released version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ install-tools:
 	cd ./internal/tools && go install github.com/tcnksm/ghr
 	cd ./internal/tools && go install golang.org/x/tools/cmd/goimports
 	cd ./internal/tools && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment
-	cd ./internal/tools && go install golang.org/x/vuln/cmd/govulncheck@master
+	cd ./internal/tools && go install golang.org/x/vuln/cmd/govulncheck@latest
 
 
 .PHONY: generate-metrics


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`compile` is failing on `main` due to the `govulncheck@master` package requiring `>= go 1.23`. Since we're still on `go 1.22` for testing, we can pin this dependency to the latest release instead. This should keep it updated enough to save us from manually updating it, while also preserving us from breaking changes in `master` unexpectedly between releases.

**Testing:**
```
$ go install golang.org/x/vuln/cmd/govulncheck@latest
$ govulncheck --version
Go: go1.22.10
Scanner: govulncheck@v1.1.4
```