### PR TITLE
[chef] Add option to set service CLI args

### DIFF
--- a/deployments/chef/README.md
+++ b/deployments/chef/README.md
@@ -148,6 +148,10 @@ required `splunk_access_token` attribute and some optional attributes:
   `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\splunk-otel-collector`
   registry key.
 
+- `collector_command_line_args`: Additional command line arguments to pass to the
+  collector service. The value will be set to the `OTELCOL_OPTIONS` environment
+  variable for the collector service (**default:** `''`).
+
 ### Fluentd
 
 - `with_fluentd`: Whether to install/manage Fluentd and dependencies for log

--- a/deployments/chef/attributes/default.rb
+++ b/deployments/chef/attributes/default.rb
@@ -31,6 +31,7 @@ default['splunk_otel_collector']['fluentd_version'] = if platform_family?('debia
                                                         '4.3.2'
                                                       end
 default['splunk_otel_collector']['collector_additional_env_vars'] = {}
+default['splunk_otel_collector']['collector_command_line_args'] = ''
 
 if platform_family?('windows')
   default['splunk_otel_collector']['collector_version'] = 'latest'

--- a/deployments/chef/kitchen.yml
+++ b/deployments/chef/kitchen.yml
@@ -92,6 +92,7 @@ suites:
         collector_additional_env_vars:
           MY_CUSTOM_VAR1: value1
           MY_CUSTOM_VAR2: value2
+        collector_command_line_args: --discovery
         with_fluentd: true
 
   - name: with_default_preload_instrumentation

--- a/deployments/chef/templates/splunk-otel-collector.conf.erb
+++ b/deployments/chef/templates/splunk-otel-collector.conf.erb
@@ -39,6 +39,11 @@ SPLUNK_BUNDLE_DIR=<%= node['splunk_otel_collector']['splunk_bundle_dir'] %>
 # This directory must be read/writable by the collector process.
 SPLUNK_COLLECTD_DIR=<%= node['splunk_otel_collector']['splunk_collectd_dir'] %>
 
+<% unless node['splunk_otel_collector']['collector_command_line_args'].to_s.strip.empty? -%>
+# Additional command line arguments for the collector.
+OTELCOL_OPTIONS=<%= node['splunk_otel_collector']['collector_command_line_args'] %>
+<% end -%>
+
 # Additional environment variables.
 <% @node['splunk_otel_collector']['collector_additional_env_vars'].each do |key,value| -%>
 <%= key %>=<%= value %>

--- a/deployments/chef/test/integration/custom_vars/test.rb
+++ b/deployments/chef/test/integration/custom_vars/test.rb
@@ -65,6 +65,7 @@ else
     its('content') { should match /^SPLUNK_REALM=test$/ }
     its('content') { should match /^MY_CUSTOM_VAR1=value1$/ }
     its('content') { should match /^MY_CUSTOM_VAR2=value2$/ }
+    its('content') { should match /^OTELCOL_OPTIONS=--discovery$/ }
   end
   describe file('/etc/systemd/system/splunk-otel-collector.service.d/service-owner.conf') do
     its('content') { should match /^User=custom-user$/ }


### PR DESCRIPTION
Adds a specific option to set the command-line arguments used to launch the collector service on Linux - Windows implementation is coming after https://github.com/signalfx/splunk-otel-collector/pull/6268 is released.

The test for this new config setting is piggy-backing on the test for custom environment variables due to the similarities and to avoid yet another test for some CI that is already relatively long to run.