### PR TITLE
[chore] forgot to update test for 1.4.3 release

### DIFF
--- a/packaging/technical-addon/packaging-scripts/cicd-tests/happypath-test.sh
+++ b/packaging/technical-addon/packaging-scripts/cicd-tests/happypath-test.sh
@@ -120,7 +120,7 @@ fi
 # For release, ensure version is as expected.  TODO move this to another test and compare against tag
 actual_version="$(grep "Version" "$TEST_FOLDER/splunk/otel.log" | head -1 | awk -F 'Version": "' '{print $2}' | awk -F '", "' '{print $1}')"
 echo "actual version: $actual_version"
-[[ "$actual_version" != "v0.122.0" ]] && echo "Test failed -- invalid version" && exit 1
+[[ "$actual_version" != "v0.128.0" ]] && echo "Test failed -- invalid version" && exit 1
 
 # clean up orca container
 splunk_orca --cloud ${ORCA_CLOUD} destroy "${deployment_id}"


### PR DESCRIPTION
happy path test fails on last line which is checking this.  Test fails indicating the desired (`v0.128.0`) app was detected in the addon instead of the "erroneously expected" `v0.122.0`

This should never happen again given the update we're about to make to the script