### PR TITLE
[chore] Address GitHub's brownout of windows-2019 runners

### DIFF
--- a/.github/workflows/otelcol-fips.yml
+++ b/.github/workflows/otelcol-fips.yml
@@ -134,7 +134,7 @@ jobs:
     needs: [ otelcol-fips ]
     strategy:
       matrix:
-        WIN_VERSION: [ 2019, 2022 ]
+        WIN_VERSION: [ 2022, 2025 ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -159,7 +159,7 @@ jobs:
     needs: [ "binaries-windows_amd64" ]
     strategy:
       matrix:
-        OS: [ windows-2019, windows-2022 ]
+        OS: [ windows-2022, windows-2025 ]
       fail-fast: false
     env:
       PIP_CACHE_DIR: ${{ github.workspace }}/.cache/pip
@@ -181,8 +181,8 @@ jobs:
           $ErrorActionPreference = 'Stop'
           Copy-Item .\bin\otelcol_windows_amd64.exe .\cmd\otelcol\otelcol.exe
           Copy-Item .\dist\agent-bundle_windows_amd64.zip .\cmd\otelcol\agent-bundle_windows_amd64.zip
-          if ("${{ matrix.OS }}" -eq "windows-2019") {
-            $base_image = "mcr.microsoft.com/windows/servercore:ltsc2019"
+          if ("${{ matrix.OS }}" -eq "windows-2025") {
+            $base_image = "mcr.microsoft.com/windows/servercore:ltsc2025"
           } else {
             $base_image = "mcr.microsoft.com/windows/servercore:ltsc2022"
           }

--- a/deployments/chef/kitchen.windows.yml
+++ b/deployments/chef/kitchen.windows.yml
@@ -19,14 +19,14 @@ verifier:
   name: inspec
 
 platforms:
-  - name: windows-2019
-    driver:
-      dockerfile: test/windows/Dockerfile.windows-2019
-      build_context: true
-      platform: windows
   - name: windows-2022
     driver:
       dockerfile: test/windows/Dockerfile.windows-2022
+      build_context: true
+      platform: windows
+  - name: windows-2025
+    driver:
+      dockerfile: test/windows/Dockerfile.windows-2025
       build_context: true
       platform: windows
 

--- a/deployments/chef/test/windows/Dockerfile.windows-2025
+++ b/deployments/chef/test/windows/Dockerfile.windows-2025
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2025
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Workflows running on windows-2019 runners [started instantly stopping today](https://github.com/signalfx/splunk-otel-collector/actions/runs/15421647171?pr=6271) with a warning referencing [this issue](https://github.com/actions/runner-images/issues/12045). This is to upgrade Windows runners from 2019 -> 2025.