### PR TITLE
[tiny] Upload Splunk_TA_otel as asset of splunk-ta-otel workflow

### DIFF
--- a/.github/workflows/splunk-ta-otel.yml
+++ b/.github/workflows/splunk-ta-otel.yml
@@ -107,6 +107,12 @@ jobs:
           set -o pipefail
           PLATFORM="all" make -e distribute-ta
 
+      - name: Upload Collector TA
+        uses: actions/upload-artifact@v4
+        with:
+          name: Splunk_TA_otel
+          path: ./build/out/distribution/Splunk_TA_otel.tgz
+
   test-discovery:
     name: test-discovery
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Makes easier to get a not yet published Splunk_TA_otel by collecting the tgz as an asset of the CI run.