### PR TITLE
[ansible] Add option to set service CLI args

### DIFF
--- a/deployments/ansible/CHANGELOG.md
+++ b/deployments/ansible/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## ansible-v0.32.0
+
+### 💡 Enhancements 💡
+
+- Add support for the `splunk_otel_collector_command_line_args` option to
+  configure the command line arguments for the Splunk OpenTelemetry Collector
+  service.
+
 ## ansible-v0.31.0
 
 ### 🛑 Breaking changes 🛑

--- a/deployments/ansible/molecule/custom_vars/converge.yml
+++ b/deployments/ansible/molecule/custom_vars/converge.yml
@@ -12,6 +12,7 @@
     splunk_service_user: custom-user
     splunk_service_group: custom-group
     splunk_memory_total_mib: 256
+    splunk_otel_collector_command_line_args: "--discovery"
     gomemlimit: 230
     splunk_listen_interface: 1.2.3.4
     splunk_fluentd_config: /etc/otel/collector/fluentd/custom_fluentd.conf

--- a/deployments/ansible/molecule/custom_vars/verify.yml
+++ b/deployments/ansible/molecule/custom_vars/verify.yml
@@ -44,6 +44,13 @@
         state: present
       check_mode: yes
 
+    - name: Assert OTELCOL_OPTIONS env var is set per splunk_otel_collector_command_line_args
+      ansible.builtin.lineinfile:
+        line: OTELCOL_OPTIONS=--discovery
+        dest: /etc/otel/collector/splunk-otel-collector.conf
+        state: present
+      check_mode: yes
+
     - name: Assert MY_CUSTOM_VAR1 env var is set
       ansible.builtin.lineinfile:
         line: MY_CUSTOM_VAR1=value1

--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -121,6 +121,16 @@ $> ansible-playbook playbook.yaml -e start_service=false
   `splunk_otel_collector_proxy_http` or `splunk_otel_collector_proxy_https` is
   defined. (**default:** `localhost,127.0.0.1,::1`)
 
+- `splunk_otel_collector_command_line_args`: Command-line arguments to pass to the
+  Splunk OpenTelemetry Collector. These will be added as arguments to the service
+  command line.
+  (**default:** `""`)
+  
+  Example:
+  ```yaml
+  splunk_otel_collector_command_line_args: "--discovery --set=processors.batch.timeout=10s"
+  ```
+
 - `splunk_memory_total_mib`: Amount of memory in MiB allocated to the Splunk OTel 
   Collector. (**default:** `512`)
 

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -8,6 +8,9 @@ splunk_realm: us0
 
 splunk_otel_collector_version: latest
 
+# Command-line arguments to pass to the collector service.
+splunk_otel_collector_command_line_args: ""
+
 # Set this variable to /etc/otel/collector/gateway_config.yaml on linux,
 # "Program Files\Splunk\OpenTelemetry Collector\gateway_config.yaml" on Windows
 # in order to deploy splunk-otel-collector in gateway mode.

--- a/deployments/ansible/roles/collector/templates/splunk-otel-collector.conf.j2
+++ b/deployments/ansible/roles/collector/templates/splunk-otel-collector.conf.j2
@@ -1,3 +1,4 @@
+OTELCOL_CONFIG={{ splunk_otel_collector_command_line_args }}
 SPLUNK_CONFIG={{ splunk_otel_collector_config }}
 SPLUNK_ACCESS_TOKEN={{ splunk_access_token }}
 SPLUNK_REALM={{ splunk_realm }}


### PR DESCRIPTION
Adds a specific option to set the command-line arguments used to launch the collector service on Linux - Windows implementation is coming after #6268 is released.

The test for this new config setting is piggy-backing on the test for custom environment variables due to the similarities and to avoid yet another test for some CI that is already relatively long to run.