### PR TITLE
[chore] Upgrade release version used in mass deployment testing

### DIFF
--- a/deployments/ansible/molecule/custom_vars/converge.yml
+++ b/deployments/ansible/molecule/custom_vars/converge.yml
@@ -6,7 +6,7 @@
     splunk_access_token: fake-token
     splunk_ingest_url: https://fake-splunk-ingest.com
     splunk_api_url: https://fake-splunk-api.com
-    splunk_otel_collector_version: 0.48.0
+    splunk_otel_collector_version: 0.126.0
     splunk_otel_collector_config: /etc/otel/collector/custom_config.yml
     splunk_otel_collector_config_source: ./custom_collector_config.yml
     splunk_service_user: custom-user

--- a/deployments/ansible/molecule/custom_vars/verify.yml
+++ b/deployments/ansible/molecule/custom_vars/verify.yml
@@ -63,7 +63,7 @@
 
     - name: Assert specified version of splunk-otel-collector is installed
       assert:
-        that: ansible_facts.packages['splunk-otel-collector'][0].version == '0.48.0'
+        that: ansible_facts.packages['splunk-otel-collector'][0].version == '0.126.0'
 
     - name: Assert custom service user is set
       ansible.builtin.lineinfile:

--- a/deployments/ansible/molecule/custom_vars/windows-converge.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-converge.yml
@@ -8,7 +8,7 @@
     splunk_api_url: https://fake-splunk-api.com
     splunk_hec_url: https://fake-splunk-hec.com
     splunk_hec_token: fake-hec-token
-    splunk_otel_collector_version: 0.48.0
+    splunk_otel_collector_version: 0.126.0
     splunk_otel_collector_config: '{{ansible_env.ProgramData}}\Splunk\OpenTelemetry Collector\custom_config.yml'
     splunk_otel_collector_config_source: ./custom_collector_config.yml
     splunk_memory_total_mib: 256

--- a/deployments/ansible/molecule/custom_vars/windows-verify.yml
+++ b/deployments/ansible/molecule/custom_vars/windows-verify.yml
@@ -45,20 +45,20 @@
       assert:
         that: not service_status.changed
 
-    - name: Download splunk-otel-collector 0.48.0 MSI
+    - name: Download splunk-otel-collector 0.126.0 MSI
       ansible.windows.win_get_url:
-        url: https://dl.signalfx.com/splunk-otel-collector/msi/release/splunk-otel-collector-0.48.0-amd64.msi
+        url: https://dl.signalfx.com/splunk-otel-collector/msi/release/splunk-otel-collector-0.126.0-amd64.msi
         dest: "{{ansible_env.TEMP}}"
       register: otel_msi_package
 
-    - name: Install splunk-otel-collector 0.48.0 MSI
+    - name: Install splunk-otel-collector 0.126.0 MSI
       ansible.windows.win_package:
         path: "{{otel_msi_package.dest}}"
         state: present
       check_mode: yes
       register: msi_installed
 
-    - name: Assert splunk-otel-collector 0.48.0 MSI is already installed
+    - name: Assert splunk-otel-collector 0.126.0 MSI is already installed
       assert:
         that: not msi_installed.changed
 

--- a/deployments/ansible/molecule/with_instrumentation/converge.yml
+++ b/deployments/ansible/molecule/with_instrumentation/converge.yml
@@ -6,7 +6,7 @@
     splunk_access_token: fake-token
     splunk_realm: fake-realm
     install_splunk_otel_auto_instrumentation: true
-    splunk_otel_auto_instrumentation_version: 0.50.0
+    splunk_otel_auto_instrumentation_version: latest
     splunk_otel_auto_instrumentation_resource_attributes: deployment.environment=test
     splunk_otel_auto_instrumentation_service_name: test
     splunk_otel_auto_instrumentation_generate_service_name: false

--- a/deployments/ansible/molecule/with_instrumentation/verify.yml
+++ b/deployments/ansible/molecule/with_instrumentation/verify.yml
@@ -15,7 +15,7 @@
 
     - name: Assert specified version of splunk-otel-auto-instrumentation is installed
       assert:
-        that: ansible_facts.packages['splunk-otel-auto-instrumentation'][0].version == '0.50.0'
+        that: ansible_facts.packages['splunk-otel-auto-instrumentation'][0].version == 'latest'
 
     - name: Check for the new config files
       ansible.builtin.stat:
@@ -60,7 +60,7 @@
 
     - name: Assert instrumentation config contains resource attribute
       ansible.builtin.lineinfile:
-        line: resource_attributes=splunk.zc.method=splunk-otel-auto-instrumentation-0.50.0,deployment.environment=test
+        line: resource_attributes=splunk.zc.method=splunk-otel-auto-instrumentation-latest,deployment.environment=test
         dest: /usr/lib/splunk-instrumentation/instrumentation.conf
         state: present
       check_mode: yes

--- a/deployments/chef/kitchen.windows.yml
+++ b/deployments/chef/kitchen.windows.yml
@@ -55,7 +55,7 @@ suites:
         splunk_memory_total_mib: "256"
         splunk_hec_token: fake-hec-token
         splunk_listen_interface: "0.0.0.0"
-        collector_version: 0.48.0
+        collector_version: 0.126.0
         collector_additional_env_vars:
           MY_CUSTOM_VAR1: value1
           MY_CUSTOM_VAR2: value2

--- a/packaging/tests/deployments/puppet/puppet_test.py
+++ b/packaging/tests/deployments/puppet/puppet_test.py
@@ -214,9 +214,9 @@ def test_puppet_with_custom_vars(distro, puppet_release):
         try:
             api_url = "https://fake-splunk-api.com"
             ingest_url = "https://fake-splunk-ingest.com"
-            config = CUSTOM_VARS_CONFIG.substitute(api_url=api_url, ingest_url=ingest_url, version="0.86.0")
+            config = CUSTOM_VARS_CONFIG.substitute(api_url=api_url, ingest_url=ingest_url, version="0.126.0")
             run_puppet_apply(container, config)
-            verify_package_version(container, "splunk-otel-collector", "0.86.0")
+            verify_package_version(container, "splunk-otel-collector", "0.126.0")
             verify_env_file(container, api_url, ingest_url, "fake-hec-token")
             verify_config_file(container, SPLUNK_ENV_PATH, "SPLUNK_LISTEN_INTERFACE", "0.0.0.0")
             verify_config_file(container, SPLUNK_ENV_PATH, "MY_CUSTOM_VAR1", "value1")

--- a/packaging/tests/deployments/salt/salt_test.py
+++ b/packaging/tests/deployments/salt/salt_test.py
@@ -204,7 +204,7 @@ splunk-otel-collector:
   splunk_ingest_url: 'https://fake-ingest.com'
   splunk_api_url: 'https://fake-api.com'
   splunk_hec_token: 'fake-hec-token'
-  collector_version: '0.86.0'
+  collector_version: '0.126.0'
   splunk_service_user: 'test-user'
   splunk_service_group: 'test-user'
   splunk_listen_interface: '0.0.0.0'

--- a/packaging/tests/installer_test.py
+++ b/packaging/tests/installer_test.py
@@ -265,7 +265,7 @@ def test_installer_custom(distro, arch):
     if distro == "opensuse-12" and arch == "arm64":
         pytest.skip("opensuse-12 arm64 no longer supported")
 
-    collector_version = "0.75.0"
+    collector_version = "0.126.0"
     service_owner = "test-user"
     custom_config = "/etc/my-custom-config.yaml"
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Many mass deployment tests are using old versions of the Splunk distribution of the OpenTelemetry Collector. This updates the versions being used to latest.