### PR TITLE
[chore][chef]Set `with_fluentd` to false for debian-11 tests

### DIFF
--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -93,6 +93,13 @@ jobs:
         with:
           version: ${{ env.CHEF_VERSION }}
 
+
+      # Install of fluentd is failing on Debian 11, so we disable it for that distro.
+      - name: Set `with_fluentd` to false on Debian 11
+        if: matrix.DISTRO == 'debian-11'
+        run: |
+          yq eval '(.suites[] | select(.name=="custom_vars").attributes.splunk_otel_collector.with_fluentd) = false' -i kitchen.yml
+
       - run: kitchen test ${{ matrix.DISTRO }}
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Deploying fluentd on Debian 11 is failing during CI, setting `with_fluentd` to false as a temporary workaround.