### PR TITLE
[smartagent] Use system cert pool as default on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🧰 Bug fixes 🧰
+
+- (Splunk) `receiver/smartagent`: Use the system certificate pool as the default pool on Windows, keeping behavior of monitors consistent with other OSes. ([#TBD](https://github.com/signalfx/splunk-otel-collector/pull/TBD))
+
 ## v0.125.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.125.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.125.0)

--- a/internal/signalfx-agent/pkg/core/common/auth/tls.go
+++ b/internal/signalfx-agent/pkg/core/common/auth/tls.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
-	"runtime"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -58,10 +57,6 @@ func TLSConfig(tlsConfig *tls.Config, caCertPath string, clientCertPath string, 
 
 // CertPool returns the system cert pool for non-Windows platforms
 func CertPool() (*x509.CertPool, error) {
-	if runtime.GOOS == "windows" {
-		return x509.NewCertPool(), nil
-	}
-
 	certs, err := x509.SystemCertPool()
 	if err != nil {
 		return nil, fmt.Errorf("Could not load system x509 cert pool: %w", err)

--- a/internal/signalfx-agent/pkg/core/common/auth/tls_test.go
+++ b/internal/signalfx-agent/pkg/core/common/auth/tls_test.go
@@ -1,0 +1,20 @@
+package auth
+
+import (
+	"crypto/x509"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultCertPoolMustBeSystemPool(t *testing.T) {
+	// Get a reference system pool for comparison
+	systemPool, sysErr := x509.SystemCertPool()
+	require.NoError(t, sysErr)
+	require.NotNil(t, systemPool)
+
+	defaultCertPool, err := CertPool()
+	require.NoError(t, err)
+	require.NotNil(t, defaultCertPool)
+	require.Equal(t, systemPool, defaultCertPool)
+}

--- a/internal/signalfx-agent/pkg/monitors/http/http_test.go
+++ b/internal/signalfx-agent/pkg/monitors/http/http_test.go
@@ -1,0 +1,133 @@
+package http
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/signalfx/golib/v3/event"
+	"github.com/signalfx/golib/v3/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/signalfx/signalfx-agent/pkg/core/common/httpclient"
+	"github.com/signalfx/signalfx-agent/pkg/core/config"
+	"github.com/signalfx/signalfx-agent/pkg/core/dpfilters"
+	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
+)
+
+func TestMonitorCanReachMicrosoft(t *testing.T) {
+	output := &fakeOutput{}
+	output.sendDatapointsCall.Add(1)
+
+	monitor := &Monitor{
+		Output:      output,
+		monitorName: "http-monitor",
+	}
+
+	// Configure the monitor to check microsoft.com
+	err := monitor.Configure(&Config{
+		MonitorConfig: config.MonitorConfig{
+			IntervalSeconds: 1,
+		},
+		HTTPConfig: httpclient.HTTPConfig{
+			UseHTTPS: true,
+		},
+		Host:   "www.microsoft.com",
+		Port:   443,
+		Path:   "/",
+		Method: "GET",
+	})
+	require.NoError(t, err)
+	defer monitor.Shutdown()
+
+	output.sendDatapointsCall.Wait()
+	require.NotEmpty(t, output.datapoints, "Expected to receive datapoints")
+
+	// Check for specific metrics
+	var foundStatusCode, foundResponseTime, foundCertExpiry, foundCertValid bool
+	for _, dp := range output.datapoints {
+		switch dp.Metric {
+		case "http.status_code":
+			foundStatusCode = true
+			assert.Equal(t, int64(200), dp.Value.(datapoint.IntValue).Int())
+		case "http.response_time":
+			foundResponseTime = true
+			assert.Greater(t, dp.Value.(datapoint.FloatValue).Float(), float64(0))
+		case "http.cert_expiry":
+			foundCertExpiry = true
+			assert.Greater(t, dp.Value.(datapoint.FloatValue).Float(), float64(0))
+		case "http.cert_valid":
+			foundCertValid = true
+			assert.Greater(t, dp.Value.(datapoint.IntValue).Int(), int64(0))
+		}
+	}
+
+	require.True(t, foundStatusCode, "Expected to find http.status_code metric")
+	require.True(t, foundResponseTime, "Expected to find http.response_time metric")
+	require.True(t, foundCertExpiry, "Expected to find http.cert_expiry metric")
+	require.True(t, foundCertValid, "Expected to find http.cert_valid metric")
+}
+
+type fakeOutput struct {
+	sendDatapointsCall sync.WaitGroup
+	datapoints         []*datapoint.Datapoint
+}
+
+var _ types.FilteringOutput = (*fakeOutput)(nil)
+
+// AddDatapointExclusionFilter implements types.FilteringOutput.
+func (fo *fakeOutput) AddDatapointExclusionFilter(filter dpfilters.DatapointFilter) {
+	panic("unimplemented")
+}
+
+// AddExtraDimension implements types.FilteringOutput.
+func (fo *fakeOutput) AddExtraDimension(key string, value string) {
+	panic("unimplemented")
+}
+
+// Copy implements types.FilteringOutput.
+func (fo *fakeOutput) Copy() types.Output {
+	panic("unimplemented")
+}
+
+// EnabledMetrics implements types.FilteringOutput.
+func (fo *fakeOutput) EnabledMetrics() []string {
+	panic("unimplemented")
+}
+
+// HasAnyExtraMetrics implements types.FilteringOutput.
+func (fo *fakeOutput) HasAnyExtraMetrics() bool {
+	panic("unimplemented")
+}
+
+// HasEnabledMetricInGroup implements types.FilteringOutput.
+func (fo *fakeOutput) HasEnabledMetricInGroup(group string) bool {
+	panic("unimplemented")
+}
+
+// SendDimensionUpdate implements types.FilteringOutput.
+func (fo *fakeOutput) SendDimensionUpdate(dim *types.Dimension) {
+	panic("unimplemented")
+}
+
+// SendEvent implements types.FilteringOutput.
+func (fo *fakeOutput) SendEvent(e *event.Event) {
+	panic("unimplemented")
+}
+
+// SendMetrics implements types.FilteringOutput.
+func (fo *fakeOutput) SendMetrics(metrics ...pmetric.Metric) {
+	panic("unimplemented")
+}
+
+// SendSpans implements types.FilteringOutput.
+func (fo *fakeOutput) SendSpans(spans ...*trace.Span) {
+	panic("unimplemented")
+}
+
+func (fo *fakeOutput) SendDatapoints(dps ...*datapoint.Datapoint) {
+	fo.datapoints = append(fo.datapoints, dps...)
+	fo.sendDatapointsCall.Done()
+}


### PR DESCRIPTION
**Description:** 
The system certificate pool should be the default on Windows, the same behavior of the other supported OSes.
 
**Testing:**
Added 2 new tests to cover the new default.

**Documentation:**
N/A this should be correct default.
