### PR TITLE
[chore] Update IIS test to retry GET requests until successful

### DIFF
--- a/tests/zeroconfig/windows/windows_iis_test.go
+++ b/tests/zeroconfig/windows/windows_iis_test.go
@@ -122,7 +122,7 @@ func testExpectedTracesForHTTPGetRequest(t *testing.T, otlp *testutils.OTLPRecei
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
-		status, err := checkHTTPGetRequestSuccess(t, url)
+		status, err := checkHTTPGetRequest(t, url)
 		if err != nil || status != http.StatusOK {
 			// Check err first as status code will be set to 0 upon error, which also enters this
 			// if statement

--- a/tests/zeroconfig/windows/windows_iis_test.go
+++ b/tests/zeroconfig/windows/windows_iis_test.go
@@ -95,7 +95,9 @@ func requireNoErrorExecCommand(t *testing.T, name string, arg ...string) {
 	var out strings.Builder
 	cmd.Stdout = &out
 	err := cmd.Run()
-	t.Log(out.String())
+	if out != nil {
+		t.Log(out.String())
+	}
 	require.NoError(t, err)
 }
 

--- a/tests/zeroconfig/windows/windows_iis_test.go
+++ b/tests/zeroconfig/windows/windows_iis_test.go
@@ -17,6 +17,7 @@
 package zeroconfig
 
 import (
+	"fmt"
 	"net/http"
 	"os/exec"
 	"path"
@@ -99,15 +100,17 @@ func requireNoErrorExecCommand(t *testing.T, name string, arg ...string) {
 	require.NoError(t, err)
 }
 
+// Returns status code of 0 when an error is hit. The error contains useful information
+// when the status code is 0.
 func checkHTTPGetRequest(t *testing.T, url string) (int, error) {
 	httpClient := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	defer resp.Body.Close()
@@ -121,6 +124,13 @@ func testExpectedTracesForHTTPGetRequest(t *testing.T, otlp *testutils.OTLPRecei
 	assert.Eventually(t, func() bool {
 		status, err := checkHTTPGetRequestSuccess(t, url)
 		if err != nil || status != http.StatusOK {
+			// Check err first as status code will be set to 0 upon error, which also enters this
+			// if statement
+			if err != nil {
+				t.Log(err)
+			} else {
+				t.Log(fmt.Sprintf("Expected status code %i, received %i. Retrying.", http.StatusOK, status))
+			}
 			return false
 		}
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This test is failing pretty consistently on either the returned status of the GET request is `500`, or the target machine actively refuses the request. This is to test to see if retrying the check after some time passes allows the server to be up and running and successfully process the command.