### PR TITLE
[chore][docs] Add document providing Fluentd deprecation directions

### DIFF
--- a/docs/deprecations/fluentd-support.md
+++ b/docs/deprecations/fluentd-support.md
@@ -1,0 +1,10 @@
+# Fluentd support deprecation
+
+Fluentd support has been deprecated and will be removed in a future release.
+
+## Replacement guidance
+
+Please use native OTel Collector receivers instead. A common replacement for Fluentd's functionality is the
+[filelog receiver](https://help.splunk.com/en/splunk-observability-cloud/manage-data/available-data-sources/supported-integrations-in-splunk-observability-cloud/opentelemetry-receivers/filelog-receiver).
+Many common configuration examples of the filelog receiver can be found in the [logs_config_linux.yaml](https://github.com/signalfx/splunk-otel-collector/blob/87bee7ae45b08be8d143a758d0f7004fd92d8f60/cmd/otelcol/config/collector/logs_config_linux.yaml)
+file.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Pre-requisite to #6339. This document will be used as a reference for all Fluentd deprecation messages. #6339 is blocked by broken link messages in check-links and Salt tests.