### PR TITLE
Use direct_connection in mongodb discovery

### DIFF
--- a/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
@@ -16,6 +16,7 @@
 #     default:
 #       username: splunk.discovery.default
 #       password: splunk.discovery.default
+#       direct_connection: true
 #       tls:
 #         insecure_skip_verify: true
 #         insecure: false

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
@@ -12,6 +12,7 @@ mongodb:
     default:
       username: splunk.discovery.default
       password: splunk.discovery.default
+      direct_connection: true
       tls:
         insecure_skip_verify: true
         insecure: false

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
@@ -8,6 +8,7 @@
     default:
       username: {{ defaultValue }}
       password: {{ defaultValue }}
+      direct_connection: true
       tls:
         insecure_skip_verify: true
         insecure: false


### PR DESCRIPTION
With disabled direct connection, the mongodb receiver tries to discover other endpoints by itself. Given that the discovery receiver covers all endpoints on every node, such configuration can end up in cross-nodes scraping, metric duplication and failures. The mongodb receiver 0.121.0 was also changed to actively look for secondary hosts which may result in collector stuck on startup when it cannot reach other endpoints.
