### PR TITLE
Bump minimum go version to 1.24

### DIFF
--- a/.chloggen/upgrade_go1.24.yaml
+++ b/.chloggen/upgrade_go1.24.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: all
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bump minimum go version to 1.24
+
+# One or more tracking issues related to the change
+issues: [6542]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/workflows/agent-bundle-linux.yml
+++ b/.github/workflows/agent-bundle-linux.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   agent-bundle-linux:

--- a/.github/workflows/agent-bundle-windows.yml
+++ b/.github/workflows/agent-bundle-windows.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   agent-bundle-windows:

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -29,7 +29,7 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   cross-compile:

--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_VERSION: '3.13'
   PIP_VERSION: '24.2'
   REQUIREMENTS_PATH: "packaging/tests/requirements.txt"
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   cross-compile:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   tidy:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   build-package:

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -24,7 +24,7 @@ concurrency:
 env:
   CHEF_VERSION: "22.12.1024"
   CHEF_LICENSE: accept
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   setup-environment:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   compile:

--- a/.github/workflows/dotnet-instr-deployer-add-on.yml
+++ b/.github/workflows/dotnet-instr-deployer-add-on.yml
@@ -23,7 +23,7 @@ on:
         default: '6b4ebe426ca6'
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
   # Provide default values for non-manually triggered executions
   splunk_uf_version: ${{ github.event.inputs.splunk_uf_version || '9.4.0' }}
   splunk_uf_build_hash: ${{ github.event.inputs.splunk_uf_build_hash || '6b4ebe426ca6' }}

--- a/.github/workflows/gendependabot.yml
+++ b/.github/workflows/gendependabot.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/scripts/gendependabot.sh'
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   gendependabot:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 jobs:
   agent-bundle-linux:
     strategy:

--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   lint:

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -22,7 +22,7 @@ env:
   PYTHON_VERSION: '3.13'
   PIP_VERSION: '24.2'
   REQUIREMENTS_PATH: "packaging/tests/requirements.txt"
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   cross-compile:

--- a/.github/workflows/msi-build.yml
+++ b/.github/workflows/msi-build.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   msi-build:

--- a/.github/workflows/otelcol-fips.yml
+++ b/.github/workflows/otelcol-fips.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   otelcol-fips:

--- a/.github/workflows/splunk-ta-otel.yml
+++ b/.github/workflows/splunk-ta-otel.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
   ADDONS_SOURCE_DIR: "${{github.workspace}}/packaging/technical-addon"
   BUILD_DIR: "${{github.workspace}}/build"
 jobs:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -11,7 +11,7 @@ on:
         type: boolean
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   unit-test:

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -14,7 +14,7 @@ on:
     - cron: '0 0 * * 1-5' # Every weekday at midnight UTC
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 concurrency:
   group: vuln-scans-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 jobs:
   cross-compile:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 
 concurrency:
   group: windows-test-${{ github.event.pull_request.number || github.ref }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
   RELEASE_VERSION:
     value: ""
     description: "Version to release (must be in format v1.2.3)"
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
   WIN_2019_BASE_IMAGE: mcr.microsoft.com/windows/servercore:ltsc2019
   WIN_2022_BASE_IMAGE: mcr.microsoft.com/windows/servercore:ltsc2022
   SPLUNK_OTELCOL_DOWNLOAD_BASE:
@@ -374,7 +374,7 @@ compile:
       - bin/migratecheckpoint_*
 
 otelcol-fips:
-  image: '${DOCKER_CICD_REPO}/ci-container/golang-1.23:3.9.0'
+  image: '${DOCKER_CICD_REPO}/ci-container/golang-1.24:4.0.0'
   extends:
     - .trigger-filter
   stage: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🛑 Breaking changes 🛑
+
+- (Splunk) Bump minimum go version to 1.24 ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
+
 ## v0.131.1
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.131.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.131.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### 🛑 Breaking changes 🛑
-
-- (Splunk) Bump minimum go version to 1.24 ([#](https://github.com/signalfx/splunk-otel-collector/pull/))
-
 ## v0.131.1
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.131.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.131.0)

--- a/cmd/otelcol/fips/build/Dockerfile.linux
+++ b/cmd/otelcol/fips/build/Dockerfile.linux
@@ -1,5 +1,5 @@
 ARG DOCKER_REPO=docker.io
-ARG GO_VERSION=1.23
+ARG GO_VERSION=1.24
 FROM ${DOCKER_REPO}/golang:${GO_VERSION}
 
 # https://splunk.atlassian.net/wiki/x/qYqRDfs

--- a/cmd/otelcol/fips/build/Dockerfile.linux
+++ b/cmd/otelcol/fips/build/Dockerfile.linux
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.24
 FROM ${DOCKER_REPO}/golang:${GO_VERSION}
 
 # https://splunk.atlassian.net/wiki/x/qYqRDfs
-ENV BORING_SHA="c1dd71f0ea77e385796db11102c461896ee0824825c773979751983e2bf49912"
+ENV BORING_SHA="2ace5a99ae43b388845592472026b0225cf1f07c9b28124c23f0f3fef77f0210"
 ENV BORING_PATH="src/crypto/internal/boring/syso/goboringcrypto_linux_amd64.syso"
 RUN echo "$BORING_SHA" "$( go env GOROOT )/${BORING_PATH}" | sha256sum --check || ( echo "$BORING_PATH SHA256 doesn't match $BORING_SHA" && exit 1 )
 

--- a/cmd/otelcol/fips/build/Dockerfile.windows
+++ b/cmd/otelcol/fips/build/Dockerfile.windows
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.23
+ARG GO_VERSION=1.24
 FROM mcr.microsoft.com/oss/go/microsoft/golang:${GO_VERSION}
 
 ARG TARGETARCH

--- a/examples/prometheus-federation/prom-counter/go.mod
+++ b/examples/prometheus-federation/prom-counter/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/prometheus-federation/prom-counter
 
-go 1.23.10
+go 1.24.5
 
 require (
 	go.opentelemetry.io/otel v0.20.0

--- a/examples/prometheus-federation/prom-counter/go.mod
+++ b/examples/prometheus-federation/prom-counter/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/prometheus-federation/prom-counter
 
-go 1.24.5
+go 1.24.0
 
 require (
 	go.opentelemetry.io/otel v0.20.0

--- a/examples/splunk-hec-traces/tracing/go.mod
+++ b/examples/splunk-hec-traces/tracing/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/splunk-hec-traces/tracing
 
-go 1.24.5
+go 1.24.0
 
 require (
 	go.opentelemetry.io/otel v1.1.0

--- a/examples/splunk-hec-traces/tracing/go.mod
+++ b/examples/splunk-hec-traces/tracing/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/splunk-hec-traces/tracing
 
-go 1.23.10
+go 1.24.5
 
 require (
 	go.opentelemetry.io/otel v1.1.0

--- a/examples/splunk-hec/logging/go.mod
+++ b/examples/splunk-hec/logging/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/splunk-hec/logging
 
-go 1.24.5
+go 1.24.0
 
 require go.uber.org/zap v1.27.0
 

--- a/examples/splunk-hec/logging/go.mod
+++ b/examples/splunk-hec/logging/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/splunk-hec/logging
 
-go 1.23.10
+go 1.24.5
 
 require go.uber.org/zap v1.27.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector
 
-go 1.24.5
+go 1.24.0
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector
 
-go 1.23.10
+go 1.24.5
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4

--- a/internal/signalfx-agent/go.mod
+++ b/internal/signalfx-agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/signalfx-agent
 
-go 1.23.10
+go 1.24.5
 
 replace (
 	code.cloudfoundry.org/go-loggregator => github.com/signalfx/go-loggregator v1.0.1-0.20200205155641-5ba5ca92118d

--- a/internal/signalfx-agent/go.mod
+++ b/internal/signalfx-agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/signalfx-agent
 
-go 1.24.5
+go 1.24.0
 
 replace (
 	code.cloudfoundry.org/go-loggregator => github.com/signalfx/go-loggregator v1.0.1-0.20200205155641-5ba5ca92118d

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/internal/tools
 
-go 1.23.10
+go 1.24.5
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/internal/tools
 
-go 1.24.5
+go 1.24.0
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/packaging/dotnet-instr-deployer-add-on/go.mod
+++ b/packaging/dotnet-instr-deployer-add-on/go.mod
@@ -1,6 +1,6 @@
 module github.com/splunk/splunk_otel_dotnet_deployer
 
-go 1.24.5
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/packaging/dotnet-instr-deployer-add-on/go.mod
+++ b/packaging/dotnet-instr-deployer-add-on/go.mod
@@ -1,6 +1,6 @@
 module github.com/splunk/splunk_otel_dotnet_deployer
 
-go 1.23.10
+go 1.24.5
 
 require github.com/stretchr/testify v1.10.0
 

--- a/packaging/technical-addon/go.mod
+++ b/packaging/technical-addon/go.mod
@@ -1,6 +1,6 @@
 module github.com/splunk/splunk-technical-addon
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/deckarep/golang-set/v2 v2.8.0

--- a/pkg/extension/smartagentextension/go.mod
+++ b/pkg/extension/smartagentextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension
 
-go 1.24.5
+go 1.24.0
 
 require (
 	github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657

--- a/pkg/extension/smartagentextension/go.mod
+++ b/pkg/extension/smartagentextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension
 
-go 1.23.10
+go 1.24.5
 
 require (
 	github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657

--- a/pkg/processor/timestampprocessor/go.mod
+++ b/pkg/processor/timestampprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocessor
 
-go 1.23.10
+go 1.24.5
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/pkg/processor/timestampprocessor/go.mod
+++ b/pkg/processor/timestampprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocessor
 
-go 1.24.5
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/pkg/receiver/smartagentreceiver/go.mod
+++ b/pkg/receiver/smartagentreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver
 
-go 1.24.5
+go 1.24.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.131.0

--- a/pkg/receiver/smartagentreceiver/go.mod
+++ b/pkg/receiver/smartagentreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver
 
-go 1.23.10
+go 1.24.5
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.131.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest v0.131.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/stretchr/testify v1.10.0
-	github.com/testcontainers/testcontainers-go v0.37.0
+	github.com/testcontainers/testcontainers-go v0.38.0
 	go.opentelemetry.io/collector/component v1.37.0
 	go.opentelemetry.io/collector/component/componenttest v0.131.0
 	go.opentelemetry.io/collector/config/configgrpc v0.131.0
@@ -48,7 +48,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/ebitengine/purego v0.8.2 // indirect
+	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/foxboron/go-tpm-keyfiles v0.0.0-20250323135004-b31fac66206e // indirect
@@ -100,7 +100,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/rs/cors v1.11.1 // indirect
-	github.com/shirou/gopsutil/v4 v4.25.1 // indirect
+	github.com/shirou/gopsutil/v4 v4.25.5 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/tests
 
-go 1.24.5
+go 1.24.0
 
 require (
 	github.com/docker/docker v28.3.2+incompatible

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/tests
 
-go 1.23.10
+go 1.24.5
 
 require (
 	github.com/docker/docker v28.3.2+incompatible

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -70,8 +70,8 @@ github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
-github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0omw=
+github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -376,8 +376,8 @@ github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIH
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shirou/gopsutil/v3 v3.24.5 h1:i0t8kL+kQTvpAYToeuiVk3TgDeKOFioZO3Ztz/iZ9pI=
 github.com/shirou/gopsutil/v3 v3.24.5/go.mod h1:bsoOS1aStSs9ErQ1WWfxllSeS1K5D+U30r2NfcubMVk=
-github.com/shirou/gopsutil/v4 v4.25.1 h1:QSWkTc+fu9LTAWfkZwZ6j8MSUk4A2LV7rbH0ZqmLjXs=
-github.com/shirou/gopsutil/v4 v4.25.1/go.mod h1:RoUCUpndaJFtT+2zsZzzmhvbfGoDCJ7nFXKJf8GqJbI=
+github.com/shirou/gopsutil/v4 v4.25.5 h1:rtd9piuSMGeU8g1RMXjZs9y9luK5BwtnG7dZaQUJAsc=
+github.com/shirou/gopsutil/v4 v4.25.5/go.mod h1:PfybzyydfZcN+JMMjkF6Zb8Mq1A/VcogFFg7hj50W9c=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
@@ -405,8 +405,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/testcontainers/testcontainers-go v0.37.0 h1:L2Qc0vkTw2EHWQ08djon0D2uw7Z/PtHS/QzZZ5Ra/hg=
-github.com/testcontainers/testcontainers-go v0.37.0/go.mod h1:QPzbxZhQ6Bclip9igjLFj6z0hs01bU8lrl2dHQmgFGM=
+github.com/testcontainers/testcontainers-go v0.38.0 h1:d7uEapLcv2P8AvH8ahLqDMMxda2W9gQN1nRbHS28HBw=
+github.com/testcontainers/testcontainers-go v0.38.0/go.mod h1:C52c9MoHpWO+C4aqmgSU+hxlR5jlEayWtgYrb8Pzz1w=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/tests/receivers/smartagent/telegraf-exec/testdata/exec/Dockerfile
+++ b/tests/receivers/smartagent/telegraf-exec/testdata/exec/Dockerfile
@@ -1,7 +1,7 @@
 ARG SPLUNK_OTEL_COLLECTOR_IMAGE
 ARG IMAGE_PLATFORM
 
-FROM --platform=${IMAGE_PLATFORM} golang:1.23 as golang
+FROM --platform=${IMAGE_PLATFORM} golang:1.24 as golang
 COPY telegraf-exec.go /opt/telegraf-exec.go
 RUN go build -o /opt/telegraf-exec /opt/telegraf-exec.go
 

--- a/tests/tools/go.mod
+++ b/tests/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/tests/tools
 
-go 1.23.10
+go 1.24.5
 
 require github.com/Songmu/gotesplit v0.3.1
 

--- a/tests/tools/go.mod
+++ b/tests/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/tests/tools
 
-go 1.24.5
+go 1.24.0
 
 require github.com/Songmu/gotesplit v0.3.1
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
As discussed, we're upgrading our minimum go dependency before upstream. This follows the [previous PR](https://github.com/signalfx/splunk-otel-collector/pull/5920) upgrading the version fo golang.