### PR TITLE
[chore][CI/CD] Run Puppet tests even when puppet-rake-spec fails

### DIFF
--- a/.github/workflows/puppet-test.yml
+++ b/.github/workflows/puppet-test.yml
@@ -85,7 +85,6 @@ jobs:
     timeout-minutes: 60
     needs:
       - puppet-lint
-      - puppet-rake-spec
       - puppet-test-matrix
     strategy:
       matrix: ${{ fromJSON(needs.puppet-test-matrix.outputs.matrix) }}
@@ -149,7 +148,6 @@ jobs:
     timeout-minutes: 60
     needs:
       - puppet-lint
-      - puppet-rake-spec
     strategy:
       matrix:
         OS: [ "windows-2022" ]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
As we investigate `puppet-rake-spec` failures, we should still let puppet tests run even if `puppet-rake-spec` fails.