### PR TITLE
[windows installer script] Mark Fluentd support as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### 🚩 Deprecations 🚩
+
+- (Splunk) `Windows installer script`: Fluentd support has been deprecated and will be removed in a future release. ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
+  Please refer to [deprecation documentation](https://github.com/signalfx/splunk-otel-collector/blob/main/docs/deprecations/fluentd-support.md) for more information.
+
 ## v0.127.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.127.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.127.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🚩 Deprecations 🚩
 
-- (Splunk) `Windows installer script`: Fluentd support has been deprecated and will be removed in a future release. ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
+- (Splunk) `Windows installer script`: Fluentd support has been deprecated and will be removed in a future release. ([#6362](https://github.com/signalfx/splunk-otel-collector/pull/6362))
   Please refer to [deprecation documentation](https://github.com/signalfx/splunk-otel-collector/blob/main/docs/deprecations/fluentd-support.md) for more information.
 
 ## v0.127.0

--- a/packaging/installer/install.ps1
+++ b/packaging/installer/install.ps1
@@ -61,6 +61,7 @@
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -hec_token "HECTOKEN"
 .PARAMETER with_fluentd
+    DEPRECATED: Fluentd support has been deprecated and will be removed in a future release. Please refer to documentation for more information: https://github.com/signalfx/splunk-otel-collector/blob/main/docs/deprecations/fluentd-support.md
     (OPTIONAL) Whether to install and configure fluentd to forward log events to the collector (default: $false)
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -with_fluentd $true
@@ -683,6 +684,7 @@ following PowerShell commands:
 echo "$message"
 
 if ($with_fluentd) {
+    Write-Warning '[DEPRECATED] Fluentd support has been deprecated and will be removed in a future release. Please refer to documentation for more information: https://github.com/signalfx/splunk-otel-collector/blob/main/docs/deprecations/fluentd-support.md'
     $default_fluentd_config = "$installation_path\fluentd\td-agent.conf"
     $default_confd_dir = "$installation_path\fluentd\conf.d"
 


### PR DESCRIPTION
**Description:**
Follow up to https://github.com/signalfx/splunk-otel-collector/pull/6264, for the Windows installer script this time.

**Testing:** <Describe what testing was performed and which tests were added.>
```
> Get-Help .\packaging\installer\install.ps1 -detailed
...
    -with_fluentd <Boolean>
        DEPRECATED: Fluentd support has been deprecated and will be removed in a future release.
        Please refer to documentation for more information: https://github.com/signalfx/splunk-ot
        el-collector/blob/main/docs/deprecations/fluentd-support.md
        (OPTIONAL) Whether to install and configure fluentd to forward log events to the
        collector (default: $false)
> .\packaging\installer\install.ps1 -with_fluentd $True
...
WARNING: [DEPRECATED] Fluentd support has been deprecated and will be removed in a future release.
 Please refer to documentation for more information:
https://github.com/signalfx/splunk-otel-collector/blob/main/docs/deprecations/fluentd-support.md
```