### PR TITLE
[chore] Upgrade qemu docker image version from v7.0.0 to v9.2.0

### DIFF
--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -266,7 +266,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64,ppc64le
-          image: tonistiigi/binfmt:qemu-v7.0.0
+          image: tonistiigi/binfmt:qemu-v9.2.0
 
       - name: Downloading binaries-linux_amd64
         uses: actions/download-artifact@v4


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
An unrelated PR is failing on this step of the `linux-package-test` workflow with the following message:
```
Error response from daemon: image with reference tonistiigi/binfmt:qemu-v7.0.0 was found but does not provide the specified platform (linux/amd64)
```
This attempts to resolve that issue.