### PR TITLE
[chore] Remove impi tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ all-modules:
 	@echo $(ALL_MODS) | tr ' ' '\n' | sort
 
 .PHONY: all
-all: checklicense impi lint misspell test otelcol
+all: checklicense lint misspell test otelcol
 
 .PHONY: for-all
 for-all:
@@ -232,7 +232,6 @@ install-tools:
 	cd ./internal/tools && go install github.com/google/addlicense
 	cd ./internal/tools && go install github.com/jstemmer/go-junit-report
 	cd ./internal/tools && go install go.opentelemetry.io/collector/cmd/mdatagen
-	cd ./internal/tools && go install github.com/pavius/impi/cmd/impi
 	cd ./internal/tools && go install github.com/tcnksm/ghr
 	cd ./internal/tools && go install golang.org/x/tools/cmd/goimports
 	cd ./internal/tools && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -38,7 +38,6 @@ MDLINKCHECK=markdown-link-check
 MISSPELL=misspell -error
 MISSPELL_CORRECTION=misspell -w
 LINT=golangci-lint
-IMPI=impi
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release
 
@@ -83,7 +82,7 @@ all-pkg-dirs:
 .DEFAULT_GOAL := common
 
 .PHONY: common
-common: checklicense impi lint misspell
+common: checklicense lint misspell
 
 .PHONY: test
 test:
@@ -138,7 +137,7 @@ fmt: addlicense misspell-correction
 	fieldalignment -fix ./... || true
 
 .PHONY: lint
-lint: checklicense misspell impi
+lint: checklicense misspell
 	$(LINT) run --allow-parallel-runners -j$(NUM_CORES)
 
 .PHONY: tidy
@@ -154,10 +153,6 @@ misspell:
 .PHONY: misspell-correction
 misspell-correction:
 	$(MISSPELL_CORRECTION) $(ALL_SRC_AND_DOC)
-
-.PHONY: impi
-impi:
-	@$(IMPI) --local github.com/signalfx/splunk-otel-collector --skip internal/signalfx-agent --scheme stdThirdPartyLocal --ignore-generated=true ./...
 
 .PHONY: moddownload
 moddownload:

--- a/internal/signalfx-agent/Makefile
+++ b/internal/signalfx-agent/Makefile
@@ -77,9 +77,6 @@ check: lint vet test
 .PHONY: checklicense
 checklicense: checklicense-noop
 
-.PHONY: impi
-impi: impi-noop
-
 .PHONY: misspell
 misspell: misspell-noop
 

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/golangci/golangci-lint v1.64.8
 	github.com/google/addlicense v1.1.1
 	github.com/jstemmer/go-junit-report v1.0.0
-	github.com/pavius/impi v0.0.3
 	github.com/tcnksm/ghr v0.16.2
 	go.opentelemetry.io/collector/cmd/mdatagen v0.125.0
 	golang.org/x/tools v0.32.0
@@ -107,7 +106,6 @@ require (
 	github.com/julz/importas v0.2.0 // indirect
 	github.com/karamaru-alpha/copyloopvar v1.2.1 // indirect
 	github.com/kisielk/errcheck v1.9.0 // indirect
-	github.com/kisielk/gotool v1.0.0 // indirect
 	github.com/kkHAIKE/contextcheck v1.1.6 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect
 	github.com/knadh/koanf/v2 v2.2.0 // indirect

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -359,7 +359,6 @@ github.com/karamaru-alpha/copyloopvar v1.2.1/go.mod h1:nFmMlFNlClC2BPvNaHMdkirmT
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/errcheck v1.9.0 h1:9xt1zI9EBfcYBvdU1nVrzMzzUPUtPKs9bVSIM3TAb3M=
 github.com/kisielk/errcheck v1.9.0/go.mod h1:kQxWMMVZgIkDq7U8xtG/n2juOjbLgZtedi0D+/VL/i8=
-github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkHAIKE/contextcheck v1.1.6 h1:7HIyRcnyzxL9Lz06NGhiKvenXq7Zw6Q0UQu/ttjfJCE=
 github.com/kkHAIKE/contextcheck v1.1.6/go.mod h1:3dDbMRNBFaq8HFXWC1JyvDSPm43CmE6IuHam8Wr0rkg=
@@ -488,8 +487,6 @@ github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT9
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
-github.com/pavius/impi v0.0.3 h1:DND6MzU+BLABhOZXbELR3FU8b+zDgcq4dOCNLhiTYuI=
-github.com/pavius/impi v0.0.3/go.mod h1:x/hU0bfdWIhuOT1SKwiJg++yvkk6EuOtJk8WtDZqgr8=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -23,7 +23,6 @@ import (
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/google/addlicense"
 	_ "github.com/jstemmer/go-junit-report"
-	_ "github.com/pavius/impi/cmd/impi"
 	_ "github.com/tcnksm/ghr"
 	_ "go.opentelemetry.io/collector/cmd/mdatagen"
 	_ "golang.org/x/tools/cmd/goimports"


### PR DESCRIPTION
This is redundant. We already use `go fmt` and `goimport` linter for the same purpose. Unblocks https://github.com/signalfx/splunk-otel-collector/pull/6189 because impi doesn't support more than one local prefix