### PR TITLE
[receiver/discovery] Set service.type as part of a discovery rule

### DIFF
--- a/cmd/otelcol/config/collector/config.d.linux/receivers/apache.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/apache.discovery.yaml
@@ -8,6 +8,7 @@
 #####################################################################################
 # apache:
 #   enabled: true
+#   service_type: apache
 #   rule:
 #     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)(httpd|apache2).*"}) and not (command matches "splunk.discovery")
 #     host_observer: type == "hostport" and command matches "(?i)(httpd|apache2).*" and not (command matches "splunk.discovery")

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/envoy.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/envoy.discovery.yaml
@@ -8,6 +8,7 @@
 #####################################################################################
 # prometheus:
 #   enabled: true
+#   service_type: envoy
 #   rule:
 #     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)envoy"}) and not (command matches "splunk.discovery")
 #     host_observer: type == "hostport" and command matches "(?i)envoy" and not (command matches "splunk.discovery")

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/istio.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/istio.discovery.yaml
@@ -8,6 +8,7 @@
 #####################################################################################
 # prometheus/istio:
 #   enabled: false
+#   service_type: istio
 #   rule:
 #     k8s_observer: type == "pod" and ("istio.io/rev" in annotations or labels["istio"] == "pilot" or name matches "istio.*")
 #   config:

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/jmx-cassandra.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/jmx-cassandra.discovery.yaml
@@ -8,6 +8,7 @@
 #####################################################################################
 # jmx/cassandra:
 #   enabled: true
+#   service_type: cassandra
 #   rule:
 #     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)cassandra.*"}) and not (command matches "splunk.discovery")
 #     host_observer: type == "hostport" and command matches "(?i)cassandra.*" and not (command matches "splunk.discovery")

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/kafkametrics.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/kafkametrics.discovery.yaml
@@ -8,6 +8,7 @@
 #####################################################################################
 # kafkametrics:
 #   enabled: true
+#   service_type: kafka
 #   rule:
 #     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)kafka.*"}) and not (command matches "splunk.discovery")
 #     host_observer: type == "hostport" and command matches "(?i)kafka.*" and not (command matches "splunk.discovery")

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/mongodb.discovery.yaml
@@ -8,6 +8,7 @@
 #####################################################################################
 # mongodb:
 #   enabled: true
+#   service_type: mongodb
 #   rule:
 #     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)mongo"}) and not (command matches "splunk.discovery")
 #     host_observer: type == "hostport" and command matches "(?i)mongo" and not (command matches "splunk.discovery")

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/mysql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/mysql.discovery.yaml
@@ -8,6 +8,7 @@
 #####################################################################################
 # mysql:
 #   enabled: true
+#   service_type: mysql
 #   rule:
 #     docker_observer: type == "container" and port != 33060 and any([name, image, command], {# matches "(?i)mysql"}) and not (command matches "splunk.discovery")
 #     host_observer: type == "hostport" and port != 33060 and  command matches "(?i)mysqld"

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/nginx.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/nginx.discovery.yaml
@@ -8,6 +8,7 @@
 #####################################################################################
 # nginx:
 #   enabled: true
+#   service_type: nginx
 #   rule:
 #     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)nginx"}) and not (command matches "splunk.discovery")
 #     host_observer: type == "hostport" and command matches "(?i)nginx" and not (command matches "splunk.discovery")

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/oracledb.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/oracledb.discovery.yaml
@@ -8,6 +8,7 @@
 #####################################################################################
 # oracledb:
 #   enabled: true
+#   service_type: oracledb
 #   rule:
 #     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)oracle"}) and not (command matches "splunk.discovery")
 #     host_observer: type == "hostport" and command matches "(?i)oracle" and not (command matches "splunk.discovery")

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/postgresql.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/postgresql.discovery.yaml
@@ -8,6 +8,7 @@
 #####################################################################################
 # postgresql:
 #   enabled: true
+#   service_type: postgresql
 #   rule:
 #     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)postgres"}) and not (command matches "splunk.discovery")
 #     host_observer: type == "hostport" and command matches "(?i)postgres" and not (command matches "splunk.discovery")

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/rabbitmq.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/rabbitmq.discovery.yaml
@@ -8,6 +8,7 @@
 #####################################################################################
 # rabbitmq:
 #   enabled: true
+#   service_type: rabbitmq
 #   rule:
 #     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)rabbitmq.*"}) and not (command matches "splunk.discovery")
 #     host_observer: type == "hostport" and command matches "(?i)rabbitmq.*" and not (command matches "splunk.discovery")

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/redis.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/redis.discovery.yaml
@@ -8,6 +8,7 @@
 #####################################################################################
 # redis:
 #   enabled: true
+#   service_type: redis
 #   rule:
 #     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)redis"}) and not (command matches "splunk.discovery")
 #     host_observer: type == "hostport" and command matches "(?i)redis" and not (command matches "splunk.discovery")

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/sqlserver.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/sqlserver.discovery.yaml
@@ -8,6 +8,7 @@
 #####################################################################################
 # sqlserver:
 #   enabled: true
+#   service_type: sqlserver
 #   rule:
 #     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)mssql"}) and not (command matches "splunk.discovery")
 #     host_observer: type == "hostport" and command matches "(?i)mssql" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/apache.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/apache.discovery.yaml
@@ -4,6 +4,7 @@
 #####################################################################################
 apache:
   enabled: true
+  service_type: apache
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)(httpd|apache2).*"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)(httpd|apache2).*" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/apache.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/apache.discovery.yaml.tmpl
@@ -1,5 +1,6 @@
 {{ receiver "apache" }}:
   enabled: true
+  service_type: apache
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)(httpd|apache2).*"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)(httpd|apache2).*" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/envoy.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/envoy.discovery.yaml
@@ -4,6 +4,7 @@
 #####################################################################################
 prometheus:
   enabled: true
+  service_type: envoy
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)envoy"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)envoy" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/envoy.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/envoy.discovery.yaml.tmpl
@@ -1,5 +1,6 @@
 {{ receiver "prometheus" }}:
   enabled: true
+  service_type: envoy
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)envoy"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)envoy" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/istio.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/istio.discovery.yaml
@@ -4,6 +4,7 @@
 #####################################################################################
 prometheus/istio:
   enabled: false
+  service_type: istio
   rule:
     k8s_observer: type == "pod" and ("istio.io/rev" in annotations or labels["istio"] == "pilot" or name matches "istio.*")
   config:

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/istio.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/istio.discovery.yaml.tmpl
@@ -1,5 +1,6 @@
 {{ receiver "prometheus/istio" }}:
   enabled: false
+  service_type: istio
   rule:
     k8s_observer: type == "pod" and ("istio.io/rev" in annotations or labels["istio"] == "pilot" or name matches "istio.*")
   config:

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/jmx-cassandra.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/jmx-cassandra.discovery.yaml
@@ -4,6 +4,7 @@
 #####################################################################################
 jmx/cassandra:
   enabled: true
+  service_type: cassandra
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)cassandra.*"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)cassandra.*" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/jmx-cassandra.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/jmx-cassandra.discovery.yaml.tmpl
@@ -1,5 +1,6 @@
 {{ receiver "jmx/cassandra" }}:
   enabled: true
+  service_type: cassandra
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)cassandra.*"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)cassandra.*" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/kafkametrics.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/kafkametrics.discovery.yaml
@@ -4,6 +4,7 @@
 #####################################################################################
 kafkametrics:
   enabled: true
+  service_type: kafka
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)kafka.*"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)kafka.*" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/kafkametrics.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/kafkametrics.discovery.yaml.tmpl
@@ -1,5 +1,6 @@
 {{ receiver "kafkametrics" }}:
   enabled: true
+  service_type: kafka
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)kafka.*"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)kafka.*" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml
@@ -4,6 +4,7 @@
 #####################################################################################
 mongodb:
   enabled: true
+  service_type: mongodb
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)mongo"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)mongo" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mongodb.discovery.yaml.tmpl
@@ -1,5 +1,6 @@
 {{ receiver "mongodb" }}:
   enabled: true
+  service_type: mongodb
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)mongo"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)mongo" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml
@@ -4,6 +4,7 @@
 #####################################################################################
 mysql:
   enabled: true
+  service_type: mysql
   rule:
     docker_observer: type == "container" and port != 33060 and any([name, image, command], {# matches "(?i)mysql"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and port != 33060 and  command matches "(?i)mysqld"

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/mysql.discovery.yaml.tmpl
@@ -1,5 +1,6 @@
 {{ receiver "mysql" }}:
   enabled: true
+  service_type: mysql
   rule:
     docker_observer: type == "container" and port != 33060 and any([name, image, command], {# matches "(?i)mysql"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and port != 33060 and  command matches "(?i)mysqld"

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/nginx.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/nginx.discovery.yaml
@@ -4,6 +4,7 @@
 #####################################################################################
 nginx:
   enabled: true
+  service_type: nginx
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)nginx"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)nginx" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/nginx.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/nginx.discovery.yaml.tmpl
@@ -1,5 +1,6 @@
 {{ receiver "nginx" }}:
   enabled: true
+  service_type: nginx
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)nginx"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)nginx" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml
@@ -4,6 +4,7 @@
 #####################################################################################
 oracledb:
   enabled: true
+  service_type: oracledb
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)oracle"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)oracle" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/oracledb.discovery.yaml.tmpl
@@ -1,5 +1,6 @@
 {{ receiver "oracledb" }}:
   enabled: true
+  service_type: oracledb
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)oracle"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)oracle" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml
@@ -4,6 +4,7 @@
 #####################################################################################
 postgresql:
   enabled: true
+  service_type: postgresql
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)postgres"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)postgres" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/postgresql.discovery.yaml.tmpl
@@ -1,5 +1,6 @@
 {{ receiver "postgresql" }}:
   enabled: true
+  service_type: postgresql
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)postgres"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)postgres" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/rabbitmq.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/rabbitmq.discovery.yaml
@@ -4,6 +4,7 @@
 #####################################################################################
 rabbitmq:
   enabled: true
+  service_type: rabbitmq
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)rabbitmq.*"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)rabbitmq.*" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/rabbitmq.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/rabbitmq.discovery.yaml.tmpl
@@ -1,5 +1,6 @@
 {{ receiver "rabbitmq" }}:
   enabled: true
+  service_type: rabbitmq
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)rabbitmq.*"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)rabbitmq.*" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml
@@ -4,6 +4,7 @@
 #####################################################################################
 redis:
   enabled: true
+  service_type: redis
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)redis"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)redis" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/redis.discovery.yaml.tmpl
@@ -1,5 +1,6 @@
 {{ receiver "redis" }}:
   enabled: true
+  service_type: redis
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)redis"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)redis" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/sqlserver.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/sqlserver.discovery.yaml
@@ -4,6 +4,7 @@
 #####################################################################################
 sqlserver:
   enabled: true
+  service_type: sqlserver
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)mssql"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)mssql" and not (command matches "splunk.discovery")

--- a/internal/confmapprovider/discovery/bundle/bundle.d/receivers/sqlserver.discovery.yaml.tmpl
+++ b/internal/confmapprovider/discovery/bundle/bundle.d/receivers/sqlserver.discovery.yaml.tmpl
@@ -1,5 +1,6 @@
 {{ receiver "sqlserver" }}:
   enabled: true
+  service_type: sqlserver
   rule:
     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)mssql"}) and not (command matches "splunk.discovery")
     host_observer: type == "hostport" and command matches "(?i)mssql" and not (command matches "splunk.discovery")

--- a/internal/receiver/discoveryreceiver/config.go
+++ b/internal/receiver/discoveryreceiver/config.go
@@ -62,6 +62,7 @@ type ReceiverEntry struct {
 	Status             *Status           `mapstructure:"status"`
 	ResourceAttributes map[string]string `mapstructure:"resource_attributes"`
 	Rule               Rule              `mapstructure:"rule"`
+	ServiceType        string            `mapstructure:"service_type"`
 }
 
 // Status defines the Match rules for applicable app and telemetry sources.
@@ -111,6 +112,9 @@ func (cfg *Config) Validate() error {
 }
 
 func (re *ReceiverEntry) validate() error {
+	if re.ServiceType == "" {
+		return fmt.Errorf("`service_type` must be defined for each receiver")
+	}
 	return re.Status.validate()
 }
 

--- a/internal/receiver/discoveryreceiver/config_test.go
+++ b/internal/receiver/discoveryreceiver/config_test.go
@@ -47,6 +47,7 @@ func TestValidConfig(t *testing.T) {
 	require.Equal(t, &Config{
 		Receivers: map[component.ID]ReceiverEntry{
 			component.MustNewIDWithName("smartagent", "redis"): {
+				ServiceType: "redis",
 				Config: map[string]any{
 					"auth": "password",
 					"host": "`host`",
@@ -101,6 +102,7 @@ func TestInvalidConfigs(t *testing.T) {
 	tests := []struct{ name, expectedError string }{
 		{name: "no_watch_observers", expectedError: "`watch_observers` must be defined and include at least one configured observer extension"},
 		{name: "missing_status", expectedError: "receiver \"a_receiver\" validation failure: `status` must be defined and contain at least one `metrics` or `statements` mapping"},
+		{name: "missing_service_type", expectedError: "receiver \"smartagent/redis\" validation failure: `service_type` must be defined for each receiver"},
 		{name: "missing_match_status", expectedError: "receiver \"a_receiver\" validation failure: \"metrics\" status match validation failed: status cannot be empty; \"statements\" status match validation failed: status cannot be empty"},
 		{name: "missing_status_metrics_and_statements", expectedError: "receiver \"a_receiver\" validation failure: `status` must be defined and contain at least one `metrics` or `statements` mapping"},
 		{name: "invalid_status_types", expectedError: `receiver "a_receiver" validation failure: "metrics" status match validation failed: invalid status "unsupported". must be one of [successful partial failed]; "statements" status match validation failed: invalid status "another_unsupported". must be one of [successful partial failed]`},

--- a/internal/receiver/discoveryreceiver/endpoint_tracker.go
+++ b/internal/receiver/discoveryreceiver/endpoint_tracker.go
@@ -268,7 +268,6 @@ func entityEvents(observerID component.ID, endpoints []observer.Endpoint, correl
 		for k, v := range endpointAttrs {
 			attrs.PutStr(k, v)
 		}
-		attrs.PutStr(serviceTypeAttr, deduceServiceType(attrs))
 		attrs.PutStr(string(conventions.ServiceNameKey), deduceServiceName(attrs))
 
 		event := events.AppendEmpty()
@@ -393,16 +392,6 @@ func deduceServiceName(attrs pcommon.Map) string {
 		return val.AsString()
 	}
 	if val, ok := attrs.Get("process_name"); ok {
-		return val.AsString()
-	}
-	return "unknown"
-}
-
-func deduceServiceType(attrs pcommon.Map) string {
-	if val, ok := attrs.Get(serviceTypeAttr); ok {
-		return val.AsString()
-	}
-	if val, ok := attrs.Get(discovery.ReceiverTypeAttr); ok {
 		return val.AsString()
 	}
 	return "unknown"

--- a/internal/receiver/discoveryreceiver/endpoint_tracker_test.go
+++ b/internal/receiver/discoveryreceiver/endpoint_tracker_test.go
@@ -510,7 +510,6 @@ func expectedPLogs() plog.Logs {
 	lr.Attributes().PutStr(discovery.OtelEntityTypeAttr, entityType)
 	lr.Attributes().PutStr(discovery.OtelEntityEventTypeAttr, discovery.OtelEntityEventTypeState)
 	id := lr.Attributes().PutEmptyMap(discovery.OtelEntityIDAttr)
-	id.PutStr("service.type", "unknown")
 	id.PutStr("service.name", "unknown")
 	attrs := lr.Attributes().PutEmptyMap(discovery.OtelEntityAttributesAttr)
 	attrs.PutStr(observerNameAttr, "observer.name")
@@ -751,6 +750,7 @@ func TestEntityStateEvents(t *testing.T) {
 	cStore := newCorrelationStore(logger, cfg.CorrelationTTL)
 	cStore.UpdateAttrs(portEndpoint.ID, map[string]string{
 		discovery.ReceiverTypeAttr: "redis",
+		"service.type":             "redis",
 		discovery.StatusAttr:       "successful",
 		"attr1":                    "val1",
 		"attr2":                    "val2",
@@ -809,7 +809,6 @@ func TestEntityDeleteEvents(t *testing.T) {
 	assert.Equal(t, experimentalmetricmetadata.EventTypeDelete, event.EventType())
 	assert.Equal(t, t0, event.Timestamp().AsTime())
 	assert.Equal(t, map[string]any{
-		"service.type": "unknown",
 		"service.name": "redis-cart",
 		sourcePortAttr: int64(1),
 		"k8s.pod.uid":  "uid",

--- a/internal/receiver/discoveryreceiver/evaluator.go
+++ b/internal/receiver/discoveryreceiver/evaluator.go
@@ -122,9 +122,11 @@ func (e *evaluator) correlateResourceAttributes(cfg *Config, to map[string]strin
 		to[discovery.ObserverIDAttr] = observerID
 	}
 
+	rEntry := cfg.Receivers[corr.receiverID] // it's safe to assume this exists.
+	to[serviceTypeAttr] = rEntry.ServiceType
+
 	if e.config.EmbedReceiverConfig {
 		embeddedConfig := map[string]any{}
-		rEntry := cfg.Receivers[corr.receiverID] // it's safe to assume this exists.
 		embeddedReceiversConfig := map[string]any{}
 		receiverConfig := map[string]any{}
 		receiverConfig["rule"] = rEntry.Rule

--- a/internal/receiver/discoveryreceiver/evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/evaluator_test.go
@@ -111,7 +111,8 @@ func TestCorrelateResourceAttrs(t *testing.T) {
 			cfg := &Config{
 				Receivers: map[component.ID]ReceiverEntry{
 					receiverID: {
-						Rule: mustNewRule(`type == "container"`),
+						ServiceType: "a_service",
+						Rule:        mustNewRule(`type == "container"`),
 						Config: map[string]any{
 							"config_option": "val",
 						},
@@ -128,6 +129,7 @@ func TestCorrelateResourceAttrs(t *testing.T) {
 			eval.correlateResourceAttributes(cfg, to, corr)
 
 			expectedResourceAttrs := map[string]string{
+				"service.type":          "a_service",
 				"discovery.observer.id": "type/name",
 			}
 

--- a/internal/receiver/discoveryreceiver/metric_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/metric_evaluator_test.go
@@ -69,8 +69,9 @@ func TestConsumeMetrics(t *testing.T) {
 					cfg := &Config{
 						Receivers: map[component.ID]ReceiverEntry{
 							receiverID: {
-								Rule:   Rule{text: "a.rule", program: nil},
-								Status: &Status{Metrics: []Match{match}},
+								ServiceType: "a_service",
+								Rule:        Rule{text: "a.rule", program: nil},
+								Status:      &Status{Metrics: []Match{match}},
 							},
 						},
 						WatchObservers: []component.ID{observerID},
@@ -125,6 +126,7 @@ func TestConsumeMetrics(t *testing.T) {
 					emitWG.Wait()
 
 					require.Equal(t, map[string]string{
+						"service.type":            "a_service",
 						"discovery.observer.id":   "an_observer/observer.name",
 						"discovery.receiver.name": "receiver.name",
 						"discovery.receiver.type": "a_receiver",

--- a/internal/receiver/discoveryreceiver/statement_evaluator_test.go
+++ b/internal/receiver/discoveryreceiver/statement_evaluator_test.go
@@ -49,8 +49,9 @@ func TestStatementEvaluation(t *testing.T) {
 					cfg := &Config{
 						Receivers: map[component.ID]ReceiverEntry{
 							component.MustNewIDWithName("a_receiver", "receiver.name"): {
-								Rule:   mustNewRule(`type == "container"`),
-								Status: &Status{Statements: []Match{match}},
+								ServiceType: "a_service",
+								Rule:        mustNewRule(`type == "container"`),
+								Status:      &Status{Statements: []Match{match}},
 							},
 						},
 						WatchObservers: []component.ID{observerID},
@@ -102,6 +103,7 @@ func TestStatementEvaluation(t *testing.T) {
 
 					// Validate the attributes
 					require.Equal(t, map[string]string{
+						"service.type":            "a_service",
 						"discovery.observer.id":   "an_observer/observer.name",
 						"discovery.receiver.name": "receiver.name",
 						"discovery.receiver.type": "a_receiver",

--- a/internal/receiver/discoveryreceiver/testdata/conflicting_rules.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/conflicting_rules.yaml
@@ -3,12 +3,14 @@ discovery:
     - an_observer
   receivers:
     receiver_1:
+      service_type: a_service
       rule: type == "container" && name == "app"
       status:
         metrics:
           - status: successful
             regexp: '.*'
     receiver_2:
+      service_type: a_service
       rule: type == "container" && name == "app"
       status:
         statements:

--- a/internal/receiver/discoveryreceiver/testdata/invalid_status_types.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/invalid_status_types.yaml
@@ -3,6 +3,7 @@ discovery:
     - an_observer
   receivers:
     a_receiver:
+      service_type: a_service
       rule: type == "container"
       status:
         metrics:

--- a/internal/receiver/discoveryreceiver/testdata/missing_match_status.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/missing_match_status.yaml
@@ -3,6 +3,7 @@ discovery:
     - an_observer
   receivers:
     a_receiver:
+      service_type: a_service
       rule: type == "container"
       status:
         metrics:

--- a/internal/receiver/discoveryreceiver/testdata/missing_service_type.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/missing_service_type.yaml
@@ -2,19 +2,14 @@ discovery:
   watch_observers:
     - an_observer
     - another_observer/with_name
-  embed_receiver_config: true
-  correlation_ttl: 25s
   receivers:
     smartagent/redis:
-      service_type: redis
       rule: type == "container" && name matches "(?i)redis"
       config:
         type: collectd/redis
         auth: password
         host: '`host`'
         port: '`port`'
-      resource_attributes:
-        receiver_attribute: receiver_attribute_value
       status:
         metrics:
           - status: successful
@@ -24,6 +19,3 @@ discovery:
           - status: failed
             regexp: ConnectionRefusedError
             message: container appears to not be accepting redis connections
-          - status: partial
-            regexp: (WRONGPASS|NOAUTH|ERR AUTH)
-            message: desired log invalid auth log body

--- a/internal/receiver/discoveryreceiver/testdata/missing_status.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/missing_status.yaml
@@ -3,4 +3,5 @@ discovery:
     - an_observer
   receivers:
     a_receiver:
+      service_type: a_service
       rule: type == "container"

--- a/internal/receiver/discoveryreceiver/testdata/missing_status_metrics_and_statements.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/missing_status_metrics_and_statements.yaml
@@ -3,5 +3,6 @@ discovery:
     - an_observer
   receivers:
     a_receiver:
+      service_type: a_service
       rule: type == "container"
       status:

--- a/internal/receiver/discoveryreceiver/testdata/multiple_status_match_types.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/multiple_status_match_types.yaml
@@ -3,6 +3,7 @@ discovery:
     - an_observer
   receivers:
     a_receiver:
+      service_type: a_service
       rule: type == "container"
       status:
         metrics:

--- a/internal/receiver/discoveryreceiver/testdata/reserved_receiver_creator.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/reserved_receiver_creator.yaml
@@ -3,6 +3,7 @@ discovery:
     - an_observer
   receivers:
     receiver_creator/with-name:
+      service_type: a_service
       rule: type == "container"
       status:
         metrics:

--- a/internal/receiver/discoveryreceiver/testdata/reserved_receiver_name.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/reserved_receiver_name.yaml
@@ -3,6 +3,7 @@ discovery:
     - an_observer
   receivers:
     a_receiver/with-receiver_creator/in-name:
+      service_type: a_service
       rule: type == "container"
       status:
         metrics:

--- a/internal/receiver/discoveryreceiver/testdata/reserved_receiver_name_with_endpoint.yaml
+++ b/internal/receiver/discoveryreceiver/testdata/reserved_receiver_name_with_endpoint.yaml
@@ -3,6 +3,7 @@ discovery:
     - an_observer
   receivers:
     receiver/with{endpoint=}/:
+      service_type: a_service
       rule: type == "container"
       status:
         metrics:

--- a/packaging/technical-addon/packaging-scripts/cicd-tests/discovery/docker_observer_without_ssl_kafkametrics_config.yaml
+++ b/packaging/technical-addon/packaging-scripts/cicd-tests/discovery/docker_observer_without_ssl_kafkametrics_config.yaml
@@ -6,6 +6,7 @@ receivers:
     embed_receiver_config: true
     receivers:
       kafkametrics:
+        service_type: kafka
         config:
           client_id: "otel-integration-test"
           protocol_version: "2.0.0"

--- a/tests/receivers/apache/testdata/docker_observer_apache_config.yaml
+++ b/tests/receivers/apache/testdata/docker_observer_apache_config.yaml
@@ -7,6 +7,7 @@ receivers:
     embed_receiver_config: true
     receivers:
       apache:
+        service_type: apache
         config:
           endpoint: http://`endpoint`/server-status?auto
         rule: type == "container" and any([name, image, command], {# matches "(?i)(httpd|apache2).*"}) and not (command matches "splunk.discovery")

--- a/tests/receivers/jmx/cassandra/testdata/docker_observer_without_ssl_jmx_cassandra_config.yaml
+++ b/tests/receivers/jmx/cassandra/testdata/docker_observer_without_ssl_jmx_cassandra_config.yaml
@@ -9,6 +9,7 @@ receivers:
       # For more information on configuring JMX receivers, see
       # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/jmxreceiver/README.md
       jmx/cassandra:
+        service_type: cassandra
         config:
           # Jar path must be set.  It is bundled in most of our installations (including the docker image).
           # see https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/jmxreceiver/README.md#jar_path-default-optopentelemetry-java-contrib-jmx-metricsjar

--- a/tests/receivers/kafkametrics/testdata/docker_observer_without_ssl_kafkametrics_config.yaml
+++ b/tests/receivers/kafkametrics/testdata/docker_observer_without_ssl_kafkametrics_config.yaml
@@ -7,6 +7,7 @@ receivers:
     embed_receiver_config: true
     receivers:
       kafkametrics:
+        service_type: kafka
         config:
           client_id: "otel-integration-test"
           protocol_version: "2.0.0"

--- a/tests/receivers/mongodb/testdata/docker_observer_with_ssl_mongodb_config.yaml
+++ b/tests/receivers/mongodb/testdata/docker_observer_with_ssl_mongodb_config.yaml
@@ -6,6 +6,7 @@ receivers:
     embed_receiver_config: true
     receivers:
       mongodb:
+        service_type: mongodb
         config:
           password: user1
           tls:

--- a/tests/receivers/mongodb/testdata/docker_observer_without_ssl_mongodb_config.yaml
+++ b/tests/receivers/mongodb/testdata/docker_observer_without_ssl_mongodb_config.yaml
@@ -7,6 +7,7 @@ receivers:
     embed_receiver_config: true
     receivers:
       mongodb:
+        service_type: mongodb
         config:
           username: user1
           tls:

--- a/tests/receivers/mongodb/testdata/docker_observer_without_ssl_with_wrong_authentication_mongodb_config.yaml
+++ b/tests/receivers/mongodb/testdata/docker_observer_without_ssl_with_wrong_authentication_mongodb_config.yaml
@@ -7,6 +7,7 @@ receivers:
     embed_receiver_config: true
     receivers:
       mongodb:
+        service_type: mongodb
         config:
           username: user2
           tls:

--- a/tests/receivers/nginx/testdata/docker_observer_nginx_config.yaml
+++ b/tests/receivers/nginx/testdata/docker_observer_nginx_config.yaml
@@ -11,6 +11,7 @@ receivers:
     embed_receiver_config: true
     receivers:
       nginx:
+        service_type: nginx
         config:
           endpoint: '`(port in [443] ? "https://" : "http://")``endpoint`/nginx_status}}'
           auth:


### PR DESCRIPTION
Figuring out the service.type attribute value from existing data isn't reliable. For example, a discovered Kafka service may get "kafkametrics" as the service.type value.

This change adds a required field to the service discovery rule to explicitly indicate the type of service being discovered.