### PR TITLE
[chore] Adds release-nupkg to the dependencies of the github-release job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1564,7 +1564,7 @@ release-installers:
   before_script:
     - cp -f dist/signed/install.ps1 packaging/installer/install.ps1
 
-nupkg-release:
+release-nupkg:
   extends: .trigger-filter
   stage: release
   dependencies:
@@ -1585,13 +1585,13 @@ nupkg-release:
     - Test-Path .\dist\signed\splunk-otel-collector.${version}.nupkg
   artifacts:
     paths:
-      - dist/signed/*.nupkg
+      - .\dist\signed\*.nupkg
 
 choco-release:
   extends: .trigger-filter
   stage: publish-release
   dependencies:
-    - nupkg-release
+    - release-nupkg
   tags:
     - splunk-otel-collector-windows
   script:
@@ -1780,6 +1780,7 @@ github-release:
     - sign-exe
     - sign-osx
     - release-debs
+    - release-nupkg
     - release-rpms
     - sign-msi
     - sign-tar


### PR DESCRIPTION
Also renames `nupkg-release` to `release-nupkg`

I believe this is why we haven't seen nupkg be released since making github release independent of choco

