### PR TITLE
[chore][codecov] Fix muting errors bug in make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,12 +136,12 @@ integration-test-istio-discovery-k8s:
 
 .PHONY: gotest-with-codecov
 gotest-with-codecov:
-	@$(MAKE) for-all-target TARGET="test-with-codecov" || true
+	@$(MAKE) for-all-target TARGET="test-with-codecov"
 	$(GOCMD) tool covdata textfmt -i=./coverage -o ./coverage.txt
 
 .PHONY: gotest-cover-without-race
 gotest-cover-without-race:
-	@$(MAKE) for-all-target TARGET="test-cover-without-race" || true
+	@$(MAKE) for-all-target TARGET="test-cover-without-race"
 	$(GOCMD) tool covdata textfmt -i=./coverage  -o ./coverage.txt
 
 .PHONY: gendependabot


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`|| true` means that any command will be successful and continue to the next step. This would make workflow runs green even if there were failures. This was helpful testing locally when code coverage output could be saved even with unsuccessful tests, but should be not in our branch.

This was introduced in my codecov changes yesterday: https://github.com/signalfx/splunk-otel-collector/pull/6084