### PR TITLE
update rules to not use deprecated syntax and allow for manual pushes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,12 +122,14 @@ fossa:
   eval $(creds-helper aws --eval "aws:v1/o11y-infra/role/o11y_gdi_otel_releaser_role")
 
 .trigger-filter:
-  only:
-    variables:
-      - $CI_COMMIT_BRANCH == "main"
-      - $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
-  except:
-    - schedules
+  rules:
+    - &main-condition
+      if: $CI_COMMIT_BRANCH == "main"
+    - &release-condition
+      if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+    - &no-schedules-condition
+      if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
 
 .deploy-release:
   image: '${DOCKER_CICD_REPO}/ci-container/python-3.12-bookworm:3.5.0'
@@ -431,7 +433,13 @@ agent-bundle-windows:
   artifacts:
     paths:
       - dist/agent-bundle_windows_amd64.zip
-
+.ta-trigger:
+  rules:
+    - <<*main-condition
+    - <<*release-condition
+    - <<*no-schedules-condition
+    - if: $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_TAG == null && $CI_COMMIT_REF_PROTECTED == 'true'
+      when: manual
 .auth-setup:
   id_tokens:
     CI_JOB_JWT:
@@ -474,7 +482,7 @@ agent-bundle-windows:
 
 package-technical-addon:
   extends:
-    - .trigger-filter
+    - .ta-trigger
   image: "${DOCKER_CICD_REPO}/ci-container/python-3.11-bullseye:1.19.0"
   stage: "package"
   script: |
@@ -491,7 +499,7 @@ package-technical-addon:
 test-happypath-ta:
   image: "${DOCKER_CICD_REPO}/ci-container/python-3.11-bullseye:1.19.0"
   extends:
-    - .trigger-filter
+    - .ta-trigger
     - .auth-setup
   stage: orca-tests
   dependencies:
@@ -523,7 +531,7 @@ test-happypath-ta:
 test-collectd-ta:
   image: "${DOCKER_CICD_REPO}/ci-container/python-3.11-bullseye:1.19.0"
   extends:
-    - .trigger-filter
+    - .ta-trigger
     - .auth-setup
   stage: orca-tests
   variables:
@@ -585,7 +593,7 @@ test-gateway-ta:
       - "$BUILD_DIR/$CI_JOB_ID/**/*"
 AppInspect_local:
   extends:
-    - .trigger-filter
+    - .ta-trigger
   dependencies:
     - "package-technical-addon"
   stage: code-analysis


### PR DESCRIPTION
1. [only/except is deprecated](https://docs.gitlab.com/ci/yaml/#only--except)
2. Allows for manual runs of technical addon branches if you manually protect them