### PR TITLE
[ansible] Fix incorrect environmental variable naming

### DIFF
--- a/deployments/ansible/galaxy.yml
+++ b/deployments/ansible/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: signalfx
 name: splunk_otel_collector
 description: Ansible collection for Splunk OpenTelemetry Collector
-version: 0.32.0
+version: 0.31.0
 readme: README.md
 authors:
   - Splunk Inc.

--- a/deployments/ansible/galaxy.yml
+++ b/deployments/ansible/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: signalfx
 name: splunk_otel_collector
 description: Ansible collection for Splunk OpenTelemetry Collector
-version: 0.31.0
+version: 0.32.0
 readme: README.md
 authors:
   - Splunk Inc.

--- a/deployments/ansible/molecule/custom_vars/verify.yml
+++ b/deployments/ansible/molecule/custom_vars/verify.yml
@@ -22,6 +22,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert SPLUNK_INGEST_URL env var is set
       ansible.builtin.lineinfile:
@@ -29,6 +31,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert SPLUNK_API_URL env var is set
       ansible.builtin.lineinfile:
@@ -36,6 +40,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert SPLUNK_HEC_URL env var is set
       ansible.builtin.lineinfile:
@@ -43,6 +49,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert OTELCOL_OPTIONS env var is set per splunk_otel_collector_command_line_args
       ansible.builtin.lineinfile:
@@ -50,6 +58,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert MY_CUSTOM_VAR1 env var is set
       ansible.builtin.lineinfile:
@@ -57,6 +67,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert MY_CUSTOM_VAR2 env var is set
       ansible.builtin.lineinfile:
@@ -64,6 +76,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Populate package facts
       ansible.builtin.package_facts:
@@ -78,6 +92,8 @@
         dest: /etc/systemd/system/splunk-otel-collector.service.d/service-owner.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert custom service group is set
       ansible.builtin.lineinfile:
@@ -85,6 +101,8 @@
         dest: /etc/systemd/system/splunk-otel-collector.service.d/service-owner.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert SPLUNK_MEMORY_TOTAL_MIB env var is set
       ansible.builtin.lineinfile:
@@ -92,6 +110,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert SPLUNK_LISTEN_INTERFACE env var is set
       ansible.builtin.lineinfile:
@@ -99,6 +119,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert GOMEMLIMIT env var is set
       ansible.builtin.lineinfile:
@@ -106,6 +128,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Check custom_fluentd.conf
       stat:
@@ -124,6 +148,8 @@
         state: present
       check_mode: yes
       when: fluentd_supported
+      register: config
+      failed_when: config is changed
 
     - name: Send a test log message
       ansible.builtin.uri:

--- a/deployments/ansible/molecule/default/verify.yml
+++ b/deployments/ansible/molecule/default/verify.yml
@@ -21,6 +21,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert SPLUNK_REALM env var is set
       ansible.builtin.lineinfile:
@@ -28,6 +30,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert SPLUNK_INGEST_URL env var is set
       ansible.builtin.lineinfile:
@@ -35,6 +39,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert SPLUNK_API_URL env var is set
       ansible.builtin.lineinfile:
@@ -42,6 +48,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert SPLUNK_HEC_URL env var is set
       ansible.builtin.lineinfile:
@@ -49,3 +57,5 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible/molecule/default/verify.yml
+++ b/deployments/ansible/molecule/default/verify.yml
@@ -44,7 +44,7 @@
 
     - name: Assert SPLUNK_API_URL env var is set
       ansible.builtin.lineinfile:
-        line: SPLUNK_INGEST_URL=https://api.fake-realm.signalfx.com
+        line: SPLUNK_API_URL=https://api.fake-realm.signalfx.com
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes

--- a/deployments/ansible/roles/collector/templates/splunk-otel-collector.conf.j2
+++ b/deployments/ansible/roles/collector/templates/splunk-otel-collector.conf.j2
@@ -1,4 +1,4 @@
-OTELCOL_CONFIG={{ splunk_otel_collector_command_line_args }}
+OTELCOL_OPTIONS={{ splunk_otel_collector_command_line_args }}
 SPLUNK_CONFIG={{ splunk_otel_collector_config }}
 SPLUNK_ACCESS_TOKEN={{ splunk_access_token }}
 SPLUNK_REALM={{ splunk_realm }}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Without the `register` and `failed_when` checks, the test passes with output saying that lines would have been added if values don't match. The goal is to test to see if an env var is set, by matching lines in a file. If the env var is set to the expected value, no lines would be added. So rather than failing the test, there was just a log message saying a line would be added. This change makes it so tests fail if the env var isn't set to the expected value.

This is already being done in other tests, `with_instrumentation` [for example.](https://github.com/signalfx/splunk-otel-collector/blob/be1bce1d7544b25a2f51e5411d5c076af7a195bb/deployments/ansible/molecule/with_instrumentation/verify.yml#L85)

Edit: After adding verification, `custom_vars` was failing. This was happening because in https://github.com/signalfx/splunk-otel-collector/pull/6270 the variable was named as `OTELCOL_CONFIG`, but the test was checking for `OTELCOL_OPTIONS`. I think `OTELCOL_OPTIONS` was more clear so I'm updating the environment variable, rather than the test.