### PR TITLE
doubles timeout for compile step of gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -310,6 +310,7 @@ tidy-dependabot-pr:
     - .gitlab/tidy-dependabot-pr.sh
 
 compile:
+  timeout: 2h
   extends:
     - .trigger-filter
     - .go-cache


### PR DESCRIPTION
Need to verify that the runners we want to do this on also have a sufficient timeout