### PR TITLE
[chore][puppet tests] Upgrade minimum Node.js version to v18

### DIFF
--- a/packaging/tests/deployments/puppet/images/deb/Dockerfile.debian-bullseye
+++ b/packaging/tests/deployments/puppet/images/deb/Dockerfile.debian-bullseye
@@ -9,7 +9,7 @@ RUN wget https://apt.puppetlabs.com/puppet${PUPPET_RELEASE}-release-bullseye.deb
     apt-get update && \
     apt-get install -y puppet-agent
 
-RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-x64.tar.gz && \
     mkdir -p /opt/ && \
     tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
     mv /opt/node* /opt/node

--- a/packaging/tests/deployments/puppet/images/deb/Dockerfile.ubuntu-focal
+++ b/packaging/tests/deployments/puppet/images/deb/Dockerfile.ubuntu-focal
@@ -9,7 +9,7 @@ RUN wget https://apt.puppetlabs.com/puppet${PUPPET_RELEASE}-release-focal.deb &&
     apt-get update && \
     apt-get install -y puppet-agent
 
-RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-x64.tar.gz && \
     mkdir -p /opt/ && \
     tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
     mv /opt/node* /opt/node

--- a/packaging/tests/deployments/puppet/images/deb/Dockerfile.ubuntu-jammy
+++ b/packaging/tests/deployments/puppet/images/deb/Dockerfile.ubuntu-jammy
@@ -9,7 +9,7 @@ RUN wget https://apt.puppetlabs.com/puppet${PUPPET_RELEASE}-release-jammy.deb &&
     apt-get update && \
     apt-get install -y puppet-agent
 
-RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-x64.tar.gz && \
     mkdir -p /opt/ && \
     tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
     mv /opt/node* /opt/node

--- a/packaging/tests/deployments/puppet/images/rpm/Dockerfile.amazonlinux-2023
+++ b/packaging/tests/deployments/puppet/images/rpm/Dockerfile.amazonlinux-2023
@@ -8,7 +8,7 @@ ARG PUPPET_RELEASE="6"
 RUN rpm -Uvh https://yum.puppet.com/puppet${PUPPET_RELEASE}-release-el-9.noarch.rpm && \
     yum install -y puppet-agent
 
-RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-x64.tar.gz && \
     mkdir -p /opt/ && \
     tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
     mv /opt/node* /opt/node

--- a/packaging/tests/deployments/puppet/images/rpm/Dockerfile.centos-8
+++ b/packaging/tests/deployments/puppet/images/rpm/Dockerfile.centos-8
@@ -11,7 +11,7 @@ ARG PUPPET_RELEASE="6"
 RUN rpm -Uvh https://yum.puppet.com/puppet${PUPPET_RELEASE}-release-el-8.noarch.rpm && \
     dnf install -y puppet-agent
 
-RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-x64.tar.gz && \
     mkdir -p /opt/ && \
     tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
     mv /opt/node* /opt/node

--- a/packaging/tests/deployments/puppet/images/rpm/Dockerfile.centos-9
+++ b/packaging/tests/deployments/puppet/images/rpm/Dockerfile.centos-9
@@ -10,7 +10,7 @@ ARG PUPPET_RELEASE="6"
 RUN rpm -Uvh https://yum.puppet.com/puppet${PUPPET_RELEASE}-release-el-9.noarch.rpm && \
     dnf install -y puppet-agent
 
-RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-x64.tar.gz && \
     mkdir -p /opt/ && \
     tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
     mv /opt/node* /opt/node

--- a/packaging/tests/deployments/puppet/images/rpm/Dockerfile.opensuse-15
+++ b/packaging/tests/deployments/puppet/images/rpm/Dockerfile.opensuse-15
@@ -14,7 +14,7 @@ RUN rpm -Uvh https://yum.puppet.com/puppet${PUPPET_RELEASE}-release-sles-15.noar
     zypper --gpg-auto-import-keys -n refresh && \
     zypper install -y puppet-agent procps
 
-RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-x64.tar.gz && \
     mkdir -p /opt/ && \
     tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
     mv /opt/node* /opt/node

--- a/packaging/tests/deployments/puppet/images/rpm/Dockerfile.oraclelinux-8
+++ b/packaging/tests/deployments/puppet/images/rpm/Dockerfile.oraclelinux-8
@@ -8,7 +8,7 @@ ARG PUPPET_RELEASE="6"
 RUN rpm -Uvh https://yum.puppet.com/puppet${PUPPET_RELEASE}-release-el-8.noarch.rpm && \
     dnf install -y puppet-agent
 
-RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz && \
+RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-x64.tar.gz && \
     mkdir -p /opt/ && \
     tar -C /opt/ -xzf /tmp/nodejs.tar.gz && \
     mv /opt/node* /opt/node


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
[Failure link](https://github.com/signalfx/splunk-otel-collector/actions/runs/15079744379/job/42394416205#step:5:1032):
```
Notice: /Stage[main]/Splunk_otel_collector/Exec[Install splunk-otel-js]/returns: npm WARN EBADENGINE Unsupported engine {
Notice: /Stage[main]/Splunk_otel_collector/Exec[Install splunk-otel-js]/returns: npm WARN EBADENGINE   package: '@splunk/otel@3.1.2',
Notice: /Stage[main]/Splunk_otel_collector/Exec[Install splunk-otel-js]/returns: npm WARN EBADENGINE   required: { node: '>=18' },
Notice: /Stage[main]/Splunk_otel_collector/Exec[Install splunk-otel-js]/returns: npm WARN EBADENGINE   current: { node: 'v16.20.2', npm: '8.19.4' }
Notice: /Stage[main]/Splunk_otel_collector/Exec[Install splunk-otel-js]/returns: npm WARN EBADENGINE }
Notice: /Stage[main]/Splunk_otel_collector/Exec[Install splunk-otel-js]/returns: npm notice 
Notice: /Stage[main]/Splunk_otel_collector/Exec[Install splunk-otel-js]/returns: npm notice New major version of npm available! 8.19.4 -> 11.4.0
Notice: /Stage[main]/Splunk_otel_collector/Exec[Install splunk-otel-js]/returns: npm notice Changelog: <https://github.com/npm/cli/releases/tag/v11.4.0>
Notice: /Stage[main]/Splunk_otel_collector/Exec[Install splunk-otel-js]/returns: npm notice Run `npm install -g npm@11.4.0` to update!
Notice: /Stage[main]/Splunk_otel_collector/Exec[Install splunk-otel-js]/returns: npm notice 
Notice: /Stage[main]/Splunk_otel_collector/Exec[Install splunk-otel-js]/returns: npm ERR! code 1
```
Updating all nodejs version references to v18.