### PR TITLE
[chore] Stabilize .NET zeroconfig test by using large runner

### DIFF
--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Download Splunk OTel Collector msi
         uses: actions/download-artifact@v4.1.3
         with:
-          name: msi-build-${{ matrix.OS }}
+          name: msi-build-windows-2025
           path: ./tests/zeroconfig/windows/testdata/docker-setup/
 
       - name: Run the test script

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -60,10 +60,7 @@ jobs:
       OS: ${{ matrix.OS }}
 
   dotnet-zeroconfig-e2e-test:
-    runs-on: ${{ matrix.OS }}
-    strategy:
-      matrix:
-        OS: [ "windows-2022", "windows-2025" ]
+    runs-on: otel-windows
     needs: [msi-build]
     steps:
       - name: Check out the codebase.


### PR DESCRIPTION
No way to validate, but given the success rate on retry there is reason to think that this test is suffering from noisy neighbor issues. The hope here is that the larger runner won't experience similar issues.