### PR TITLE
Bump minimum go version to 1.23

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -137,6 +137,10 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "docker"
+    directory: "/docker/envoy"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
     directory: "/docker/haproxy"
     schedule:
       interval: "weekly"

--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -22,7 +22,7 @@ env:
   PYTHON_VERSION: '3.13'
   PIP_VERSION: '24.2'
   REQUIREMENTS_PATH: "packaging/tests/requirements.txt"
-  GO_VERSION: 1.22.10
+  GO_VERSION: 1.23.6
 
 jobs:
   cross-compile:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.22.10
+  GO_VERSION: 1.23.6
 
 jobs:
   setup-environment:

--- a/.github/workflows/darwin-test.yml
+++ b/.github/workflows/darwin-test.yml
@@ -19,7 +19,7 @@ on:
       - '!packaging/**'
 
 env:
-  GO_VERSION: '1.22.10'
+  GO_VERSION: '1.23.6'
 
 concurrency:
   group: darwin-test-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/gendependabot.yml
+++ b/.github/workflows/gendependabot.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/scripts/gendependabot.sh'
 
 env:
-  GO_VERSION: 1.22.10
+  GO_VERSION: 1.23.6
 
 jobs:
   gendependabot:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -27,7 +27,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.22.10"
+  GO_VERSION: "1.23.6"
 jobs:
   agent-bundle-linux:
     runs-on: ${{ fromJSON('["ubuntu-24.04", "otel-arm64"]')[matrix.ARCH == 'arm64'] }}

--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.22.10
+  GO_VERSION: 1.23.6
 
 jobs:
   lint:

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -22,7 +22,7 @@ env:
   PYTHON_VERSION: '3.13'
   PIP_VERSION: '24.2'
   REQUIREMENTS_PATH: "packaging/tests/requirements.txt"
-  GO_VERSION: 1.22.10
+  GO_VERSION: 1.23.6
 
 jobs:
   setup-environment:

--- a/.github/workflows/otelcol-fips.yml
+++ b/.github/workflows/otelcol-fips.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.22.10"
+  GO_VERSION: "1.23.6"
 
 jobs:
   otelcol-fips:

--- a/.github/workflows/splunk-ta-otel.yml
+++ b/.github/workflows/splunk-ta-otel.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.22.10
+  GO_VERSION: 1.23.6
 
 jobs:
   setup-environment:

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -14,7 +14,7 @@ on:
     - cron: '0 0 * * 1-5' # Every weekday at midnight UTC
 
 env:
-  GO_VERSION: '1.22.10'
+  GO_VERSION: '1.23.6'
 
 concurrency:
   group: vuln-scans-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.22.10
+  GO_VERSION: 1.23.6
 
 jobs:
   setup-environment:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -18,7 +18,7 @@ on:
       - '!packaging/**'
 
 env:
-  GO_VERSION: '1.22.10'
+  GO_VERSION: '1.23.6'
 
 concurrency:
   group: windows-test-${{ github.event.pull_request.number || github.ref }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,7 +163,7 @@ fossa:
       fi
 
 .go-cache:
-  image: '${DOCKER_HUB_REPO}/golang:1.22.10'
+  image: '${DOCKER_HUB_REPO}/golang:1.23.6'
   variables:
     GOPATH: "$CI_PROJECT_DIR/.go"
   before_script:
@@ -325,7 +325,7 @@ compile:
       - bin/migratecheckpoint_*
 
 otelcol-fips:
-  image: '${DOCKER_CICD_REPO}/ci-container/golang-1.22:3.5.0'
+  image: '${DOCKER_CICD_REPO}/ci-container/golang-1.23:3.9.0'
   extends:
     - .trigger-filter
   stage: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛑 Breaking changes 🛑
 
-- (all) Bump minimum go version to 1.23
+- (all) Bump minimum go version to 1.23 ([#5920](https://github.com/signalfx/splunk-otel-collector/pull/5920))
 
 ## v0.119.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- (all) Bump minimum go version to 1.23
+
 ## v0.119.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.119.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.119.0) and the [opentelemetry-collector-contrib v0.119.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.119.0) releases where appropriate.

--- a/cmd/otelcol/fips/build/Dockerfile.linux
+++ b/cmd/otelcol/fips/build/Dockerfile.linux
@@ -1,5 +1,5 @@
 ARG DOCKER_REPO=docker.io
-ARG GO_VERSION=1.22.10
+ARG GO_VERSION=1.23
 FROM ${DOCKER_REPO}/golang:${GO_VERSION}
 
 # https://splunk.atlassian.net/wiki/x/qYqRDfs

--- a/cmd/otelcol/fips/build/Dockerfile.windows
+++ b/cmd/otelcol/fips/build/Dockerfile.windows
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.22.10
+ARG GO_VERSION=1.23
 FROM mcr.microsoft.com/oss/go/microsoft/golang:${GO_VERSION}
 
 ARG TARGETARCH

--- a/examples/prometheus-federation/prom-counter/go.mod
+++ b/examples/prometheus-federation/prom-counter/go.mod
@@ -1,8 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/prometheus-federation/prom-counter
 
-go 1.22.5
-
-toolchain go1.22.7
+go 1.23.0
 
 require (
 	go.opentelemetry.io/otel v0.20.0

--- a/examples/splunk-hec-traces/tracing/go.mod
+++ b/examples/splunk-hec-traces/tracing/go.mod
@@ -1,8 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/splunk-hec-traces/tracing
 
-go 1.22.5
-
-toolchain go1.22.7
+go 1.23.0
 
 require (
 	go.opentelemetry.io/otel v1.1.0

--- a/examples/splunk-hec/logging/go.mod
+++ b/examples/splunk-hec/logging/go.mod
@@ -1,8 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/splunk-hec/logging
 
-go 1.22.5
-
-toolchain go1.22.7
+go 1.23.0
 
 require go.uber.org/zap v1.27.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/signalfx/splunk-otel-collector
 
-go 1.22.7
-
-toolchain go1.22.10
+go 1.23.0
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.1

--- a/internal/signalfx-agent/go.mod
+++ b/internal/signalfx-agent/go.mod
@@ -1,8 +1,6 @@
 module github.com/signalfx/signalfx-agent
 
-go 1.22.5
-
-toolchain go1.22.7
+go 1.23.0
 
 replace (
 	code.cloudfoundry.org/go-loggregator => github.com/signalfx/go-loggregator v1.0.1-0.20200205155641-5ba5ca92118d

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,8 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/internal/tools
 
-go 1.22.5
-
-toolchain go1.22.7
+go 1.23.0
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/pkg/extension/smartagentextension/go.mod
+++ b/pkg/extension/smartagentextension/go.mod
@@ -1,8 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension
 
-go 1.22.5
-
-toolchain go1.22.7
+go 1.23.0
 
 require (
 	github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657

--- a/pkg/processor/timestampprocessor/go.mod
+++ b/pkg/processor/timestampprocessor/go.mod
@@ -1,8 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocessor
 
-go 1.22.5
-
-toolchain go1.22.7
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/pkg/receiver/smartagentreceiver/go.mod
+++ b/pkg/receiver/smartagentreceiver/go.mod
@@ -1,8 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver
 
-go 1.22.7
-
-toolchain go1.22.10
+go 1.23.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.119.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,8 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/tests
 
-go 1.22.5
-
-toolchain go1.22.7
+go 1.23.0
 
 require (
 	github.com/docker/docker v27.4.0+incompatible

--- a/tests/tools/go.mod
+++ b/tests/tools/go.mod
@@ -1,8 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/tests/tools
 
-go 1.22.5
-
-toolchain go1.22.7
+go 1.23.0
 
 require github.com/Songmu/gotesplit v0.3.1
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This keeps us up to date with upstream
[Upstream contrib PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37875)
[Previous Splunk PR upgrading golang version](https://github.com/signalfx/splunk-otel-collector/pull/5248)