### PR TITLE
[chore][chef] Run tests against locally built artifact

### DIFF
--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -47,17 +47,17 @@ jobs:
     needs: [ setup-environment, chef-lint-spec-test ]
     strategy:
       matrix:
-        SYS_BINARIES: [ "binaries-linux_amd64", "binaries-linux_arm64", "binaries-windows_amd64" ]
+        SYS_BINARIES: [ "binaries-linux_amd64", "binaries-windows_amd64" ]
     uses: ./.github/workflows/compile.yml
     with:
       sys_binary: ${{ matrix.SYS_BINARIES }}
 
   agent-bundle-linux:
     needs: [chef-lint-spec-test]
-    runs-on: ${{ fromJSON('["ubuntu-24.04", "otel-arm64"]')[matrix.ARCH == 'arm64'] }}
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        ARCH: [ "amd64", "arm64" ]
+        ARCH: [ "amd64" ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -83,8 +83,8 @@ jobs:
     needs: [ cross-compile, agent-bundle-linux ]
     strategy:
       matrix:
-        SYS_PACKAGE: [ "deb", "rpm", "tar" ]
-        ARCH: [ "amd64", "arm64" ]
+        SYS_PACKAGE: [ "deb", "rpm" ]
+        ARCH: [ "amd64" ]
       fail-fast: false
     steps:
       - name: Check out the codebase.
@@ -300,25 +300,21 @@ jobs:
         run: |
           ls -al /tmp
 
-          sudo tar -xzf /tmp/deb-amd64-package
-          sudo tar -xzf /tmp/rpm-amd64-package
+          ls -al /tmp/deb-amd64-package
+          ls -al /tmp/rpm-amd64-package
+
+#          sudo tar -xzf /tmp/deb-amd64-package
+#          sudo tar -xzf /tmp/rpm-amd64-package
 
           ls -al /tmp
 
-          deb_path=$(find /tmp/splunk-otel-collector*amd64.deb)
+          mkdir -p files
+          deb_path=$(find /tmp/deb-amd64-package/splunk-otel-collector*amd64.deb)
           mv $deb_path ./files/deb-amd64-package
-          rpm_path=$(find /tmp/splunk-otel-collector*x86_64.rpm)
+          rpm_path=$(find /tmp/rpm-amd64-package/splunk-otel-collector*x86_64.rpm)
           mv $rpm_path ./files/rpm-amd64-package
 
-          sudo tar -xzf /tmp/deb-arm64-package
-          sudo tar -xzf /tmp/rpmn-arm64-package
-
-          ls -al /tmp
-
-          deb_path=$(find /tmp/splunk-otel-collector*arm64.deb)
-          mv $deb_path ./files/deb-arm64-package
-          rpm_path=$(find /tmp/splunk-otel-collector*aarch64.rpm)
-          mv $rpm_path ./files/rpm-amd64-package
+          ls -al ./files
 
       - name: Install chef
         uses: actionshub/chef-install@3.0.1
@@ -364,10 +360,11 @@ jobs:
         run: |
           ls /tmp
 
-          sudo tar -xzf /tmp/msi-build
+#          sudo tar -xzf /tmp/msi-build
 
-          ls /tmp
+#          ls /tmp
 
+          mkdir files
           Get-ChildItem /tmp -Recurse -Include 'splunk-otel-collector*.msi' | Select FullName -OutVariable msiPath
           echo $msiPath.FullName
           mv $msiPath.FullName ./files/splunk-otel-collector.msi

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -45,7 +45,6 @@ jobs:
 
   cross-compile:
     needs: [ setup-environment, chef-lint-spec-test ]
-    runs-on: ubuntu-24.04
     strategy:
       matrix:
         SYS_BINARIES: [ "binaries-linux_amd64", "binaries-linux_arm64", "binaries-windows_amd64" ]

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -305,9 +305,9 @@ jobs:
 
           mkdir -p files
           deb_path=$(find /tmp/deb-amd64-package/splunk-otel-collector*amd64.deb)
-          mv $deb_path ./files/deb-amd64-package
+          mv $deb_path ./files/soc.deb
           rpm_path=$(find /tmp/rpm-amd64-package/splunk-otel-collector*x86_64.rpm)
-          mv $rpm_path ./files/rpm-amd64-package
+          mv $rpm_path ./files/soc.rpm
 
           ls -al ./files
 

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -352,7 +352,6 @@ jobs:
         run: |
           mkdir files
           Get-ChildItem /tmp -Recurse -Include 'splunk-otel-collector*.msi' | Select FullName -OutVariable msiPath
-          echo $msiPath.FullName
           mv $msiPath.FullName ./files/splunk-otel-collector.msi
 
       - name: Install chef

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -303,11 +303,6 @@ jobs:
           ls -al /tmp/deb-amd64-package
           ls -al /tmp/rpm-amd64-package
 
-#          sudo tar -xzf /tmp/deb-amd64-package
-#          sudo tar -xzf /tmp/rpm-amd64-package
-
-          ls -al /tmp
-
           mkdir -p files
           deb_path=$(find /tmp/deb-amd64-package/splunk-otel-collector*amd64.deb)
           mv $deb_path ./files/deb-amd64-package
@@ -359,10 +354,6 @@ jobs:
       - name: Extract artifacts
         run: |
           ls /tmp
-
-#          sudo tar -xzf /tmp/msi-build
-
-#          ls /tmp
 
           mkdir files
           Get-ChildItem /tmp -Recurse -Include 'splunk-otel-collector*.msi' | Select FullName -OutVariable msiPath

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -21,18 +21,125 @@ concurrency:
   group: chef-test-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    working-directory: 'deployments/chef'
-
 env:
   CHEF_VERSION: "22.12.1024"
   CHEF_LICENSE: accept
+  GO_VERSION: 1.23.10
 
 jobs:
+  setup-environment:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
+
+      - name: Installing dependency
+        run: |
+          make install-tools
+
+  cross-compile:
+    runs-on: ubuntu-24.04
+    needs: [ setup-environment ]
+    strategy:
+      matrix:
+        SYS_BINARIES: [ "binaries-linux_amd64", "binaries-linux_arm64", "binaries-linux_ppc64le" ]
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
+
+      - name: Build Collector
+        run: |
+          make ${{ matrix.SYS_BINARIES }}
+      - name: Uploading binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.SYS_BINARIES }}
+          path: |
+            ./bin/*
+
+  agent-bundle-linux:
+    runs-on: ${{ fromJSON('["ubuntu-24.04", "otel-arm64"]')[matrix.ARCH == 'arm64'] }}
+    strategy:
+      matrix:
+        ARCH: [ "amd64", "arm64" ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        id: bundle-cache
+        with:
+          path: .cache/buildx/agent-bundle-${{ matrix.ARCH }}
+          key: agent-bundle-buildx-${{ matrix.ARCH }}-${{ hashFiles('packaging/bundle/**') }}
+          restore-keys: |
+            agent-bundle-buildx-${{ matrix.ARCH }}-
+      - run: make -C packaging/bundle agent-bundle-linux ARCH=${{ matrix.ARCH }}
+        env:
+          BUNDLE_CACHE_HIT: "${{ steps.bundle-cache.outputs.cache-hit }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: agent-bundle-linux-${{ matrix.ARCH }}
+          path: ./dist/agent-bundle_linux_${{ matrix.ARCH }}.tar.gz
+
+  build-package:
+    runs-on: ubuntu-24.04
+    needs: [ cross-compile, agent-bundle-linux ]
+    strategy:
+      matrix:
+        SYS_PACKAGE: [ "deb", "rpm", "tar" ]
+        ARCH: [ "amd64", "arm64" ]
+      fail-fast: false
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
+
+      - name: Downloading binaries-linux_${{ matrix.ARCH }}
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-linux_${{ matrix.ARCH }}
+          path: ./bin
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: agent-bundle-linux-${{ matrix.ARCH }}
+          path: ./dist
+
+      - name: Build ${{ matrix.SYS_PACKAGE }} ${{ matrix.ARCH }} package
+        run: make ${{ matrix.SYS_PACKAGE }}-package SKIP_COMPILE=true SKIP_BUNDLE=true VERSION="" ARCH="${{ matrix.ARCH }}"
+
+      - name: Uploading ${{ matrix.SYS_PACKAGE }} ${{ matrix.ARCH }} package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.SYS_PACKAGE }}-${{ matrix.ARCH }}-package
+          path: ./dist/splunk-otel-collector*
+
   chef-lint-spec-test:
     name: chef-lint-spec-test
     runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: 'deployments/chef'
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v4
@@ -46,6 +153,9 @@ jobs:
 
   chef-kitchen-matrix:
     runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: 'deployments/chef'
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -81,6 +191,9 @@ jobs:
   chef-kitchen-linux:
     runs-on: ubuntu-24.04
     needs: [chef-lint-spec-test, chef-kitchen-matrix]
+    defaults:
+      run:
+        working-directory: 'deployments/chef'
     strategy:
       matrix: ${{ fromJSON(needs.chef-kitchen-matrix.outputs.linux-matrix) }}
       fail-fast: false
@@ -88,11 +201,26 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp
+
+      # Chef doesn't have an easy way to get names of files from unarchived packages
+      # It's simpler to unarchive and move the built artifacts manually to the
+      # cookbook files directory
+      # Cookbook files reference: https://docs.chef.io/files/
+      - name: Extract artifacts
+        run: |
+          deb_path=$(find /tmp/splunk-otel-collector*amd64.deb)
+          mv $deb_path ./files/deb-amd64-package
+
+          deb_path=$(find /tmp/splunk-otel-collector*arm64.deb)
+          mv $deb_path ./files/deb-arm64-package
+
       - name: Install chef
         uses: actionshub/chef-install@3.0.1
         with:
           version: ${{ env.CHEF_VERSION }}
-
 
       # Install of fluentd is failing on Debian 11, so we disable it for that distro.
       - name: Set `with_fluentd` to false on Debian 11
@@ -111,6 +239,9 @@ jobs:
   chef-kitchen-windows:
     runs-on: ${{ matrix.DISTRO }}
     needs: [chef-lint-spec-test, chef-kitchen-matrix]
+    defaults:
+      run:
+        working-directory: 'deployments/chef'
     strategy:
       matrix: ${{ fromJSON(needs.chef-kitchen-matrix.outputs.win-matrix) }}
       fail-fast: false

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -293,23 +293,18 @@ jobs:
           path: /tmp
 
       # Chef doesn't have an easy way to get names of files from unarchived packages
-      # It's simpler to unarchive and move the built artifacts manually to the
-      # cookbook files directory
+      # It's simpler to manually unarchive and move the built artifacts to the
+      # cookbook files directory here. The files/ dir under the Chef deployment is a special
+      # directory in Chef, used for copying files from the cookbook to the host running
+      # Chef.
       # Cookbook files reference: https://docs.chef.io/files/
       - name: Extract artifacts
         run: |
-          ls -al /tmp
-
-          ls -al /tmp/deb-amd64-package
-          ls -al /tmp/rpm-amd64-package
-
           mkdir -p files
           deb_path=$(find /tmp/deb-amd64-package/splunk-otel-collector*amd64.deb)
           mv $deb_path ./files/soc.deb
           rpm_path=$(find /tmp/rpm-amd64-package/splunk-otel-collector*x86_64.rpm)
           mv $rpm_path ./files/soc.rpm
-
-          ls -al ./files
 
       - name: Install chef
         uses: actionshub/chef-install@3.0.1
@@ -349,18 +344,16 @@ jobs:
 
       # Chef doesn't have an easy way to get names of files from unarchived packages
       # It's simpler to unarchive and move the built artifacts manually to the
-      # cookbook files directory
+      # cookbook files directory. The files/ dir under the Chef deployment is a special
+      # directory in Chef, used for copying files from the cookbook to the host running
+      # Chef.
       # Cookbook files reference: https://docs.chef.io/files/
       - name: Extract artifacts
         run: |
-          ls /tmp
-
           mkdir files
           Get-ChildItem /tmp -Recurse -Include 'splunk-otel-collector*.msi' | Select FullName -OutVariable msiPath
           echo $msiPath.FullName
           mv $msiPath.FullName ./files/splunk-otel-collector.msi
-
-          ls ./files
 
       - name: Install chef
         uses: actionshub/chef-install@3.0.1

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -300,13 +300,25 @@ jobs:
         run: |
           ls -al /tmp
 
-          sudo tar -xzf /tmp/deb-amd64-deb
+          sudo tar -xzf /tmp/deb-amd64-package
+          sudo tar -xzf /tmp/rpm-amd64-package
+
+          ls -al /tmp
+
           deb_path=$(find /tmp/splunk-otel-collector*amd64.deb)
           mv $deb_path ./files/deb-amd64-package
+          rpm_path=$(find /tmp/splunk-otel-collector*x86_64.rpm)
+          mv $rpm_path ./files/rpm-amd64-package
 
-          sudo tar -xzf /tmp/deb-arm64-deb
+          sudo tar -xzf /tmp/deb-arm64-package
+          sudo tar -xzf /tmp/rpmn-arm64-package
+
+          ls -al /tmp
+
           deb_path=$(find /tmp/splunk-otel-collector*arm64.deb)
           mv $deb_path ./files/deb-arm64-package
+          rpm_path=$(find /tmp/splunk-otel-collector*aarch64.rpm)
+          mv $rpm_path ./files/rpm-amd64-package
 
       - name: Install chef
         uses: actionshub/chef-install@3.0.1
@@ -350,7 +362,17 @@ jobs:
       # Cookbook files reference: https://docs.chef.io/files/
       - name: Extract artifacts
         run: |
-          ls -al /tmp
+          ls /tmp
+
+          sudo tar -xzf /tmp/msi-build
+
+          ls /tmp
+
+          Get-ChildItem /tmp -Recurse -Include 'splunk-otel-collector*.msi' | Select FullName -OutVariable msiPath
+          echo $msiPath.FullName
+          mv $msiPath.FullName ./files/splunk-otel-collector.msi
+
+          ls ./files
 
       - name: Install chef
         uses: actionshub/chef-install@3.0.1

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -190,7 +190,7 @@ jobs:
 
   chef-kitchen-linux:
     runs-on: ubuntu-24.04
-    needs: [chef-lint-spec-test, chef-kitchen-matrix]
+    needs: [chef-lint-spec-test, chef-kitchen-matrix, build-package]
     defaults:
       run:
         working-directory: 'deployments/chef'

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -44,32 +44,17 @@ jobs:
           make install-tools
 
   cross-compile:
+    needs: [ setup-environment, chef-lint-spec-test ]
     runs-on: ubuntu-24.04
-    needs: [ setup-environment ]
     strategy:
       matrix:
-        SYS_BINARIES: [ "binaries-linux_amd64", "binaries-linux_arm64", "binaries-linux_ppc64le" ]
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-
-      - name: Build Collector
-        run: |
-          make ${{ matrix.SYS_BINARIES }}
-      - name: Uploading binaries
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.SYS_BINARIES }}
-          path: |
-            ./bin/*
+        SYS_BINARIES: [ "binaries-linux_amd64", "binaries-linux_arm64", "binaries-windows_amd64" ]
+    uses: ./.github/workflows/compile.yml
+    with:
+      sys_binary: ${{ matrix.SYS_BINARIES }}
 
   agent-bundle-linux:
+    needs: [chef-lint-spec-test]
     runs-on: ${{ fromJSON('["ubuntu-24.04", "otel-arm64"]')[matrix.ARCH == 'arm64'] }}
     strategy:
       matrix:
@@ -133,6 +118,109 @@ jobs:
         with:
           name: ${{ matrix.SYS_PACKAGE }}-${{ matrix.ARCH }}-package
           path: ./dist/splunk-otel-collector*
+
+  agent-bundle-windows:
+    needs: [chef-lint-spec-test]
+    runs-on: ${{ matrix.OS }}
+    strategy:
+      matrix:
+        OS: [ "windows-2025" ]
+    env:
+      PIP_CACHE_DIR: ${{ github.workspace }}/.cache/pip
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.PIP_CACHE_DIR }}
+          key: agent-bundle-windows-pip-${{ hashFiles('packaging/bundle/collectd-plugins.yaml', 'packaging/bundle/scripts/requirements.txt') }}
+
+      - run: ./packaging/bundle/scripts/windows/make.ps1 bundle
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: agent-bundle-windows-${{ matrix.OS }}
+          path: ./dist/agent-bundle_windows_amd64.zip
+
+  msi-custom-actions:
+    needs: [chef-lint-spec-test]
+    runs-on: windows-2025
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+
+      - name: Uninstall default WiX
+        run: choco uninstall wixtoolset
+
+      - name: Install WiX 3.14.0
+        run: choco install wixtoolset --version 3.14.0 --allow-downgrade --force
+
+      - name: Build Custom Actions
+        working-directory: packaging/msi/SplunkCustomActions
+        run: |
+          dotnet test ./test/SplunkCustomActionsTests.csproj -c Release
+          dotnet publish ./src/SplunkCustomActions.csproj -c Release -o ./bin/Release
+      - name: Package Custom Actions
+        run: |
+          $WixPath = "${Env:ProgramFiles(x86)}\WiX Toolset v3.14"
+          $sfxcaDll = "${WixPath}\SDK\x64\sfxca.dll"
+          $Env:PATH = "${WixPath}\SDK;" + $Env:PATH
+          $customActionDir = "${PWD}\packaging\msi\SplunkCustomActions"
+          $customActionBinDir = "${customActionDir}\bin\Release"
+          MakeSfxCA.exe "${PWD}\dist\SplunkCustomActions.CA.dll" `
+            "${sfxcaDll}" `
+            "${customActionBinDir}\SplunkCustomActions.dll" `
+            "${customActionBinDir}\Microsoft.Deployment.WindowsInstaller.dll" `
+            "${customActionDir}\src\CustomAction.config"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: msi-custom-actions
+          path: ./dist/SplunkCustomActions.CA.dll
+
+  msi-build:
+    runs-on: ubuntu-24.04
+    env:
+      WINDOWS_VER: "windows-2025"
+    needs: [cross-compile, agent-bundle-windows, msi-custom-actions]
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Downloading binaries-windows_amd64
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-windows_amd64
+          path: ./bin
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: '**/go.sum'
+
+      - name: Downloading agent-bundle-windows
+        uses: actions/download-artifact@v4
+        with:
+          name: agent-bundle-windows-${{ env.WINDOWS_VER }}
+          path: ./dist
+
+      - name: Downloading msi-custom-actions
+        uses: actions/download-artifact@v4
+        with:
+          name: msi-custom-actions
+          path: ./packaging/msi/SplunkCustomActions/bin/Release
+
+      - name: Build MSI
+        run: |
+          mkdir -p dist
+          make msi SKIP_COMPILE=true VERSION=""
+      - name: Uploading msi build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: msi-build
+          path: ./dist/*.msi
 
   chef-lint-spec-test:
     name: chef-lint-spec-test
@@ -211,7 +299,7 @@ jobs:
       # Cookbook files reference: https://docs.chef.io/files/
       - name: Extract artifacts
         run: |
-          ls -al
+          ls -al /tmp
 
           sudo tar -xzf /tmp/deb-amd64-deb
           deb_path=$(find /tmp/splunk-otel-collector*amd64.deb)
@@ -242,7 +330,7 @@ jobs:
 
   chef-kitchen-windows:
     runs-on: ${{ matrix.DISTRO }}
-    needs: [chef-lint-spec-test, chef-kitchen-matrix]
+    needs: [chef-lint-spec-test, chef-kitchen-matrix, msi-build]
     defaults:
       run:
         working-directory: 'deployments/chef'
@@ -252,6 +340,18 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp
+
+      # Chef doesn't have an easy way to get names of files from unarchived packages
+      # It's simpler to unarchive and move the built artifacts manually to the
+      # cookbook files directory
+      # Cookbook files reference: https://docs.chef.io/files/
+      - name: Extract artifacts
+        run: |
+          ls -al /tmp
 
       - name: Install chef
         uses: actionshub/chef-install@3.0.1

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -211,9 +211,13 @@ jobs:
       # Cookbook files reference: https://docs.chef.io/files/
       - name: Extract artifacts
         run: |
+          ls -al
+
+          sudo tar -xzf /tmp/deb-amd64-deb
           deb_path=$(find /tmp/splunk-otel-collector*amd64.deb)
           mv $deb_path ./files/deb-amd64-package
 
+          sudo tar -xzf /tmp/deb-arm64-deb
           deb_path=$(find /tmp/splunk-otel-collector*arm64.deb)
           mv $deb_path ./files/deb-arm64-package
 

--- a/deployments/chef/attributes/default.rb
+++ b/deployments/chef/attributes/default.rb
@@ -33,6 +33,10 @@ default['splunk_otel_collector']['fluentd_version'] = if platform_family?('debia
 default['splunk_otel_collector']['collector_additional_env_vars'] = {}
 default['splunk_otel_collector']['collector_command_line_args'] = ''
 
+# Set to true for testing against a locally built artifact of the Splunk OTel Collector
+# When enabled, defaults for remote URLs and collector versions are overridden
+default['splunk_otel_collector']['local_artifact_testing_enabled'] = false
+
 if platform_family?('windows')
   default['splunk_otel_collector']['collector_version'] = 'latest'
   default['splunk_otel_collector']['collector_version_url'] = "#{node['splunk_otel_collector']['windows_repo_url']}/#{node['splunk_otel_collector']['service_name']}/msi/#{node['splunk_otel_collector']['package_stage']}/latest.txt"

--- a/deployments/chef/kitchen.windows.yml
+++ b/deployments/chef/kitchen.windows.yml
@@ -36,6 +36,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
     verifier:
@@ -48,6 +49,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         splunk_ingest_url: https://fake-splunk-ingest.com

--- a/deployments/chef/kitchen.yml
+++ b/deployments/chef/kitchen.yml
@@ -72,6 +72,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
 
@@ -80,6 +81,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         splunk_ingest_url: https://fake-splunk-ingest.com
@@ -174,6 +176,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -185,6 +188,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -206,6 +210,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -218,6 +223,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -316,6 +322,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -327,6 +334,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -348,6 +356,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -360,6 +369,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -381,6 +391,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -390,6 +401,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true

--- a/deployments/chef/recipes/collector_deb_repo.rb
+++ b/deployments/chef/recipes/collector_deb_repo.rb
@@ -7,10 +7,40 @@ remote_file '/etc/apt/trusted.gpg.d/splunk.gpg' do
   action :create
 end
 
-file '/etc/apt/sources.list.d/splunk-otel-collector.list' do
-  content "deb #{node['splunk_otel_collector']['debian_repo_url']} #{node['splunk_otel_collector']['package_stage']} main\n"
-  mode '0644'
-  notifies :update, 'apt_update[update apt cache]', :immediately
+if node['splunk_otel_collector']['local_artifact_testing_enabled']
+  cpu_arch = 'amd64'
+  if arm?
+    cpu_arch = 'arm64'
+  end
+
+  file_name = 'deb-' + cpu_arch + '-package'
+  deb_install_dir = '/etc/otel/collector/'
+  deb_install_path = deb_install_dir + file_name
+
+  # Create destination dir on target machine
+  directory deb_install_dir do
+    mode '0644'
+    action :create
+    recursive true
+  end
+
+  # Copy deb file from source to target
+  cookbook_file deb_install_path do
+    source file_name
+    mode '0644'
+  end
+
+  dpkg_package deb_install_path do
+    source deb_install_path
+    action :install
+  end
+
+else
+  file '/etc/apt/sources.list.d/splunk-otel-collector.list' do
+    content "deb #{node['splunk_otel_collector']['debian_repo_url']} #{node['splunk_otel_collector']['package_stage']} main\n"
+    mode '0644'
+    notifies :update, 'apt_update[update apt cache]', :immediately
+  end
 end
 
 apt_update 'update apt cache' do

--- a/deployments/chef/recipes/collector_deb_repo.rb
+++ b/deployments/chef/recipes/collector_deb_repo.rb
@@ -8,12 +8,8 @@ remote_file '/etc/apt/trusted.gpg.d/splunk.gpg' do
 end
 
 if node['splunk_otel_collector']['local_artifact_testing_enabled']
-  cpu_arch = 'amd64'
-  if arm?
-    cpu_arch = 'arm64'
-  end
 
-  file_name = 'deb-' + cpu_arch + '-package'
+  file_name = 'soc.deb'
   deb_install_dir = '/etc/otel/collector/'
   deb_install_path = deb_install_dir + file_name
 

--- a/deployments/chef/recipes/collector_deb_repo.rb
+++ b/deployments/chef/recipes/collector_deb_repo.rb
@@ -23,7 +23,7 @@ if node['splunk_otel_collector']['local_artifact_testing_enabled']
     mode '0644'
   end
 
-  dpkg_package deb_install_path do
+  dpkg_package 'splunk-otel-collector' do
     source deb_install_path
     action :install
   end

--- a/deployments/chef/recipes/collector_deb_repo.rb
+++ b/deployments/chef/recipes/collector_deb_repo.rb
@@ -7,8 +7,13 @@ remote_file '/etc/apt/trusted.gpg.d/splunk.gpg' do
   action :create
 end
 
-if node['splunk_otel_collector']['local_artifact_testing_enabled']
+file '/etc/apt/sources.list.d/splunk-otel-collector.list' do
+  content "deb #{node['splunk_otel_collector']['debian_repo_url']} #{node['splunk_otel_collector']['package_stage']} main\n"
+  mode '0644'
+  notifies :update, 'apt_update[update apt cache]', :immediately
+end
 
+if node['splunk_otel_collector']['local_artifact_testing_enabled']
   file_name = 'soc.deb'
   deb_install_dir = '/etc/otel/collector/'
   deb_install_path = deb_install_dir + file_name
@@ -29,13 +34,6 @@ if node['splunk_otel_collector']['local_artifact_testing_enabled']
   dpkg_package deb_install_path do
     source deb_install_path
     action :install
-  end
-
-else
-  file '/etc/apt/sources.list.d/splunk-otel-collector.list' do
-    content "deb #{node['splunk_otel_collector']['debian_repo_url']} #{node['splunk_otel_collector']['package_stage']} main\n"
-    mode '0644'
-    notifies :update, 'apt_update[update apt cache]', :immediately
   end
 end
 

--- a/deployments/chef/recipes/collector_deb_repo.rb
+++ b/deployments/chef/recipes/collector_deb_repo.rb
@@ -15,15 +15,7 @@ end
 
 if node['splunk_otel_collector']['local_artifact_testing_enabled']
   file_name = 'soc.deb'
-  deb_install_dir = '/etc/otel/collector/'
-  deb_install_path = deb_install_dir + file_name
-
-  # Create destination dir on target machine
-  directory deb_install_dir do
-    mode '0644'
-    action :create
-    recursive true
-  end
+  deb_install_path = '/tmp/' + file_name
 
   # Copy deb file from source to target
   cookbook_file deb_install_path do

--- a/deployments/chef/recipes/collector_win_install.rb
+++ b/deployments/chef/recipes/collector_win_install.rb
@@ -16,10 +16,10 @@ collector_version = if node['splunk_otel_collector']['collector_version'] == 'la
 remote_destination_path = "#{ENV['TEMP']}/splunk-otel-collector-#{collector_version}-amd64.msi"
 
 if node['splunk_otel_collector']['local_artifact_testing_enabled']
-    cookbook_file remote_destination_path do
-      source "splunk-otel-collector.msi"
-      mode '0644'
-    end
+  cookbook_file remote_destination_path do
+    source "splunk-otel-collector.msi"
+    mode '0644'
+  end
 else
   remote_file 'Download msi' do
     path remote_destination_path

--- a/deployments/chef/recipes/collector_win_install.rb
+++ b/deployments/chef/recipes/collector_win_install.rb
@@ -17,7 +17,7 @@ remote_destination_path = "#{ENV['TEMP']}/splunk-otel-collector-#{collector_vers
 
 if node['splunk_otel_collector']['local_artifact_testing_enabled']
   cookbook_file remote_destination_path do
-    source "splunk-otel-collector.msi"
+    source 'splunk-otel-collector.msi'
     mode '0644'
   end
 else

--- a/deployments/chef/recipes/collector_yum_repo.rb
+++ b/deployments/chef/recipes/collector_yum_repo.rb
@@ -13,15 +13,7 @@ end
 
 if node['splunk_otel_collector']['local_artifact_testing_enabled']
   file_name = 'soc.rpm'
-  rpm_install_dir = '/etc/otel/collector/'
-  rpm_install_path = rpm_install_dir + file_name
-
-  # Create destination dir on target machine
-  directory rpm_install_dir do
-    mode '0644'
-    action :create
-    recursive true
-  end
+  rpm_install_path = '/tmp/' + file_name
 
   # Copy rpm file from source to target
   cookbook_file rpm_install_path do

--- a/deployments/chef/recipes/collector_yum_repo.rb
+++ b/deployments/chef/recipes/collector_yum_repo.rb
@@ -1,14 +1,40 @@
 # Cookbook:: splunk_otel_collector
 # Recipe:: collector_yum_repo
 
-yum_repository 'splunk-otel-collector' do
-  description 'Splunk OpenTelemetry Collector Repository'
-  baseurl "#{node['splunk_otel_collector']['rhel_repo_url']}/#{node['splunk_otel_collector']['package_stage']}/$basearch/"
-  gpgcheck true
-  gpgkey node['splunk_otel_collector']['rhel_gpg_key_url']
-  enabled true
-  action :create
-  notifies :run, 'execute[add-rhel-key]', :immediately
+if node['splunk_otel_collector']['local_artifact_testing_enabled']
+
+  file_name = 'soc.rpm'
+  rpm_install_dir = '/etc/otel/collector/'
+  rpm_install_path = rpm_install_dir + file_name
+
+  # Create destination dir on target machine
+  directory rpm_install_dir do
+    mode '0644'
+    action :create
+    recursive true
+  end
+
+  # Copy rpm file from source to target
+  cookbook_file rpm_install_path do
+    source file_name
+    mode '0644'
+  end
+
+  rpm_package rpm_install_path do
+    source rpm_install_path
+    action :install
+  end
+
+else
+  yum_repository 'splunk-otel-collector' do
+    description 'Splunk OpenTelemetry Collector Repository'
+    baseurl "#{node['splunk_otel_collector']['rhel_repo_url']}/#{node['splunk_otel_collector']['package_stage']}/$basearch/"
+    gpgcheck true
+    gpgkey node['splunk_otel_collector']['rhel_gpg_key_url']
+    enabled true
+    action :create
+    notifies :run, 'execute[add-rhel-key]', :immediately
+  end
 end
 
 execute 'add-rhel-key' do

--- a/deployments/chef/recipes/collector_yum_repo.rb
+++ b/deployments/chef/recipes/collector_yum_repo.rb
@@ -1,8 +1,17 @@
 # Cookbook:: splunk_otel_collector
 # Recipe:: collector_yum_repo
 
-if node['splunk_otel_collector']['local_artifact_testing_enabled']
+yum_repository 'splunk-otel-collector' do
+  description 'Splunk OpenTelemetry Collector Repository'
+  baseurl "#{node['splunk_otel_collector']['rhel_repo_url']}/#{node['splunk_otel_collector']['package_stage']}/$basearch/"
+  gpgcheck true
+  gpgkey node['splunk_otel_collector']['rhel_gpg_key_url']
+  enabled true
+  action :create
+  notifies :run, 'execute[add-rhel-key]', :immediately
+end
 
+if node['splunk_otel_collector']['local_artifact_testing_enabled']
   file_name = 'soc.rpm'
   rpm_install_dir = '/etc/otel/collector/'
   rpm_install_path = rpm_install_dir + file_name
@@ -23,17 +32,6 @@ if node['splunk_otel_collector']['local_artifact_testing_enabled']
   rpm_package rpm_install_path do
     source rpm_install_path
     action :install
-  end
-
-else
-  yum_repository 'splunk-otel-collector' do
-    description 'Splunk OpenTelemetry Collector Repository'
-    baseurl "#{node['splunk_otel_collector']['rhel_repo_url']}/#{node['splunk_otel_collector']['package_stage']}/$basearch/"
-    gpgcheck true
-    gpgkey node['splunk_otel_collector']['rhel_gpg_key_url']
-    enabled true
-    action :create
-    notifies :run, 'execute[add-rhel-key]', :immediately
   end
 end
 

--- a/deployments/chef/recipes/collector_yum_repo.rb
+++ b/deployments/chef/recipes/collector_yum_repo.rb
@@ -21,7 +21,7 @@ if node['splunk_otel_collector']['local_artifact_testing_enabled']
     mode '0644'
   end
 
-  rpm_package rpm_install_path do
+  rpm_package 'splunk-otel-collector' do
     source rpm_install_path
     action :install
   end

--- a/deployments/chef/recipes/collector_zypper_repo.rb
+++ b/deployments/chef/recipes/collector_zypper_repo.rb
@@ -1,8 +1,18 @@
 # Cookbook:: splunk_otel_collector
 # Recipe:: collector_zypper_repo
 
-if node['splunk_otel_collector']['local_artifact_testing_enabled']
+zypper_repository 'splunk-otel-collector' do
+  description 'Splunk OpenTelemetry Collector Repository'
+  baseurl "#{node['splunk_otel_collector']['rhel_repo_url']}/#{node['splunk_otel_collector']['package_stage']}/$basearch/"
+  gpgcheck true
+  gpgkey node['splunk_otel_collector']['rhel_gpg_key_url']
+  type 'yum'
+  enabled true
+  action :create
+  notifies :run, 'execute[add-rhel-key]', :immediately
+end
 
+if node['splunk_otel_collector']['local_artifact_testing_enabled']
   file_name = 'soc.rpm'
   rpm_install_dir = '/etc/otel/collector/'
   rpm_install_path = rpm_install_dir + file_name
@@ -25,20 +35,6 @@ if node['splunk_otel_collector']['local_artifact_testing_enabled']
     gpg_check false
     action :install
   end
-
-else
-
-  zypper_repository 'splunk-otel-collector' do
-    description 'Splunk OpenTelemetry Collector Repository'
-    baseurl "#{node['splunk_otel_collector']['rhel_repo_url']}/#{node['splunk_otel_collector']['package_stage']}/$basearch/"
-    gpgcheck true
-    gpgkey node['splunk_otel_collector']['rhel_gpg_key_url']
-    type 'yum'
-    enabled true
-    action :create
-    notifies :run, 'execute[add-rhel-key]', :immediately
-  end
-
 end
 
 execute 'add-rhel-key' do

--- a/deployments/chef/recipes/collector_zypper_repo.rb
+++ b/deployments/chef/recipes/collector_zypper_repo.rb
@@ -14,15 +14,7 @@ end
 
 if node['splunk_otel_collector']['local_artifact_testing_enabled']
   file_name = 'soc.rpm'
-  rpm_install_dir = '/etc/otel/collector/'
-  rpm_install_path = rpm_install_dir + file_name
-
-  # Create destination dir on target machine
-  directory rpm_install_dir do
-    mode '0644'
-    action :create
-    recursive true
-  end
+  rpm_install_path = '/tmp/' + file_name
 
   # Copy rpm file from source to target
   cookbook_file rpm_install_path do

--- a/deployments/chef/recipes/collector_zypper_repo.rb
+++ b/deployments/chef/recipes/collector_zypper_repo.rb
@@ -1,15 +1,44 @@
 # Cookbook:: splunk_otel_collector
 # Recipe:: collector_zypper_repo
 
-zypper_repository 'splunk-otel-collector' do
-  description 'Splunk OpenTelemetry Collector Repository'
-  baseurl "#{node['splunk_otel_collector']['rhel_repo_url']}/#{node['splunk_otel_collector']['package_stage']}/$basearch/"
-  gpgcheck true
-  gpgkey node['splunk_otel_collector']['rhel_gpg_key_url']
-  type 'yum'
-  enabled true
-  action :create
-  notifies :run, 'execute[add-rhel-key]', :immediately
+if node['splunk_otel_collector']['local_artifact_testing_enabled']
+
+  file_name = 'soc.rpm'
+  rpm_install_dir = '/etc/otel/collector/'
+  rpm_install_path = rpm_install_dir + file_name
+
+  # Create destination dir on target machine
+  directory rpm_install_dir do
+    mode '0644'
+    action :create
+    recursive true
+  end
+
+  # Copy rpm file from source to target
+  cookbook_file rpm_install_path do
+    source file_name
+    mode '0644'
+  end
+
+  zypper_package 'splunk-otel-collector' do
+    source rpm_install_path
+    gpg_check false
+    action :install
+  end
+
+else
+
+  zypper_repository 'splunk-otel-collector' do
+    description 'Splunk OpenTelemetry Collector Repository'
+    baseurl "#{node['splunk_otel_collector']['rhel_repo_url']}/#{node['splunk_otel_collector']['package_stage']}/$basearch/"
+    gpgcheck true
+    gpgkey node['splunk_otel_collector']['rhel_gpg_key_url']
+    type 'yum'
+    enabled true
+    action :create
+    notifies :run, 'execute[add-rhel-key]', :immediately
+  end
+
 end
 
 execute 'add-rhel-key' do

--- a/deployments/chef/recipes/default.rb
+++ b/deployments/chef/recipes/default.rb
@@ -56,7 +56,7 @@ elsif platform_family?('debian', 'rhel', 'amazon', 'suse')
   end
 
   # Packages should already be installed for local artifact testing
-  if !node['splunk_otel_collector']['local_artifact_testing_enabled']
+  unless node['splunk_otel_collector']['local_artifact_testing_enabled']
     package 'splunk-otel-collector' do
       action :install
       version node['splunk_otel_collector']['collector_version'] if node['splunk_otel_collector']['collector_version'] != 'latest'

--- a/deployments/chef/recipes/default.rb
+++ b/deployments/chef/recipes/default.rb
@@ -55,7 +55,7 @@ elsif platform_family?('debian', 'rhel', 'amazon', 'suse')
     include_recipe 'splunk_otel_collector::collector_zypper_repo'
   end
 
-  # Packages should already be installed for local artifact testing
+  # splunk-otel-collector package should already be installed for local artifact testing
   unless node['splunk_otel_collector']['local_artifact_testing_enabled']
     package 'splunk-otel-collector' do
       action :install

--- a/deployments/chef/recipes/default.rb
+++ b/deployments/chef/recipes/default.rb
@@ -55,16 +55,19 @@ elsif platform_family?('debian', 'rhel', 'amazon', 'suse')
     include_recipe 'splunk_otel_collector::collector_zypper_repo'
   end
 
-  package 'splunk-otel-collector' do
-    action :install
-    version node['splunk_otel_collector']['collector_version'] if node['splunk_otel_collector']['collector_version'] != 'latest'
-    flush_cache [ :before ] if platform_family?('amazon', 'rhel')
-    options '--allow-downgrades' if platform_family?('debian') \
-      && node['packages'] \
-      && node['packages']['apt'] \
-      && Gem::Version.new(node['packages']['apt']['version'].split('~').first) >= Gem::Version.new('1.1.0')
-    allow_downgrade true if platform_family?('amazon', 'rhel', 'suse')
-    notifies :restart, 'service[splunk-otel-collector]', :delayed
+  # Packages should already be installed for local artifact testing
+  if not node['splunk_otel_collector']['local_artifact_testing_enabled']
+    package 'splunk-otel-collector' do
+      action :install
+      version node['splunk_otel_collector']['collector_version'] if node['splunk_otel_collector']['collector_version'] != 'latest'
+      flush_cache [ :before ] if platform_family?('amazon', 'rhel')
+      options '--allow-downgrades' if platform_family?('debian') \
+        && node['packages'] \
+        && node['packages']['apt'] \
+        && Gem::Version.new(node['packages']['apt']['version'].split('~').first) >= Gem::Version.new('1.1.0')
+      allow_downgrade true if platform_family?('amazon', 'rhel', 'suse')
+      notifies :restart, 'service[splunk-otel-collector]', :delayed
+    end
   end
 
   include_recipe 'splunk_otel_collector::collector_service_owner'

--- a/deployments/chef/recipes/default.rb
+++ b/deployments/chef/recipes/default.rb
@@ -56,7 +56,7 @@ elsif platform_family?('debian', 'rhel', 'amazon', 'suse')
   end
 
   # Packages should already be installed for local artifact testing
-  if not node['splunk_otel_collector']['local_artifact_testing_enabled']
+  if !node['splunk_otel_collector']['local_artifact_testing_enabled']
     package 'splunk-otel-collector' do
       action :install
       version node['splunk_otel_collector']['collector_version'] if node['splunk_otel_collector']['collector_version'] != 'latest'


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Same idea as https://github.com/signalfx/splunk-otel-collector/pull/6284, updating Chef tests to run against locally built artifacts.

- Introduced a new variable `local_artifact_testing_enabled` that will install the collector from a local artifact when set to true.
- Added workflow build functionality is all copied from other workflows. Once https://github.com/signalfx/splunk-otel-collector/pull/6329 is merged we can reuse the reusable workflows.