### PR TITLE
Updates TA to splunk-otel-collector v0.128.0 and marks TA as v1.4.3

### DIFF
--- a/packaging/technical-addon/Makefile
+++ b/packaging/technical-addon/Makefile
@@ -3,7 +3,7 @@ THIS_MAKEFILE_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 include $(abspath $(THIS_MAKEFILE_DIR)/../../Makefile.Common)
 
 # Used for packaging
-OTEL_COLLECTOR_VERSION?=0.122.0
+OTEL_COLLECTOR_VERSION?=0.128.0
 SPLUNK_OTELCOL_DOWNLOAD_BASE?=https://github.com/signalfx/splunk-otel-collector/releases/download
 PLATFORM?=linux
 ARCH?=amd64

--- a/packaging/technical-addon/Splunk_TA_otel/default/app.conf
+++ b/packaging/technical-addon/Splunk_TA_otel/default/app.conf
@@ -18,11 +18,11 @@ label = Splunk Add-on for OpenTelemetry Agent
 [launcher]
 author = Splunk, Inc.
 description = Splunk Add-on for OpenTelemetry is used to easily deploy OpenTelemetry Agent alongside Splunk Universal Forwarder to collect traces and metrics
-version = 1.4.2
+version = 1.4.3
 
 [package]
 id = Splunk_TA_otel
 
 [id]
 name = Splunk_TA_otel
-version = 1.4.2
+version = 1.4.3


### PR DESCRIPTION
Did not see any relevant changes to the changelog.md TA configuration

This release reduces the number of utilities required on the system to run the TA script