### PR TITLE
Cherry-pick a receiver/sqlserver improvement change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - (Splunk) `receiver/discovery`: Reduce amount of attributes sent with the entities to the required set ([#6419](https://github.com/signalfx/splunk-otel-collector/pull/6419))
 - (Splunk) `receiver/discovery`: Use `app.kubernetes.io/instance` pod label for `service.name` entity attribute value if available ([#6435](https://github.com/signalfx/splunk-otel-collector/pull/6435))
+- (Contrib) `receiver/sqlserver` Make queries compatible with Azure SQL Database ([#41102](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41102))
 
 ### 🧰 Bug fixes 🧰
 

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver v0.130.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver v0.130.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.130.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.130.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.130.1-0.20250715203006-ed1505300a3d
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver v0.130.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.130.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.130.0

--- a/go.sum
+++ b/go.sum
@@ -1557,8 +1557,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecrece
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver v0.130.0/go.mod h1:YGXZHpFpgTPUob3VVREDq766DxRJqR+rpbdsTIlfeh4=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.130.0 h1:1rtVAouvss2HMeXDYcvFRgC339tunYLCPUb4QpChkIE=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.130.0/go.mod h1:yixq6TAQfmir5YIFFdU2fO+3NtTwSSspmLDB1o3f2nM=
-github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.130.0 h1:pLvza8xX1f5H3TfFE3sJkzs/WLncEMysGtwg7NY2v7o=
-github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.130.0/go.mod h1:G9FlwydTi+nUAfE4U5cFCCGjzfEi2U5iqefO0bYNvsk=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.130.1-0.20250715203006-ed1505300a3d h1:dIB3tNGE6y62Ie87Q3LE4njONBE3QCeywyFdr67iYAA=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.130.1-0.20250715203006-ed1505300a3d/go.mod h1:PcSGypL5BB3cFesD1C7wpGJ9BXqlXbT6DJ5+42pQDh0=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver v0.130.0 h1:gv7ICm0v0eeFvLUfX0X8i6kw93ioZdNOVIqpR5gPo44=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver v0.130.0/go.mod h1:oqAHZqOXUJ5NWSTZjOrbZnfvED8b4Kk7qgBlEIMFd1w=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.130.0 h1:956BiskEMc98W4WVeku2OIJ+QRJBW8DzoB3BWLQ3YbE=


### PR DESCRIPTION
Pulling https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41102 to 0.130.0 release
