### PR TITLE
[chore] add github tag creation to release pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ default:
         - "$SECRETS_URL"
 
 variables:
+
   GO_VERSION: 1.23.10
   WIN_2019_BASE_IMAGE: mcr.microsoft.com/windows/servercore:ltsc2019
   WIN_2022_BASE_IMAGE: mcr.microsoft.com/windows/servercore:ltsc2022
@@ -21,6 +22,7 @@ variables:
     description: 'in this CI, where the addons source directory is located'
 
 stages:
+  - manual-release
   - update-deps
   - sast-oss-scan
   - build
@@ -47,6 +49,35 @@ include:
   - project: 'core-ee/signing/api-integration'
     ref: develop
     file: '/templates/.sign-client.yml'
+
+
+# Manual release job
+manual_release_trigger:
+  stage: manual-release
+  script:
+    - |
+      if [ -z "$RELEASE_VERSION" ]; then
+        echo "RELEASE_VERSION is not set. Cannot proceed." && exit 1
+      fi
+      # Validate version format (must be v1.2.3)
+      if ! echo "$RELEASE_VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+        echo "RELEASE_VERSION must be in format v1.2.3" && exit 1
+      fi
+      # Validate version is in changelog
+      if ! grep -q "^## $RELEASE_VERSION" CHANGELOG.md; then
+        echo "Version $RELEASE_VERSION not found in CHANGELOG.md" && exit 1
+      fi
+      echo "Manual release triggered for version $RELEASE_VERSION"
+      echo "RELEASE_VERSION=$RELEASE_VERSION" > release_version.env
+  when: manual
+  allow_failure: false
+  only:
+    - main
+  needs: []
+  variables:
+    RELEASE_VERSION:
+      description: "Version to release (e.g. v1.2.3)"
+      value: ""
 
 semgrep:
   stage: sast-oss-scan
@@ -114,9 +145,9 @@ fossa:
   - |
     set -ex
     export STAGE="test"
-    if [[ "${CI_COMMIT_TAG:-}" =~ beta ]]; then
+    if [[ "${CI_COMMIT_TAG:-}" =~ beta ]] || [[ "${RELEASE_VERSION:-}" =~ beta ]]; then
       export STAGE="beta"
-    elif [[ "${CI_COMMIT_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    elif [[ "${CI_COMMIT_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "${RELEASE_VERSION:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
       export STAGE="release"
     fi
 
@@ -130,6 +161,8 @@ fossa:
       if: $CI_COMMIT_BRANCH == "main"
     - &release-condition
       if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+    - &manual-release-condition
+      if: $RELEASE_VERSION && $CI_COMMIT_BRANCH == "main"
     - &no-schedules-condition
       if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
@@ -322,8 +355,12 @@ compile:
       - TARGET: [binaries-darwin_amd64, binaries-darwin_arm64, binaries-linux_amd64, binaries-linux_arm64, binaries-windows_amd64, binaries-linux_ppc64le]
   script:
     - |
-      if [[ -n "${CI_COMMIT_TAG:-}" ]]; then
-        make $TARGET VERSION=${CI_COMMIT_TAG}
+      VERSION_TAG="${CI_COMMIT_TAG:-}"
+      if [[ -n "${RELEASE_VERSION:-}" ]]; then
+        VERSION_TAG="${RELEASE_VERSION}"
+      fi
+      if [[ -n "${VERSION_TAG}" ]]; then
+        make $TARGET VERSION=${VERSION_TAG}
       else
         make $TARGET
       fi
@@ -360,8 +397,12 @@ otelcol-fips:
   script:
     - *docker-reader-role
     - |
-      if [[ -n "${CI_COMMIT_TAG:-}" ]]; then
-        make otelcol-fips VERSION=${CI_COMMIT_TAG} DOCKER_REPO=${DOCKER_HUB_REPO}
+      VERSION_TAG="${CI_COMMIT_TAG:-}"
+      if [[ -n "${RELEASE_VERSION:-}" ]]; then
+        VERSION_TAG="${RELEASE_VERSION}"
+      fi
+      if [[ -n "${VERSION_TAG}" ]]; then
+        make otelcol-fips VERSION=${VERSION_TAG} DOCKER_REPO=${DOCKER_HUB_REPO}
       else
         make otelcol-fips DOCKER_REPO=${DOCKER_HUB_REPO}
       fi
@@ -635,7 +676,7 @@ AppInspect_local:
   before_script:
     - ./instrumentation/packaging/fpm/install-deps.sh
   script:
-    - ./instrumentation/packaging/fpm/${PKG_TYPE}/build.sh "${CI_COMMIT_TAG:-}" "$ARCH" "./dist"
+    - ./instrumentation/packaging/fpm/${PKG_TYPE}/build.sh "${CI_COMMIT_TAG:-${RELEASE_VERSION}}" "$ARCH" "./dist"
     - *xray-publish-package
 
 instrumentation-deb:
@@ -732,7 +773,7 @@ sign-osx:
   before_script:
     - ./packaging/fpm/install-deps.sh
   script:
-    - ./packaging/fpm/${PKG_TYPE}/build.sh "${CI_COMMIT_TAG:-}" "$ARCH" "./dist"
+    - ./packaging/fpm/${PKG_TYPE}/build.sh "${CI_COMMIT_TAG:-${RELEASE_VERSION}}" "$ARCH" "./dist"
     - *xray-publish-package
 
 build-deb:
@@ -799,7 +840,12 @@ build-msi:
       aud: $CICD_VAULT_ADDR
   script:
     - *docker-reader-role
-    - make msi SKIP_COMPILE=true VERSION=${CI_COMMIT_TAG:-} DOCKER_REPO=${DOCKER_HUB_REPO}
+    - |
+      VERSION_TAG="${CI_COMMIT_TAG:-}"
+      if [[ -n "${RELEASE_VERSION:-}" ]]; then
+        VERSION_TAG="${RELEASE_VERSION}"
+      fi
+      make msi SKIP_COMPILE=true VERSION=${VERSION_TAG} DOCKER_REPO=${DOCKER_HUB_REPO}
   artifacts:
     paths:
       - dist/*.msi
@@ -1590,6 +1636,10 @@ release-nupkg:
 choco-release:
   extends: .trigger-filter
   stage: publish-release
+  needs:
+    - job: manual_release_trigger
+      artifacts: true
+      optional: true
   dependencies:
     - release-nupkg
   tags:
@@ -1606,9 +1656,18 @@ choco-release:
       }
     - Test-Path .\dist\signed\splunk-otel-collector.${version}.nupkg
     - |
-      # Only push the choco package for stable release tags
+      # Only push the choco package for stable release tags or manual releases
+      $should_release = $false
       if ($env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$') {
+        $should_release = $true
+      } elseif ($env:RELEASE_VERSION -match '^v\d+\.\d+\.\d+$') {
+        $should_release = $true
+      }
+      
+      if ($should_release) {
         choco push -k $env:CHOCO_TOKEN .\dist\signed\splunk-otel-collector.${version}.nupkg
+      } else {
+        Write-Host "Skipping choco push - not a stable release tag or manual release"
       }
 
 push-multiarch-manifest:
@@ -1773,6 +1832,10 @@ github-release:
     - .go-cache
   tags: [large]
   stage: publish-release
+  needs:
+    - job: manual_release_trigger
+      artifacts: true
+      optional: true
   dependencies:
     - compile
     - otelcol-fips
@@ -1786,6 +1849,8 @@ github-release:
     - sign-tar
     - push-multiarch-manifest
     - sign-agent-bundles
+  before_script:
+    - .gitlab/install-gh-cli.sh
   script:
     - mkdir -p dist/assets
     - cp bin/otelcol_linux_* dist/assets/
@@ -1793,24 +1858,31 @@ github-release:
     - cp instrumentation/dist/libsplunk_*.so dist/assets/
     - cp dist/signed/* dist/assets/
     - |
-      # rename agent bundles to include the version for stable releases
       set -e
-      if [[ "${CI_COMMIT_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        mv dist/assets/agent-bundle_linux_amd64.tar.gz dist/assets/agent-bundle_${CI_COMMIT_TAG#v}_linux_amd64.tar.gz
-        mv dist/assets/agent-bundle_linux_amd64.tar.gz.asc dist/assets/agent-bundle_${CI_COMMIT_TAG#v}_linux_amd64.tar.gz.asc
-        mv dist/assets/agent-bundle_windows_amd64.zip dist/assets/agent-bundle_${CI_COMMIT_TAG#v}_windows_amd64.zip
-        mv dist/assets/agent-bundle_windows_amd64.zip.asc dist/assets/agent-bundle_${CI_COMMIT_TAG#v}_windows_amd64.zip.asc
+      VERSION_TAG="${CI_COMMIT_TAG:-}"
+      if [[ -n "${RELEASE_VERSION:-}" ]]; then
+        VERSION_TAG="${RELEASE_VERSION}"
+      fi
+      # Rename agent bundles to include the version for stable releases
+      if [[ "$VERSION_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        VERSION="${VERSION_TAG#v}"
+        mv dist/assets/agent-bundle_linux_amd64.tar.gz dist/assets/agent-bundle_${VERSION}_linux_amd64.tar.gz
+        mv dist/assets/agent-bundle_linux_amd64.tar.gz.asc dist/assets/agent-bundle_${VERSION}_linux_amd64.tar.gz.asc
+        mv dist/assets/agent-bundle_windows_amd64.zip dist/assets/agent-bundle_${VERSION}_windows_amd64.zip
+        mv dist/assets/agent-bundle_windows_amd64.zip.asc dist/assets/agent-bundle_${VERSION}_windows_amd64.zip.asc
         # exclude the arm64 bundle from release assets
         rm -f dist/assets/agent-bundle_linux_arm64.tar.gz
         rm -f dist/assets/agent-bundle_linux_arm64.tar.gz.asc
       fi
-    - pushd dist/assets && shasum -a 256 * > checksums.txt && popd
-    - |
-      # only create github release for stable release tags
-      set -e
-      if [[ "${CI_COMMIT_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        release_notes="$( ./packaging/release/gh-release-notes.sh "$CI_COMMIT_TAG" )"
-        ghr -t "$GITHUB_TOKEN" -u signalfx -r splunk-otel-collector -n "$CI_COMMIT_TAG" -b "$release_notes" --replace "$CI_COMMIT_TAG" dist/assets/
+      pushd dist/assets && shasum -a 256 * > checksums.txt && popd
+      # Tag if this is a manual release (RELEASE_VERSION set, CI_COMMIT_TAG not set)
+      if [[ -n "${RELEASE_VERSION:-}" && -z "${CI_COMMIT_TAG:-}" ]]; then
+        ./packaging/release/tag-on-github.sh "$VERSION_TAG" "$CI_COMMIT_SHA"
+      fi
+      # Only create github release for stable release tags
+      if [[ "$VERSION_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        release_notes="$( ./packaging/release/gh-release-notes.sh "$VERSION_TAG" )"
+        ghr -t "$GITHUB_TOKEN" -u signalfx -r splunk-otel-collector -n "$VERSION_TAG" -b "$release_notes" --replace "$VERSION_TAG" dist/assets/
       fi
   artifacts:
     when: always
@@ -1965,3 +2037,4 @@ dotnet-instrumentation-deployer-release:
         echo "Failed to get version from $CI_COMMIT_TAG"
         exit 1
       fi
+

--- a/packaging/release/tag-on-github.sh
+++ b/packaging/release/tag-on-github.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script handles tagging a commit on GitHub and pushing the tag.
+# Usage: ./tag-on-github.sh <version_tag> <commit_sha>
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <version_tag> <commit_sha>" >&2
+  exit 1
+fi
+
+VERSION_TAG="$1"
+COMMIT_SHA="$2"
+REPO="signalfx/splunk-otel-collector"
+REPO_URL="https://srv-gh-o11y-gdi:${GITHUB_TOKEN}@github.com/${REPO}.git"
+
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$SCRIPT_DIR/../../../.gitlab/common.sh"
+
+setup_gpg
+import_gpg_secret_key "$GITHUB_BOT_GPG_KEY"
+setup_git
+
+echo ">>> Cloning $REPO ..."
+git clone --no-checkout "$REPO_URL" repo-tmp
+cd repo-tmp
+git fetch origin
+git checkout "$COMMIT_SHA"
+
+echo ">>> Creating signed tag $VERSION_TAG for $COMMIT_SHA ..."
+git tag -s "$VERSION_TAG" "$COMMIT_SHA" -m "Release $VERSION_TAG"
+
+echo ">>> Pushing tag $VERSION_TAG to GitHub ..."
+git push origin "$VERSION_TAG"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Adds a manual pipeline option to start a release. The tag is expected as pipeline input. The github-release stage has been updated to first create the tag and then the github release. Note - I have kept the original option of release being triggered by a manually added tag to github for now.
