### PR TITLE
[chore][CICD] Add GitHub action linter

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -7,47 +7,65 @@ self-hosted-runner:
 
 # Path-specific configurations.
 paths:
-  # All Windows Paths should ignore errors related to PowerShell formatting.
-  # Linter shellcheck is not supported for PowerShell
-  .github/workflows/**/*win*.{yml,yaml}:
-    ignore:
-      # Ignore the specific error from shellcheck
-      - 'shellcheck reported issue in this script: SC1001:.+'
-      - 'shellcheck reported issue in this script: SC1009:.+'
-      - 'shellcheck reported issue in this script: SC1012:.+'
-      - 'shellcheck reported issue in this script: SC1050:.+'
-      - 'shellcheck reported issue in this script: SC1070:.+'
-      - 'shellcheck reported issue in this script: SC1072:.+'
-      - 'shellcheck reported issue in this script: SC1073:.+'
-      - 'shellcheck reported issue in this script: SC1087:.+'
-      - 'shellcheck reported issue in this script: SC1133:.+'
-      - 'shellcheck reported issue in this script: SC2006:.+'
-      - 'shellcheck reported issue in this script: SC2046:.+'
-      - 'shellcheck reported issue in this script: SC2086:.+'
-      - 'shellcheck reported issue in this script: SC2283:.+'
-
-  .github/workflows/**/*msi*.{yml,yaml}:
-    ignore:
-      # Ignore the specific error from shellcheck
-      - 'shellcheck reported issue in this script: SC1001:.+'
-      - 'shellcheck reported issue in this script: SC1009:.+'
-      - 'shellcheck reported issue in this script: SC1012:.+'
-      - 'shellcheck reported issue in this script: SC1050:.+'
-      - 'shellcheck reported issue in this script: SC1070:.+'
-      - 'shellcheck reported issue in this script: SC1072:.+'
-      - 'shellcheck reported issue in this script: SC1073:.+'
-      - 'shellcheck reported issue in this script: SC1087:.+'
-      - 'shellcheck reported issue in this script: SC1133:.+'
-      - 'shellcheck reported issue in this script: SC2006:.+'
-      - 'shellcheck reported issue in this script: SC2046:.+'
-      - 'shellcheck reported issue in this script: SC2086:.+'
-      - 'shellcheck reported issue in this script: SC2283:.+'
-
   # Configs are meant to be workflow helpers, not valid GitHub actions. Ignore all errors
   # from these files.
   .github/workflows/configs/**:
     ignore:
       - '.*'
+
+  # Ignore these notifications/errors for all workflows
+  .github/workflows/*.{yml,yaml}:
+    ignore:
+      - 'index access of array must be type of number but.*' # Caused by taking advantage of GitHub's automatic conversion of bools to integers in for array indexing
+
+  # All Windows Paths should ignore errors related to PowerShell formatting.
+  # Linter shellcheck is not supported for PowerShell
+  .github/workflows/**/*win*.{yml,yaml}:
+    ignore:
+      - 'shellcheck reported issue in this script: SC1001:.+'
+      - 'shellcheck reported issue in this script: SC1009:.+'
+      - 'shellcheck reported issue in this script: SC1012:.+'
+      - 'shellcheck reported issue in this script: SC1050:.+'
+      - 'shellcheck reported issue in this script: SC1070:.+'
+      - 'shellcheck reported issue in this script: SC1072:.+'
+      - 'shellcheck reported issue in this script: SC1073:.+'
+      - 'shellcheck reported issue in this script: SC1087:.+'
+      - 'shellcheck reported issue in this script: SC1133:.+'
+      - 'shellcheck reported issue in this script: SC2006:.+'
+      - 'shellcheck reported issue in this script: SC2046:.+'
+      - 'shellcheck reported issue in this script: SC2086:.+'
+      - 'shellcheck reported issue in this script: SC2283:.+'
+
+  # PowerShell lint messages need to be ignored
+  .github/workflows/**/*msi*.{yml,yaml}:
+    ignore:
+      - 'shellcheck reported issue in this script: SC1001:.+'
+      - 'shellcheck reported issue in this script: SC1009:.+'
+      - 'shellcheck reported issue in this script: SC1012:.+'
+      - 'shellcheck reported issue in this script: SC1050:.+'
+      - 'shellcheck reported issue in this script: SC1070:.+'
+      - 'shellcheck reported issue in this script: SC1072:.+'
+      - 'shellcheck reported issue in this script: SC1073:.+'
+      - 'shellcheck reported issue in this script: SC1087:.+'
+      - 'shellcheck reported issue in this script: SC1133:.+'
+      - 'shellcheck reported issue in this script: SC2006:.+'
+      - 'shellcheck reported issue in this script: SC2046:.+'
+      - 'shellcheck reported issue in this script: SC2086:.+'
+      - 'shellcheck reported issue in this script: SC2283:.+'
+
+  # PowerShell lint messages need to be ignored
+  .github/workflows/chef-test.yml:
+    ignore:
+      - 'shellcheck reported issue in this script: SC1081:.+'
+      - 'shellcheck reported issue in this script: SC2086:.+'
+
+  # PowerShell lint messages need to be ignored
+
+  .github/workflows/puppet-test.yml:
+    ignore:
+      - 'shellcheck reported issue in this script: SC1050:.+'
+      - 'shellcheck reported issue in this script: SC1072:.+'
+      - 'shellcheck reported issue in this script: SC1073:.+'
 
   # PowerShell lint messages need to be ignored
   .github/workflows/vuln-scans.yml:
@@ -55,15 +73,3 @@ paths:
       - 'shellcheck reported issue in this script: SC1050:.+'
       - 'shellcheck reported issue in this script: SC1072:.+'
       - 'shellcheck reported issue in this script: SC1073:.+'
-
-  # Ignore PowerShell related issues
-  .github/workflows/puppet-test.yml:
-    ignore:
-      - 'shellcheck reported issue in this script: SC1050:.+'
-      - 'shellcheck reported issue in this script: SC1072:.+'
-      - 'shellcheck reported issue in this script: SC1073:.+'
-
-  # Ignore these notifications/errors for all workflows
-  .github/workflows/*.{yml,yaml}:
-    ignore:
-      - 'index access of array must be type of number but.*' # Caused by taking advantage of GitHub's automatic conversion of bools to integers in for array indexing

--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,69 @@
+# Configuration related to self-hosted runner.
+self-hosted-runner:
+  # Labels of self-hosted runner in array of strings.
+  labels:
+    - otel-arm64
+    - otel-windows
+
+# Path-specific configurations.
+paths:
+  # All Windows Paths should ignore errors related to PowerShell formatting.
+  # Linter shellcheck is not supported for PowerShell
+  .github/workflows/**/*win*.{yml,yaml}:
+    ignore:
+      # Ignore the specific error from shellcheck
+      - 'shellcheck reported issue in this script: SC1001:.+'
+      - 'shellcheck reported issue in this script: SC1009:.+'
+      - 'shellcheck reported issue in this script: SC1012:.+'
+      - 'shellcheck reported issue in this script: SC1050:.+'
+      - 'shellcheck reported issue in this script: SC1070:.+'
+      - 'shellcheck reported issue in this script: SC1072:.+'
+      - 'shellcheck reported issue in this script: SC1073:.+'
+      - 'shellcheck reported issue in this script: SC1087:.+'
+      - 'shellcheck reported issue in this script: SC1133:.+'
+      - 'shellcheck reported issue in this script: SC2006:.+'
+      - 'shellcheck reported issue in this script: SC2046:.+'
+      - 'shellcheck reported issue in this script: SC2086:.+'
+      - 'shellcheck reported issue in this script: SC2283:.+'
+
+  .github/workflows/**/*msi*.{yml,yaml}:
+    ignore:
+      # Ignore the specific error from shellcheck
+      - 'shellcheck reported issue in this script: SC1001:.+'
+      - 'shellcheck reported issue in this script: SC1009:.+'
+      - 'shellcheck reported issue in this script: SC1012:.+'
+      - 'shellcheck reported issue in this script: SC1050:.+'
+      - 'shellcheck reported issue in this script: SC1070:.+'
+      - 'shellcheck reported issue in this script: SC1072:.+'
+      - 'shellcheck reported issue in this script: SC1073:.+'
+      - 'shellcheck reported issue in this script: SC1087:.+'
+      - 'shellcheck reported issue in this script: SC1133:.+'
+      - 'shellcheck reported issue in this script: SC2006:.+'
+      - 'shellcheck reported issue in this script: SC2046:.+'
+      - 'shellcheck reported issue in this script: SC2086:.+'
+      - 'shellcheck reported issue in this script: SC2283:.+'
+
+  # Configs are meant to be workflow helpers, not valid GitHub actions. Ignore all errors
+  # from these files.
+  .github/workflows/configs/**:
+    ignore:
+      - '.*'
+
+  # PowerShell lint messages need to be ignored
+  .github/workflows/vuln-scans.yml:
+    ignore:
+      - 'shellcheck reported issue in this script: SC1050:.+'
+      - 'shellcheck reported issue in this script: SC1072:.+'
+      - 'shellcheck reported issue in this script: SC1073:.+'
+
+  # Ignore PowerShell related issues
+  .github/workflows/puppet-test.yml:
+    ignore:
+      - 'shellcheck reported issue in this script: SC1050:.+'
+      - 'shellcheck reported issue in this script: SC1072:.+'
+      - 'shellcheck reported issue in this script: SC1073:.+'
+
+  # Ignore these notifications/errors for all workflows
+  .github/workflows/*.{yml,yaml}:
+    ignore:
+      - 'index access of array must be type of number but.*' # Caused by taking advantage of GitHub's automatic conversion of bools to integers in for array indexing

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -165,7 +165,7 @@ jobs:
           # workaround for https://github.com/yaml/pyyaml/issues/724
           pip3 install 'wheel==0.40.0'
           pip3 install 'Cython<3.0' 'PyYaml~=5.0' --no-build-isolation
-          pip3 install --use-pep517 -r ${GITHUB_WORKSPACE}/requirements.txt
+          pip3 install --use-pep517 -r "${GITHUB_WORKSPACE}/requirements.txt"
 
       - name: Run Molecule tests.
         run: molecule --debug -v --base-config ./molecule/config/docker.yml test --all

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -240,16 +240,16 @@ jobs:
           cache-dependency-path: "${{ github.workspace }}/requirements.txt"
 
       - name: Install test dependencies.
-        run: pip3 install --use-pep517 -r ${GITHUB_WORKSPACE}/requirements.txt
+        run: pip3 install --use-pep517 -r "${GITHUB_WORKSPACE}/requirements.txt"
 
       - name: Download vagrant box
         run: |
           box=$( yq ".platforms[] | select(.name == \"${{ matrix.distro }}\") | .box" ./molecule/config/windows.yml )
           box_version=$( yq ".platforms[] | select(.name == \"${{ matrix.distro }}\") | .box_version" ./molecule/config/windows.yml )
           eval "box_version=${box_version}"
-          json=$( wget -nv -O- https://vagrantcloud.com/api/v2/vagrant/${box} )
+          json=$( wget -nv -O- "https://vagrantcloud.com/api/v2/vagrant/${box}" )
           url=$( echo "$json" | jq -r ".versions[] | select(.version == \"${box_version}\") | .providers[] | select(.name == \"virtualbox\") | .url" )
-          wget -nv -O /tmp/vagrant.box $url
+          wget -nv -O /tmp/vagrant.box "$url"
 
       - name: Clean VirtualBox cache
         run: |

--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -80,7 +80,7 @@ jobs:
           exclude='{"ARCH": "arm64", "TESTCASE": "dotnet"}'
           matrix="{\"DISTRO\": [${distro%,}], \"ARCH\": [${arch}], \"TESTCASE\": [${testcase}], \"exclude\": [${exclude}]}"
           echo "$matrix" | jq
-          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
 
@@ -99,7 +99,7 @@ jobs:
         run: |
           for pkg in "deb" "rpm"; do
             if [[ -f "packaging/tests/instrumentation/images/${pkg}/Dockerfile.${{ matrix.DISTRO }}" ]]; then
-              echo "SYS_PACKAGE=${pkg}" >> $GITHUB_ENV
+              echo "SYS_PACKAGE=${pkg}" >> "$GITHUB_ENV"
               exit 0
             fi
           done

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,6 +78,18 @@ jobs:
         run: |
           make for-all CMD="make lint"
 
+  actionlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/03d0035/scripts/download-actionlint.bash) # v1.7.7
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash
+
   test:
     name: unit-test
     strategy:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-environment
 
-      - run: echo "GOLANGCI_LINT_CACHE=${HOME}/.cache/golangci-lint" >> $GITHUB_ENV
+      - run: echo "GOLANGCI_LINT_CACHE=${HOME}/.cache/golangci-lint" >> "$GITHUB_ENV"
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -255,7 +255,7 @@ jobs:
             echo "Failed to get platforms from kitchen.yml!" >&2
             exit 1
           fi
-          echo "matrix={'DISTRO': [${distros}]}" >> $GITHUB_OUTPUT
+          echo "matrix={'DISTRO': [${distros}]}" >> "$GITHUB_OUTPUT"
 
       - name: Get windows distros and suites
         id: get-win-matrix
@@ -270,7 +270,7 @@ jobs:
             echo "Failed to get suites from kitchen.windows.yml!" >&2
             exit 1
           fi
-          echo "matrix={'DISTRO': [${distros}], 'SUITE': [${suites}]}" >> $GITHUB_OUTPUT
+          echo "matrix={'DISTRO': [${distros}], 'SUITE': [${suites}]}" >> "$GITHUB_OUTPUT"
     outputs:
       linux-matrix: ${{ steps.get-linux-matrix.outputs.matrix }}
       win-matrix: ${{ steps.get-win-matrix.outputs.matrix }}
@@ -302,9 +302,9 @@ jobs:
         run: |
           mkdir -p files
           deb_path=$(find /tmp/deb-amd64-package/splunk-otel-collector*amd64.deb)
-          mv $deb_path ./files/soc.deb
+          mv "$deb_path" ./files/soc.deb
           rpm_path=$(find /tmp/rpm-amd64-package/splunk-otel-collector*x86_64.rpm)
-          mv $rpm_path ./files/soc.rpm
+          mv "$rpm_path" ./files/soc.rpm
 
       - name: Install chef
         uses: actionshub/chef-install@3.0.1
@@ -351,8 +351,8 @@ jobs:
       - name: Extract artifacts
         run: |
           mkdir files
-          Get-ChildItem /tmp -Recurse -Include 'splunk-otel-collector*.msi' | Select FullName -OutVariable msiPath
-          mv $msiPath.FullName ./files/splunk-otel-collector.msi
+          Get-ChildItem /tmp -Recurse -Include 'splunk-otel-collector*.msi' | "Select FullName -OutVariable msiPath"
+          mv "$msiPath.FullName" ./files/splunk-otel-collector.msi
 
       - name: Install chef
         uses: actionshub/chef-install@3.0.1

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -351,8 +351,8 @@ jobs:
       - name: Extract artifacts
         run: |
           mkdir files
-          Get-ChildItem /tmp -Recurse -Include 'splunk-otel-collector*.msi' | "Select FullName -OutVariable msiPath"
-          mv "$msiPath.FullName" ./files/splunk-otel-collector.msi
+          Get-ChildItem /tmp -Recurse -Include 'splunk-otel-collector*.msi' | Select FullName -OutVariable msiPath
+          mv $msiPath.FullName ./files/splunk-otel-collector.msi
 
       - name: Install chef
         uses: actionshub/chef-install@3.0.1

--- a/.github/workflows/chef.yml
+++ b/.github/workflows/chef.yml
@@ -31,7 +31,7 @@ jobs:
             echo "Failed to get version from deployments/chef/metadata.rb"
             exit 1
           fi
-          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Push new release tag if it doesn't exist
         uses: actions/github-script@v7

--- a/.github/workflows/cleanup-closed-pr.yml
+++ b/.github/workflows/cleanup-closed-pr.yml
@@ -27,7 +27,7 @@ jobs:
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR
           do
-              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+              gh actions-cache delete "$cacheKey" -R $REPO -B $BRANCH --confirm
           done
           echo "Done"
         env:

--- a/.github/workflows/dotnet-instr-deployer-add-on.yml
+++ b/.github/workflows/dotnet-instr-deployer-add-on.yml
@@ -102,7 +102,7 @@ jobs:
         id: read-app-conf
         run: |
           version=$(grep -oP '^version = \K.*' packaging/dotnet-instr-deployer-add-on/assets/default/app.conf)
-          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Ensure version is read from app.conf
         if: steps.read-app-conf.outputs.version == ''

--- a/.github/workflows/installer-script-test.yml
+++ b/.github/workflows/installer-script-test.yml
@@ -30,7 +30,7 @@ jobs:
         id: get-matrix
         run: |
           # create test matrix for distro images and archs
-          dockerfiles=$(ls packaging/tests/images/deb/Dockerfile.* packaging/tests/images/rpm/Dockerfile.* | cut -d '.' -f2- | sort -u)
+          dockerfiles=$(find packaging/tests/images/deb/Dockerfile.* packaging/tests/images/rpm/Dockerfile.* | cut -d '.' -f2- | sort -u)
           if [ -z "$dockerfiles" ]; then
             echo "Failed to get dockerfiles from packaging/tests/images!" >&2
             exit 1
@@ -40,7 +40,7 @@ jobs:
           instrumentation='"none","preload","systemd"'
           matrix="{\"DISTRO\": [${distro%,}], \"ARCH\": [${arch}], \"INSTRUMENTATION\": [${instrumentation}]}"
           echo "$matrix" | jq
-          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -160,7 +160,7 @@ jobs:
           for image in $images; do
             service=$(basename "$image" | cut -d ':' -f1)
             if [[ -f docker/${service}/Dockerfile ]]; then
-              docker build --cache-from=quay.io/splunko11ytest/${service}:latest -t quay.io/splunko11ytest/${service}:latest docker/${service}
+              docker build --cache-from="quay.io/splunko11ytest/${service}:latest" -t "quay.io/splunko11ytest/${service}:latest" "docker/${service}"
             fi
           done
           docker system prune -f
@@ -207,11 +207,12 @@ jobs:
           if [[ "${{ matrix.PROFILE }}" = "smartagent" ]]; then
             target="smartagent-integration-test-with-cover"
           fi
-          export CONTAINER_COVER_SRC="$(realpath .)/tests/coverage"
-          make $target 2>&1 | tee $TEST_OUTPUT
+          CONTAINER_COVER_SRC="$(realpath .)/tests/coverage"
+          export CONTAINER_COVER_SRC
+          make $target 2>&1 | tee "$TEST_OUTPUT"
           exit_status=${PIPESTATUS[0]}
           echo "Exit status: $exit_status"
-          exit $exit_status
+          exit "$exit_status"
         env:
           CONTAINER_COVER_DEST: '/etc/otel/collector/coverage'
           SPLUNK_OTEL_COLLECTOR_IMAGE: 'otelcol:latest'
@@ -253,7 +254,7 @@ jobs:
           for image in $images; do
             service=$(basename "$image" | cut -d ':' -f1)
             if [[ -f docker/${service}/Dockerfile ]]; then
-              docker build --cache-from=quay.io/splunko11ytest/${service}:latest -t quay.io/splunko11ytest/${service}:latest docker/${service}
+              docker build --cache-from="quay.io/splunko11ytest/${service}:latest" -t "quay.io/splunko11ytest/${service}:latest" "docker/${service}"
             fi
           done
           docker system prune -f
@@ -271,7 +272,7 @@ jobs:
           path: ./dist
       - run: sudo mkdir -p /usr/lib/splunk-otel-collector
       - run: sudo tar -xzf dist/agent-bundle_linux_amd64.tar.gz -C /usr/lib/splunk-otel-collector
-      - run: sudo chown -R $USER /usr/lib/splunk-otel-collector
+      - run: sudo chown -R "$USER" /usr/lib/splunk-otel-collector
       - run: /usr/lib/splunk-otel-collector/agent-bundle/bin/patch-interpreter /usr/lib/splunk-otel-collector/agent-bundle
       - uses: actions/download-artifact@v4
         with:
@@ -295,11 +296,12 @@ jobs:
           if [[ "${{ matrix.PROFILE }}" = "smartagent" ]]; then
             target="smartagent-integration-test-with-cover"
           fi
-          export CONTAINER_COVER_SRC="$(realpath .)/tests/coverage"
-          make $target 2>&1 | tee $TEST_OUTPUT
+          CONTAINER_COVER_SRC="$(realpath .)/tests/coverage"
+          export CONTAINER_COVER_SRC
+          make $target 2>&1 | tee "$TEST_OUTPUT"
           exit_status=${PIPESTATUS[0]}
           echo "Exit status: $exit_status"
-          exit $exit_status
+          exit "$exit_status"
         env:
           CONTAINER_COVER_DEST: '/etc/otel/collector/coverage'
           SPLUNK_OTEL_COLLECTOR_IMAGE: ""
@@ -342,7 +344,7 @@ jobs:
           done
           matrix="{\"include\": [${includes#,}]}"
           echo "$matrix" | jq
-          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
 
   integration-test-discovery:
       name: integration-test-discovery
@@ -375,7 +377,8 @@ jobs:
         - run: chmod a+x ./bin/*
         - name: Run ${{ matrix.SERVICE }} Discovery Integration Test With Cover
           run: |
-            export CONTAINER_COVER_SRC="$(realpath .)/tests/coverage"
+            CONTAINER_COVER_SRC="$(realpath .)/tests/coverage"
+            export CONTAINER_COVER_SRC
             make integration-test-${{ matrix.SERVICE }}-discovery-with-cover
           env:
             CONTAINER_COVER_DEST: '/etc/otel/collector/coverage'
@@ -404,7 +407,7 @@ jobs:
           done
           matrix="{\"include\": [${includes#,}]}"
           echo "$matrix" | jq
-          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
 
   integration-test-discovery-k8s:
     name: integration-test-discovery-k8s
@@ -447,7 +450,8 @@ jobs:
           kind load docker-image otelcol:latest --name kind
       - name: Run ${{ matrix.SERVICE }} Discovery Kubernetes Integration Test With Cover
         run: |
-          export CONTAINER_COVER_SRC="$(realpath .)/tests/coverage"
+          CONTAINER_COVER_SRC="$(realpath .)/tests/coverage"
+          export CONTAINER_COVER_SRC
           KUBECONFIG=$HOME/.kube/config SKIP_TEARDOWN=true make integration-test-${{ matrix.SERVICE }}-discovery-k8s-with-cover
         env:
           CONTAINER_COVER_DEST: '/etc/otel/collector/coverage'
@@ -455,7 +459,7 @@ jobs:
         if: failure()
         run: |
           kubectl get pods -A 
-          kubectl get pod -A -l app=otelcol -o jsonpath="{range .items[*]}{.metadata.namespace} {.metadata.name}{'\n'}{end}" | xargs -r -n2 sh -c 'kubectl logs -n $0 $1'
+          kubectl get pod -A -l app=otelcol -o jsonpath="{range .items[*]}{.metadata.namespace} {.metadata.name}{'\n'}{end}" | xargs -r -n2 sh -c "kubectl logs -n $0 $1"
       - name: Upload coverage report
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # 5.4.3
         with:

--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Lint
         run: |
           make install-tools
+          shopt -s globstar nullglob
           for gomod in examples/**/go.mod; do
             dir=$(dirname "$gomod")
             pushd "$dir" >/dev/null

--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Lint
         run: |
           make install-tools
-          for gomod in $(find examples -name "go.mod"); do
-            dir=$(dirname $gomod)
-            pushd $dir >/dev/null
+          for gomod in examples/**/go.mod; do
+            dir=$(dirname "$gomod")
+            pushd "$dir" >/dev/null
             echo "Running 'make lint' in $dir ..."
             make lint
             popd >/dev/null

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -73,7 +73,7 @@ jobs:
           arch="\"amd64\", \"arm64\""
           matrix="{\"DISTRO\": [${distro%,}], \"ARCH\": [${arch}]}"
           echo "$matrix" | jq
-          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
 
@@ -92,7 +92,7 @@ jobs:
         run: |
           for pkg in "deb" "rpm" "tar"; do
             if [[ -f "packaging/tests/images/${pkg}/Dockerfile.${{ matrix.DISTRO }}" ]]; then
-              echo "SYS_PACKAGE=${pkg}" >> $GITHUB_ENV
+              echo "SYS_PACKAGE=${pkg}" >> "$GITHUB_ENV"
               exit 0
             fi
           done
@@ -264,18 +264,18 @@ jobs:
 
           # get all provided config files from the container
           tmpdir=$(mktemp -d)
-          docker cp otelcol:/etc/otel/collector $tmpdir
+          docker cp otelcol:/etc/otel/collector "$tmpdir"
           docker rm -f otelcol
 
           # ensure the collector can start with all provided config files
-          configs=$(ls ${tmpdir}/collector/ 2>/dev/null)
+          configs=$(ls "${tmpdir}/collector/" 2>/dev/null)
           if [ -z "$configs" ]; then
             echo "failed to get config files from otelcol:/etc/otel/collector"
             exit 1
           fi
           for config in $configs; do
             # TODO: set fake-token back to 12345 once https://github.com/open-telemetry/opentelemetry-collector/issues/10937 is resolved
-            docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_CONFIG=/etc/otel/collector/${config} -e SPLUNK_ACCESS_TOKEN=fake-token -e SPLUNK_REALM=fake-realm -e ECS_CONTAINER_METADATA_URI_V4=http://localhost --name otelcol otelcol:latest
+            docker run --platform linux/${{ matrix.ARCH }} -d -e SPLUNK_CONFIG="/etc/otel/collector/${config}" -e SPLUNK_ACCESS_TOKEN=fake-token -e SPLUNK_REALM=fake-realm -e ECS_CONTAINER_METADATA_URI_V4=http://localhost --name otelcol otelcol:latest
             sleep 10
             if [ -z "$( docker ps --filter=status=running --filter=name=otelcol -q )" ]; then
               docker logs otelcol

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install Nomad Service.
         run: |
-          sudo echo "
+          echo "
           [Unit]
           Description=Nomad
           Documentation=https://www.nomadproject.io/docs/
@@ -69,14 +69,14 @@ jobs:
 
           [Install]
           WantedBy=multi-user.target
-          " >> nomad.service
+          " | sudo tee -a nomad.service
           
           sudo mv nomad.service /etc/systemd/system/nomad.service
           sudo systemctl enable nomad
 
       - name: Install Consul Service.
         run: |
-          sudo echo "
+          echo "
           [Unit]
           Description=Consul
           Documentation=https://www.consul.io/docs
@@ -84,7 +84,7 @@ jobs:
           After=network-online.target
 
           [Service]
-          Environment="HOME=/tmp"
+          Environment=\"HOME=/tmp\"
           ExecReload=/bin/kill -HUP $MAINPID
           ExecStart=/usr/bin/consul agent -dev
           KillMode=process
@@ -99,7 +99,7 @@ jobs:
 
           [Install]
           WantedBy=multi-user.target
-          " >> consul.service
+          " | sudo tee -a consul.service
           sudo mv consul.service /etc/systemd/system/consul.service
           sudo systemctl enable consul
       - name: Start Nomad and Consul
@@ -109,16 +109,16 @@ jobs:
           sudo systemctl start nomad
           sudo systemctl status nomad
           a=0
-          while [ "$a" -lt 10 ];
+          while [ $a -lt 10 ];
           do
-            if [ $(sudo systemctl is-active consul.service) == "active" -a $(sudo systemctl is-active nomad.service) == "active" ];
+            if [ "$(sudo systemctl is-active consul.service)" == "active" ] && [ "$(sudo systemctl is-active nomad.service)" == "active" ];
             then 
               echo "Consul and nomad services are running.";
               break;
             else 
               sleep 10;
             fi
-            a=`expr $a + 1`
+            ((a++))
           done
           if [ "$a" -eq 10 ];
           then

--- a/.github/workflows/otelcol-fips.yml
+++ b/.github/workflows/otelcol-fips.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Ensure the collector container can run with all included configs
         run: |
           for config in cmd/otelcol/fips/config/*.yaml; do
-            docker run -d --name otelcol-fips -e SPLUNK_ACCESS_TOKEN=fake-token -e SPLUNK_REALM=fake-realm -e SPLUNK_CONFIG="/etc/otel/collector/$(basename "$config") otelcol-fips:${{ matrix.ARCH }}"
+            docker run -d --name otelcol-fips -e SPLUNK_ACCESS_TOKEN=fake-token -e SPLUNK_REALM=fake-realm -e SPLUNK_CONFIG="/etc/otel/collector/$(basename "$config")" otelcol-fips:${{ matrix.ARCH }}
             sleep 30
             docker logs otelcol-fips
             if [ -z "$( docker ps --filter=status=running --filter=name=otelcol-fips -q )" ]; then

--- a/.github/workflows/otelcol-fips.yml
+++ b/.github/workflows/otelcol-fips.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Ensure the collector container can run with all included configs
         run: |
           for config in cmd/otelcol/fips/config/*.yaml; do
-            docker run -d --name otelcol-fips -e SPLUNK_ACCESS_TOKEN=fake-token -e SPLUNK_REALM=fake-realm -e SPLUNK_CONFIG=/etc/otel/collector/$(basename $config) otelcol-fips:${{ matrix.ARCH }}
+            docker run -d --name otelcol-fips -e SPLUNK_ACCESS_TOKEN=fake-token -e SPLUNK_REALM=fake-realm -e SPLUNK_CONFIG="/etc/otel/collector/$(basename "$config") otelcol-fips:${{ matrix.ARCH }}"
             sleep 30
             docker logs otelcol-fips
             if [ -z "$( docker ps --filter=status=running --filter=name=otelcol-fips -q )" ]; then
@@ -161,7 +161,7 @@ jobs:
         shell: bash
         run: |
           for config in cmd/otelcol/fips/config/*.yaml; do
-            docker run -d --name otelcol-fips -e SPLUNK_ACCESS_TOKEN=fake-token -e SPLUNK_REALM=fake-realm -e SPLUNK_CONFIG="C:\\ProgramData\\Splunk\\OpenTelemetry Collector\\$(basename $config)" otelcol-fips:${{ matrix.WIN_VERSION }}
+            docker run -d --name otelcol-fips -e SPLUNK_ACCESS_TOKEN=fake-token -e SPLUNK_REALM=fake-realm -e SPLUNK_CONFIG="C:\\ProgramData\\Splunk\\OpenTelemetry Collector\\$(basename "$config")" otelcol-fips:${{ matrix.WIN_VERSION }}
             sleep 30
             docker logs otelcol-fips
             if [ -z "$( docker ps --filter=status=running --filter=name=otelcol-fips -q )" ]; then

--- a/.github/workflows/puppet-test.yml
+++ b/.github/workflows/puppet-test.yml
@@ -74,7 +74,7 @@ jobs:
           with_instrumentation='"true","false"'
           matrix="{\"DISTRO\": [${distro%,}], \"PUPPET_RELEASE\": [${puppet_release}], \"WITH_INSTRUMENTATION\": [${with_instrumentation}]}"
           echo "$matrix" | jq
-          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
 

--- a/.github/workflows/salt-test.yml
+++ b/.github/workflows/salt-test.yml
@@ -62,7 +62,7 @@ jobs:
           config="\"default\", \"custom\""
           matrix="{\"DISTRO\": [${distro%,}], \"CONFIG\": [${config}]}"
           echo "$matrix" | jq
-          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
 

--- a/.github/workflows/splunk-ta-otel.yml
+++ b/.github/workflows/splunk-ta-otel.yml
@@ -84,23 +84,23 @@ jobs:
         id: changed-files
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "files=$(git diff --name-only origin/${{ github.base_ref }} ${{ github.sha }} | tr '\n' ' ')" >> $GITHUB_OUTPUT
+            echo "files=$(git diff --name-only origin/${{ github.base_ref }} ${{ github.sha }} | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
           else
-            echo "files=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | tr '\n' ' ')" >> $GITHUB_OUTPUT
+            echo "files=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
           fi
       - name: Filter paths
         id: filter
         run: |
           files="${{ steps.changed-files.outputs.files }}"
           if echo "$files" | grep -qE "packaging/technical-addon"; then
-            echo "ta_packaging_change=true" >> $GITHUB_OUTPUT
+            echo "ta_packaging_change=true" >> "$GITHUB_OUTPUT"
           else
-            echo "ta_packaging_change=false" >> $GITHUB_OUTPUT
+            echo "ta_packaging_change=false" >> "$GITHUB_OUTPUT"
           fi
           if echo "$files" | grep -qE ".github/workflows/splunk-ta-otel.yml"; then
-            echo "ta_workflow_change=true" >> $GITHUB_OUTPUT
+            echo "ta_workflow_change=true" >> "$GITHUB_OUTPUT"
           else
-            echo "ta_workflow_change=false" >> $GITHUB_OUTPUT
+            echo "ta_workflow_change=false" >> "$GITHUB_OUTPUT"
           fi
 
   distribute-ta:

--- a/.github/workflows/tanzu-tile.yml
+++ b/.github/workflows/tanzu-tile.yml
@@ -41,14 +41,14 @@ jobs:
         run: |
           ./make-latest-tile
           tanzu_tile_regex="product/splunk-otel-collector-*.pivotal"
-          size="$(stat -c '%s' $tanzu_tile_regex)"
+          size="$(stat -c '%s' "$tanzu_tile_regex")"
           if [[ $size -eq 0 ]]; then
             echo "File is empty!" >&2
             exit 1
           fi
 
-          tanzu_tile_path=$(pwd)/$tanzu_tile_regex
-          echo "tanzu_tile_path=$tanzu_tile_path" >> $GITHUB_ENV
+          tanzu_tile_path=$(pwd)/"$tanzu_tile_regex"
+          echo "tanzu_tile_path=$tanzu_tile_path" >> "$GITHUB_ENV"
 
       - name: Uploading artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -212,9 +212,9 @@ jobs:
         id: snyk-token-check
         run: |
           if [ -n "${{ secrets.SNYK_TOKEN }}" ]; then
-            echo "defined=true" >> $GITHUB_OUTPUT
+            echo "defined=true" >> "$GITHUB_OUTPUT"
           else
-            echo "defined=false" >> $GITHUB_OUTPUT
+            echo "defined=false" >> "$GITHUB_OUTPUT"
             echo "ERROR: The Snyk token is not available. The token is not available on PRs triggered from forked repositories."
             exit 1
           fi
@@ -328,7 +328,7 @@ jobs:
           category=$(for p in $(echo -e "$packages"); do echo "\"$p\","; done)
           matrix=$(echo "{\"category\": [${category%,}]}" | tr -d '\n')
           echo "$matrix" | jq
-          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
 
   govulncheck-upload:
     runs-on: ubuntu-24.04

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    paths:
 
 env:
   GO_VERSION: 1.23.10


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The goal is to lint GitHub actions to ensure there are no syntax errors. As seen in #6360, if a workflow has a syntax error the failure is not shown in the PR introducing the error, causing workflows to break silently until after the PR is merged, causing more noise on `main`. As suggested: https://github.com/signalfx/splunk-otel-collector/pull/6360#pullrequestreview-2954822075

**Testing:**

I broke the Ansible workflow in the same way it had broken on `main`, and the `actionlint` [job failed](https://github.com/signalfx/splunk-otel-collector/actions/runs/15888090505/job/44804872103?pr=6363) with the following message:
```
.github/workflows/ansible.yml:36:5: when a reusable workflow is called with "uses", "runs-on" is not available. only following keys are allowed: "name", "uses", "with", "secrets", "needs", "if", and "permissions" in job "cross-compile" [syntax-check]
   |
36 |     runs-on: ubuntu-24.04
   |     ^~~~~~~~
```