### PR TITLE
[chore][ansible] Upgrade versions used in testing

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -61,11 +61,11 @@ jobs:
       matrix:
         ansible:
           # Testing only the versions currently supported per https://endoflife.date/ansible
-          - ansible~=9.2.0
-          - ansible~=8.7.0
+          - ansible~=11.6.0
+          - ansible~=10.7.0
         distro:
           - amazonlinux2023
-          - centos8
+          - centos9
           - debian11
           - debian12
           - ubuntu2004
@@ -118,8 +118,8 @@ jobs:
       matrix:
         ansible:
           # Testing only the versions currently supported per https://endoflife.date/ansible
-          - ansible~=9.2.0
-          - ansible~=8.7.0
+          - ansible~=11.6.0
+          - ansible~=10.7.0
         distro:
           - "2016"
           - "2019"

--- a/deployments/ansible/molecule/config/vagrant.yml
+++ b/deployments/ansible/molecule/config/vagrant.yml
@@ -11,8 +11,8 @@ driver:
 platforms:
   - name: focal64
     box: ubuntu/focal64
-  - name: centos8
-    box: centos/8
+  - name: centos9
+    box: centos/stream9
   - name: bookworm64
     box: debian/bookworm64
 provisioner:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
- [Ansible](https://endoflife.date/ansible)
- CentOS 8 ([EOL Dec 31, 2021](https://www.centos.org/centos-linux-eol/))-> CentOS Stream 9 ([EOL May 31, 2027](https://endoflife.date/centos-stream))