### PR TITLE
[chore][CI/CD][Apache Spark] Reduce collection interval in flaky test

### DIFF
--- a/tests/receivers/apachespark/testdata/all_metrics_config.yaml
+++ b/tests/receivers/apachespark/testdata/all_metrics_config.yaml
@@ -1,6 +1,6 @@
 receivers:
   apachespark:
-    collection_interval: 15s
+    collection_interval: 1s
 
 exporters:
   otlp:

--- a/tests/receivers/apachespark/testdata/all_metrics_config.yaml
+++ b/tests/receivers/apachespark/testdata/all_metrics_config.yaml
@@ -1,6 +1,6 @@
 receivers:
   apachespark:
-    collection_interval: 1s
+    collection_interval: 5s
 
 exporters:
   otlp:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
[Recent failure](https://github.com/signalfx/splunk-otel-collector/actions/runs/13866560120/job/38807065209?pr=5980)

The test has a timeout of 30 seconds, so which means accounting for the initial delay and collection interval, the test would only scrape twice. 15 seconds should have been enough time to get metrics, but this test is flaky without any changes impacting it. This should at least help as there isn't any obvious bug occurring.

If the collection interval is hit before a previous scrape is complete, the scraper fails and the test fails, resulting in more flakiness. We have to balance it here.