### PR TITLE
[chore] fix dry-run of choco-release in gitlab on main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1601,8 +1601,11 @@ choco-release:
     - |
       $ErrorActionPreference = 'Stop'
       Set-PSDebug -Trace 1
+      if (-not (Test-Path .\dist\signed\splunk-otel-collector*.msi)) {
+        throw "MSI artifact not found in dist/signed/"
+      }
       $msi_file_name = Resolve-Path .\dist\signed\splunk-otel-collector*.msi | Split-Path -leaf
-      if ($msi_file_name -match '(\d+\.\d+\.\d+)(\.\d+)?') {
+      if ($msi_file_name -match '(\d+\.\d+\.\d+(\.\d+)?)') {
         $version = $matches[0]
       } else {
         throw "Failed to get version from $msi_file_name"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
choco-release when not releasing is broken with error like below

```
$ $ErrorActionPreference = 'Stop' # collapsed multi-line command
DEBUG: 384+ >>>> $msi_file_name = Resolve-Path .\dist\signed\splunk-otel-collector*.msi | Split-Path -leaf
DEBUG: 385+ if ( >>>> $msi_file_name -match '(\d+.\d+.\d+)(.\d+)?') {
DEBUG: 388+ >>>> throw "Failed to get version from $msi_file_name"
Failed to get version from
At line:388 char:3

throw "Failed to get version from $msi_file_name"
```