### PR TITLE
[deployment/chef] Fix custom variables handling on Windows

### DIFF
--- a/deployments/chef/CHANGELOG.md
+++ b/deployments/chef/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## chef-v0.18.0
+
+- Bug fix: Fix bug that caused custom variables to not be set when running on Windows
+  with a Splunk OTel Collector version >= `0.98.0`.
+
 ## chef-v0.17.0
 
 - Remove the option `with_signalfx_dotnet_auto_instrumentation` used to

--- a/deployments/chef/CHANGELOG.md
+++ b/deployments/chef/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Changelog
 
-## chef-v0.18.0
+## chef-v0.17.0
 
 - Bug fix: Fix bug that caused custom variables to not be set when running on Windows
   with a Splunk OTel Collector version >= `0.98.0`.
-
-## chef-v0.17.0
-
 - Remove the option `with_signalfx_dotnet_auto_instrumentation` used to
 install the deprecated `SignalFx Auto Instrumentation for .NET` on Windows.
 

--- a/deployments/chef/kitchen.windows.yml
+++ b/deployments/chef/kitchen.windows.yml
@@ -55,7 +55,7 @@ suites:
         splunk_memory_total_mib: "256"
         splunk_hec_token: fake-hec-token
         splunk_listen_interface: "0.0.0.0"
-        collector_version: 0.48.0
+        collector_version: 0.126.0
         collector_additional_env_vars:
           MY_CUSTOM_VAR1: value1
           MY_CUSTOM_VAR2: value2

--- a/deployments/chef/metadata.rb
+++ b/deployments/chef/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Splunk, Inc.'
 maintainer_email 'signalfx-support@splunk.com'
 license 'Apache-2.0'
 description 'Install/Configure the Splunk OpenTelemetry Collector'
-version '0.16.0'
+version '0.18.0'
 chef_version '>= 16.0'
 
 supports 'amazon'

--- a/deployments/chef/metadata.rb
+++ b/deployments/chef/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Splunk, Inc.'
 maintainer_email 'signalfx-support@splunk.com'
 license 'Apache-2.0'
 description 'Install/Configure the Splunk OpenTelemetry Collector'
-version '0.18.0'
+version '0.17.0'
 chef_version '>= 16.0'
 
 supports 'amazon'

--- a/deployments/chef/recipes/collector_win_install.rb
+++ b/deployments/chef/recipes/collector_win_install.rb
@@ -27,8 +27,6 @@ msi_install_properties = node['splunk_otel_collector']['collector_win_env_vars']
                          .map { |item| "#{item[:name]}=\"#{item[:data]}\"" }
                          .join(' ')
 
-puts "MSI install properties: #{msi_install_properties}"
-
 windows_package 'splunk-otel-collector' do
   source "#{ENV['TEMP']}/splunk-otel-collector-#{collector_version}-amd64.msi"
   options msi_install_properties # If the MSI is not configurable, this will be ignored during installation.

--- a/deployments/chef/recipes/collector_win_install.rb
+++ b/deployments/chef/recipes/collector_win_install.rb
@@ -27,6 +27,8 @@ msi_install_properties = node['splunk_otel_collector']['collector_win_env_vars']
                          .map { |item| "#{item[:name]}=\"#{item[:data]}\"" }
                          .join(' ')
 
+puts "MSI install properties: #{msi_install_properties}"
+
 windows_package 'splunk-otel-collector' do
   source "#{ENV['TEMP']}/splunk-otel-collector-#{collector_version}-amd64.msi"
   options msi_install_properties # If the MSI is not configurable, this will be ignored during installation.

--- a/deployments/chef/recipes/default.rb
+++ b/deployments/chef/recipes/default.rb
@@ -14,7 +14,7 @@ if platform_family?('windows')
 
   # Older MSI versions can't properly setup the collector configuration
   # in this case, we need to use the registry to set the environment variables.
-  # Testing also showed custom configuration variables also require this.
+  # Custom variables also require using the registry, as the MSI doesn't support it.
   if !node['splunk_otel_collector']['collector_msi_is_configurable'] || !node['splunk_otel_collector']['collector_additional_env_vars'].empty?
     include_recipe 'splunk_otel_collector::collector_win_registry'
   end

--- a/deployments/chef/recipes/default.rb
+++ b/deployments/chef/recipes/default.rb
@@ -12,9 +12,10 @@ if platform_family?('windows')
   include_recipe 'splunk_otel_collector::collector_win_config_options'
   include_recipe 'splunk_otel_collector::collector_win_install'
 
-  # Older MSI versions can't properly setup the collector configuration
+  # Older MSI versions can't properly setup the collector configuration,
   # in this case, we need to use the registry to set the environment variables.
-  unless node['splunk_otel_collector']['collector_msi_is_configurable']
+  # Testing also showed custom configuration variables also require this.
+  if !node['splunk_otel_collector']['collector_msi_is_configurable'] || !node['splunk_otel_collector']['collector_additional_env_vars'].empty?
     include_recipe 'splunk_otel_collector::collector_win_registry'
   end
 

--- a/deployments/chef/recipes/default.rb
+++ b/deployments/chef/recipes/default.rb
@@ -12,7 +12,7 @@ if platform_family?('windows')
   include_recipe 'splunk_otel_collector::collector_win_config_options'
   include_recipe 'splunk_otel_collector::collector_win_install'
 
-  # Older MSI versions can't properly setup the collector configuration,
+  # Older MSI versions can't properly setup the collector configuration
   # in this case, we need to use the registry to set the environment variables.
   # Testing also showed custom configuration variables also require this.
   if !node['splunk_otel_collector']['collector_msi_is_configurable'] || !node['splunk_otel_collector']['collector_additional_env_vars'].empty?

--- a/deployments/chef/test/integration/custom_vars/test.rb
+++ b/deployments/chef/test/integration/custom_vars/test.rb
@@ -41,6 +41,8 @@ if os[:family] == 'windows'
   collector_env_vars_strings.sort!
   describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\splunk-otel-collector') do
     it { should have_property 'Environment' }
+    puts "Value of collector_env_vars_strings: #{collector_env_vars_strings}"
+    puts "Value of #{'Environment'}"
     it { should have_property_value('Environment', :multi_string, collector_env_vars_strings) }
   end
   describe service('fluentdwinsvc') do

--- a/deployments/chef/test/integration/custom_vars/test.rb
+++ b/deployments/chef/test/integration/custom_vars/test.rb
@@ -40,6 +40,7 @@ if os[:family] == 'windows'
   end
   collector_env_vars_strings.sort!
   describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\splunk-otel-collector') do
+    it { should have_property 'Environment' }
     it { should have_property_value('Environment', :multi_string, collector_env_vars_strings) }
   end
   describe service('fluentdwinsvc') do

--- a/deployments/chef/test/integration/custom_vars/test.rb
+++ b/deployments/chef/test/integration/custom_vars/test.rb
@@ -41,7 +41,6 @@ if os[:family] == 'windows'
   collector_env_vars_strings.sort!
   describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\splunk-otel-collector') do
     it { should have_property 'Environment' }
-    puts "Value of collector_env_vars_strings: #{collector_env_vars_strings}"
     it { should have_property_value('Environment', :multi_string, collector_env_vars_strings) }
   end
   describe service('fluentdwinsvc') do

--- a/deployments/chef/test/integration/custom_vars/test.rb
+++ b/deployments/chef/test/integration/custom_vars/test.rb
@@ -42,7 +42,6 @@ if os[:family] == 'windows'
   describe registry_key('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\splunk-otel-collector') do
     it { should have_property 'Environment' }
     puts "Value of collector_env_vars_strings: #{collector_env_vars_strings}"
-    puts "Value of #{'Environment'}"
     it { should have_property_value('Environment', :multi_string, collector_env_vars_strings) }
   end
   describe service('fluentdwinsvc') do


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This fixes how Chef handles custom variables for the `splunk-otel-collector` on Windows deployments. The MSI doesn't support custom variables, it supports a set of known variables. To properly set custom variables we need to use the registry.

Also, update version of the collector being used in testing.