### PR TITLE
Test custom cmd line set via Windows install script

### DIFF
--- a/.github/workflows/scripts/win-test-services.ps1
+++ b/.github/workflows/scripts/win-test-services.ps1
@@ -6,7 +6,8 @@ param (
     [string]$with_fluentd = "true",
     [string]$with_msi_uninstall_comments = "",
     [string]$api_url = "https://api.${realm}.signalfx.com",
-    [string]$ingest_url = "https://ingest.${realm}.signalfx.com"
+    [string]$ingest_url = "https://ingest.${realm}.signalfx.com",
+    [string]$with_svc_args = ""
 )
 
 $ErrorActionPreference = 'Stop'
@@ -95,4 +96,19 @@ if ($installed_version -gt [Version]"0.97.0.0") {
 
 If (!(Test-Path -Path "${Env:ProgramData}\Splunk\OpenTelemetry Collector\*_config.yaml")) {
     throw "No config files found in ${Env:ProgramData}\Splunk\OpenTelemetry Collector these files are expected after the install"
+}
+
+$svc_commandline = ""
+try {
+    $svc_commandline = Get-ItemPropertyValue -Path "HKLM:\SYSTEM\CurrentControlSet\Services\splunk-otel-collector" -Name "ImagePath"
+} catch {
+    throw "Failed to retrieve the service command line from the registry."
+}
+
+if ($with_svc_args -ne "") {
+    if ($svc_commandline.EndsWith($with_svc_args)) {
+        throw "Service command line does not match the expected arguments. Found: '$svc_commandline', Expected to end with: '$with_svc_args'"
+    } else {
+        Write-Host "Service command line matches the expected arguments."
+    }
 }

--- a/.github/workflows/scripts/win-test-services.ps1
+++ b/.github/workflows/scripts/win-test-services.ps1
@@ -106,7 +106,7 @@ try {
 }
 
 if ($with_svc_args -ne "") {
-    if ($svc_commandline.EndsWith($with_svc_args)) {
+    if (-not $svc_commandline.EndsWith($with_svc_args)) {
         throw "Service command line does not match the expected arguments. Found: '$svc_commandline', Expected to end with: '$with_svc_args'"
     } else {
         Write-Host "Service command line matches the expected arguments."

--- a/.github/workflows/win-installer-script-test.yml
+++ b/.github/workflows/win-installer-script-test.yml
@@ -37,9 +37,9 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $env:VERIFY_ACCESS_TOKEN = "false"
-          .\packaging\installer\install.ps1 -access_token "testing123" -realm "test" -mode "${{ matrix.MODE }}" -memory "256" -with_fluentd $${{ matrix.WITH_FLUENTD }} -msi_public_properties "ARPCOMMENTS=`"Installed via install.ps1`""
+          .\packaging\installer\install.ps1 -access_token "testing123" -realm "test" -mode "${{ matrix.MODE }}" -memory "256" -with_fluentd $${{ matrix.WITH_FLUENTD }} -msi_public_properties "ARPCOMMENTS=`"Installed via install.ps1`" COLLECTOR_SVC_ARGS=`"--discovery --set=processors.batch.timeout=10s`""
           Start-Sleep -s 30
-          & ${{ github.workspace }}\.github\workflows\scripts\win-test-services.ps1 -mode "${{ matrix.MODE }}" -access_token "testing123" -realm "test" -memory "256" -with_fluentd "${{ matrix.WITH_FLUENTD }}" -with_msi_uninstall_comments "Installed via install.ps1"
+          & ${{ github.workspace }}\.github\workflows\scripts\win-test-services.ps1 -mode "${{ matrix.MODE }}" -access_token "testing123" -realm "test" -memory "256" -with_fluentd "${{ matrix.WITH_FLUENTD }}" -with_msi_uninstall_comments "Installed via install.ps1" -with_svc_args "--discovery --set=processors.batch.timeout=10s"
           & ${{ github.workspace }}\.github\workflows\scripts\win-test-support-bundle.ps1 -mode "${{ matrix.MODE }}" -with_fluentd "${{ matrix.WITH_FLUENTD }}"
 
       - name: splunk-otel-collector logs


### PR DESCRIPTION
Adding a test to validate the Windows install script support of customization of the command-line used to launch the collector service. This can be used, for instance, to enable discovery when installing the collector via the install script.