### PR TITLE
[chore][envoy discovery] Extend integration test timeout

### DIFF
--- a/tests/receivers/envoy/bundled_test.go
+++ b/tests/receivers/envoy/bundled_test.go
@@ -85,5 +85,5 @@ func TestEnvoyDockerObserver(t *testing.T) {
 			pmetrictest.IgnoreMetricValues(),
 		)
 		assert.NoError(tt, err)
-	}, 30*time.Second, 1*time.Second)
+	}, 60*time.Second, 1*time.Second)
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This test is flaky in GitHub CI and when run locally. Successful runs often take 20+ seconds, which gets close to the timeout as it is. Other discovery tests have a timeout of 1 or 2 minutes, so this update simple aligns this test with others.