### PR TITLE
[chore][CICD] Fix broken Ansible workflow

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -35,7 +35,7 @@ jobs:
   cross-compile:
     strategy:
       matrix:
-        SYS_BINARIES: [ "binaries-linux_amd64", "binaries-linux_arm64", "binaries-linux_ppc64le" ]
+        SYS_BINARIES: [ "binaries-linux_amd64", "binaries-linux_arm64", "binaries-linux_ppc64le", "binaries-windows_amd64"]
     uses: ./.github/workflows/compile.yml
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
@@ -63,7 +63,6 @@ jobs:
 
   agent-bundle-windows:
     needs: lint
-    runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
         OS: [ "windows-2025" ]
@@ -212,7 +211,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: msi-build
+          name: msi-build-windows-2025
           path: /tmp/msi-build
 
       - name: Install vagrant and virtualbox


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
I believe this was broken by https://github.com/signalfx/splunk-otel-collector/pull/6329 ([failure example](https://github.com/signalfx/splunk-otel-collector/actions/runs/15834169378)), since the workflow wasn't formatted properly it didn't show up in the PR as failed, you have to go to actions to see the faiilure.

1. Compile a windows AMD64 image
2. Can only have one of: `runs-on` or `uses`
3. Download properly named msi package