### PR TITLE
[chore][receive/smartagent] Centralize test logic

### DIFF
--- a/tests/receivers/smartagent/collectd-activemq/collectd_activemq_test.go
+++ b/tests/receivers/smartagent/collectd-activemq/collectd_activemq_test.go
@@ -17,20 +17,7 @@
 package tests
 
 import (
-	"context"
-	"fmt"
-	"path/filepath"
-	"runtime"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/receiver/otlpreceiver"
-	"go.opentelemetry.io/collector/receiver/receivertest"
-	"go.uber.org/zap"
 
 	"github.com/signalfx/splunk-otel-collector/tests/testutils"
 )
@@ -78,7 +65,7 @@ func TestCollectdActiveMQReceiverProvidesAllMetrics(t *testing.T) {
 		"jmx_memory.used",
 		"total_time_in_ms.collection_time",
 	}
-	checkMetricsPresence(t, metricNames, "all_metrics_config.yaml")
+	testutils.CheckMetricsPresence(t, metricNames, "all_metrics_config.yaml")
 }
 func TestCollectdActiveMQReceiverProvidesDefaultMetrics(t *testing.T) {
 	metricNames := []string{
@@ -111,61 +98,5 @@ func TestCollectdActiveMQReceiverProvidesDefaultMetrics(t *testing.T) {
 		"jmx_memory.used",
 		"total_time_in_ms.collection_time",
 	}
-	checkMetricsPresence(t, metricNames, "default_metrics_config.yaml")
-}
-
-func checkMetricsPresence(t *testing.T, metricNames []string, configFile string) {
-	f := otlpreceiver.NewFactory()
-	port := testutils.GetAvailablePort(t)
-	c := f.CreateDefaultConfig().(*otlpreceiver.Config)
-	c.GRPC.NetAddr.Endpoint = fmt.Sprintf("localhost:%d", port)
-	sink := &consumertest.MetricsSink{}
-	receiver, err := f.CreateMetrics(context.Background(), receivertest.NewNopSettings(f.Type()), c, sink)
-	require.NoError(t, err)
-	require.NoError(t, receiver.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() {
-		require.NoError(t, receiver.Shutdown(context.Background()))
-	})
-	logger, _ := zap.NewDevelopment()
-
-	dockerHost := "0.0.0.0"
-	if runtime.GOOS == "darwin" {
-		dockerHost = "host.docker.internal"
-	}
-	p, err := testutils.NewCollectorContainer().
-		WithImage(testutils.GetCollectorImageOrSkipTest(t)).
-		WithConfigPath(filepath.Join("testdata", configFile)).
-		WithLogger(logger).
-		WithEnv(map[string]string{"OTLP_ENDPOINT": fmt.Sprintf("%s:%d", dockerHost, port)}).
-		Build()
-	require.NoError(t, err)
-	require.NoError(t, p.Start())
-	t.Cleanup(func() {
-		require.NoError(t, p.Shutdown())
-	})
-
-	missingMetrics := make(map[string]any, len(metricNames))
-	for _, m := range metricNames {
-		missingMetrics[m] = struct{}{}
-	}
-
-	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
-		for i := 0; i < len(sink.AllMetrics()); i++ {
-			m := sink.AllMetrics()[i]
-			for j := 0; j < m.ResourceMetrics().Len(); j++ {
-				rm := m.ResourceMetrics().At(j)
-				for k := 0; k < rm.ScopeMetrics().Len(); k++ {
-					sm := rm.ScopeMetrics().At(k)
-					for l := 0; l < sm.Metrics().Len(); l++ {
-						delete(missingMetrics, sm.Metrics().At(l).Name())
-					}
-				}
-			}
-		}
-		msg := "Missing metrics:\n"
-		for k := range missingMetrics {
-			msg += fmt.Sprintf("- %q\n", k)
-		}
-		assert.Len(tt, missingMetrics, 0, msg)
-	}, 1*time.Minute, 1*time.Second)
+	testutils.CheckMetricsPresence(t, metricNames, "default_metrics_config.yaml")
 }

--- a/tests/receivers/smartagent/collectd-cassandra/collectd_cassandra_test.go
+++ b/tests/receivers/smartagent/collectd-cassandra/collectd_cassandra_test.go
@@ -17,20 +17,7 @@
 package tests
 
 import (
-	"context"
-	"fmt"
-	"path/filepath"
-	"runtime"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/receiver/otlpreceiver"
-	"go.opentelemetry.io/collector/receiver/receivertest"
-	"go.uber.org/zap"
 
 	"github.com/signalfx/splunk-otel-collector/tests/testutils"
 )
@@ -83,7 +70,7 @@ func TestCollectdCassandraReceiverProvidesAllMetrics(t *testing.T) {
 		"jmx_memory.used",
 		"total_time_in_ms.collection_time",
 	}
-	checkMetricsPresence(t, metricNames, "all_metrics_config.yaml")
+	testutils.CheckMetricsPresence(t, metricNames, "all_metrics_config.yaml")
 }
 
 func TestCollectdCassandraReceiverProvidesDefaultMetrics(t *testing.T) {
@@ -116,61 +103,5 @@ func TestCollectdCassandraReceiverProvidesDefaultMetrics(t *testing.T) {
 		"jmx_memory.used",
 		"total_time_in_ms.collection_time",
 	}
-	checkMetricsPresence(t, metricNames, "default_metrics_config.yaml")
-}
-
-func checkMetricsPresence(t *testing.T, metricNames []string, configFile string) {
-	f := otlpreceiver.NewFactory()
-	port := testutils.GetAvailablePort(t)
-	c := f.CreateDefaultConfig().(*otlpreceiver.Config)
-	c.GRPC.NetAddr.Endpoint = fmt.Sprintf("localhost:%d", port)
-	sink := &consumertest.MetricsSink{}
-	receiver, err := f.CreateMetrics(context.Background(), receivertest.NewNopSettings(f.Type()), c, sink)
-	require.NoError(t, err)
-	require.NoError(t, receiver.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() {
-		require.NoError(t, receiver.Shutdown(context.Background()))
-	})
-	logger, _ := zap.NewDevelopment()
-
-	dockerHost := "0.0.0.0"
-	if runtime.GOOS == "darwin" {
-		dockerHost = "host.docker.internal"
-	}
-	p, err := testutils.NewCollectorContainer().
-		WithImage(testutils.GetCollectorImageOrSkipTest(t)).
-		WithConfigPath(filepath.Join("testdata", configFile)).
-		WithLogger(logger).
-		WithEnv(map[string]string{"OTLP_ENDPOINT": fmt.Sprintf("%s:%d", dockerHost, port)}).
-		Build()
-	require.NoError(t, err)
-	require.NoError(t, p.Start())
-	t.Cleanup(func() {
-		require.NoError(t, p.Shutdown())
-	})
-
-	missingMetrics := make(map[string]any, len(metricNames))
-	for _, m := range metricNames {
-		missingMetrics[m] = struct{}{}
-	}
-
-	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
-		for i := 0; i < len(sink.AllMetrics()); i++ {
-			m := sink.AllMetrics()[i]
-			for j := 0; j < m.ResourceMetrics().Len(); j++ {
-				rm := m.ResourceMetrics().At(j)
-				for k := 0; k < rm.ScopeMetrics().Len(); k++ {
-					sm := rm.ScopeMetrics().At(k)
-					for l := 0; l < sm.Metrics().Len(); l++ {
-						delete(missingMetrics, sm.Metrics().At(l).Name())
-					}
-				}
-			}
-		}
-		msg := "Missing metrics:\n"
-		for k := range missingMetrics {
-			msg += fmt.Sprintf("- %q\n", k)
-		}
-		assert.Len(tt, missingMetrics, 0, msg)
-	}, 1*time.Minute, 1*time.Second)
+	testutils.CheckMetricsPresence(t, metricNames, "default_metrics_config.yaml")
 }

--- a/tests/receivers/smartagent/collectd-hadoop/collectd_hadoop_test.go
+++ b/tests/receivers/smartagent/collectd-hadoop/collectd_hadoop_test.go
@@ -17,21 +17,8 @@
 package tests
 
 import (
-	"context"
-	"fmt"
 	"path"
-	"path/filepath"
-	"runtime"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/receiver/otlpreceiver"
-	"go.opentelemetry.io/collector/receiver/receivertest"
-	"go.uber.org/zap"
 
 	"github.com/signalfx/splunk-otel-collector/tests/testutils"
 )
@@ -54,7 +41,7 @@ func TestCollectdHadoopReceiverProvidesAllMetrics(t *testing.T) {
 	_, stop := tc.Containers(containers...)
 	defer stop()
 
-	checkMetricsPresence(t, []string{
+	testutils.CheckMetricsPresence(t, []string{
 		"counter.hadoop.cluster.metrics.total_mb",
 		"counter.hadoop.cluster.metrics.total_nodes",
 		"counter.hadoop.cluster.metrics.total_virtual_cores",
@@ -104,60 +91,4 @@ func TestCollectdHadoopReceiverProvidesAllMetrics(t *testing.T) {
 		"gauge.hadoop.resource.manager.scheduler.root.queue.maxCapacity",
 		"gauge.hadoop.resource.manager.scheduler.root.queue.usedCapacity",
 	}, "all_metrics_config.yaml")
-}
-
-func checkMetricsPresence(t *testing.T, metricNames []string, configFile string) {
-	f := otlpreceiver.NewFactory()
-	port := testutils.GetAvailablePort(t)
-	c := f.CreateDefaultConfig().(*otlpreceiver.Config)
-	c.GRPC.NetAddr.Endpoint = fmt.Sprintf("localhost:%d", port)
-	sink := &consumertest.MetricsSink{}
-	receiver, err := f.CreateMetrics(context.Background(), receivertest.NewNopSettings(f.Type()), c, sink)
-	require.NoError(t, err)
-	require.NoError(t, receiver.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() {
-		require.NoError(t, receiver.Shutdown(context.Background()))
-	})
-	logger, _ := zap.NewDevelopment()
-
-	dockerHost := "0.0.0.0"
-	if runtime.GOOS == "darwin" {
-		dockerHost = "host.docker.internal"
-	}
-	p, err := testutils.NewCollectorContainer().
-		WithImage(testutils.GetCollectorImageOrSkipTest(t)).
-		WithConfigPath(filepath.Join("testdata", configFile)).
-		WithLogger(logger).
-		WithEnv(map[string]string{"OTLP_ENDPOINT": fmt.Sprintf("%s:%d", dockerHost, port)}).
-		Build()
-	require.NoError(t, err)
-	require.NoError(t, p.Start())
-	t.Cleanup(func() {
-		require.NoError(t, p.Shutdown())
-	})
-
-	missingMetrics := make(map[string]any, len(metricNames))
-	for _, m := range metricNames {
-		missingMetrics[m] = struct{}{}
-	}
-
-	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
-		for i := 0; i < len(sink.AllMetrics()); i++ {
-			m := sink.AllMetrics()[i]
-			for j := 0; j < m.ResourceMetrics().Len(); j++ {
-				rm := m.ResourceMetrics().At(j)
-				for k := 0; k < rm.ScopeMetrics().Len(); k++ {
-					sm := rm.ScopeMetrics().At(k)
-					for l := 0; l < sm.Metrics().Len(); l++ {
-						delete(missingMetrics, sm.Metrics().At(l).Name())
-					}
-				}
-			}
-		}
-		msg := "Missing metrics:\n"
-		for k := range missingMetrics {
-			msg += fmt.Sprintf("- %q\n", k)
-		}
-		assert.Len(tt, missingMetrics, 0, msg)
-	}, 1*time.Minute, 1*time.Second)
 }

--- a/tests/receivers/smartagent/collectd-kafka/collectd_kafka_test.go
+++ b/tests/receivers/smartagent/collectd-kafka/collectd_kafka_test.go
@@ -17,20 +17,7 @@
 package tests
 
 import (
-	"context"
-	"fmt"
-	"path/filepath"
-	"runtime"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/receiver/otlpreceiver"
-	"go.opentelemetry.io/collector/receiver/receivertest"
-	"go.uber.org/zap"
 
 	"github.com/signalfx/splunk-otel-collector/tests/testutils"
 )
@@ -70,7 +57,7 @@ func TestCollectdKafkaReceiversAllBrokerMetrics(t *testing.T) {
 		"jmx_memory.used",
 		"total_time_in_ms.collection_time",
 	}
-	checkMetricsPresence(t, metricNames, "all_broker_metrics_config.yaml")
+	testutils.CheckMetricsPresence(t, metricNames, "all_broker_metrics_config.yaml")
 }
 
 func TestCollectdKafkaReceiversAllConsumerMetrics(t *testing.T) {
@@ -89,7 +76,7 @@ func TestCollectdKafkaReceiversAllConsumerMetrics(t *testing.T) {
 		"jmx_memory.used",
 		"total_time_in_ms.collection_time",
 	}
-	checkMetricsPresence(t, metricNames, "all_consumer_metrics_config.yaml")
+	testutils.CheckMetricsPresence(t, metricNames, "all_consumer_metrics_config.yaml")
 }
 
 func TestCollectdKafkaReceiversAllProducerMetrics(t *testing.T) {
@@ -113,61 +100,5 @@ func TestCollectdKafkaReceiversAllProducerMetrics(t *testing.T) {
 		"jmx_memory.used",
 		"total_time_in_ms.collection_time",
 	}
-	checkMetricsPresence(t, metricNames, "all_producer_metrics_config.yaml")
-}
-
-func checkMetricsPresence(t *testing.T, metricNames []string, configFile string) {
-	f := otlpreceiver.NewFactory()
-	port := testutils.GetAvailablePort(t)
-	c := f.CreateDefaultConfig().(*otlpreceiver.Config)
-	c.GRPC.NetAddr.Endpoint = fmt.Sprintf("localhost:%d", port)
-	sink := &consumertest.MetricsSink{}
-	receiver, err := f.CreateMetrics(context.Background(), receivertest.NewNopSettings(f.Type()), c, sink)
-	require.NoError(t, err)
-	require.NoError(t, receiver.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() {
-		require.NoError(t, receiver.Shutdown(context.Background()))
-	})
-	logger, _ := zap.NewDevelopment()
-
-	dockerHost := "0.0.0.0"
-	if runtime.GOOS == "darwin" {
-		dockerHost = "host.docker.internal"
-	}
-	p, err := testutils.NewCollectorContainer().
-		WithImage(testutils.GetCollectorImageOrSkipTest(t)).
-		WithConfigPath(filepath.Join("testdata", configFile)).
-		WithLogger(logger).
-		WithEnv(map[string]string{"OTLP_ENDPOINT": fmt.Sprintf("%s:%d", dockerHost, port)}).
-		Build()
-	require.NoError(t, err)
-	require.NoError(t, p.Start())
-	t.Cleanup(func() {
-		require.NoError(t, p.Shutdown())
-	})
-
-	missingMetrics := make(map[string]any, len(metricNames))
-	for _, m := range metricNames {
-		missingMetrics[m] = struct{}{}
-	}
-
-	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
-		for i := 0; i < len(sink.AllMetrics()); i++ {
-			m := sink.AllMetrics()[i]
-			for j := 0; j < m.ResourceMetrics().Len(); j++ {
-				rm := m.ResourceMetrics().At(j)
-				for k := 0; k < rm.ScopeMetrics().Len(); k++ {
-					sm := rm.ScopeMetrics().At(k)
-					for l := 0; l < sm.Metrics().Len(); l++ {
-						delete(missingMetrics, sm.Metrics().At(l).Name())
-					}
-				}
-			}
-		}
-		msg := "Missing metrics:\n"
-		for k := range missingMetrics {
-			msg += fmt.Sprintf("- %q\n", k)
-		}
-		assert.Len(tt, missingMetrics, 0, msg)
-	}, 1*time.Minute, 1*time.Second)
+	testutils.CheckMetricsPresence(t, metricNames, "all_producer_metrics_config.yaml")
 }

--- a/tests/receivers/smartagent/collectd-tomcat/tomcat_test.go
+++ b/tests/receivers/smartagent/collectd-tomcat/tomcat_test.go
@@ -16,26 +16,13 @@
 package tests
 
 import (
-	"context"
-	"fmt"
-	"path/filepath"
-	"runtime"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/receiver/otlpreceiver"
-	"go.opentelemetry.io/collector/receiver/receivertest"
-	"go.uber.org/zap"
 
 	"github.com/signalfx/splunk-otel-collector/tests/testutils"
 )
 
 func TestCollectdTomcatReceiverProvidesDefaultMetrics(t *testing.T) {
-	checkMetricsPresence(t, []string{
+	testutils.CheckMetricsPresence(t, []string{
 		"counter.tomcat.GlobalRequestProcessor.bytesReceived",
 		"counter.tomcat.GlobalRequestProcessor.bytesSent",
 		"counter.tomcat.GlobalRequestProcessor.errorCount",
@@ -53,60 +40,4 @@ func TestCollectdTomcatReceiverProvidesDefaultMetrics(t *testing.T) {
 		"jmx_memory.committed",
 		"total_time_in_ms.collection_time",
 	}, "default_metrics_config.yaml")
-}
-
-func checkMetricsPresence(t *testing.T, metricNames []string, configFile string) {
-	f := otlpreceiver.NewFactory()
-	port := testutils.GetAvailablePort(t)
-	c := f.CreateDefaultConfig().(*otlpreceiver.Config)
-	c.GRPC.NetAddr.Endpoint = fmt.Sprintf("localhost:%d", port)
-	sink := &consumertest.MetricsSink{}
-	receiver, err := f.CreateMetrics(context.Background(), receivertest.NewNopSettings(f.Type()), c, sink)
-	require.NoError(t, err)
-	require.NoError(t, receiver.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() {
-		require.NoError(t, receiver.Shutdown(context.Background()))
-	})
-	logger, _ := zap.NewDevelopment()
-
-	dockerHost := "0.0.0.0"
-	if runtime.GOOS == "darwin" {
-		dockerHost = "host.docker.internal"
-	}
-	p, err := testutils.NewCollectorContainer().
-		WithImage(testutils.GetCollectorImageOrSkipTest(t)).
-		WithConfigPath(filepath.Join("testdata", configFile)).
-		WithLogger(logger).
-		WithEnv(map[string]string{"OTLP_ENDPOINT": fmt.Sprintf("%s:%d", dockerHost, port)}).
-		Build()
-	require.NoError(t, err)
-	require.NoError(t, p.Start())
-	t.Cleanup(func() {
-		require.NoError(t, p.Shutdown())
-	})
-
-	missingMetrics := make(map[string]any, len(metricNames))
-	for _, m := range metricNames {
-		missingMetrics[m] = struct{}{}
-	}
-
-	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
-		for i := 0; i < len(sink.AllMetrics()); i++ {
-			m := sink.AllMetrics()[i]
-			for j := 0; j < m.ResourceMetrics().Len(); j++ {
-				rm := m.ResourceMetrics().At(j)
-				for k := 0; k < rm.ScopeMetrics().Len(); k++ {
-					sm := rm.ScopeMetrics().At(k)
-					for l := 0; l < sm.Metrics().Len(); l++ {
-						delete(missingMetrics, sm.Metrics().At(l).Name())
-					}
-				}
-			}
-		}
-		msg := "Missing metrics:\n"
-		for k := range missingMetrics {
-			msg += fmt.Sprintf("- %q\n", k)
-		}
-		assert.Len(tt, missingMetrics, 0, msg)
-	}, 1*time.Minute, 1*time.Second)
 }

--- a/tests/testutils/testcase.go
+++ b/tests/testutils/testcase.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -185,4 +186,38 @@ func (t *Testcase) PrintLogsOnFailure() {
 // Validating shutdown helper for the Testcase's OTLPReceiverSink
 func (t *Testcase) ShutdownOTLPReceiverSink() {
 	require.NoError(t, t.OTLPReceiverSink.Shutdown())
+}
+
+func CheckMetricsPresence(t *testing.T, metricNames []string, configFile string) {
+	tc := NewTestcase(t)
+	defer tc.PrintLogsOnFailure()
+	defer tc.ShutdownOTLPReceiverSink()
+
+	_, shutdown := tc.SplunkOtelCollectorContainer(configFile)
+	tc.Cleanup(shutdown)
+
+	missingMetrics := make(map[string]any, len(metricNames))
+	for _, m := range metricNames {
+		missingMetrics[m] = struct{}{}
+	}
+
+	assert.EventuallyWithT(tc, func(tt *assert.CollectT) {
+		for i := 0; i < len(tc.OTLPReceiverSink.AllMetrics()); i++ {
+			m := tc.OTLPReceiverSink.AllMetrics()[i]
+			for j := 0; j < m.ResourceMetrics().Len(); j++ {
+				rm := m.ResourceMetrics().At(j)
+				for k := 0; k < rm.ScopeMetrics().Len(); k++ {
+					sm := rm.ScopeMetrics().At(k)
+					for l := 0; l < sm.Metrics().Len(); l++ {
+						delete(missingMetrics, sm.Metrics().At(l).Name())
+					}
+				}
+			}
+		}
+		msg := "Missing metrics:\n"
+		for k := range missingMetrics {
+			msg += fmt.Sprintf("- %q\n", k)
+		}
+		assert.Len(tt, missingMetrics, 0, msg)
+	}, 1*time.Minute, 1*time.Second)
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
There are a number of smartagent receiver tests that have duplicate logic. This change moves all duplicate logic to a central method. This was found in my efforts to add codecov support.

`jmx_test.go` is the only added code coverage in this PR.