### PR TITLE
Small fixes to TA testing code to make it work on mac

### DIFF
--- a/packaging/technical-addon/packaging-scripts/cicd-tests/test-utils.sh
+++ b/packaging/technical-addon/packaging-scripts/cicd-tests/test-utils.sh
@@ -14,9 +14,9 @@ repack_with_access_token() {
     chmod -R a+rwx "$TEMP_DIR"
     echo "$token" > "$TEMP_DIR/Splunk_TA_otel/local/access_token"
 
-    random_suffix="$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 6)"
+    random_suffix="$(LC_CTYPE=c tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 6)"
     repacked="$TEMP_DIR/Splunk_TA_otel-${random_suffix}.tgz"
-    tar -C "$TEMP_DIR" -hcz --file "$repacked"  "Splunk_TA_otel"
+    COPYFILE_DISABLE=1 tar --format ustar -C "$TEMP_DIR" -hcz --file "$repacked"  "Splunk_TA_otel"
     chmod a+rwx "$repacked"
 
     echo "$repacked"


### PR DESCRIPTION
`tr` complains with `Illegal byte sequence`
Setting `LC_TYPE=c` helps: https://unix.stackexchange.com/questions/141420/tr-complains-of-illegal-byte-sequence

See https://community.splunk.com/t5/All-Apps-and-Add-ons/Why-am-I-getting-error-quot-archive-contains-more-than-one/m-p/248831 for the rationale of the fix to the tar file. The tar.gz built on my mac is rejected by Splunk otherwise.
