### PR TITLE
[chore][examples] Remove reference to deprecated logging exporter

### DIFF
--- a/examples/otel-logs-severity-splunk/otel-collector-config.yml
+++ b/examples/otel-logs-severity-splunk/otel-collector-config.yml
@@ -26,7 +26,8 @@ exporters:
           # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
           # For this demo, we use a self-signed certificate on the Splunk docker instance, so this flag is set to true.
           insecure_skip_verify: true
-    logging:
+    debug:
+        verbosity: detailed
 processors:
     batch:
     transform/log:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The `logging` exporter was replaced with the `debug` exporter. Most references were updated in https://github.com/signalfx/splunk-otel-collector/pull/3755. The exporter in the pipeline is shown as `debug`, but it looks like we missed updating the definition.

Found this while working on #6265 as there was another `logging` exporter reference in Ansible testing.