### PR TITLE
[DRAFT][salt] Add option to set service CLI args

### DIFF
--- a/deployments/salt/README.md
+++ b/deployments/salt/README.md
@@ -5,6 +5,7 @@ collect metrics, traces and logs from Linux machines and send data to [Splunk
 Observability Cloud](https://www.splunk.com/en_us/products/observability.html). 
 
 ## Linux
+
 Currently, the following Linux distributions and versions are supported:
 
 - Amazon Linux: 2, 2023 (**Note:** Log collection with Fluentd not currently supported for Amazon Linux 2023.)
@@ -99,6 +100,10 @@ splunk-otel-collector:
 
 - `splunk_listen_interface`: The network interface the collector receivers will listen
   on. (**default:** `127.0.0.1` for agent config, `0.0.0.0` otherwise)
+
+- `splunk_otel_collector_command_line_args`: Additional command line arguments to
+  pass to the Splunk OTel Collector service. This value will be set as the
+  `OTELCOL_OPTIONS` environment variable for the collector service. (**default:** `""`)
 
 - `collector_additional_env_vars`: Dictionary of additional environment
   variables from the collector configuration file for the collector service

--- a/deployments/salt/pillar.example
+++ b/deployments/salt/pillar.example
@@ -5,3 +5,5 @@ splunk-otel-collector:
   splunk_otel_collector_config: '/etc/otel/collector/agent_config.yaml'
   splunk_service_user: splunk-otel-collector
   splunk_service_group: splunk-otel-collector
+  # Command-line arguments to pass to the collector service.
+  splunk_otel_collector_command_line_args: ""

--- a/deployments/salt/splunk-otel-collector/collector_config.sls
+++ b/deployments/salt/splunk-otel-collector/collector_config.sls
@@ -26,11 +26,14 @@
 
 {% set splunk_listen_interface = salt['pillar.get']('splunk-otel-collector:splunk_listen_interface', '') %}
 
+{% set splunk_otel_collector_command_line_args = salt['pillar.get']('splunk-otel-collector:splunk_otel_collector_command_line_args', '') %}
+
 {% set collector_additional_env_vars = salt['pillar.get']('splunk-otel-collector:collector_additional_env_vars', {}) %}
 
 /etc/otel/collector/splunk-otel-collector.conf:
   file.managed:
     - contents: |
+        OTELCOL_OPTIONS={{ splunk_otel_collector_command_line_args }}
         SPLUNK_CONFIG={{ splunk_otel_collector_config }}
         SPLUNK_ACCESS_TOKEN={{ splunk_access_token }}
         SPLUNK_REALM={{ splunk_realm }}

--- a/packaging/tests/deployments/salt/salt_test.py
+++ b/packaging/tests/deployments/salt/salt_test.py
@@ -126,7 +126,11 @@ def verify_config_file(container, path, key, value=None, exists=True):
         assert not match, f"'{line}' found in {path}:\n{config}"
 
 
-def verify_env_file(container, api_url=SPLUNK_API_URL, ingest_url=SPLUNK_INGEST_URL, hec_token=SPLUNK_ACCESS_TOKEN, listen_interface=None):
+def verify_env_file(container, api_url=SPLUNK_API_URL, ingest_url=SPLUNK_INGEST_URL, hec_token=SPLUNK_ACCESS_TOKEN, listen_interface=None, command_line_args=None):
+    if command_line_args:
+        verify_config_file(container, SPLUNK_ENV_PATH, "OTELCOL_OPTIONS", command_line_args)
+    else:
+        verify_config_file(container, SPLUNK_ENV_PATH, "OTELCOL_OPTIONS=", None, exists=True)
     verify_config_file(container, SPLUNK_ENV_PATH, "SPLUNK_CONFIG", SPLUNK_CONFIG)
     verify_config_file(container, SPLUNK_ENV_PATH, "SPLUNK_ACCESS_TOKEN", SPLUNK_ACCESS_TOKEN)
     verify_config_file(container, SPLUNK_ENV_PATH, "SPLUNK_REALM", SPLUNK_REALM)
@@ -208,6 +212,7 @@ splunk-otel-collector:
   splunk_service_user: 'test-user'
   splunk_service_group: 'test-user'
   splunk_listen_interface: '0.0.0.0'
+  splunk_otel_collector_command_line_args: '--discovery --set=processors.batch.timeout=10s'
   collector_additional_env_vars:
     MY_CUSTOM_VAR1: value1
     MY_CUSTOM_VAR2: value2
@@ -237,7 +242,8 @@ def test_salt_custom(distro):
                 api_url="https://fake-api.com",
                 ingest_url="https://fake-ingest.com",
                 hec_token="fake-hec-token",
-                listen_interface="0.0.0.0"
+                listen_interface="0.0.0.0",
+                command_line_args="--discovery --set=processors.batch.timeout=10s"
             )
             verify_config_file(container, SPLUNK_ENV_PATH, "MY_CUSTOM_VAR1", "value1")
             verify_config_file(container, SPLUNK_ENV_PATH, "MY_CUSTOM_VAR2", "value2")


### PR DESCRIPTION
Adds a specific option to set the command-line arguments used to launch the collector service on installed via Salt.

The test for this new config setting is piggy-backing on the test for custom environment variables due to the similarities and to avoid yet another test for some CI that is already relatively long to run.
