### PR TITLE
Deprecate cadvisor and kubelet-stats monitors

### DIFF
--- a/.chloggen/deprecate-smartagent-cadvisor-monitor.yaml
+++ b/.chloggen/deprecate-smartagent-cadvisor-monitor.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/kubelet-stats
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "The kubelet-stats monitor is deprecated and will be removed by the end of October 2025. Please use the prometheus receiver instead."
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/deprecate-smartagent-cadvisor-monitor.yaml
+++ b/.chloggen/deprecate-smartagent-cadvisor-monitor.yaml
@@ -8,7 +8,7 @@ component: smartagent/kubelet-stats
 note: "The kubelet-stats monitor is deprecated and will be removed by the end of October 2025. Please use the prometheus receiver instead."
 
 # One or more tracking issues related to the change
-issues: []
+issues: [6597]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/deprecate-smartagent-kubelet-stats-monitor.yaml
+++ b/.chloggen/deprecate-smartagent-kubelet-stats-monitor.yaml
@@ -8,7 +8,7 @@ component: smartagent/cadvisor
 note: "The cadvisor monitor is deprecated and will be removed by the end of October 2025. Please use the prometheus receiver instead."
 
 # One or more tracking issues related to the change
-issues: []
+issues: [6597]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/deprecate-smartagent-kubelet-stats-monitor.yaml
+++ b/.chloggen/deprecate-smartagent-kubelet-stats-monitor.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/cadvisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "The cadvisor monitor is deprecated and will be removed by the end of October 2025. Please use the prometheus receiver instead."
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/signalfx-agent/pkg/monitors/cadvisor/cadvisor.go
+++ b/internal/signalfx-agent/pkg/monitors/cadvisor/cadvisor.go
@@ -32,6 +32,7 @@ type Cadvisor struct {
 
 // Configure the cAdvisor monitor
 func (c *Cadvisor) Configure(conf *CHTTPConfig) error {
+	c.logger.Warn("[NOTICE] The cadvisor monitor is deprecated. Please use the prometheus receiver instead. This plugin will be removed by the end of October 2025.")
 	cadvisorClient, err := client.NewClient(conf.CAdvisorURL)
 	if err != nil {
 		return fmt.Errorf("could not create cAdvisor client: %w", err)

--- a/internal/signalfx-agent/pkg/monitors/cadvisor/kubeletstats.go
+++ b/internal/signalfx-agent/pkg/monitors/cadvisor/kubeletstats.go
@@ -46,6 +46,8 @@ type KubeletStatsMonitor struct {
 
 // Configure the Kubelet Stats monitor
 func (ks *KubeletStatsMonitor) Configure(conf *KubeletStatsConfig) error {
+	ks.logger.Warn("[NOTICE] The kubelet-stats monitor is deprecated. Please use the prometheus receiver instead. This plugin will be removed by the end of October 2025.")
+
 	ks.logger = logrus.WithFields(logrus.Fields{"monitorType": conf.MonitorConfig.Type, "monitorID": conf.MonitorID})
 	client, err := kubelet.NewClient(&conf.KubeletAPI, ks.logger)
 	if err != nil {

--- a/internal/signalfx-agent/pkg/monitors/cadvisor/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/cadvisor/metadata.yaml
@@ -17,6 +17,9 @@ monitors:
     kubernetes_pod_uid:
       description: The UID of the pod instance under which this container runs
   doc: |
+    **This plugin is deprecated and will be removed by the end of October 2025.
+    Please use the prometheus receiver instead.**
+
     This monitor pulls metrics directly from cadvisor, which
     conventionally runs on port 4194, but can be configured to anything.  If you
     are running on Kubernetes, consider the [kubelet-stats](./kubelet-stats.md)
@@ -230,6 +233,9 @@ monitors:
   properties:
 - <<: *cadvisor
   doc: |
+    **This plugin is deprecated and will be removed by the end of October 2025.
+    Please use the prometheus receiver instead.**
+
     **As of Kubernetes 1.18 the `/spec` and `/stats/containers` endpoint that
     this monitor uses have been deprecated.  Therefore, this monitor is
     deprecated in favor of the kubelet-metrics` monitor, which uses the


### PR DESCRIPTION
Deprecate `cadvisor` and `kubelet-stats` monitors since they don't have any usage per telemetry data.