### PR TITLE
[tiny] Fix HEC error when using conf example

### DIFF
--- a/packaging/fpm/etc/otel/collector/splunk-otel-collector.conf.example
+++ b/packaging/fpm/etc/otel/collector/splunk-otel-collector.conf.example
@@ -41,7 +41,7 @@ SPLUNK_HEC_URL=https://ingest.us0.signalfx.com/v1/log
 # SPLUNK_HEC_URL=https://example.com:8088/services/collector
 
 # Splunk HEC token.
-SPLUNK_HEC_TOKEN=12345
+SPLUNK_HEC_TOKEN=abc123
 
 # Total memory in MIB to allocate to the collector.
 # Automatically configures the memory limit.


### PR DESCRIPTION
Avoid the following error when just copying the .conf example for quick tests (not worried about the data failing to be ingested)

```
error decoding 'exporters': error reading configuration for "splunk_hec": decoding failed due to the following error
'token' expected type 'configopaque.String', got unconvertible type 'int', value: '12345'
```