### PR TITLE
[chore][vuln-scan] Workaround anchore-scan not showing vulnerabilities

### DIFF
--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -151,12 +151,18 @@ jobs:
           path: ./dist
       - run: docker load -i ./dist/image.tar
       - uses: anchore/scan-action@v6
+        id: anchore-scan
         with:
           severity-cutoff: "high"
           only-fixed: true
           add-cpes-if-none: true
-          output-format: "table"
+          output-format: sarif
           image: "otelcol${{ matrix.FIPS == true && '-fips' || '' }}:latest"
+      - name: Upload result to GitHub Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.anchore-scan.outputs.sarif }}
 
   anchore-win-image-scan:
     runs-on: ${{ matrix.OS }}


### PR DESCRIPTION
I got a report of vulnerability detected by `anchore-scan`, but the scan didn't show any useful information about the scan, see https://github.com/signalfx/splunk-otel-collector/actions/runs/14158623610/job/39661248327?pr=6052#step:5:21

Surprisingly, the scan ended up clean here and on a retry on the original PR, but, reporting the vulnerabilities to GH code scanning is done for the other scans and more importantly ensures that we have some information in case of vulnerability detection.