### PR TITLE
fixes script for downloading latest otel version

### DIFF
--- a/packaging/technical-addon/packaging-scripts/update-otel-version.sh
+++ b/packaging/technical-addon/packaging-scripts/update-otel-version.sh
@@ -19,7 +19,7 @@
 #SPLUNK_OTEL_VERSION="v0.88.0"
 SPLUNK_OTEL_VERSION="${SPLUNK_OTEL_VERSION:-}"
 if [ -z "$SPLUNK_OTEL_VERSION" ]; then
-    SPLUNK_OTEL_VERSION="$(curl "https://api.github.com/repos/signalfx/splunk-otel-collector/tags" | jq -r '[.[].name | select(test("v[0-9]+\\.[0-9]+\\.[0-9]+")) | sub("^v"; "")] | sort_by(split(".") | map(tonumber)) | last | "v" + .')"
+    SPLUNK_OTEL_VERSION="$(curl "https://api.github.com/repos/signalfx/splunk-otel-collector/tags" | jq -r '[.[].name | select(test("v[0-9]+\\.[0-9]+\\.[0-9]+$")) | sub("^v"; "")] | sort_by(split(".") | map(tonumber)) | last | "v" + .')"
 fi
 echo "updating otel to version $SPLUNK_OTEL_VERSION"
 sed -i'.old' "s/^OTEL_COLLECTOR_VERSION?=.*$/OTEL_COLLECTOR_VERSION?=${SPLUNK_OTEL_VERSION#v}/g" "$ADDONS_SOURCE_DIR/Makefile" && rm "$ADDONS_SOURCE_DIR/Makefile.old"


### PR DESCRIPTION
We now have rc releases, but afaik we only want to release the addon on prod releases, so update the "get latest" tag

Note one could always manually update the `Makefile` if needed for an RC release/test, or we could change this to permit RC releases