### PR TITLE
[ansible] Upgrade node.js to v18

### DIFF
--- a/deployments/ansible/molecule/shared/install_nodejs.yml
+++ b/deployments/ansible/molecule/shared/install_nodejs.yml
@@ -21,7 +21,7 @@
 
 - name: "download and extract nodejs"
   unarchive:
-    src: https://nodejs.org/download/release/v16.20.2/node-v16.20.2-linux-x64.tar.gz
+    src: https://nodejs.org/download/release/v18.20.8/node-v18.20.8-linux-x64.tar.gz
     dest: /usr/local
     remote_src: yes
   register: result
@@ -31,7 +31,7 @@
 
 - name: "create symlinks in /usr/bin"
   file:
-    src: "/usr/local/node-v16.20.2-linux-x64/bin/{{ item }}"
+    src: "/usr/local/node-v18.20.8-linux-x64/bin/{{ item }}"
     dest: "/usr/bin/{{ item }}"
     state: link
     mode: '755'


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This resolves test failures running Ansible tests on Linux. Errors from [previous actions](https://github.com/signalfx/splunk-otel-collector/actions/runs/14961242885/job/42070350592) show the node version must be upgraded to >= 18 to meet requirements.

_All usages of this file that I could find are for tests so I don't believe this requires a changelog._