### PR TITLE
[chore] Update .lychee.toml for  docs.splunk.com to help.splunk.com redirects

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -22,6 +22,7 @@ exclude = [
     "https://bugs.mysql.com/*", # Failing with 403 Forbidden. Likely rejecting the user agent
 ]
 max_concurrency = 20
+max_redirects = 10
 max_retries = 5
 retry_wait_time = 30
 timeout = 30


### PR DESCRIPTION
The max redirects is 5 and tests show failures for "too many redirects", let's double the max redirects to 10.
