### PR TITLE
[OTL-3302] SA Processlist, escape new line when encoding

### DIFF
--- a/internal/signalfx-agent/pkg/monitors/processlist/processlist.go
+++ b/internal/signalfx-agent/pkg/monitors/processlist/processlist.go
@@ -172,6 +172,7 @@ func (m *Monitor) encodeProcess(proc *TopProcess, sampleInterval time.Duration) 
 		nice = strconv.Itoa(*proc.Nice)
 	}
 
+	replacer := strings.NewReplacer(`"`, `'`, "\n", `\n`)
 	return fmt.Sprintf(`"%d":["%s",%d,"%s",%d,%d,%d,"%s",%.2f,%.2f,"%s","%s"]`,
 		proc.ProcessID,
 		strings.ReplaceAll(proc.Username, `"`, "'"),
@@ -184,7 +185,7 @@ func (m *Monitor) encodeProcess(proc *TopProcess, sampleInterval time.Duration) 
 		cpuPercent,
 		proc.MemPercent,
 		toTime(proc.TotalCPUTime.Seconds()),
-		strings.ReplaceAll(proc.Command, `"`, `'`),
+		replacer.Replace(proc.Command),
 	)
 }
 

--- a/internal/signalfx-agent/pkg/monitors/processlist/processlist_test.go
+++ b/internal/signalfx-agent/pkg/monitors/processlist/processlist_test.go
@@ -1,0 +1,26 @@
+package processlist
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapedCharacters(t *testing.T) {
+	var m = Monitor{
+		lastCPUCounts: make(map[procKey]time.Duration),
+	}
+	top := &TopProcess{
+		CreatedTime: time.Now(),
+		Nice:        new(int),
+		Username:    "test\"with nested\"quotes",
+		Status:      "running",
+		Command:     "echo test with line break \n character",
+		ProcessID:   200,
+	}
+	encodedVal := m.encodeProcess(top, 10*time.Second)
+	expectedVal := "\"200\":[\"test'with nested'quotes\",0,\"0\",0,0,0,\"running\",0.00,0.00,\"00:00.00\",\"echo test with line break \\n character\"]"
+	assert.Equal(t, encodedVal, expectedVal)
+
+}


### PR DESCRIPTION
**Description:**

This has only been seen on Linux. 
User reported the below error. 
Theory is that If you start a process programmatically, ie: bypassing the command line interpreter, it's possible to start a process with a command that contains an actual new line (not escaped) in its argument.
This is ok from OTEL perspective and the event will be stored fine in our backend, however, when the UI tries to fetch it, the backend fails to decode the event with this error
````
{
  "message" : "Illegal unquoted character ((CTRL-CHAR, code 10)): has to be escaped using backslash to be included in string value\n at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 27545] (through reference chain: java.util.LinkedHashMap[\"240602\"]->java.util.ArrayList[10])",
  "status" : 500,
  "type" : "error"
}
````

**Solution**

String replacer has been used to include existing quote escapes and the new \n replacement with the separate `\` `n` .
Benchmarking showed that `replacer` is more efficient from memory perspective but for 1 or 2 different replacement, `ReplaceAll` is slightly more efficient from CPU usage, but its negligent.

**Testing:** <Describe what testing was performed and which tests were added.>

Added a new unit test.
end to end test; manually reproduced and validated the fix.