### PR TITLE
[chore] Ensure entire repo is formatted in workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -86,7 +86,7 @@ jobs:
       - name: gofmt
         run: |
           make install-tools
-          make fmt
+          make for-all CMD="make fmt"
           if ! git diff --exit-code; then
             echo "One or more Go files are not formatted correctly. Run 'make fmt' and push the changes."
             exit 1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -88,7 +88,7 @@ jobs:
           make install-tools
           make for-all CMD="make fmt"
           if ! git diff --exit-code; then
-            echo "One or more Go files are not formatted correctly. Run 'make fmt' and push the changes."
+            echo "One or more Go files are not formatted correctly. Run 'make for-all CMD="make fmt"' and push the changes."
             exit 1
           fi
 

--- a/tests/testutils/golden.go
+++ b/tests/testutils/golden.go
@@ -36,9 +36,9 @@ import (
 )
 
 type metricCollectionTestOpts struct {
+	compareMetricsOptions []pmetrictest.CompareMetricsOption
 	collectorEnvVars      map[string]string
 	fileMounts            map[string]string
-	compareMetricsOptions []pmetrictest.CompareMetricsOption
 }
 
 type MetricsCollectionTestOption func(*metricCollectionTestOpts)

--- a/tests/testutils/golden.go
+++ b/tests/testutils/golden.go
@@ -36,9 +36,9 @@ import (
 )
 
 type metricCollectionTestOpts struct {
-	compareMetricsOptions []pmetrictest.CompareMetricsOption
 	collectorEnvVars      map[string]string
 	fileMounts            map[string]string
+	compareMetricsOptions []pmetrictest.CompareMetricsOption
 }
 
 type MetricsCollectionTestOption func(*metricCollectionTestOpts)

--- a/tests/testutils/socket_proxy.go
+++ b/tests/testutils/socket_proxy.go
@@ -25,13 +25,13 @@ import (
 )
 
 type SocketProxy struct {
+	listener          net.Listener
+	t                 testing.TB
 	Path              string
 	Endpoint          string
 	ContainerEndpoint string
-	listener          net.Listener
 	wg                sync.WaitGroup
 	active            atomic.Bool
-	t                 testing.TB
 }
 
 func CreateDockerSocketProxy(t testing.TB) *SocketProxy {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The `gofmt` job in the `build-and-test` workflow is only checking the main module for formatting, rather than every module in the repo. This needs to be updated to check all modules.

**Testing:**
The `gofmt` [action failed](https://github.com/signalfx/splunk-otel-collector/actions/runs/14542033047/job/40801790137?pr=6148) when a formatting error was included in a submodule, when the action passed before.