### PR TITLE
[discovery] Fix disabling observers with properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
+### 💡 Enhancements 💡
+
 - (Splunk) `receiver/discovery`: Reduce amount of attributes sent with the entities to the required set ([#6419](https://github.com/signalfx/splunk-otel-collector/pull/6419))
+
+### 🧰 Bug fixes 🧰
+
+- (Splunk) `receiver/discovery`: Fix disabling observers with properties ([#6437](https://github.com/signalfx/splunk-otel-collector/pull/6437))
 
 ## v0.129.0
 

--- a/internal/confmapprovider/discovery/discoverer.go
+++ b/internal/confmapprovider/discovery/discoverer.go
@@ -278,6 +278,10 @@ func (d *discoverer) startObservers(cfg *Config) []context.CancelFunc {
 	var cancels []context.CancelFunc
 	d.operationalObservers = make(map[component.ID]component.Component, len(cfg.DiscoveryObservers))
 	for observerID, observerEntry := range cfg.DiscoveryObservers {
+		if observerEntry.Enabled != nil && !*observerEntry.Enabled {
+			d.logger.Debug(fmt.Sprintf("skipping observer %q as it is disabled", observerID))
+			continue
+		}
 		d.logger.Debug(fmt.Sprintf("creating observer %q", observerID))
 		observerFactory, err := factoryForObserverType(observerID.Type())
 		if err != nil {

--- a/internal/confmapprovider/discovery/provider_test.go
+++ b/internal/confmapprovider/discovery/provider_test.go
@@ -173,3 +173,41 @@ func TestDiscoveryProvider_ContinuousDiscoveryConfig(t *testing.T) {
 	assert.Equal(t, []component.ID{component.MustNewIDWithName("otlphttp", "entities")},
 		pipelines[pipeline.NewIDWithName(pipeline.SignalLogs, "entities")].Exporters)
 }
+
+func TestDiscoveryProvider_HostObserverDisabled(t *testing.T) {
+	confmapProvider, err := New()
+	require.NoError(t, err)
+
+	provider, err := otelcol.NewConfigProvider(otelcol.ConfigProviderSettings{
+		ResolverSettings: confmap.ResolverSettings{
+			URIs: []string{
+				fmt.Sprintf("file:%s", filepath.Join("testdata", "base-config.yaml")),
+				fmt.Sprintf("%s:%s", propertiesFileScheme, filepath.Join("testdata", "disable-host-observer.properties.yaml")),
+				fmt.Sprintf("%s:%s", discoveryModeScheme, filepath.Join("testdata", "config.d")),
+			},
+			ProviderFactories: []confmap.ProviderFactory{
+				fileprovider.NewFactory(),
+				confmapProvider.DiscoveryModeProviderFactory(),
+				envprovider.NewFactory(),
+				confmapProvider.PropertiesFileProviderFactory(),
+			},
+			ConverterFactories: []confmap.ConverterFactory{configconverter.ConverterFactoryFromFunc(configconverter.SetupDiscovery)},
+			DefaultScheme:      "env",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	factories, err := components.Get()
+	require.NoError(t, err)
+
+	conf, err := provider.Get(context.Background(), factories)
+	require.NoError(t, err)
+	assert.NotNil(t, conf)
+
+	// The only functional host observer must be disabled in the provided properties file.
+	assert.Empty(t, conf.Extensions)
+
+	// Discovery receivers should not be created if no discovery observers available.
+	assert.Empty(t, conf.Receivers)
+}

--- a/internal/confmapprovider/discovery/testdata/disable-host-observer.properties.yaml
+++ b/internal/confmapprovider/discovery/testdata/disable-host-observer.properties.yaml
@@ -1,0 +1,4 @@
+splunk.discovery:
+  extensions:
+    host_observer:
+      enabled: false


### PR DESCRIPTION
Fixes a bug where observers couldn't be disabled using properties
