### PR TITLE
[chore][CI/CD] Run tidy action on PR update and push

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -291,7 +291,7 @@ update-dotnet-agent:
 
 tidy-dependabot-pr:
   rules:
-    - if: $CI_COMMIT_BRANCH =~ /^dependabot\/go_modules\/.*/ && $CI_COMMIT_AUTHOR =~ /^dependabot.*/
+    - if: ($CI_COMMIT_BRANCH =~ /^dependabot\/go_modules\/.*/) && ($CI_COMMIT_AUTHOR =~ /^dependabot.*/) && (($CI_PIPELINE_SOURCE == "merge_request_event) || ($CI_PIPELINE_SOURCE == "push"))
   extends: .go-cache
   stage: update-deps
   needs: []


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This job is used to update dependabot PRs with by automatically tidying them when necessary. It's currently only running on new PRs. This changes it to run when existing PRs are updated or the relevant branch is pushed.