### PR TITLE
[chore][deployment/databricks] Reload systemctl daemon

### DIFF
--- a/deployments/databricks/deploy_collector.sh
+++ b/deployments/databricks/deploy_collector.sh
@@ -181,6 +181,7 @@ WantedBy=multi-user.target
 
 echo "$collector_service" > $SERVICE_FILE
 chmod 755 $SERVICE_FILE
+systemctl daemon-reload
 
 # The collector is run as a service on the current node
 systemctl start $SPLUNK_OTEL_BINARY_NAME


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
[Change requested by in original PR.](https://github.com/signalfx/splunk-otel-collector/pull/5893#discussion_r1965835492). I've tested with and without the reload, it worked both times. I figure it's at least safer to add the reload just in case.