### PR TITLE
[chore][codecov] Implicitly pass secret to reusable workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -88,6 +88,7 @@ jobs:
     with:
       OS: ${{ matrix.OS }}
       COVERAGE: true
+    secrets: inherit
 
   coverage:
     name: coverage


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
From directions in [documentation](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow), reusable workflows can share secrets implicitly in the same organization by using `secrets: inherit`.