### PR TITLE
govulncheck: safely use scan mode symbol by using a large runner

### DIFF
--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -268,7 +268,7 @@ jobs:
           sarif_file: snyk.sarif
 
   govulncheck-run:
-    runs-on: ubuntu-24.04
+    runs-on: macos-14-large
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
@@ -286,7 +286,7 @@ jobs:
 
       - name: Run `govulncheck` script
         env:
-          GOVULN_OPTS: --format sarif --scan package
+          GOVULN_OPTS: --format sarif --scan symbol
         run: ./.github/workflows/scripts/govulncheck-run.sh
 
       - name: Save govulncheck results as artifact

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -268,8 +268,8 @@ jobs:
           sarif_file: snyk.sarif
 
   govulncheck-run:
+    # Running on a large macOS runner to reliably use scan mode as symbol without hitting OOM.
     runs-on: macos-14-large
-    timeout-minutes: 30
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Running with scan mode `symbol` is preferable to scan mode `package` due to more precise diagnostics. A large runner has enough memory to do that reliably.

Successful runs:
1. https://github.com/signalfx/splunk-otel-collector/actions/runs/14071720581/job/39407165670?pr=6031
2. https://github.com/signalfx/splunk-otel-collector/actions/runs/14071833700/job/39407508906?pr=6031