### PR TITLE
[receiver/discovery]: Update extraction of `service.name` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - (Splunk) `receiver/discovery`: Reduce amount of attributes sent with the entities to the required set ([#6419](https://github.com/signalfx/splunk-otel-collector/pull/6419))
+- (Splunk) `receiver/discovery`: Use `app.kubernetes.io/instance` pod label for `service.name` entity attribute value if available ([#6435](https://github.com/signalfx/splunk-otel-collector/pull/6435))
 
 ## v0.129.0
 

--- a/internal/receiver/discoveryreceiver/endpoint_tracker.go
+++ b/internal/receiver/discoveryreceiver/endpoint_tracker.go
@@ -369,6 +369,9 @@ func extractServiceName(endpointType observer.EndpointType, endpointEnv observer
 
 	// First, try to extract the service name from labels.
 	if labelsFound {
+		if val, ok := labels["app.kubernetes.io/instance"]; ok {
+			return val
+		}
 		if val, ok := labels["app.kubernetes.io/name"]; ok {
 			return val
 		}

--- a/internal/receiver/discoveryreceiver/endpoint_tracker_test.go
+++ b/internal/receiver/discoveryreceiver/endpoint_tracker_test.go
@@ -721,6 +721,21 @@ func TestDeduceServiceName(t *testing.T) {
 			expected: "my-app",
 		},
 		{
+			name:         "pod-port-k8s-instance-labels",
+			endpointType: observer.PortType,
+			endpointEnv: observer.EndpointEnv{
+				"pod": observer.EndpointEnv{
+					"labels": map[string]string{
+						"app.kubernetes.io/instance": "my-app-instance",
+						"app.kubernetes.io/name":     "my-app-new-name",
+						"app":                        "my-app-old-name",
+					},
+				},
+				"process_name": "my-process",
+			},
+			expected: "my-app-instance",
+		},
+		{
 			name:         "pod-port-new-k8s-labels",
 			endpointType: observer.PortType,
 			endpointEnv: observer.EndpointEnv{


### PR DESCRIPTION
Use `app.kubernetes.io/instance` pod label for setting `service.name` entity attribute in addition to other sources.

Addressing https://github.com/signalfx/splunk-otel-collector/pull/6419#discussion_r2201364747