### PR TITLE
[splunk_ta_otel] Workaround ungraceful shutdown of splunkd on Windows

### DIFF
--- a/packaging/technical-addon/Splunk_TA_otel/windows_x86_64/bin/Splunk_TA_otel_utils.ps1
+++ b/packaging/technical-addon/Splunk_TA_otel/windows_x86_64/bin/Splunk_TA_otel_utils.ps1
@@ -15,9 +15,12 @@ function isOtelProcessRunning($processName)
 	$parent = (Get-WmiObject win32_process | ? processid -eq $PID).parentprocessid
 	$Global:parentPid = $parent
 	otelLogWrite "INFO Parent process id: $parent"
+	$grandParent = (Get-WmiObject win32_process | ? processid -eq $parentPid).parentprocessid
+	$Global:grandParentPid = $grandParent
+	otelLogWrite "INFO GrandParent process id: $Global:grandParentPid"
 	$child = (Get-WmiObject win32_process | ? parentprocessid -eq $parent | ? processname -eq $processName).processid
 	$Global:otelPid = $child
-	otelLogWrite "INFO Collector process id: $child"
+	otelLogWrite "INFO Collector process id: $otelPid"
 	$otelProcess = Get-Process -Id $child
 	if($otelProcess)
 	{
@@ -55,7 +58,7 @@ otelLogWrite "INFO Splunk_TA_otelutils.ps1 started"
 start-sleep -s 3
 if (isOtelProcessRunning($otelProcessName)) {
 	otelLogWrite "INFO Otel agent running"
-	waitForExit($parentPid)
+	waitForExit($grandParentPid)
 	forceStopOtelProcess($otelPid)
 	CheckOtelProcessStop($otelPid)
 } else {


### PR DESCRIPTION
When `splunkd` dies ungracefully on Windows it doesn't terminate the 
`cmd` process created to run `Splunk_TA_otel.cmd`, the parent process on which `Splunk_TA_otel_utils.ps1` is waiting. As a workaround this change listens on the grand parent process instead (`splunkd.exe`). This does not improve on other issues related to shutdown of the modular input and the collector, but ensures that the collector process is terminated if the parent `splunkd` process terminates (gracefully or not).