### PR TITLE
[linux installer script] Deprecate Fluentd support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🚩 Deprecations 🚩
+
+- (Splunk) `Linux installer script`: Fluentd support has been deprecated and will be removed in a future release. ([#]())
+
 ## v0.126.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.126.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.126.0)

--- a/packaging/installer/install.sh
+++ b/packaging/installer/install.sh
@@ -929,7 +929,7 @@ Collector:
                                         target system that provides the 'splunk-otel-collector' deb/rpm package.
   --test                                Use the test package repo instead of the primary.
 
-Fluentd:
+Fluentd [DEPRECATED]:
   --with[out]-fluentd                   Whether to install and configure fluentd to forward log events to the collector.
                                         (default: --without-fluentd)
   --skip-fluentd-repo                   By default, a apt/yum repo definition file will be created to download the
@@ -1327,6 +1327,7 @@ parse_args_and_install() {
         ;;
       --with-fluentd)
         with_fluentd="true"
+        echo "[WARNING] Fluentd support has been deprecated and will be removed in a future release." >&2
         if ! fluentd_supported; then
           echo "[WARNING] Ignoring the --with-fluentd option since fluentd is currently not supported for ${distro}:${distro_version} ${distro_arch}." >&2
         fi


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Add notes that the functionality has been deprecated in help output as well as log a message when the CLI option is used.

**Testing:** <Describe what testing was performed and which tests were added.>
```
$ ./install.sh --help
...
Fluentd [DEPRECATED]:
...
$ ./install.sh --with-fluentd
[WARNING] Fluentd support has been deprecated and will be removed in a future release.
Please enter your Splunk access token:
```