### PR TITLE
[chore][CI/CD] Extend docker observer test timeout

### DIFF
--- a/tests/general/discoverymode/docker_observer_discovery_test.go
+++ b/tests/general/discoverymode/docker_observer_discovery_test.go
@@ -274,7 +274,7 @@ func TestDockerObserver(t *testing.T) {
 	}
 	require.Equal(t, expectedEffective, cc.EffectiveConfig(t, 55554))
 
-	sc, stdout, stderr := cc.Container.AssertExec(t, 25*time.Second,
+	sc, stdout, stderr := cc.Container.AssertExec(t, 3*time.Minute,
 		"sh", "-c", `SPLUNK_DISCOVERY_LOG_LEVEL=error SPLUNK_DEBUG_CONFIG_SERVER=false \
 SPLUNK_DISCOVERY_EXTENSIONS_k8s_observer_ENABLED=false \
 SPLUNK_DISCOVERY_EXTENSIONS_docker_observer_ENABLED=true \


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
[Flaky test failure](https://github.com/signalfx/splunk-otel-collector/actions/runs/13842229250/job/38732965681), the deadline was hit here. This test failed without any recent relevant changes, so this PR attempts to have a less aggressive timeout to reduce flakiness.
