### PR TITLE
[chore][installer-script-test] Upgrade minimum version of Node.js to v18 in testing

### DIFF
--- a/packaging/tests/installer_test.py
+++ b/packaging/tests/installer_test.py
@@ -498,7 +498,7 @@ def test_installer_with_instrumentation_custom(distro, arch, method, sdk):
         pytest.skip("opensuse-12 arm64 no longer supported")
 
     # minimum supported node version required for profiling
-    node_version = 16
+    node_version = 18
     if arch == "arm64" and distro in ("centos-7"):
         # g++ for these distros is too old to build/compile splunk-otel-js with node v16:
         #   g++: error: unrecognized command line option '-std=gnu++14'

--- a/packaging/tests/installer_test.py
+++ b/packaging/tests/installer_test.py
@@ -379,7 +379,7 @@ def test_installer_with_instrumentation_default(distro, arch, method):
         pytest.skip("opensuse-12 arm64 no longer supported")
 
     # minimum supported node version required for profiling
-    node_version = 16
+    node_version = 18
     if arch == "arm64" and distro in ("centos-7"):
         # g++ for these distros is too old to build/compile splunk-otel-js with node v16:
         #   g++: error: unrecognized command line option '-std=gnu++14'


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Test failure output from `linux-installer-script-test`:
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@splunk/otel@3.1.2',
npm WARN EBADENGINE   required: { node: '>=18' },
npm WARN EBADENGINE   current: { node: 'v16.20.2', npm: '8.19.4' }
npm WARN EBADENGINE }
```
[Failure link](https://github.com/signalfx/splunk-otel-collector/actions/runs/14815389621/job/41595172679#step:6:955)

**NOTE:** [`v16` has been EOL since August 2023](https://nodejs.org/en/about/previous-releases). v18 is also EOL, but I think it makes sense to upgrade one major version at a time for now.