### PR TITLE
Move smart agent config validation from unmarshal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🧰 Bug fixes 🧰
+
+- (Splunk) `receiver/smartagent`: Fix the receiver failing to start by receiver_creator since 0.124.0 ([#6187](https://github.com/signalfx/splunk-otel-collector/pull/6187))
+
 ## v0.124.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.124.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.124.0)

--- a/pkg/receiver/smartagentreceiver/config_linux_test.go
+++ b/pkg/receiver/smartagentreceiver/config_linux_test.go
@@ -44,6 +44,7 @@ func TestLoadConfigWithLinuxOnlyMonitors(t *testing.T) {
 	err = cm.Unmarshal(&apacheCfg)
 	require.NoError(t, err)
 	require.Equal(t, &Config{
+		MonitorType: "collectd/apache",
 		monitorConfig: &apache.Config{
 			MonitorConfig: saconfig.MonitorConfig{
 				Type:                "collectd/apache",
@@ -64,6 +65,7 @@ func TestLoadConfigWithLinuxOnlyMonitors(t *testing.T) {
 	err = cm.Unmarshal(&kafkaCfg)
 	require.NoError(t, err)
 	require.Equal(t, &Config{
+		MonitorType: "collectd/kafka",
 		monitorConfig: &kafka.Config{
 			Config: genericjmx.Config{
 				MonitorConfig: saconfig.MonitorConfig{
@@ -87,6 +89,7 @@ func TestLoadConfigWithLinuxOnlyMonitors(t *testing.T) {
 	err = cm.Unmarshal(&memcachedCfg)
 	require.NoError(t, err)
 	require.Equal(t, &Config{
+		MonitorType: "collectd/memcached",
 		monitorConfig: &memcached.Config{
 			MonitorConfig: saconfig.MonitorConfig{
 				Type:                "collectd/memcached",
@@ -106,6 +109,7 @@ func TestLoadConfigWithLinuxOnlyMonitors(t *testing.T) {
 	err = cm.Unmarshal(&phpCfg)
 	require.NoError(t, err)
 	require.Equal(t, &Config{
+		MonitorType: "collectd/php-fpm",
 		monitorConfig: &php.Config{
 			MonitorConfig: saconfig.MonitorConfig{
 				Type:                "collectd/php-fpm",

--- a/pkg/receiver/smartagentreceiver/factory_test.go
+++ b/pkg/receiver/smartagentreceiver/factory_test.go
@@ -37,6 +37,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateMetrics(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
+	cfg.(*Config).MonitorType = "haproxy"
 	cfg.(*Config).monitorConfig = &haproxy.Config{}
 
 	params := otelcolreceiver.Settings{ID: component.MustNewID(typeStr)}
@@ -55,7 +56,7 @@ func TestCreateMetricsWithInvalidConfig(t *testing.T) {
 	params := otelcolreceiver.Settings{ID: component.MustNewID(typeStr)}
 	receiver, err := factory.CreateMetrics(context.Background(), params, cfg, consumertest.NewNop())
 	require.Error(t, err)
-	assert.EqualError(t, err, "you must supply a valid Smart Agent Monitor config")
+	assert.EqualError(t, err, `you must specify a "type" for a smartagent receiver`)
 	assert.Nil(t, receiver)
 
 	assert.NotContains(t, receiverStore, cfg)
@@ -64,6 +65,7 @@ func TestCreateMetricsWithInvalidConfig(t *testing.T) {
 func TestCreateLogs(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
+	cfg.(*Config).MonitorType = "haproxy"
 	cfg.(*Config).monitorConfig = &haproxy.Config{}
 
 	params := otelcolreceiver.Settings{ID: component.MustNewID(typeStr)}
@@ -82,7 +84,7 @@ func TestCreateLogsWithInvalidConfig(t *testing.T) {
 	params := otelcolreceiver.Settings{ID: component.MustNewID(typeStr)}
 	receiver, err := factory.CreateLogs(context.Background(), params, cfg, consumertest.NewNop())
 	require.Error(t, err)
-	assert.EqualError(t, err, "you must supply a valid Smart Agent Monitor config")
+	assert.EqualError(t, err, `you must specify a "type" for a smartagent receiver`)
 	assert.Nil(t, receiver)
 
 	assert.NotContains(t, receiverStore, cfg)
@@ -91,6 +93,7 @@ func TestCreateLogsWithInvalidConfig(t *testing.T) {
 func TestCreateTraces(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
+	cfg.(*Config).MonitorType = "haproxy"
 	cfg.(*Config).monitorConfig = &haproxy.Config{}
 
 	params := otelcolreceiver.Settings{ID: component.MustNewID(typeStr)}
@@ -109,7 +112,7 @@ func TestCreateTracesWithInvalidConfig(t *testing.T) {
 	params := otelcolreceiver.Settings{ID: component.MustNewID(typeStr)}
 	receiver, err := factory.CreateTraces(context.Background(), params, cfg, consumertest.NewNop())
 	require.Error(t, err)
-	assert.EqualError(t, err, "you must supply a valid Smart Agent Monitor config")
+	assert.EqualError(t, err, `you must specify a "type" for a smartagent receiver`)
 	assert.Nil(t, receiver)
 
 	assert.NotContains(t, receiverStore, cfg)
@@ -118,6 +121,7 @@ func TestCreateTracesWithInvalidConfig(t *testing.T) {
 func TestCreateMetricsThenLogsAndThenTracesReceiver(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
+	cfg.(*Config).MonitorType = "haproxy"
 	cfg.(*Config).monitorConfig = &haproxy.Config{}
 
 	params := otelcolreceiver.Settings{ID: component.MustNewID(typeStr)}
@@ -148,6 +152,7 @@ func TestCreateMetricsThenLogsAndThenTracesReceiver(t *testing.T) {
 func TestCreateTracesThenLogsAndThenMetricsReceiver(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
+	cfg.(*Config).MonitorType = "haproxy"
 	cfg.(*Config).monitorConfig = &haproxy.Config{}
 
 	params := otelcolreceiver.Settings{ID: component.MustNewID(typeStr)}

--- a/pkg/receiver/smartagentreceiver/receiver_test.go
+++ b/pkg/receiver/smartagentreceiver/receiver_test.go
@@ -26,10 +26,6 @@ import (
 	"testing"
 	"time"
 
-	saconfig "github.com/signalfx/signalfx-agent/pkg/core/config"
-	"github.com/signalfx/signalfx-agent/pkg/monitors"
-	"github.com/signalfx/signalfx-agent/pkg/monitors/cpu"
-	"github.com/signalfx/signalfx-agent/pkg/utils/hostfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -47,6 +43,11 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+
+	saconfig "github.com/signalfx/signalfx-agent/pkg/core/config"
+	"github.com/signalfx/signalfx-agent/pkg/monitors"
+	"github.com/signalfx/signalfx-agent/pkg/monitors/cpu"
+	"github.com/signalfx/signalfx-agent/pkg/utils/hostfs"
 
 	"github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension"
 )
@@ -95,6 +96,7 @@ var (
 
 func newConfig(monitorType string, intervalSeconds int) Config {
 	return Config{
+		MonitorType: monitorType,
 		monitorConfig: &cpu.Config{
 			MonitorConfig: saconfig.MonitorConfig{
 				Type:            monitorType,


### PR DESCRIPTION
This fixes receiver_creator failing to start smartagent receivers since 0.124.0 with the following error:
```
2025-05-01T09:35:43.989Z	info	receivercreator@v0.124.1-0.20250415150511-f840bdff19ca/observerhandler.go:201	starting receiver	{"name": "smartagent/coredns", "endpoint": "10.42.0.8", "endpoint_id": "k8s_observer/c7a1646a-969d-4e5d-9bbd-a95574b903b3", "config": {"extraDimensions":{"metric_source":"k8s-coredns"},"port":9153,"type":"coredns"}}
2025-05-01T09:35:43.991Z	error	receivercreator@v0.124.1-0.20250415150511-f840bdff19ca/observerhandler.go:217	failed to start receiver	{"receiver": "smartagent/coredns", "error": "failed creating endpoint-derived receiver: Validation error in field 'Config.host': host is a required field (got '')"}
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator.(*observerHandler).startReceiver
	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator@v0.124.1-0.20250415150511-f840bdff19ca/observerhandler.go:217
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator.(*observerHandler).OnAdd
	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator@v0.124.1-0.20250415150511-f840bdff19ca/observerhandler.go:105
github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/endpointswatcher.(*EndpointsWatcher).updateAndNotifyOfEndpoints
	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer@v0.124.1/endpointswatcher/endpointswatcher.go:114
```