### PR TITLE
[chore][molecule] Update default image in docker config

### DIFF
--- a/deployments/ansible/molecule/config/docker.yml
+++ b/deployments/ansible/molecule/config/docker.yml
@@ -9,7 +9,7 @@ driver:
 platforms:
   - name: instance
     dockerfile: Dockerfile.j2
-    image: ${MOLECULE_DISTRO:-centos8}
+    image: ${MOLECULE_DISTRO:-centos9}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Centos8 is EOL, this reference was missed in https://github.com/signalfx/splunk-otel-collector/pull/6250/. This currently has no impact in CICD as `MOLECULE_DISTRO` is set in the GitHub workflow. It's only hit locally if `MOLECULE_DISTRO` is not set.