### PR TITLE
[collector] add prometheusremotewritereceiver to the distribution

### DIFF
--- a/.chloggen/add_prometheusremotewritereceiver.yaml
+++ b/.chloggen/add_prometheusremotewritereceiver.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: new_component
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: collector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the Prometheus Remote Write receiver to the distribution.
+
+# One or more tracking issues related to the change
+issues: [6632]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusremotewritereceiver

--- a/docs/components.md
+++ b/docs/components.md
@@ -56,6 +56,7 @@ The distribution offers support for the following components.
 | [otlp](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver)                                                                  | [stable]         |
 | [postgresql](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/postgresqlreceiver)                                              | [beta]           |
 | [prometheus](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)                                              | [beta]           |
+| [prometheusremotewrite](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusremotewritereceiver)                        | [alpha]          |
 | [prometheus_simple](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/simpleprometheusreceiver)                                 | [beta]           |
 | [purefa](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/purefareceiver)                                                      | [alpha]          |
 | [rabbitmq](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/rabbitmqreceiver)                                                  | [beta]           |

--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver v0.135.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.135.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.135.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver v0.135.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver v0.135.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver v0.135.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator v0.135.0

--- a/go.sum
+++ b/go.sum
@@ -1552,6 +1552,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlrec
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.135.0/go.mod h1:gZUOZHhx3qlnR9/sAzcMxaMTWdJ5ZSukYBF2TmnrS/s=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.135.0 h1:HBNPVpCIYEMbypyNAAQPM/0j5UTqk94f+0Bi145oZNo=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.135.0/go.mod h1:M89Ila5LSmmui0R/tHO5SA/04eYyPkXOhyS3qNHcTE8=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver v0.135.0 h1:M4j8YXE+g0u+1DCSkQOfGwA0HKOXQyqH8q+FzFDOE9I=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver v0.135.0/go.mod h1:Wf7iVbTgUlrWMlhHB7S6sAkNPk9i+5UTP3J/ED5MxiM=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver v0.135.0 h1:r5jg4c5jp3rBeyMoUnYMe9HgaXahQWDzrlVD1vUFUtI=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver v0.135.0/go.mod h1:wKffgskx/9chwbEO6kMplRVGVrwTgpuhhsfYOtiuxvE=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver v0.135.0 h1:MNfTgbl/SqVl2uxfBMu0NWPguC2hToR6K3p9UWIw1AY=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -98,6 +98,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator"
@@ -216,6 +217,7 @@ func Get() (otelcol.Factories, error) {
 		otlpreceiver.NewFactory(),
 		postgresqlreceiver.NewFactory(),
 		prometheusreceiver.NewFactory(),
+		prometheusremotewritereceiver.NewFactory(),
 		purefareceiver.NewFactory(),
 		rabbitmqreceiver.NewFactory(),
 		receivercreator.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -89,6 +89,7 @@ func TestDefaultComponents(t *testing.T) {
 		"otlp",
 		"postgresql",
 		"prometheus",
+		"prometheusremotewrite",
 		"prometheus_simple",
 		"purefa",
 		"rabbitmq",


### PR DESCRIPTION
**Description:**
This adds the prometheusremotewritereceiver to the distribution. This component is in alpha. This component is ready to be used for limited non-critical production workloads, and the authors of this component welcome user feedback.