### PR TITLE
Add experimental github workflow to automate kicking off downstream releases or dependency updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -290,6 +290,16 @@ update-dotnet-agent:
     - .gitlab/install-gh-cli.sh
     - .gitlab/update-dotnet-agent.sh
 
+update-downstream-chart:
+  only:
+    - schedules
+  stage: update-deps
+  needs: []
+  dependencies: []
+  script:
+    - .gitlab/install-gh-cli.sh
+    - .gitlab/update-downstream-chart.sh
+
 tidy-dependabot-pr:
   rules:
     - if: ($CI_COMMIT_BRANCH =~ /^dependabot\/go_modules\/.*/) && ($CI_COMMIT_AUTHOR =~ /^dependabot.*/) && (($CI_PIPELINE_SOURCE == "merge_request_event") || ($CI_PIPELINE_SOURCE == "push"))
@@ -1768,6 +1778,16 @@ github-release:
     when: always
     paths:
       - dist/assets
+
+github-release-downstream-chart:
+  extends:
+    - .trigger-filter
+  stage: github-release
+  dependencies:
+    - github-release
+  script:
+    - .gitlab/install-gh-cli.sh
+    - .gitlab/update-downstream-chart.sh
 
 .ansible:
   image: 'cimg/python:3.9'

--- a/.gitlab/update-downstream-chart.sh
+++ b/.gitlab/update-downstream-chart.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# NOTE: Triggers Github workflows to create PRs to update the downstream Helm chart.
+# - Repo: https://github.com/signalfx/splunk-otel-collector-chart
+# - Opens PRs to update instrumentation library dependencies.
+# - Opens a PR to prepare a new chart release after a collector release.
+# - This script uses the GitHub bot from this repo to trigger downstream chart PRs, ensuring GitHub
+#   checks/tests run automatically with these PRs. Without this, maintainers would have to manually
+#   reopen chart PRs to trigger the PR checks/tests. In the future, the chart repo may have its own
+#   GitLab mirror and Github bot integration.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# shellcheck source-path=SCRIPTDIR
+source "${SCRIPT_DIR}/common.sh"
+
+ROOT_DIR="${SCRIPT_DIR}/../"
+cd "${ROOT_DIR}"
+
+run_chart_github_workflows() {
+  local repo="signalfx/splunk-otel-collector-chart"
+  local repo_url="https://srv-gh-o11y-gdi:${GITHUB_TOKEN}@github.com/${repo}.git"
+  local branch="main"
+  local workflows=(
+    "update_chart_dependencies.yaml"
+    "update_docker_images.yaml"
+    "release_drafter.yaml"
+  )
+
+  for workflow in "${workflows[@]}"; do
+    echo "Triggering workflow: $workflow"
+    if gh workflow run "$workflow" --repo "$repo_url" --ref "$branch"; then
+      echo "Triggered: $workflow"
+    else
+      echo "Failed to trigger: $workflow — continuing..."
+    fi
+  done
+}
+
+setup_gpg
+import_gpg_secret_key "$GITHUB_BOT_GPG_KEY"
+setup_git
+run_chart_github_workflows


### PR DESCRIPTION
- This PR is an experiment to explore automating some of the manual downstream tasks using the GitLab bot in this project. The goal is to streamline our workflows and reduce repetitive grunt work.
- If successful, this approach would eliminate the need for the "close/reopen PR to trigger checks" workaround currently used in the chart project.