### PR TITLE
Revert "Bump debian from 12 to 13 in /packaging/fpm (#6618)"

### DIFF
--- a/packaging/fpm/Dockerfile
+++ b/packaging/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:13
+FROM debian:12
 
 VOLUME /repo
 WORKDIR /repo


### PR DESCRIPTION
This reverts commit ca127fd2cff445cf13e4a7631e93d7eda03eac1c.

Need to hold of the upgrade since the CI is failing https://github.com/signalfx/splunk-otel-collector/actions/runs/17056886210/job/48356523280