### PR TITLE
[chore][codecov] Change coverage targets

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,8 +13,8 @@ coverage:
     project:
       default:
         enabled: yes
-        target: 85%
+        target: 50%
     patch:
       default:
         enabled: yes
-        target: 95%
+        target: 85%


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This relaxes main's target to be 50% coverage on PRs, and to target 85% for a PR's changed lines coverage. Originally suggested [here](https://github.com/signalfx/splunk-otel-collector/pull/6022#discussion_r2017173964) by @dmitryax 