### PR TITLE
Fix choco publication

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1665,6 +1665,7 @@ release-nupkg:
   artifacts:
     paths:
       - .\dist\signed\*.nupkg
+      - .\dist\signed\*.msi
 
 choco-release:
   extends: .trigger-filter


### PR DESCRIPTION
Add the missing artifact to the `release-nupkg` job used by `choco-release`.
