### PR TITLE
Fail govulncheck if vulnerabilities are found

### DIFF
--- a/.github/workflows/scripts/govulncheck-run.sh
+++ b/.github/workflows/scripts/govulncheck-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
 
 mkdir -p ./govulncheck 2>/dev/null
 
@@ -13,23 +13,34 @@ FAILED=0
 # Repository prefix to remove from package names
 REPO_PREFIX=$(go list -m)
 
+if [[ "$GOVULN_OPTS" =~ .*--format[[:space:]]+([a-z]+).* ]]; then
+  FORMAT=${BASH_REMATCH[1]}
+fi
+
 # Run govulncheck for each package
 for pkg in $ALL_PKG_DIRS; do
-  # Remove the repository prefix from the package name to keep the category names short
-  # and replace slashes with underscores to make clear that the categories are not nested.
-  OUTPUT_FILE="./govulncheck/$(echo "$pkg" | sed "s|^$REPO_PREFIX/||" | tr '/' '_').sarif"
-  echo -e "\nRunning govulncheck for package $pkg"
-  if ! govulncheck ${GOVULN_OPTS:-} "$pkg" > "$OUTPUT_FILE"; then
-    echo "govulncheck failed for package $pkg, output saved to $OUTPUT_FILE"
-    FAILED=1
+  echo -e "\n**** Running govulncheck for package $pkg"
+  set +e
+  if [[ -z $FORMAT ]]; then
+    govulncheck ${GOVULN_OPTS} $pkg
   else
-    echo "govulncheck succeeded for package $pkg, output saved to $OUTPUT_FILE"
+    # Remove the repository prefix from the package name to keep the category names short
+    # and replace slashes with underscores to make clear that the categories are not nested.
+    OUTPUT_FILE="./govulncheck/$(echo "$pkg" | sed "s|^$REPO_PREFIX/||" | tr '/' '_').$FORMAT"
+    govulncheck ${GOVULN_OPTS} $pkg > $OUTPUT_FILE
   fi
+  if [ $? -eq 0 ]; then
+    echo -e "\n**** govulncheck succeeded for package $pkg"
+  else
+    echo -e "\n**** govulncheck failed for package $pkg"
+    FAILED=1
+  fi
+  set -e
 done
 
 if [ $FAILED -ne 0 ]; then
-  echo -e "\ngovulncheck failed for one or more packages"
+  echo -e "\n**** govulncheck failed for one or more packages"
   exit 1
 fi
 
-echo -e "\ngovulncheck completed successfully for all packages"
+echo -e "\n**** govulncheck completed successfully for all packages"

--- a/.github/workflows/scripts/govulncheck-run.sh
+++ b/.github/workflows/scripts/govulncheck-run.sh
@@ -13,6 +13,8 @@ FAILED=0
 # Repository prefix to remove from package names
 REPO_PREFIX=$(go list -m)
 
+# Use a bash regex to extract the the value of the --format flag
+# from the GOVULN_OPTS environment variable
 if [[ "$GOVULN_OPTS" =~ .*--format[[:space:]]+([a-z]+).* ]]; then
   FORMAT=${BASH_REMATCH[1]}
 fi

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -284,7 +284,7 @@ jobs:
 
       - run: govulncheck --version
 
-      - name: Run `govulncheck` script
+      - name: Run `govulncheck` to generate SARIF files
         env:
           GOVULN_OPTS: --format sarif --scan symbol
         run: ./.github/workflows/scripts/govulncheck-run.sh
@@ -294,6 +294,11 @@ jobs:
         with:
           name: govulncheck-results
           path: ./govulncheck/
+
+      - name: Run `govulncheck` to fail the workflow if vulnerabilities are found
+        env:
+          GOVULN_OPTS: --show verbose --scan symbol
+        run: ./.github/workflows/scripts/govulncheck-run.sh
 
   govulncheck-categories:
     runs-on: ubuntu-24.04
@@ -320,6 +325,7 @@ jobs:
   govulncheck-upload:
     runs-on: ubuntu-24.04
     needs: [govulncheck-run, govulncheck-categories]
+    if: always() # Always run to upload results to code-scanning even if the scan fails
     strategy:
       matrix: ${{ fromJSON(needs.govulncheck-categories.outputs.matrix) }}
     steps:


### PR DESCRIPTION
For consistency with other vulnerabilities scan the workflow should fail if vulnerabilites are detected.

Example of other vulnerability scans failing:
- https://github.com/signalfx/splunk-otel-collector/actions/runs/14010129646/job/39228865795
- https://github.com/signalfx/splunk-otel-collector/actions/runs/14010129646/job/39228866006