### PR TITLE
Revert "Bump bitnami/kafka from 3.9.0 to 4.0.0 in /docker/kafka (#6057)"

### DIFF
--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kafka:4.0.0
+FROM bitnami/kafka:3.9.0
 
 ENV JMX_PORT=7099
 EXPOSE 7099


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This reverts commit fe69ebd2b6486f9fa94d86214d8423b14ec27d65. I accidentally merged https://github.com/signalfx/splunk-otel-collector/pull/6057 and it broke `main`. Revert so we can resolve errors in dependabot PR.
