### PR TITLE
[receiver/discovery] Send delete entity events for discovered services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -151,7 +151,7 @@ require (
 	go.opentelemetry.io/collector/extension v1.32.0
 	go.opentelemetry.io/collector/extension/zpagesextension v0.126.0
 	go.opentelemetry.io/collector/otelcol v0.126.0
-	go.opentelemetry.io/collector/pdata v1.32.0
+	go.opentelemetry.io/collector/pdata v1.32.1-0.20250523042642-a867641d12bd
 	go.opentelemetry.io/collector/pipeline v0.126.0
 	go.opentelemetry.io/collector/processor v1.32.0
 	go.opentelemetry.io/collector/processor/batchprocessor v0.126.0
@@ -653,7 +653,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.126.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.126.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr v0.126.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.126.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.126.1-0.20250526171903-169686dbc75d
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx v0.126.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.126.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0.126.0 // indirect
@@ -723,7 +723,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	gonum.org/v1/gonum v0.16.0 // indirect
 	google.golang.org/api v0.232.0 // indirect
-	google.golang.org/grpc v1.72.0 // indirect
+	google.golang.org/grpc v1.72.1 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1439,8 +1439,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.126.0/go.mod h1:dfRudXeUgf148puPQxJ91IXABpfqsl9rarrwqFuH2Ro=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils v0.126.0 h1:A0ngaz213hmNCCX6AoKs3tqM0WAAsURHdIv5h0UXLeM=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils v0.126.0/go.mod h1:NHImkI6CD3ijcfLe4h6XP1MXQG0PSWH9TpLenZf6Wys=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.126.0 h1:e5aLwj2GldsWGMuk9e2Is+TN/EJHPh25RWmUzRWA7Ps=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.126.0/go.mod h1:o2lvKV9aHwoYUGRsND18Xriker2hi6A6zxbyr6UkEFA=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.126.1-0.20250526171903-169686dbc75d h1:tqbhR/PYfU4foM/zfEvH9Wr2V+5Mm+iPIS5QlXk7rcA=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.126.1-0.20250526171903-169686dbc75d/go.mod h1:3rl7mtPncU+cQEXs0lnYh5rmf1b0f4D2B12oIX1h0U4=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.126.0 h1:AnOgi0AF5kALP4hEILsQEnRzT/yNXfua598210Dn9ko=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.126.0/go.mod h1:jjyo4lLRH9WOUJ9djpEql6xqVAaReNDY7ciWRt23FZk=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic v0.126.0 h1:VObAgxn0ONZEAXcANe+dq9uHR7KDMqBxnQegEJu/dpM=
@@ -2112,8 +2112,8 @@ go.opentelemetry.io/collector/otelcol v0.126.0 h1:TQaIMKzDgWPR79QmuZYeC1LaiUG624
 go.opentelemetry.io/collector/otelcol v0.126.0/go.mod h1:Ve1nB64BniDT1v6IT85zF9P/qmD3bDWfL0Mry+m6cFA=
 go.opentelemetry.io/collector/otelcol/otelcoltest v0.126.0 h1:PJ0c2wT9y7e6T+Ag4S/f3Di2DYic07lrvj+z9Ep200I=
 go.opentelemetry.io/collector/otelcol/otelcoltest v0.126.0/go.mod h1:tbJaLJbeXRNEGH+5+w1YXLLrg4Xt640Qzsw5JLL3VZ8=
-go.opentelemetry.io/collector/pdata v1.32.0 h1:hBzlJV1rujr1UdD2CBy2gmaIKtC15ysg/z+x8F3McQA=
-go.opentelemetry.io/collector/pdata v1.32.0/go.mod h1:m41io9nWpy7aCm/uD1L9QcKiZwOP0ldj83JEA34dmlk=
+go.opentelemetry.io/collector/pdata v1.32.1-0.20250523042642-a867641d12bd h1:H136IWSouulaIdZFOzgXo/KCcQD1QlXhRCPoXYE7pdk=
+go.opentelemetry.io/collector/pdata v1.32.1-0.20250523042642-a867641d12bd/go.mod h1:TDvbHuvIK+g6xqu1gxtz8ti4pB2x1WcBpjFob5KfleU=
 go.opentelemetry.io/collector/pdata/pprofile v0.126.0 h1:ArYQxg5KdTb98r1X6KSZY7W6/4DPv/q6z7jSbSZ1mBc=
 go.opentelemetry.io/collector/pdata/pprofile v0.126.0/go.mod h1:2fBTFDcXjVfseBQKnt/DTM0EYTmFoPKtRpjg8ql38Ek=
 go.opentelemetry.io/collector/pdata/testdata v0.126.0 h1:CMJEYwg12tMI60GOiBIKyrZQp839bD0eJ4rmD4ttlUs=
@@ -2654,8 +2654,8 @@ google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
-google.golang.org/grpc v1.72.0 h1:S7UkcVa60b5AAQTaO6ZKamFp1zMZSU0fGDK2WZLbBnM=
-google.golang.org/grpc v1.72.0/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
+google.golang.org/grpc v1.72.1 h1:HR03wO6eyZ7lknl75XlxABNVLLFc2PAb6mHlYh756mA=
+google.golang.org/grpc v1.72.1/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/tests/receivers/istio/bundled_k8s_test.go
+++ b/tests/receivers/istio/bundled_k8s_test.go
@@ -177,8 +177,6 @@ func TestIstioEntities(t *testing.T) {
 				"server.address":          podIP,
 				"server.port":             promPort,
 				"service.instance.id":     fmt.Sprintf("%s:%s", podIP, promPort),
-				"service.name":            "istio",
-				"service.type":            "prometheus",
 				"type":                    "pod",
 				"url.scheme":              "http",
 			})


### PR DESCRIPTION
Send delete entity events once discovered services are removed to keep the "discovered services" view up-to-date.

This change requires pulling the upstream bugfix https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40279.

This also moves service.name and service.type attributes to the set of identifying attributes according to the entity definition in the inventory service.
