### PR TITLE
keep histograms in envoy prometheus receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🧰 Bug fixes 🧰
 
 - (Splunk) `receiver/smartagent`: Use the system certificate pool as the default pool on Windows, keeping behavior of monitors consistent with other OSes. ([#6240](https://github.com/signalfx/splunk-otel-collector/pull/6240))
+- (Splunk) `discovery`: Fix the prometheus config for envoy discovery receiver ([#6243](https://github.com/signalfx/splunk-otel-collector/pull/6243))
 
 ## v0.125.0
 

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/envoy.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/envoy.discovery.yaml
@@ -24,7 +24,25 @@
 #             metric_relabel_configs:
 #               - source_labels: [__name__]
 #                 action: keep
-#                 regex: '(envoy_cluster_upstream_cx_active|envoy_cluster_upstream_cx_total|envoy_cluster_upstream_cx_connect_fail|envoy_cluster_upstream_cx_connect_ms|envoy_cluster_upstream_rq_active|envoy_cluster_upstream_rq_total|envoy_cluster_upstream_rq_timeout|envoy_cluster_upstream_rq_pending_active|envoy_cluster_upstream_rq_pending_overflow|envoy_cluster_upstream_rq_time|envoy_cluster_membership_total|envoy_cluster_membership_degraded|envoy_cluster_membership_excluded|envoy_listener_downstream_cx_active|envoy_listener_downstream_cx_total|envoy_listener_downstream_cx_transport_socket_connect_timeout|envoy_listener_downstream_cx_overflow|envoy_listener_downstream_cx_overload_reject|envoy_listener_downstream_global_cx_overflow)'
+#                 regex: "(envoy_cluster_upstream_cx_active|\
+#                 envoy_cluster_upstream_cx_total|\
+#                 envoy_cluster_upstream_cx_connect_fail|\
+#                 envoy_cluster_upstream_cx_connect_ms|\
+#                 envoy_cluster_upstream_rq_active|\
+#                 envoy_cluster_upstream_rq_total|\
+#                 envoy_cluster_upstream_rq_timeout|\
+#                 envoy_cluster_upstream_rq_pending_active|\
+#                 envoy_cluster_upstream_rq_pending_overflow|\
+#                 envoy_cluster_upstream_rq_time|\
+#                 envoy_cluster_membership_total|\
+#                 envoy_cluster_membership_degraded|\
+#                 envoy_cluster_membership_excluded|\
+#                 envoy_listener_downstream_cx_active|\
+#                 envoy_listener_downstream_cx_total|\
+#                 envoy_listener_downstream_cx_transport_socket_connect_timeout|\
+#                 envoy_listener_downstream_cx_overflow|\
+#                 envoy_listener_downstream_cx_overload_reject|\
+#                 envoy_listener_downstream_global_cx_overflow)(?:_sum|_count|_bucket)?"
 #   status:
 #     metrics:
 #       - status: successful

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/envoy.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/envoy.discovery.yaml
@@ -20,7 +20,25 @@ prometheus:
             metric_relabel_configs:
               - source_labels: [__name__]
                 action: keep
-                regex: '(envoy_cluster_upstream_cx_active|envoy_cluster_upstream_cx_total|envoy_cluster_upstream_cx_connect_fail|envoy_cluster_upstream_cx_connect_ms|envoy_cluster_upstream_rq_active|envoy_cluster_upstream_rq_total|envoy_cluster_upstream_rq_timeout|envoy_cluster_upstream_rq_pending_active|envoy_cluster_upstream_rq_pending_overflow|envoy_cluster_upstream_rq_time|envoy_cluster_membership_total|envoy_cluster_membership_degraded|envoy_cluster_membership_excluded|envoy_listener_downstream_cx_active|envoy_listener_downstream_cx_total|envoy_listener_downstream_cx_transport_socket_connect_timeout|envoy_listener_downstream_cx_overflow|envoy_listener_downstream_cx_overload_reject|envoy_listener_downstream_global_cx_overflow)'
+                regex: "(envoy_cluster_upstream_cx_active|\
+                envoy_cluster_upstream_cx_total|\
+                envoy_cluster_upstream_cx_connect_fail|\
+                envoy_cluster_upstream_cx_connect_ms|\
+                envoy_cluster_upstream_rq_active|\
+                envoy_cluster_upstream_rq_total|\
+                envoy_cluster_upstream_rq_timeout|\
+                envoy_cluster_upstream_rq_pending_active|\
+                envoy_cluster_upstream_rq_pending_overflow|\
+                envoy_cluster_upstream_rq_time|\
+                envoy_cluster_membership_total|\
+                envoy_cluster_membership_degraded|\
+                envoy_cluster_membership_excluded|\
+                envoy_listener_downstream_cx_active|\
+                envoy_listener_downstream_cx_total|\
+                envoy_listener_downstream_cx_transport_socket_connect_timeout|\
+                envoy_listener_downstream_cx_overflow|\
+                envoy_listener_downstream_cx_overload_reject|\
+                envoy_listener_downstream_global_cx_overflow)(?:_sum|_count|_bucket)?"
   status:
     metrics:
       - status: successful

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/envoy.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/envoy.discovery.yaml.tmpl
@@ -16,7 +16,25 @@
             metric_relabel_configs:
               - source_labels: [__name__]
                 action: keep
-                regex: '(envoy_cluster_upstream_cx_active|envoy_cluster_upstream_cx_total|envoy_cluster_upstream_cx_connect_fail|envoy_cluster_upstream_cx_connect_ms|envoy_cluster_upstream_rq_active|envoy_cluster_upstream_rq_total|envoy_cluster_upstream_rq_timeout|envoy_cluster_upstream_rq_pending_active|envoy_cluster_upstream_rq_pending_overflow|envoy_cluster_upstream_rq_time|envoy_cluster_membership_total|envoy_cluster_membership_degraded|envoy_cluster_membership_excluded|envoy_listener_downstream_cx_active|envoy_listener_downstream_cx_total|envoy_listener_downstream_cx_transport_socket_connect_timeout|envoy_listener_downstream_cx_overflow|envoy_listener_downstream_cx_overload_reject|envoy_listener_downstream_global_cx_overflow)'
+                regex: "(envoy_cluster_upstream_cx_active|\
+                envoy_cluster_upstream_cx_total|\
+                envoy_cluster_upstream_cx_connect_fail|\
+                envoy_cluster_upstream_cx_connect_ms|\
+                envoy_cluster_upstream_rq_active|\
+                envoy_cluster_upstream_rq_total|\
+                envoy_cluster_upstream_rq_timeout|\
+                envoy_cluster_upstream_rq_pending_active|\
+                envoy_cluster_upstream_rq_pending_overflow|\
+                envoy_cluster_upstream_rq_time|\
+                envoy_cluster_membership_total|\
+                envoy_cluster_membership_degraded|\
+                envoy_cluster_membership_excluded|\
+                envoy_listener_downstream_cx_active|\
+                envoy_listener_downstream_cx_total|\
+                envoy_listener_downstream_cx_transport_socket_connect_timeout|\
+                envoy_listener_downstream_cx_overflow|\
+                envoy_listener_downstream_cx_overload_reject|\
+                envoy_listener_downstream_global_cx_overflow)(?:_sum|_count|_bucket)?"
   status:
     metrics:
       - status: successful

--- a/tests/receivers/envoy/testdata/expected.yaml
+++ b/tests/receivers/envoy/testdata/expected.yaml
@@ -4,24 +4,30 @@ resourceMetrics:
         - key: container.image.name
           value:
             stringValue: quay.io/splunko11ytest/envoy
+        - key: container.name
+          value:
+            stringValue: docker-envoy-1
+        - key: discovery.endpoint.id
+          value:
+            stringValue: 30c5122db7a66a56ed6dce3b8ec50d8ccf12a8b3a217d92020e3560c4c13c3e4:9901
         - key: http.scheme
           value:
             stringValue: http
         - key: net.host.name
           value:
-            stringValue: host.docker.internal
+            stringValue: 172.19.0.2
         - key: net.host.port
           value:
             stringValue: "9901"
         - key: server.address
           value:
-            stringValue: host.docker.internal
+            stringValue: 172.19.0.2
         - key: server.port
           value:
             stringValue: "9901"
         - key: service.instance.id
           value:
-            stringValue: host.docker.internal:9901
+            stringValue: 172.19.0.2:9901
         - key: service.name
           value:
             stringValue: envoy
@@ -30,6 +36,260 @@ resourceMetrics:
             stringValue: http
     scopeMetrics:
       - metrics:
+          - description: The number of samples the target exposed
+            gauge:
+              dataPoints:
+                - asDouble: 782
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: scrape_samples_scraped
+          - description: The approximate number of new series in this scrape
+            gauge:
+              dataPoints:
+                - asDouble: 61
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: scrape_series_added
+          - metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: envoy_cluster_upstream_cx_connect_fail
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+          - metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: envoy_cluster_upstream_rq_pending_overflow
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+          - metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: envoy_cluster_upstream_rq_total
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 4
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+          - metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: envoy_listener_downstream_cx_total
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: envoy_listener_address
+                      value:
+                        stringValue: 0.0.0.0_10000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: envoy_cluster_upstream_cx_active
+          - gauge:
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: envoy_cluster_upstream_rq_active
+          - histogram:
+              aggregationTemporality: 2
+              dataPoints:
+                - attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  bucketCounts:
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "2"
+                    - "1"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                  count: "3"
+                  explicitBounds:
+                    - 0.5
+                    - 1
+                    - 5
+                    - 10
+                    - 25
+                    - 50
+                    - 100
+                    - 250
+                    - 500
+                    - 1000
+                    - 2500
+                    - 5000
+                    - 10000
+                    - 30000
+                    - 60000
+                    - 300000
+                    - 600000
+                    - 1.8e+06
+                    - 3.6e+06
+                  startTimeUnixNano: "1000000"
+                  sum: 135.5
+                  timeUnixNano: "2000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: histogram
+            name: envoy_cluster_upstream_rq_time
+          - metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: envoy_listener_downstream_cx_transport_socket_connect_timeout
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_listener_address
+                      value:
+                        stringValue: 0.0.0.0_10000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+          - metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: envoy_listener_downstream_global_cx_overflow
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_listener_address
+                      value:
+                        stringValue: 0.0.0.0_10000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+          - gauge:
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: envoy_cluster_membership_degraded
+          - gauge:
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: envoy_cluster_membership_excluded
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: envoy_listener_address
+                      value:
+                        stringValue: 0.0.0.0_10000
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: envoy_listener_downstream_cx_active
+          - metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: envoy_cluster_upstream_rq_timeout
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
           - gauge:
               dataPoints:
                 - asDouble: 1
@@ -55,229 +315,68 @@ resourceMetrics:
               - key: prometheus.type
                 value:
                   stringValue: gauge
-            name: envoy_cluster_upstream_cx_active
-          - gauge:
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: envoy_cluster_upstream_rq_active
-          - description: The scraping was successful
-            gauge:
-              dataPoints:
-                - asDouble: 1
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: up
-          - description: The number of samples the target exposed
-            gauge:
-              dataPoints:
-                - asDouble: 694
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: scrape_samples_scraped
-          - metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: counter
-            name: envoy_cluster_upstream_cx_connect_fail
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: counter
-            name: envoy_listener_downstream_global_cx_overflow
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_listener_address
-                      value:
-                        stringValue: 0.0.0.0_10000
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: envoy_cluster_membership_degraded
-          - description: The approximate number of new series in this scrape
-            gauge:
-              dataPoints:
-                - asDouble: 17
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: scrape_series_added
-          - metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: counter
-            name: envoy_cluster_upstream_cx_total
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: counter
-            name: envoy_cluster_upstream_rq_pending_overflow
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: counter
-            name: envoy_listener_downstream_cx_overload_reject
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_listener_address
-                      value:
-                        stringValue: 0.0.0.0_10000
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - description: Duration of the scrape
-            gauge:
-              dataPoints:
-                - asDouble: 0.044218584
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: scrape_duration_seconds
-            unit: s
-          - metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: counter
-            name: envoy_listener_downstream_cx_total
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_listener_address
-                      value:
-                        stringValue: 0.0.0.0_10000
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
             name: envoy_cluster_upstream_rq_pending_active
-          - gauge:
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_listener_address
-                      value:
-                        stringValue: 0.0.0.0_10000
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: envoy_listener_downstream_cx_active
-          - metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: counter
-            name: envoy_listener_downstream_cx_transport_socket_connect_timeout
-            sum:
+          - histogram:
               aggregationTemporality: 2
               dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_listener_address
-                      value:
-                        stringValue: 0.0.0.0_10000
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asDouble: 0
-                  attributes:
+                - attributes:
                     - key: envoy_cluster_name
                       value:
                         stringValue: service_envoyproxy_io
-                  timeUnixNano: "1000000"
+                  bucketCounts:
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "1"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                  count: "1"
+                  explicitBounds:
+                    - 0.5
+                    - 1
+                    - 5
+                    - 10
+                    - 25
+                    - 50
+                    - 100
+                    - 250
+                    - 500
+                    - 1000
+                    - 2500
+                    - 5000
+                    - 10000
+                    - 30000
+                    - 60000
+                    - 300000
+                    - 600000
+                    - 1.8e+06
+                    - 3.6e+06
+                  startTimeUnixNano: "1000000"
+                  sum: 60.5
+                  timeUnixNano: "2000000"
             metadata:
               - key: prometheus.type
                 value:
-                  stringValue: gauge
-            name: envoy_cluster_membership_excluded
+                  stringValue: histogram
+            name: envoy_cluster_upstream_cx_connect_ms
           - description: The number of samples remaining after metric relabeling was applied
             gauge:
               dataPoints:
-                - asDouble: 17
+                - asDouble: 61
                   timeUnixNano: "1000000"
             metadata:
               - key: prometheus.type
@@ -288,33 +387,17 @@ resourceMetrics:
               - key: prometheus.type
                 value:
                   stringValue: counter
-            name: envoy_cluster_upstream_rq_timeout
+            name: envoy_cluster_upstream_cx_total
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asDouble: 0
+                - asDouble: 1
                   attributes:
                     - key: envoy_cluster_name
                       value:
                         stringValue: service_envoyproxy_io
                   startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: counter
-            name: envoy_cluster_upstream_rq_total
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
           - metadata:
               - key: prometheus.type
@@ -330,8 +413,45 @@ resourceMetrics:
                       value:
                         stringValue: 0.0.0.0_10000
                   startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
+          - metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: envoy_listener_downstream_cx_overload_reject
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_listener_address
+                      value:
+                        stringValue: 0.0.0.0_10000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+          - description: The scraping was successful
+            gauge:
+              dataPoints:
+                - asDouble: 1
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: up
+          - description: Duration of the scrape
+            gauge:
+              dataPoints:
+                - asDouble: 0.005251709
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: scrape_duration_seconds
+            unit: s
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
-          version: v0.116.0-9-g469980bb
+          version: latest

--- a/tests/receivers/envoy/testdata/expected_k8s.yaml
+++ b/tests/receivers/envoy/testdata/expected_k8s.yaml
@@ -1,6 +1,9 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: discovery.endpoint.id
+          value:
+            stringValue: k8s_observer/aadd3afd-f140-4320-8259-5b25885cbb0a/admin(9901)
         - key: http.scheme
           value:
             stringValue: http
@@ -9,25 +12,25 @@ resourceMetrics:
             stringValue: default
         - key: k8s.pod.name
           value:
-            stringValue: envoy-test-99f9b6dd5-jh5fb
+            stringValue: envoy-test-6c668d9876-zkxdh
         - key: k8s.pod.uid
           value:
-            stringValue: 482e0c29-123b-4c8c-9ee7-bd9d0d137d0c
+            stringValue: aadd3afd-f140-4320-8259-5b25885cbb0a
         - key: net.host.name
           value:
-            stringValue: 10.244.0.6
+            stringValue: 10.244.1.2
         - key: net.host.port
           value:
             stringValue: "9901"
         - key: server.address
           value:
-            stringValue: 10.244.0.6
+            stringValue: 10.244.1.2
         - key: server.port
           value:
             stringValue: "9901"
         - key: service.instance.id
           value:
-            stringValue: 10.244.0.6:9901
+            stringValue: 10.244.1.2:9901
         - key: service.name
           value:
             stringValue: envoy
@@ -36,15 +39,129 @@ resourceMetrics:
             stringValue: http
     scopeMetrics:
       - metrics:
+          - histogram:
+              aggregationTemporality: 2
+              dataPoints:
+                - attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  bucketCounts:
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "2"
+                    - "3"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                  count: "5"
+                  explicitBounds:
+                    - 0.5
+                    - 1
+                    - 5
+                    - 10
+                    - 25
+                    - 50
+                    - 100
+                    - 250
+                    - 500
+                    - 1000
+                    - 2500
+                    - 5000
+                    - 10000
+                    - 30000
+                    - 60000
+                    - 300000
+                    - 600000
+                    - 1.8e+06
+                    - 3.6e+06
+                  startTimeUnixNano: "1000000"
+                  sum: 272.5
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: histogram
+            name: envoy_cluster_upstream_cx_connect_ms
+          - histogram:
+              aggregationTemporality: 2
+              dataPoints:
+                - attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  bucketCounts:
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "4"
+                    - "1"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                  count: "5"
+                  explicitBounds:
+                    - 0.5
+                    - 1
+                    - 5
+                    - 10
+                    - 25
+                    - 50
+                    - 100
+                    - 250
+                    - 500
+                    - 1000
+                    - 2500
+                    - 5000
+                    - 10000
+                    - 30000
+                    - 60000
+                    - 300000
+                    - 600000
+                    - 1.8e+06
+                    - 3.6e+06
+                  startTimeUnixNano: "1000000"
+                  sum: 445
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: histogram
+            name: envoy_cluster_upstream_rq_time
           - metadata:
               - key: prometheus.type
                 value:
                   stringValue: counter
-            name: envoy_cluster_upstream_cx_total
+            name: envoy_cluster_upstream_rq_timeout
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asDouble: 1
+                - asDouble: 0
                   attributes:
                     - key: envoy_cluster_name
                       value:
@@ -68,139 +185,6 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: envoy_cluster_upstream_rq_active
-          - gauge:
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_listener_address
-                      value:
-                        stringValue: 0.0.0.0_10000
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: envoy_listener_downstream_cx_active
-          - description: The number of samples the target exposed
-            gauge:
-              dataPoints:
-                - asDouble: 751
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: scrape_samples_scraped
-          - description: The number of samples remaining after metric relabeling was applied
-            gauge:
-              dataPoints:
-                - asDouble: 17
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: scrape_samples_post_metric_relabeling
-          - metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: counter
-            name: envoy_cluster_upstream_rq_timeout
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: counter
-            name: envoy_listener_downstream_cx_total
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: envoy_listener_address
-                      value:
-                        stringValue: 0.0.0.0_10000
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: envoy_cluster_membership_total
-          - description: The scraping was successful
-            gauge:
-              dataPoints:
-                - asDouble: 1
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: up
-          - metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: counter
-            name: envoy_cluster_upstream_cx_connect_fail
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: counter
-            name: envoy_cluster_upstream_rq_total
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
           - metadata:
               - key: prometheus.type
                 value:
@@ -217,67 +201,15 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: envoy_cluster_membership_degraded
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: envoy_cluster_upstream_cx_active
-          - description: The approximate number of new series in this scrape
-            gauge:
-              dataPoints:
-                - asDouble: 17
-                  timeUnixNano: "1000000"
-            metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: gauge
-            name: scrape_series_added
           - metadata:
               - key: prometheus.type
                 value:
                   stringValue: counter
-            name: envoy_cluster_upstream_rq_pending_overflow
+            name: envoy_listener_downstream_cx_total
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: envoy_cluster_name
-                      value:
-                        stringValue: service_envoyproxy_io
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - metadata:
-              - key: prometheus.type
-                value:
-                  stringValue: counter
-            name: envoy_listener_downstream_cx_transport_socket_connect_timeout
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
+                - asDouble: 5
                   attributes:
                     - key: envoy_listener_address
                       value:
@@ -289,7 +221,7 @@ resourceMetrics:
               - key: prometheus.type
                 value:
                   stringValue: counter
-            name: envoy_listener_downstream_global_cx_overflow
+            name: envoy_listener_downstream_cx_transport_socket_connect_timeout
             sum:
               aggregationTemporality: 2
               dataPoints:
@@ -326,11 +258,115 @@ resourceMetrics:
               - key: prometheus.type
                 value:
                   stringValue: gauge
+            name: envoy_cluster_upstream_cx_active
+          - gauge:
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_listener_address
+                      value:
+                        stringValue: 0.0.0.0_10000
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: envoy_listener_downstream_cx_active
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: envoy_cluster_membership_total
+          - gauge:
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: envoy_cluster_upstream_rq_active
+          - gauge:
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
             name: envoy_cluster_upstream_rq_pending_active
+          - description: The scraping was successful
+            gauge:
+              dataPoints:
+                - asDouble: 1
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: up
+          - description: The number of samples the target exposed
+            gauge:
+              dataPoints:
+                - asDouble: 781
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: scrape_samples_scraped
+          - metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: envoy_cluster_upstream_cx_total
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 5
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: envoy_listener_downstream_global_cx_overflow
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_listener_address
+                      value:
+                        stringValue: 0.0.0.0_10000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "1000000"
+              isMonotonic: true
           - description: Duration of the scrape
             gauge:
               dataPoints:
-                - asDouble: 0.007504292
+                - asDouble: 0.006037622
                   timeUnixNano: "1000000"
             metadata:
               - key: prometheus.type
@@ -338,6 +374,87 @@ resourceMetrics:
                   stringValue: gauge
             name: scrape_duration_seconds
             unit: s
+          - description: The number of samples remaining after metric relabeling was applied
+            gauge:
+              dataPoints:
+                - asDouble: 61
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: scrape_samples_post_metric_relabeling
+          - description: The approximate number of new series in this scrape
+            gauge:
+              dataPoints:
+                - asDouble: 61
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: scrape_series_added
+          - metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: envoy_cluster_upstream_cx_connect_fail
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: envoy_cluster_upstream_rq_pending_overflow
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: counter
+            name: envoy_cluster_upstream_rq_total
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 5
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - gauge:
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: envoy_cluster_name
+                      value:
+                        stringValue: service_envoyproxy_io
+                  timeUnixNano: "1000000"
+            metadata:
+              - key: prometheus.type
+                value:
+                  stringValue: gauge
+            name: envoy_cluster_membership_degraded
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
-          version: v0.116.0-28-g370fcc9f
+          version: latest


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The current config for prometheus receiver for Envoy in discovery mode is not matching with histogram metrics. This PR updates the config to additional keep metrics which match with the histogram suffixes.

**Testing:** <Describe what testing was performed and which tests were added.>
Update the tests with histogram metrics received
