### PR TITLE
gitlab-ci: Use large runners for compilation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -222,6 +222,7 @@ update-otel-deps:
   only:
     - schedules
   extends: .go-cache
+  tags: [large]
   stage: update-deps
   needs: []
   dependencies: []
@@ -233,6 +234,7 @@ update-otel-deps-nightly:
   only:
     - schedules
   extends: .go-cache
+  tags: [large]
   stage: update-deps
   needs: []
   dependencies: []
@@ -294,6 +296,7 @@ tidy-dependabot-pr:
   rules:
     - if: ($CI_COMMIT_BRANCH =~ /^dependabot\/go_modules\/.*/) && ($CI_COMMIT_AUTHOR =~ /^dependabot.*/) && (($CI_PIPELINE_SOURCE == "merge_request_event") || ($CI_PIPELINE_SOURCE == "push"))
   extends: .go-cache
+  tags: [large]
   stage: update-deps
   needs: []
   dependencies: []
@@ -305,6 +308,7 @@ compile:
   extends:
     - .trigger-filter
     - .go-cache
+  tags: [large]
   stage: build
   needs: []
   parallel:
@@ -1724,6 +1728,7 @@ github-release:
   extends:
     - .trigger-filter
     - .go-cache
+  tags: [large]
   stage: github-release
   dependencies:
     - compile
@@ -1897,6 +1902,7 @@ dotnet-instrumentation-deployer-release:
   extends:
     - .trigger-dotnet-instrumentation-deployer
     - .go-cache # Use this image since this job uses the ghr tool
+  tags: [large]
   stage: github-release
   dependencies:
     - pack-dotnet-instrumentation-deployer


### PR DESCRIPTION
Otherwise, we run out of disk due to pulling too many dependencies.  Set it to all jobs relying on go cache
