### PR TITLE
change choco to release with github artifacts and dotnet deployer addon

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1563,9 +1563,9 @@ release-installers:
   before_script:
     - cp -f dist/signed/install.ps1 packaging/installer/install.ps1
 
-choco-release:
+nupkg-release:
   extends: .trigger-filter
-  stage: publish-release
+  stage: release
   dependencies:
     - sign-msi
   tags:
@@ -1582,14 +1582,33 @@ choco-release:
       }
       .\packaging\choco\make.ps1 build_choco -Version $version -BuildDir .\dist\signed
     - Test-Path .\dist\signed\splunk-otel-collector.${version}.nupkg
+  artifacts:
+    paths:
+      - dist/signed/*.nupkg
+
+choco-release:
+  extends: .trigger-filter
+  stage: publish-release
+  dependencies:
+    - nupkg-release
+  tags:
+    - splunk-otel-collector-windows
+  script:
+    - |
+      $ErrorActionPreference = 'Stop'
+      Set-PSDebug -Trace 1
+      $msi_file_name = Resolve-Path .\dist\signed\splunk-otel-collector*.msi | Split-Path -leaf
+      if ($msi_file_name -match '(\d+\.\d+\.\d+)(\.\d+)?') {
+        $version = $matches[0]
+      } else {
+        throw "Failed to get version from $msi_file_name"
+      }
+    - Test-Path .\dist\signed\splunk-otel-collector.${version}.nupkg
     - |
       # Only push the choco package for stable release tags
       if ($env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$') {
         choco push -k $env:CHOCO_TOKEN .\dist\signed\splunk-otel-collector.${version}.nupkg
       }
-  artifacts:
-    paths:
-      - dist/signed/*.nupkg
 
 push-multiarch-manifest:
   extends: .trigger-filter


### PR DESCRIPTION
Currently, a failure in choco release will prevent github or the dotnet deployer from releasing, even though they don't reference or depend on the choco release