### PR TITLE
[chore] use needs instead of dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,9 @@ default:
         - "$SECRETS_URL"
 
 variables:
+  RELEASE_VERSION:
+    value: ""
+    description: "Version to release (must be in format v1.2.3)"
   GO_VERSION: 1.23.10
   WIN_2019_BASE_IMAGE: mcr.microsoft.com/windows/servercore:ltsc2019
   WIN_2022_BASE_IMAGE: mcr.microsoft.com/windows/servercore:ltsc2022
@@ -21,6 +24,7 @@ variables:
     description: 'in this CI, where the addons source directory is located'
 
 stages:
+  - manual-release
   - update-deps
   - sast-oss-scan
   - build
@@ -48,8 +52,6 @@ include:
     ref: develop
     file: '/templates/.sign-client.yml'
 
-<<<<<<< HEAD
-=======
 
 # Manual release job
 manual_release_trigger:
@@ -74,7 +76,6 @@ manual_release_trigger:
     - main
   needs: []
 
->>>>>>> 6373249d ([chore] remove redundant artifact from gitlab pipeline)
 semgrep:
   stage: sast-oss-scan
   extends: .sast_scan
@@ -141,9 +142,9 @@ fossa:
   - |
     set -ex
     export STAGE="test"
-    if [[ "${CI_COMMIT_TAG:-}" =~ beta ]]; then
+    if [[ "${CI_COMMIT_TAG:-}" =~ beta ]] || [[ "${RELEASE_VERSION:-}" =~ beta ]]; then
       export STAGE="beta"
-    elif [[ "${CI_COMMIT_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    elif [[ "${CI_COMMIT_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "${RELEASE_VERSION:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
       export STAGE="release"
     fi
 
@@ -157,6 +158,8 @@ fossa:
       if: $CI_COMMIT_BRANCH == "main"
     - &release-condition
       if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+    - &manual-release-condition
+      if: $RELEASE_VERSION && $CI_COMMIT_BRANCH == "main"
     - &no-schedules-condition
       if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
@@ -349,8 +352,9 @@ compile:
       - TARGET: [binaries-darwin_amd64, binaries-darwin_arm64, binaries-linux_amd64, binaries-linux_arm64, binaries-windows_amd64, binaries-linux_ppc64le]
   script:
     - |
-      if [[ -n "${CI_COMMIT_TAG:-}" ]]; then
-        make $TARGET VERSION=${CI_COMMIT_TAG}
+      VERSION_TAG="${RELEASE_VERSION:-${CI_COMMIT_TAG:-}}"
+      if [[ -n "${VERSION_TAG:-}" ]]; then
+        make $TARGET VERSION=${VERSION_TAG}
       else
         make $TARGET
       fi
@@ -387,11 +391,8 @@ otelcol-fips:
   script:
     - *docker-reader-role
     - |
-      if [[ -n "${CI_COMMIT_TAG:-}" ]]; then
-        make otelcol-fips VERSION=${CI_COMMIT_TAG} DOCKER_REPO=${DOCKER_HUB_REPO}
-      else
-        make otelcol-fips DOCKER_REPO=${DOCKER_HUB_REPO}
-      fi
+      VERSION_TAG="${RELEASE_VERSION:-${CI_COMMIT_TAG:-}}"
+      make otelcol-fips VERSION=${VERSION_TAG} DOCKER_REPO=${DOCKER_HUB_REPO}
   artifacts:
     paths:
       - bin/otelcol-fips_*
@@ -663,7 +664,9 @@ AppInspect_local:
   before_script:
     - ./instrumentation/packaging/fpm/install-deps.sh
   script:
-    - ./instrumentation/packaging/fpm/${PKG_TYPE}/build.sh "${CI_COMMIT_TAG:-}" "$ARCH" "./dist"
+    - |
+      VERSION_TAG="${RELEASE_VERSION:-${CI_COMMIT_TAG:-}}"
+      ./instrumentation/packaging/fpm/${PKG_TYPE}/build.sh "${VERSION_TAG}" "$ARCH" "./dist"
     - *xray-publish-package
 
 instrumentation-deb:
@@ -760,7 +763,9 @@ sign-osx:
   before_script:
     - ./packaging/fpm/install-deps.sh
   script:
-    - ./packaging/fpm/${PKG_TYPE}/build.sh "${CI_COMMIT_TAG:-}" "$ARCH" "./dist"
+    - |
+      VERSION_TAG="${RELEASE_VERSION:-${CI_COMMIT_TAG:-}}"
+      ./packaging/fpm/${PKG_TYPE}/build.sh "${VERSION_TAG}" "$ARCH" "./dist"
     - *xray-publish-package
 
 build-deb:
@@ -827,7 +832,9 @@ build-msi:
       aud: $CICD_VAULT_ADDR
   script:
     - *docker-reader-role
-    - make msi SKIP_COMPILE=true VERSION=${CI_COMMIT_TAG:-} DOCKER_REPO=${DOCKER_HUB_REPO}
+    - |
+      VERSION_TAG="${RELEASE_VERSION:-${CI_COMMIT_TAG:-}}"
+      make msi SKIP_COMPILE=true VERSION=${VERSION_TAG} DOCKER_REPO=${DOCKER_HUB_REPO}
   artifacts:
     paths:
       - dist/*.msi
@@ -1057,15 +1064,18 @@ build-push-linux-image:
     - |
       # Set env vars
       set -e
-      if [[ -n "${CI_COMMIT_TAG:-}" ]]; then
+      if [[ -n "${RELEASE_VERSION:-}" ]]; then
+        IMAGE_NAME="quay.io/signalfx/splunk-otel-collector"
+        IMAGE_TAG=${RELEASE_VERSION#v}
+      elif [[ -n "${CI_COMMIT_TAG:-}" ]]; then
         IMAGE_NAME="quay.io/signalfx/splunk-otel-collector"
         IMAGE_TAG=${CI_COMMIT_TAG#v}
       else
         IMAGE_NAME="quay.io/signalfx/splunk-otel-collector-dev"
-        IMAGE_TAG=${CI_COMMIT_SHA}
+        IMAGE_TAG=${CI_COMMIT_BRANCH:-${CI_COMMIT_SHA}}
       fi
       LATEST_TAG=""
-      if [[ "${CI_COMMIT_BRANCH:-}" = "main" ]] || [[ "${CI_COMMIT_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      if [[ "${CI_COMMIT_BRANCH:-}" = "main" ]] || [[ "${CI_COMMIT_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ -n "${RELEASE_VERSION:-}" ]]; then
         # Only push latest tag for main and stable releases
         LATEST_TAG="latest"
       fi
@@ -1203,7 +1213,12 @@ build-push-windows-image:
       if ($LASTEXITCODE -ne 0) { exit 1 }
     - |
       # Set env vars
-      if ($env:CI_COMMIT_TAG) {
+      if ($env:RELEASE_VERSION) {
+        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector"
+        $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows"
+        $tagNumber = $env:RELEASE_VERSION.TrimStart("v")
+        $IMAGE_TAG = "${tagNumber}-${env:WIN_VERSION}"
+      } elseif ($env:CI_COMMIT_TAG) {
         $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector"
         $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-windows"
         $tagNumber = $env:CI_COMMIT_TAG.TrimStart("v")
@@ -1214,7 +1229,7 @@ build-push-windows-image:
         $IMAGE_TAG = "${env:CI_COMMIT_SHA}-${env:WIN_VERSION}"
       }
       $LATEST_TAG = ""
-      if ($env:CI_COMMIT_BRANCH -eq "main" -or $env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$') {
+      if ($env:CI_COMMIT_BRANCH -eq "main" -or $env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$' -or $env:RELEASE_VERSION) {
         # Only push latest tag for main and stable releases
         $LATEST_TAG = "latest-${env:WIN_VERSION}"
       }
@@ -1346,7 +1361,12 @@ build-push-windows-fips-image:
       if ($LASTEXITCODE -ne 0) { exit 1 }
     - |
       # Set env vars
-      if ($env:CI_COMMIT_TAG) {
+      if ($env:RELEASE_VERSION) {
+        $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-fips"
+        $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-fips-windows"
+        $tagNumber = $env:RELEASE_VERSION.TrimStart("v")
+        $IMAGE_TAG = "${tagNumber}-${env:WIN_VERSION}"
+      } elseif ($env:CI_COMMIT_TAG) {
         $IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-fips"
         $OLD_IMAGE_NAME = "quay.io/signalfx/splunk-otel-collector-fips-windows"
         $tagNumber = $env:CI_COMMIT_TAG.TrimStart("v")
@@ -1357,8 +1377,8 @@ build-push-windows-fips-image:
         $IMAGE_TAG = "${env:CI_COMMIT_SHA}-${env:WIN_VERSION}"
       }
       $LATEST_TAG = ""
-      if ($env:CI_COMMIT_BRANCH -eq "main" -or $env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$') {
-        # Only push latest tag for main and stable releases
+      if ($env:CI_COMMIT_BRANCH -eq "main" -or $env:RELEASE_VERSION -match '^v\d+\.\d+\.\d+$' -or $env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$') {
+        # Only push latest tag for main and stable releases (manual or tag)
         $LATEST_TAG = "latest-${env:WIN_VERSION}"
       }
     - $JMX_METRIC_GATHERER_RELEASE = $(Get-Content packaging\jmx-metric-gatherer-release.txt)
@@ -1618,8 +1638,11 @@ release-nupkg:
 choco-release:
   extends: .trigger-filter
   stage: publish-release
-  dependencies:
-    - release-nupkg
+  needs:
+    - job: manual_release_trigger
+      optional: true
+    - job: release-nupkg
+      artifacts: true
   tags:
     - splunk-otel-collector-windows
   script:
@@ -1634,9 +1657,17 @@ choco-release:
       }
     - Test-Path .\dist\signed\splunk-otel-collector.${version}.nupkg
     - |
-      # Only push the choco package for stable release tags
-      if ($env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$') {
+      # Only push the choco package for stable release tags or manual releases
+      $should_release = $false
+      if ($env:RELEASE_VERSION -match '^v\d+\.\d+\.\d+$') {
+        $should_release = $true
+      } elseif ($env:CI_COMMIT_TAG -match '^v\d+\.\d+\.\d+$') {
+        $should_release = $true
+      }
+      if ($should_release) {
         choco push -k $env:CHOCO_TOKEN .\dist\signed\splunk-otel-collector.${version}.nupkg
+      } else {
+        Write-Host "Skipping choco push - not a stable release tag or manual release"
       }
 
 push-multiarch-manifest:
@@ -1801,19 +1832,35 @@ github-release:
     - .go-cache
   tags: [large]
   stage: publish-release
-  dependencies:
-    - compile
-    - otelcol-fips
-    - libsplunk
-    - sign-exe
-    - sign-osx
-    - release-debs
-    - release-nupkg
-    - release-rpms
-    - sign-msi
-    - sign-tar
-    - push-multiarch-manifest
-    - sign-agent-bundles
+  needs:
+    - job: manual_release_trigger
+      optional: true
+    - job: compile
+      artifacts: true
+    - job: otelcol-fips
+      artifacts: true
+    - job: libsplunk
+      artifacts: true
+    - job: sign-exe
+      artifacts: true
+    - job: sign-osx
+      artifacts: true
+    - job: release-debs
+      artifacts: true
+    - job: release-nupkg
+      artifacts: true
+    - job: release-rpms
+      artifacts: true
+    - job: sign-msi
+      artifacts: true
+    - job: sign-tar
+      artifacts: true
+    - job: push-multiarch-manifest
+      artifacts: true
+    - job: sign-agent-bundles
+      artifacts: true
+  before_script:
+    - .gitlab/install-gh-cli.sh
   script:
     - mkdir -p dist/assets
     - cp bin/otelcol_linux_* dist/assets/
@@ -1821,24 +1868,28 @@ github-release:
     - cp instrumentation/dist/libsplunk_*.so dist/assets/
     - cp dist/signed/* dist/assets/
     - |
-      # rename agent bundles to include the version for stable releases
       set -e
-      if [[ "${CI_COMMIT_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        mv dist/assets/agent-bundle_linux_amd64.tar.gz dist/assets/agent-bundle_${CI_COMMIT_TAG#v}_linux_amd64.tar.gz
-        mv dist/assets/agent-bundle_linux_amd64.tar.gz.asc dist/assets/agent-bundle_${CI_COMMIT_TAG#v}_linux_amd64.tar.gz.asc
-        mv dist/assets/agent-bundle_windows_amd64.zip dist/assets/agent-bundle_${CI_COMMIT_TAG#v}_windows_amd64.zip
-        mv dist/assets/agent-bundle_windows_amd64.zip.asc dist/assets/agent-bundle_${CI_COMMIT_TAG#v}_windows_amd64.zip.asc
+      VERSION_TAG="${RELEASE_VERSION:-${CI_COMMIT_TAG:-}}"
+      # Rename agent bundles to include the version for stable releases
+      if [[ "$VERSION_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        VERSION="${VERSION_TAG#v}"
+        mv dist/assets/agent-bundle_linux_amd64.tar.gz dist/assets/agent-bundle_${VERSION}_linux_amd64.tar.gz
+        mv dist/assets/agent-bundle_linux_amd64.tar.gz.asc dist/assets/agent-bundle_${VERSION}_linux_amd64.tar.gz.asc
+        mv dist/assets/agent-bundle_windows_amd64.zip dist/assets/agent-bundle_${VERSION}_windows_amd64.zip
+        mv dist/assets/agent-bundle_windows_amd64.zip.asc dist/assets/agent-bundle_${VERSION}_windows_amd64.zip.asc
         # exclude the arm64 bundle from release assets
         rm -f dist/assets/agent-bundle_linux_arm64.tar.gz
         rm -f dist/assets/agent-bundle_linux_arm64.tar.gz.asc
       fi
-    - pushd dist/assets && shasum -a 256 * > checksums.txt && popd
-    - |
-      # only create github release for stable release tags
-      set -e
-      if [[ "${CI_COMMIT_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        release_notes="$( ./packaging/release/gh-release-notes.sh "$CI_COMMIT_TAG" )"
-        ghr -t "$GITHUB_TOKEN" -u signalfx -r splunk-otel-collector -n "$CI_COMMIT_TAG" -b "$release_notes" --replace "$CI_COMMIT_TAG" dist/assets/
+      pushd dist/assets && shasum -a 256 * > checksums.txt && popd
+      # Tag if this is a manual release (RELEASE_VERSION set, CI_COMMIT_TAG not set)
+      if [[ -n "${RELEASE_VERSION:-}" && -z "${CI_COMMIT_TAG:-}" ]]; then
+        ./packaging/release/create-github-tag.sh "$VERSION_TAG" "$CI_COMMIT_SHA"
+      fi
+      # Only create github release for stable release tags
+      if [[ "$VERSION_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        release_notes="$( ./packaging/release/gh-release-notes.sh "$VERSION_TAG" )"
+        ghr -t "$GITHUB_TOKEN" -u signalfx -r splunk-otel-collector -n "$VERSION_TAG" -b "$release_notes" --replace "$VERSION_TAG" dist/assets/
       fi
   artifacts:
     when: always

--- a/packaging/release/create-github-tag.sh
+++ b/packaging/release/create-github-tag.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script handles tagging a commit on GitHub and pushing the tag.
+# Usage: ./tag-on-github.sh <version_tag> <commit_sha>
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <version_tag> <commit_sha>" >&2
+  exit 1
+fi
+
+VERSION_TAG="$1"
+COMMIT_SHA="$2"
+REPO="signalfx/splunk-otel-collector"
+REPO_URL="https://srv-gh-o11y-gdi:${GITHUB_TOKEN}@github.com/${REPO}.git"
+
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$SCRIPT_DIR/../../../.gitlab/common.sh"
+
+setup_gpg
+import_gpg_secret_key "$GITHUB_BOT_GPG_KEY"
+setup_git
+
+echo ">>> Cloning $REPO ..."
+git clone --no-checkout "$REPO_URL" repo-tmp
+cd repo-tmp
+git fetch origin
+git checkout "$COMMIT_SHA"
+
+echo ">>> Creating signed tag $VERSION_TAG for $COMMIT_SHA ..."
+git tag -s "$VERSION_TAG" "$COMMIT_SHA" -m "Release $VERSION_TAG"
+
+echo ">>> Pushing tag $VERSION_TAG to GitHub ..."
+git push origin "$VERSION_TAG"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Gitlab validation fails when both needs and dependencies exist. Looking at the best practices for gitlab, they recommended way to make sure that artifacts from previous jobs exist is to use needs instead of dependencies.
