### PR TITLE
[chore][CI/CD] Reduce scriptedinputs collection interval

### DIFF
--- a/tests/receivers/scriptedinputs/testdata/script_config_cpu.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_cpu.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/cpu:
     script_name: cpu
-    collection_interval: 1s
+    collection_interval: 3s
     source: cpu
     sourcetype: cpu
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_cpu.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_cpu.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/cpu:
     script_name: cpu
-    collection_interval: 10s
+    collection_interval: 1s
     source: cpu
     sourcetype: cpu
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_df.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_df.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/df:
     script_name: df
-    collection_interval: 1s
+    collection_interval: 3s
     source: df
     sourcetype: df
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_df.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_df.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/df:
     script_name: df
-    collection_interval: 10s
+    collection_interval: 1s
     source: df
     sourcetype: df
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_hardware.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_hardware.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/hardware:
     script_name: hardware
-    collection_interval: 10s
+    collection_interval: 1s
     source: hardware
     sourcetype: hardware
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_hardware.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_hardware.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/hardware:
     script_name: hardware
-    collection_interval: 1s
+    collection_interval: 3s
     source: hardware
     sourcetype: hardware
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_interfaces.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_interfaces.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/interfaces:
     script_name: interfaces
-    collection_interval: 10s
+    collection_interval: 1s
     source: interfaces
     sourcetype: interfaces
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_interfaces.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_interfaces.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/interfaces:
     script_name: interfaces
-    collection_interval: 1s
+    collection_interval: 3s
     source: interfaces
     sourcetype: interfaces
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_iostat.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_iostat.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/iostat:
     script_name: iostat
-    collection_interval: 10s
+    collection_interval: 1s
     source: iostat
     sourcetype: iostat
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_iostat.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_iostat.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/iostat:
     script_name: iostat
-    collection_interval: 1s
+    collection_interval: 3s
     source: iostat
     sourcetype: iostat
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_lastlog.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_lastlog.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/lastlog:
     script_name: lastlog
-    collection_interval: 10s
+    collection_interval: 1s
     source: lastlog
     sourcetype: lastlog
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_lastlog.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_lastlog.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/lastlog:
     script_name: lastlog
-    collection_interval: 1s
+    collection_interval: 3s
     source: lastlog
     sourcetype: lastlog
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_lsof.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_lsof.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/lsof:
     script_name: lsof
-    collection_interval: 10s
+    collection_interval: 1s
     source: lsof
     sourcetype: lsof
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_lsof.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_lsof.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/lsof:
     script_name: lsof
-    collection_interval: 1s
+    collection_interval: 3s
     source: lsof
     sourcetype: lsof
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_netstat.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_netstat.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/netstat:
     script_name: netstat
-    collection_interval: 10s
+    collection_interval: 1s
     source: netstat
     sourcetype: netstat
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_netstat.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_netstat.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/netstat:
     script_name: netstat
-    collection_interval: 1s
+    collection_interval: 3s
     source: netstat
     sourcetype: netstat
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_openPorts.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_openPorts.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/openPorts:
     script_name: openPorts
-    collection_interval: 10s
+    collection_interval: 1s
     source: openPorts
     sourcetype: openPorts
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_openPorts.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_openPorts.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/openPorts:
     script_name: openPorts
-    collection_interval: 1s
+    collection_interval: 3s
     source: openPorts
     sourcetype: openPorts
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_package.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_package.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/package:
     script_name: package
-    collection_interval: 10s
+    collection_interval: 1s
     source: package
     sourcetype: package
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_package.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_package.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/package:
     script_name: package
-    collection_interval: 1s
+    collection_interval: 3s
     source: package
     sourcetype: package
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_protocol.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_protocol.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/protocol:
     script_name: protocol
-    collection_interval: 1s
+    collection_interval: 3s
     source: protocol
     sourcetype: protocol
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_protocol.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_protocol.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/protocol:
     script_name: protocol
-    collection_interval: 10s
+    collection_interval: 1s
     source: protocol
     sourcetype: protocol
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_ps.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_ps.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/ps:
     script_name: ps
-    collection_interval: 10s
+    collection_interval: 1s
     source: ps
     sourcetype: ps
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_ps.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_ps.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/ps:
     script_name: ps
-    collection_interval: 1s
+    collection_interval: 3s
     source: ps
     sourcetype: ps
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_top.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_top.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/top:
     script_name: top
-    collection_interval: 10s
+    collection_interval: 1s
     source: top
     sourcetype: top
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_top.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_top.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/top:
     script_name: top
-    collection_interval: 1s
+    collection_interval: 3s
     source: top
     sourcetype: top
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_who.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_who.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/who:
     script_name: who
-    collection_interval: 1s
+    collection_interval: 3s
     source: who
     sourcetype: who
 

--- a/tests/receivers/scriptedinputs/testdata/script_config_who.yaml
+++ b/tests/receivers/scriptedinputs/testdata/script_config_who.yaml
@@ -1,7 +1,7 @@
 receivers:
   scripted_inputs/who:
     script_name: who
-    collection_interval: 10s
+    collection_interval: 1s
     source: who
     sourcetype: who
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The scripted inputs tests have flaky failures because no data is received within the 10s timeout. The original configuration of the receiver in each of these tests is to scrape [after one second](https://github.com/open-telemetry/opentelemetry-collector/blob/0e9e259750f8bc4485709067246cc869ec149781/scraper/scraperhelper/config.go#L36), then wait for another 10s from then to scrape again. The test waits 10s from starting and fails if no data is received. That means only one scrape occurs, 1 second after starting up. If the collector isn't fully up after 1 second, the test will fail without retrying to scrape.

This change updates the collection interval to scrape more often, hopefully not too frequently. If the collection interval is hit before a previous scrape is complete, the scraper fails and the test fails, resulting in more flakiness. We have to balance it here.

[Failure example](https://github.com/signalfx/splunk-otel-collector/actions/runs/13815067509/job/38646994379#step:16:1636)