### PR TITLE
[chore] Make go version consistent on all go.mod files

### DIFF
--- a/examples/prometheus-federation/prom-counter/go.mod
+++ b/examples/prometheus-federation/prom-counter/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/prometheus-federation/prom-counter
 
-go 1.23.0
+go 1.23.7
 
 require (
 	go.opentelemetry.io/otel v0.20.0

--- a/examples/splunk-hec-traces/tracing/go.mod
+++ b/examples/splunk-hec-traces/tracing/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/splunk-hec-traces/tracing
 
-go 1.23.0
+go 1.23.7
 
 require (
 	go.opentelemetry.io/otel v1.1.0

--- a/examples/splunk-hec/logging/go.mod
+++ b/examples/splunk-hec/logging/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/splunk-hec/logging
 
-go 1.23.0
+go 1.23.7
 
 require go.uber.org/zap v1.27.0
 

--- a/internal/signalfx-agent/go.mod
+++ b/internal/signalfx-agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/signalfx-agent
 
-go 1.23.0
+go 1.23.7
 
 replace (
 	code.cloudfoundry.org/go-loggregator => github.com/signalfx/go-loggregator v1.0.1-0.20200205155641-5ba5ca92118d

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/internal/tools
 
-go 1.23.0
+go 1.23.7
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/packaging/dotnet-instr-deployer-add-on/go.mod
+++ b/packaging/dotnet-instr-deployer-add-on/go.mod
@@ -1,6 +1,6 @@
 module github.com/splunk/splunk_otel_dotnet_deployer
 
-go 1.23.0
+go 1.23.7
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pkg/extension/smartagentextension/go.mod
+++ b/pkg/extension/smartagentextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension
 
-go 1.23.0
+go 1.23.7
 
 require (
 	github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657

--- a/pkg/processor/timestampprocessor/go.mod
+++ b/pkg/processor/timestampprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocessor
 
-go 1.23.0
+go 1.23.7
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/tests
 
-go 1.23.0
+go 1.23.7
 
 require (
 	github.com/docker/docker v28.0.1+incompatible

--- a/tests/tools/go.mod
+++ b/tests/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/tests/tools
 
-go 1.23.0
+go 1.23.7
 
 require github.com/Songmu/gotesplit v0.3.1
 


### PR DESCRIPTION
It seems that the modules with a version different than the one that we are using are the ones being hit by the toolchain upgrade issue by dependabot. Anyway, I'm not aware of any reason to keep these on older versions.
