### PR TITLE
[chore] Publish grype code scan results for Windows

### DIFF
--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -190,6 +190,7 @@ jobs:
           Remove-Item .\cmd\otelcol\otelcol.exe
           Remove-Item .\cmd\otelcol\agent-bundle_windows_amd64.zip
       - uses: anchore/scan-action@v6
+        id: anchore-scan
         with:
           severity-cutoff: "high"
           only-fixed: true


### PR DESCRIPTION
We want the results of the scan to be published to GH code scanning as it is done to other scanners and for grype on Linux.

This may be less user friendly on the GH job log, but, easier to manage via GH.