### PR TITLE
[chore][deployments/ansible] Update vagrant box version used for testing

### DIFF
--- a/deployments/ansible/molecule/config/windows.yml
+++ b/deployments/ansible/molecule/config/windows.yml
@@ -40,7 +40,7 @@ platforms:
     instance_raw_config_args: *vagrant_args
   - name: "2022"
     box: gusztavvargadr/iis-windows-server
-    box_version: ${MOLECULE_VAGRANT_BOX_VERSION:-2102.0.2312}
+    box_version: ${MOLECULE_VAGRANT_BOX_VERSION:-2506.0.0}
     box_url: ${MOLECULE_VAGRANT_BOX_URL}
     cpus: 2
     memory: 8192


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Ansible tests are [failing](https://github.com/signalfx/splunk-otel-collector/actions/runs/16763213352/job/47463549086?pr=6542) when attempting to download the vagrant box.
```
2025-08-05 23:17:11 URL:https://vagrantcloud.com/api/v2/vagrant/gusztavvargadr/iis-windows-server [2176] -> "-" [1]
http://: Invalid host name.
```
This attempts to resolve the issue by using an updated default version.