### PR TITLE
[chore][CI] Fix snyk vulnerability scan on arm

### DIFF
--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -253,7 +253,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image: "otelcol${{ matrix.FIPS == true && '-fips' || '' }}:${{ matrix.ARCH }}"
+          image: "otelcol${{ matrix.FIPS == true && '-fips' || '' }}:latest"
           args: --file=cmd/otelcol/Dockerfile --severity-threshold=high --sarif-file-output=snyk.sarif --policy-path=.snyk
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -50,7 +50,7 @@ jobs:
           path: "."
 
   docker-otelcol:
-    runs-on: ${{ fromJSON('["ubuntu-20.04", "otel-arm64"]')[matrix.ARCH == 'arm64'] }}
+    runs-on: ubuntu-24.04${{ matrix.ARCH == 'arm64' && '-arm' || '' }}
     strategy:
       matrix:
         ARCH: [ "amd64", "arm64" ]
@@ -253,7 +253,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image: "otelcol${{ matrix.FIPS == true && '-fips' || '' }}:latest"
+          image: "otelcol${{ matrix.FIPS == true && '-fips' || '' }}:${{ matrix.ARCH }}"
           args: --file=cmd/otelcol/Dockerfile --severity-threshold=high --sarif-file-output=snyk.sarif --policy-path=.snyk
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -254,7 +254,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: "otelcol${{ matrix.FIPS == true && '-fips' || '' }}:latest"
-          args: --file=cmd/otelcol/Dockerfile --severity-threshold=high --sarif-file-output=snyk.sarif --policy-path=.snyk
+          args: --file=cmd/otelcol/Dockerfile --severity-threshold=high --sarif-file-output=snyk.sarif --policy-path=.snyk --platform=linux/${{ matrix.ARCH == 'amd64'&& 'amd64' || 'arm64/v8' }}
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -209,6 +209,8 @@ jobs:
             echo "defined=true" >> $GITHUB_OUTPUT
           else
             echo "defined=false" >> $GITHUB_OUTPUT
+            echo "ERROR: The Snyk token is not available. The token is not available on PRs triggered from forked repositories."
+            exit 1
           fi
 
   snyk-fs-scan:

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -233,7 +233,7 @@ jobs:
           sarif_file: snyk.sarif
 
   snyk-docker-scan:
-    runs-on: ${{ matrix.ARCH == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    runs-on: ubuntu-24.04
     needs: [docker-otelcol, check-snyk-token]
     if: ${{ needs.check-snyk-token.outputs.has-snyk-token == 'true' }}
     strategy:
@@ -243,6 +243,15 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
+
+      # There is no snyk/snyk:docker image for arm64, so we need to use the
+      # docker setup-qemu-action to run the scan
+      - uses: docker/setup-qemu-action@v3
+        if: ${{ matrix.ARCH != 'amd64' }}
+        with:
+          platforms: ${{ matrix.ARCH }}
+          image: tonistiigi/binfmt:qemu-v7.0.0
+
       - uses: actions/download-artifact@v4
         with:
           name: otelcol-${{ matrix.ARCH }}${{ matrix.FIPS == true && '-fips' || '' }}
@@ -254,7 +263,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: "otelcol${{ matrix.FIPS == true && '-fips' || '' }}:latest"
-          args: --file=cmd/otelcol/Dockerfile --severity-threshold=high --sarif-file-output=snyk.sarif --policy-path=.snyk --platform=linux/${{ matrix.ARCH == 'amd64'&& 'amd64' || 'arm64/v8' }}
+          args: --file=cmd/otelcol/Dockerfile --severity-threshold=high --sarif-file-output=snyk.sarif --policy-path=.snyk --platform=linux/${{ matrix.ARCH }}
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -252,7 +252,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: "otelcol${{ matrix.FIPS == true && '-fips' || '' }}:latest"
-          args: --file=cmd/otelcol/Dockerfile --severity-threshold=high --sarif-file-output=snyk.sarif --policy-path=.snyk --platform=linux/${{ matrix.ARCH }}
+          args: --file=cmd/otelcol/Dockerfile --severity-threshold=high --sarif-file-output=snyk.sarif --policy-path=.snyk
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
Supersedes #6079

Fixes the Snyk scan on arm: the `snyk/snyk:docker` doesn't have an image for ARM so it requires qemu if scanning an image for any ARM architecture.

Side change: add message with the likely cause in case of missing Snyk token.

