### PR TITLE
[chore] update release rules for msi upload

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,7 +160,7 @@ fossa:
   rules:
     - &main-condition
       if: $CI_COMMIT_BRANCH == "main"
-    # commenting out to the original commit-tag trigger condition for collector release
+    # commenting out the original commit-tag trigger condition for collector release
     # - &release-condition
     #   if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
     - &manual-release-condition
@@ -429,7 +429,7 @@ libsplunk:
 agent-bundle-linux:
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
-    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+    # - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - <<: *manual-release-condition
   stage: build
@@ -1911,10 +1911,7 @@ github-release:
       artifacts: true
   before_script:
     - .gitlab/install-gh-cli.sh
-    - echo "PATH=$PATH"
-    - echo "GOPATH=$GOPATH"
-    - ls -la $GOPATH/bin/ || echo "GOPATH/bin does not exist"
-    - which ghr || echo "ghr not found in PATH"
+    - export PATH="$GOPATH/bin:$PATH"
   script:
     - mkdir -p dist/assets
     - cp bin/otelcol_linux_* dist/assets/
@@ -1945,6 +1942,7 @@ github-release:
         release_notes="$( ./packaging/release/gh-release-notes.sh "$VERSION_TAG" )"
         ghr -t "$GITHUB_TOKEN" -u signalfx -r splunk-otel-collector -n "$VERSION_TAG" -b "$release_notes" --replace "$VERSION_TAG" dist/assets/
       fi
+
   artifacts:
     when: always
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,8 +160,9 @@ fossa:
   rules:
     - &main-condition
       if: $CI_COMMIT_BRANCH == "main"
-    - &release-condition
-      if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+    # commenting out to the original commit-tag trigger condition for collector release
+    # - &release-condition
+    #   if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
     - &manual-release-condition
       if: $RELEASE_VERSION =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/ && $CI_COMMIT_BRANCH == "main"
     - &no-schedules-condition
@@ -1634,11 +1635,8 @@ verify-signed-metadata:
 
 # only upload the msi to S3 for stable release tags
 release-msi:
-  only:
-    variables:
-      - $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
-  except:
-    - schedules
+  rules:
+    - <<: *manual-release-condition
   extends:
     - .deploy-release
   stage: release
@@ -1649,11 +1647,8 @@ release-msi:
 
 # only upload the installer scripts to S3 for stable release tags
 release-installers:
-  only:
-    variables:
-      - $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
-  except:
-    - schedules
+  rules:
+    - <<: *manual-release-condition
   extends:
     - .deploy-release
   stage: release
@@ -1916,6 +1911,10 @@ github-release:
       artifacts: true
   before_script:
     - .gitlab/install-gh-cli.sh
+    - echo "PATH=$PATH"
+    - echo "GOPATH=$GOPATH"
+    - ls -la $GOPATH/bin/ || echo "GOPATH/bin does not exist"
+    - which ghr || echo "ghr not found in PATH"
   script:
     - mkdir -p dist/assets
     - cp bin/otelcol_linux_* dist/assets/


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

1. Updates s3 release for installers and msi to use the manual-release-condition
2. Removes CI_COMMIT_TAG from the .trigger-filters to avoid a 2nd pipeline from running after the manual-release creates a tag
3. Updates path to include GOPATH in github-release job
