### PR TITLE
[gitlab release] remove TA from release condition

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -439,7 +439,6 @@ agent-bundle-windows:
 .ta-trigger:
   rules:
     - <<: *main-condition
-    - <<: *release-condition
     - <<: *no-schedules-condition
     - if: $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_TAG == null && $CI_COMMIT_REF_PROTECTED == 'true'
       when: manual


### PR DESCRIPTION
TA releases should be run in a separate release pipeline