### PR TITLE
[tiny][chore]Remove old redirected links for SFx.NET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2024,7 +2024,7 @@ This Splunk OpenTelemetry Collector release includes changes from the [opentelem
 
 - (Splunk) The Splunk OpenTelemetry Collector [Windows install script](https://docs.splunk.com/observability/en/gdi/opentelemetry/collector-windows/install-windows.html#install-the-collector-using-the-script)
   now installs the [Splunk Distribution of OpenTelemetry .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/otel-dotnet/get-started.html#instrument-net-applications-for-splunk-observability-cloud-opentelemetry)
-  instead of the [SignalFx Instrumentation for .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/otel-dotnet/sfx/sfx-instrumentation.html#signalfx-instrumentation-for-net-deprecated)
+  instead of the `SignalFx Instrumentation for .NET`
   when the parameter `-with_dotnet_instrumentation` is set to `$true` ([#4343](https://github.com/signalfx/splunk-otel-collector/pull/4343))
 - (Core) `receiver/otlp`: Update gRPC code from `codes.InvalidArgument` to `codes.Internal` when a permanent error doesn't contain a gRPC status ([#9415](https://github.com/open-telemetry/opentelemetry-collector/pull/#9415))
 - (Contrib) `kafkareceiver`: standardizes the default topic name for metrics and logs receivers to the same topic name as the metrics and logs exporters of the kafkaexporter ([#27292](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27292))

--- a/deployments/ansible/CHANGELOG.md
+++ b/deployments/ansible/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🛑 Breaking changes 🛑
 
 - Install the [Splunk Distribution of OpenTelemetry .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/otel-dotnet/get-started.html#instrument-net-applications-for-splunk-observability-cloud-opentelemetry)
-  instead of the [SignalFx Instrumentation for .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/otel-dotnet/sfx/sfx-instrumentation.html#signalfx-instrumentation-for-net-deprecated)
+  instead of the `SignalFx Instrumentation for .NET`
   when setting `install_splunk_dotnet_auto_instrumentation` to `true`.
   Corresponding configuration options were renamed from `signalfx_dotnet_*` to `splunk_dotnet_*`.
 

--- a/deployments/chef/CHANGELOG.md
+++ b/deployments/chef/CHANGELOG.md
@@ -3,10 +3,7 @@
 ## chef-v0.17.0
 
 - Remove the option `with_signalfx_dotnet_auto_instrumentation` used to
-install the deprecated
-[SignalFx Auto Instrumentation for .NET](
-https://docs.splunk.com/Observability/gdi/get-data-in/application/dotnet/get-started.html)
-on Windows.
+install the deprecated `SignalFx Auto Instrumentation for .NET` on Windows.
 
 ## chef-v0.16.0
 

--- a/deployments/chef/README.md
+++ b/deployments/chef/README.md
@@ -303,7 +303,7 @@ after installation/configuration in order for any change to take effect.
 ### SignalFx Auto Instrumentation for .NET on Windows
 
 The option to install the [SignalFx Auto Instrumentation for .NET](
-https://docs.splunk.com/Observability/gdi/get-data-in/application/dotnet/get-started.html)
+https://docs.splunk.com/Observability/gdi/get-data-in/application/otel-dotnet/get-started.html)
 `with_signalfx_dotnet_auto_instrumentation` is deprecated and
 will have no effect after release `0.16.0`.
 Install the `Splunk Distribution of OpenTelemetry .NET`.

--- a/deployments/chef/README.md
+++ b/deployments/chef/README.md
@@ -306,5 +306,4 @@ The option to install the [SignalFx Auto Instrumentation for .NET](
 https://docs.splunk.com/Observability/gdi/get-data-in/application/dotnet/get-started.html)
 `with_signalfx_dotnet_auto_instrumentation` is deprecated and
 will have no effect after release `0.16.0`.
-Install the [Splunk Distribution of OpenTelemetry .NET](https://docs.splunk.com/observability/en/gdi/get-data-in/application/otel-dotnet/get-started.html#instrument-net-applications-for-splunk-observability-cloud-opentelemetry)
-instead.
+Install the `Splunk Distribution of OpenTelemetry .NET`.


### PR DESCRIPTION
These links are being redirected straight to the preceding link now that SFx.NET is fully retired. Removing the old links that were failing lychee workflow: https://github.com/signalfx/splunk-otel-collector/actions/runs/14088064794/job/39457294595?pr=6034#step:3:3969