### PR TITLE
[chore][Makefile] Add with-cover targets for integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -447,7 +447,7 @@ jobs:
       - name: Load Docker image in kind
         run: |
           kind load docker-image otelcol:latest --name kind
-      - name: Run ${{ matrix.SERVICE }} Discovery Kubernetes Integration Test
+      - name: Run ${{ matrix.SERVICE }} Discovery Kubernetes Integration Test With Cover
         run: KUBECONFIG=$HOME/.kube/config SKIP_TEARDOWN=true make integration-test-${{ matrix.SERVICE }}-discovery-k8s-with-cover
       - name: Print logs
         if: failure()

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -233,9 +233,9 @@ jobs:
       - name: Run Integration Test
         run: |
           set -o pipefail
-          target="integration-test"
+          target="integration-test-with-cover"
           if [[ "${{ matrix.PROFILE }}" = "smartagent" ]]; then
-            target="smartagent-integration-test"
+            target="smartagent-integration-test-with-cover"
           fi
           make $target 2>&1 | tee $TEST_OUTPUT
           exit_status=${PIPESTATUS[0]}
@@ -312,9 +312,9 @@ jobs:
       - name: Run Integration Test
         run: |
           set -o pipefail
-          target="integration-test"
+          target="integration-test-with-cover"
           if [[ "${{ matrix.PROFILE }}" = "smartagent" ]]; then
-            target="smartagent-integration-test"
+            target="smartagent-integration-test-with-cover"
           fi
           make $target 2>&1 | tee $TEST_OUTPUT
           exit_status=${PIPESTATUS[0]}
@@ -386,7 +386,7 @@ jobs:
         - run: ln -sf otelcol_linux_${{ matrix.ARCH }} ./bin/otelcol
         - run: chmod a+x ./bin/*
         - name: Run ${{ matrix.SERVICE }} Discovery Integration Test
-          run: make integration-test-${{ matrix.SERVICE }}-discovery
+          run: make integration-test-${{ matrix.SERVICE }}-discovery-with-cover
           env:
             SPLUNK_OTEL_COLLECTOR_IMAGE: 'otelcol:latest'
 
@@ -448,7 +448,7 @@ jobs:
         run: |
           kind load docker-image otelcol:latest --name kind
       - name: Run ${{ matrix.SERVICE }} Discovery Kubernetes Integration Test
-        run: KUBECONFIG=$HOME/.kube/config SKIP_TEARDOWN=true make integration-test-${{ matrix.SERVICE }}-discovery-k8s
+        run: KUBECONFIG=$HOME/.kube/config SKIP_TEARDOWN=true make integration-test-${{ matrix.SERVICE }}-discovery-k8s-with-cover
       - name: Print logs
         if: failure()
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -385,7 +385,7 @@ jobs:
         - run: docker load -i ./docker-otelcol/${{ matrix.ARCH }}/image.tar
         - run: ln -sf otelcol_linux_${{ matrix.ARCH }} ./bin/otelcol
         - run: chmod a+x ./bin/*
-        - name: Run ${{ matrix.SERVICE }} Discovery Integration Test
+        - name: Run ${{ matrix.SERVICE }} Discovery Integration Test With Cover
           run: make integration-test-${{ matrix.SERVICE }}-discovery-with-cover
           env:
             SPLUNK_OTEL_COLLECTOR_IMAGE: 'otelcol:latest'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -230,7 +230,7 @@ jobs:
         if: matrix.PROFILE == 'integration'
       - run: redis-cli set tempkey tempvalue
         if: matrix.PROFILE == 'integration'
-      - name: Run Integration Test
+      - name: Run Integration Test With Cover
         run: |
           set -o pipefail
           target="integration-test-with-cover"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -309,7 +309,7 @@ jobs:
         if: matrix.PROFILE == 'integration'
       - run: redis-cli set tempkey tempvalue
         if: matrix.PROFILE == 'integration'
-      - name: Run Integration Test
+      - name: Run Integration Test With Cover
         run: |
           set -o pipefail
           target="integration-test-with-cover"

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ CGO_ENABLED?=0
 
 # This directory is used in tests hold code coverage results.
 # It's mounted on docker containers which then write code coverage
-# results to it, making it available post-tests to the host.
+# results to it, making coverage profiles available on the host after tests.
 # 777 privileges are important to allow docker container write
 # access to host dir.
 MAKE_TEST_COVER_DIR=mkdir -m 777 -p $(TEST_COVER_DIR)

--- a/Makefile
+++ b/Makefile
@@ -242,11 +242,7 @@ generate-metrics:
 .PHONY: otelcol
 otelcol:
 	go generate ./...
-ifeq ($(COVER_TESTING), true)
-	GO111MODULE=on CGO_ENABLED=$(CGO_ENABLED) go build $(COVER_OPTS) -trimpath -o ./bin/otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) $(BUILD_INFO) ./cmd/otelcol
-else
 	GO111MODULE=on CGO_ENABLED=$(CGO_ENABLED) go build -trimpath -o ./bin/otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) $(BUILD_INFO) ./cmd/otelcol
-endif
 ifeq ($(OS), Windows_NT)
 	$(LINK_CMD) .\bin\otelcol$(EXTENSION) .\bin\otelcol_$(GOOS)_$(GOARCH)$(EXTENSION)
 else

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,13 @@ BUILD_INFO=-ldflags "${BUILD_X1} ${BUILD_X2}"
 BUILD_INFO_TESTS=-ldflags "-X $(BUILD_INFO_IMPORT_PATH_TESTS).Version=$(VERSION)"
 CGO_ENABLED?=0
 
+# This directory is used in tests hold code coverage results.
+# It's mounted on docker containers which then write code coverage
+# results to it, making it available post-tests to the host.
+# 777 privileges are important to allow docker container write
+# access to host dir.
+MAKE_TEST_COVER_DIR=mkdir -m 777 -p $(TEST_COVER_DIR)
+
 JMX_METRIC_GATHERER_RELEASE=$(shell cat packaging/jmx-metric-gatherer-release.txt)
 SKIP_COMPILE=false
 ARCH?=amd64
@@ -82,57 +89,118 @@ for-all-target: $(ALL_MODS)
 integration-vet:
 	@set -e; cd tests && go vet -tags integration,testutilsintegration,zeroconfig,testutils ./... && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) -tags testutils,testutilsintegration -v -timeout 5m -count 1 ./...
 
+.PHONY: integration-test-target
+integration-test-target:
+	@set -e; cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=$(TARGET) -v -timeout 5m -count 1 ./...
+
+.PHONY: integration-test-cover-target
+integration-test-cover-target:
+	@set -e; $(MAKE_TEST_COVER_DIR) && cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=$(TARGET) -v -timeout 5m -count 1 ./... $(COVER_TESTING_INTEGRATION_OPTS)
+	$(GOCMD) tool covdata textfmt -i=$(TEST_COVER_DIR) -o ./$(TARGET)-coverage.txt
+
 .PHONY: integration-test
 integration-test:
-	@set -e; cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=integration -v -timeout 5m -count 1 ./...
+	@make integration-test-target TARGET='integration'
+
+.PHONY: integration-test-with-cover
+integration-test-with-cover:
+	@make integration-test-cover-target TARGET='integration'
 
 .PHONY: integration-test-mongodb-discovery
 integration-test-mongodb-discovery:
-	@set -e; cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=discovery_integration_mongodb -v -timeout 5m -count 1 ./...
+	@make integration-test TARGET='discovery_integration_mongodb'
+
+.PHONY: integration-test-mongodb-discovery-with-cover
+integration-test-mongodb-discovery-with-cover:
+	@make integration-test-cover-target TARGET='discovery_integration_mongodb'
 
 .PHONY: integration-test-mysql-discovery
 integration-test-mysql-discovery:
-	@set -e; cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=discovery_integration_mysql -v -timeout 5m -count 1 ./...
+	@make integration-test TARGET='discovery_integration_mysql'
+
+.PHONY: integration-test-mysql-discovery-with-cover
+integration-test-mysql-discovery-with-cover:
+	@make integration-test-cover-target TARGET='discovery_integration_mysql'
 
 .PHONY: integration-test-kafkametrics-discovery
 integration-test-kafkametrics-discovery:
-	@set -e; cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=discovery_integration_kafkametrics -v -timeout 5m -count 1 ./...
+	@make integration-test TARGET='discovery_integration_kafkametrics'
+
+.PHONY: integration-test-kafkametrics-discovery-with-cover
+integration-test-kafkametrics-discovery-with-cover:
+	@make integration-test-cover-target TARGET='discovery_integration_kafkametrics'
 
 .PHONY: integration-test-jmx/cassandra-discovery
 integration-test-jmx/cassandra-discovery:
-	@set -e; cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=discovery_integration_jmx -v -timeout 5m -count 1 ./...
+	@make integration-test TARGET='discovery_integration_jmx'
+
+.PHONY: integration-test-jmx/cassandra-discovery-with-cover
+integration-test-jmx/cassandra-discovery-with-cover:
+	@make integration-test-cover-target TARGET='discovery_integration_jmx'
 
 .PHONY: integration-test-apache-discovery
 integration-test-apache-discovery:
-	@set -e; cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=discovery_integration_apachewebserver -v -timeout 5m -count 1 ./...
+	@make integration-test TARGET='discovery_integration_apachewebserver'
+
+.PHONY: integration-test-apache-discovery-with-cover
+integration-test-apache-discovery-with-cover:
+	@make integration-test-cover-target TARGET='discovery_integration_apachewebserver'
 
 .PHONY: integration-test-envoy-discovery
 integration-test-envoy-discovery:
-	@set -e; cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=discovery_integration_envoy -v -timeout 5m -count 1 ./...
+	@make integration-test TARGET='discovery_integration_envoy'
+
+.PHONY: integration-test-envoy-discovery-with-cover
+integration-test-envoy-discovery-with-cover:
+	@make integration-test-cover-target TARGET='discovery_integration_envoy'
 
 .PHONY: integration-test-nginx-discovery
 integration-test-nginx-discovery:
-	@set -e; cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=discovery_integration_nginx -v -timeout 5m -count 1 ./...
+	@make integration-test TARGET='discovery_integration_nginx'
+
+.PHONY: integration-test-nginx-discovery-with-cover
+integration-test-nginx-discovery-with-cover:
+	@make integration-test-cover-target TARGET='discovery_integration_nginx'
 
 .PHONY: integration-test-redis-discovery
 integration-test-redis-discovery:
-	@set -e; cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=discovery_integration_redis -v -timeout 5m -count 1 ./...
+	@make integration-test TARGET='discovery_integration_redis'
+
+.PHONY: integration-test-redis-discovery-with-cover
+integration-test-redis-discovery-with-cover:
+	@make integration-test-cover-target TARGET='discovery_integration_redis'
 
 .PHONY: integration-test-oracledb-discovery
 integration-test-oracledb-discovery:
-	@set -e; cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=discovery_integration_oracledb -v -timeout 5m -count 1 ./...
+	@make integration-test TARGET='discovery_integration_oracledb'
+
+.PHONY: integration-test-oracledb-discovery-with-cover
+integration-test-oracledb-discovery-with-cover:
+	@make integration-test-cover-target TARGET='discovery_integration_oracledb'
 
 .PHONY: smartagent-integration-test
 smartagent-integration-test:
-	@set -e; cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=smartagent_integration -v -timeout 5m -count 1 ./...
+	@make integration-test TARGET='smartagent_integration'
+
+.PHONY: smartagent-integration-test-with-cover
+smartagent-integration-test-with-cover:
+	@make integration-test-cover-target TARGET='smartagent_integration'
 
 .PHONY: integration-test-envoy-discovery-k8s
 integration-test-envoy-discovery-k8s:
-	@set -e; cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=discovery_integration_envoy_k8s -v -timeout 5m -count 1 ./...
+	@make integration-test TARGET='discovery_integration_envoy_k8s'
+
+.PHONY: integration-test-envoy-discovery-k8s-with-cover
+integration-test-envoy-discovery-k8s-with-cover:
+	@make integration-test-cover-target TARGET='discovery_integration_envoy_k8s'
 
 .PHONY: integration-test-istio-discovery-k8s
 integration-test-istio-discovery-k8s:
-	@set -e; cd tests && $(GOTEST_SERIAL) $(BUILD_INFO_TESTS) --tags=discovery_integration_istio_k8s -v -timeout 15m -count 1 ./...
+	@make integration-test TARGET='discovery_integration_istio_k8s'
+
+.PHONY: integration-test-istio-discovery-k8s-with-cover
+integration-test-istio-discovery-k8s-with-cover:
+	@make integration-test-cover-target TARGET='discovery_integration_istio_k8s'
 
 .PHONY: gotest-with-codecov
 gotest-with-codecov:
@@ -174,13 +242,16 @@ generate-metrics:
 .PHONY: otelcol
 otelcol:
 	go generate ./...
+ifeq ($(COVER_TESTING), true)
+	GO111MODULE=on CGO_ENABLED=$(CGO_ENABLED) go build $(COVER_OPTS) -trimpath -o ./bin/otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) $(BUILD_INFO) ./cmd/otelcol
+else
 	GO111MODULE=on CGO_ENABLED=$(CGO_ENABLED) go build -trimpath -o ./bin/otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) $(BUILD_INFO) ./cmd/otelcol
+endif
 ifeq ($(OS), Windows_NT)
 	$(LINK_CMD) .\bin\otelcol$(EXTENSION) .\bin\otelcol_$(GOOS)_$(GOARCH)$(EXTENSION)
 else
 	$(LINK_CMD) otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) ./bin/otelcol$(EXTENSION)
 endif
-
 
 .PHONY: migratecheckpoint
 migratecheckpoint:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This change introduces `with-cover` targets for all integration tests.

Key changes
- Introduce reusable integration test targets in `Makefile`. The original `integration` targets are functionally unchanged, but no longer used in CI/CD.
- Create a directory for cover testing that will be used to hold cover profiles created by integration tests.

**NOTE:** This does not improve code coverage results by itself. A follow up PR will introduce the functional changes enabled by this PR.