### PR TITLE
[chore] Fix github-release gitlab job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1911,9 +1911,6 @@ github-release:
       artifacts: true
     - job: sign-agent-bundles
       artifacts: true
-  before_script:
-    - .gitlab/install-gh-cli.sh
-    - export PATH="$GOPATH/bin:$PATH"
   script:
     - mkdir -p dist/assets
     - cp bin/otelcol_linux_* dist/assets/


### PR DESCRIPTION
The job fails with `/usr/bin/bash: line 253: ghr: command not found` because the `before_script` from the `.go-cache` extension is overridden by the job's own `before_script`, which misses the required `make install-tools` step. The job's `before_script` appears redundant since `gh` isn't used in the job.
