### PR TITLE
[chore] Fix deprecated Dockerfile ENV settings

### DIFF
--- a/deployments/ansible/molecule/default/Dockerfile.j2
+++ b/deployments/ansible/molecule/default/Dockerfile.j2
@@ -2,7 +2,7 @@
 FROM geerlingguy/docker-{{ item.image }}-ansible:latest
 {% elif item.image == "centos9" %}
 FROM quay.io/centos/centos:stream9
-ENV container docker
+ENV container=docker
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 RUN dnf install -y initscripts sudo systemd
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
@@ -28,7 +28,7 @@ RUN sed -i 's|download.opensuse.org|provo-mirror.opensuse.org|' /etc/zypp/repos.
 RUN zypper -n install -l ansible dbus-1 python3-rpm sudo systemd-sysvinit
 {% endif %}
 
-ENV container docker
+ENV container=docker
 
 RUN (cd /usr/lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \

--- a/deployments/ansible/molecule/default_install_remote_version/Dockerfile.j2
+++ b/deployments/ansible/molecule/default_install_remote_version/Dockerfile.j2
@@ -2,7 +2,7 @@
 FROM geerlingguy/docker-{{ item.image }}-ansible:latest
 {% elif item.image == "centos9" %}
 FROM quay.io/centos/centos:stream9
-ENV container docker
+ENV container=docker
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 RUN dnf install -y initscripts sudo systemd
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
@@ -28,7 +28,7 @@ RUN sed -i 's|download.opensuse.org|provo-mirror.opensuse.org|' /etc/zypp/repos.
 RUN zypper -n install -l ansible dbus-1 python3-rpm sudo systemd-sysvinit
 {% endif %}
 
-ENV container docker
+ENV container=docker
 
 RUN (cd /usr/lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,6 +1,6 @@
 FROM mysql:9.4
-ENV MYSQL_DATABASE testdb
-ENV MYSQL_USER testuser
-ENV MYSQL_PASSWORD testpass
-ENV MYSQL_ROOT_PASSWORD testpass
+ENV MYSQL_DATABASE=testdb
+ENV MYSQL_USER=testuser
+ENV MYSQL_PASSWORD=testpass
+ENV MYSQL_ROOT_PASSWORD=testpass
 COPY init.sql /docker-entrypoint-initdb.d

--- a/instrumentation/tests/java/Dockerfile
+++ b/instrumentation/tests/java/Dockerfile
@@ -10,9 +10,9 @@ COPY zeroconfig.conf /etc/splunk/zeroconfig/java.conf
 
 CMD java -jar Main.jar
 
-ENV OTEL_SERVICE_NAME iknowmyownservicename
+ENV OTEL_SERVICE_NAME=iknowmyownservicename
 
-ENV ANOTHER_VAR foo
+ENV ANOTHER_VAR=foo
 
 COPY libsplunk.so /usr/lib/splunk-instrumentation/libsplunk.so
 

--- a/packaging/bundle/Dockerfile
+++ b/packaging/bundle/Dockerfile
@@ -28,7 +28,7 @@ FROM ${DOCKER_REPO}/python:${PYTHON_VERSION%.*}-bookworm AS base
 
 ARG ARCH
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 
@@ -58,7 +58,7 @@ RUN mkdir -p /opt/root && \
     mv /opt/root/jdk* /opt/root/jdk && \
     rm -f /tmp/openjdk.tar.gz
 
-ENV JAVA_HOME /opt/root/jdk
+ENV JAVA_HOME=/opt/root/jdk
 
 RUN mkdir -p /opt/root/jre && \
     rm -f ${JAVA_HOME}/lib/src.zip && \
@@ -209,13 +209,13 @@ COPY --from=java /opt/root/jdk/ /opt/root/jdk/
 WORKDIR /usr/src/collectd
 
 ARG extra_cflags="-O2"
-ENV CFLAGS "-Wno-error -Wno-format-truncation -Wno-stringop-truncation -fPIC $extra_cflags"
-ENV CXXFLAGS $CFLAGS
-ENV JAVA_HOME /opt/root/jdk
+ENV CFLAGS="-Wno-error -Wno-format-truncation -Wno-stringop-truncation -fPIC $extra_cflags"
+ENV CXXFLAGS=$CFLAGS
+ENV JAVA_HOME=/opt/root/jdk
 
 # In the bundle, the java plugin so will live in /lib/collectd and the JVM
 # exists at /jre
-ENV JAVA_LDFLAGS "-Wl,-rpath -Wl,\$\$\ORIGIN/../../jre/lib/server"
+ENV JAVA_LDFLAGS="-Wl,-rpath -Wl,\$\$\ORIGIN/../../jre/lib/server"
 
 # xencpu plugin is not supported on ppc64le
 RUN autoreconf -vif &&\
@@ -387,7 +387,7 @@ RUN patch-rpath /opt/root
 FROM scratch AS final-image
 
 COPY --from=collectd /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 COPY --from=collectd /etc/nsswitch.conf /etc/nsswitch.conf
 COPY --from=collectd /usr/local/bin/patchelf /bin/

--- a/packaging/tests/deployments/puppet/images/deb/Dockerfile.debian-bullseye
+++ b/packaging/tests/deployments/puppet/images/deb/Dockerfile.debian-bullseye
@@ -16,7 +16,7 @@ RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v18.20.8/node-v18.20.8-li
 
 ENV PATH=/opt/puppetlabs/bin:/opt/node/bin:$PATH
 
-ENV container docker
+ENV container=docker
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \   
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \                    
@@ -30,7 +30,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
 RUN rm -f /usr/lib/tmpfiles.d/tmp.conf;
 
 RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
+ENV init=/lib/systemd/systemd
 
 RUN if [ $PUPPET_RELEASE -lt 8 ]; then \
       puppet module install puppetlabs-stdlib --version 4.24.0 && \

--- a/packaging/tests/deployments/puppet/images/deb/Dockerfile.ubuntu-focal
+++ b/packaging/tests/deployments/puppet/images/deb/Dockerfile.ubuntu-focal
@@ -16,7 +16,7 @@ RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v18.20.8/node-v18.20.8-li
 
 ENV PATH=/opt/puppetlabs/bin:/opt/node/bin:$PATH
 
-ENV container docker
+ENV container=docker
 
 RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
     /etc/systemd/system/*.wants/* \
@@ -26,7 +26,7 @@ RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
     /lib/systemd/system/systemd-update-utmp*
 
 RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
+ENV init=/lib/systemd/systemd
 
 RUN if [ $PUPPET_RELEASE -lt 8 ]; then \
       puppet module install puppetlabs-stdlib --version 4.24.0 && \

--- a/packaging/tests/deployments/puppet/images/deb/Dockerfile.ubuntu-jammy
+++ b/packaging/tests/deployments/puppet/images/deb/Dockerfile.ubuntu-jammy
@@ -16,7 +16,7 @@ RUN wget -O /tmp/nodejs.tar.gz https://nodejs.org/dist/v18.20.8/node-v18.20.8-li
 
 ENV PATH=/opt/puppetlabs/bin:/opt/node/bin:$PATH
 
-ENV container docker
+ENV container=docker
 
 RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
     /etc/systemd/system/*.wants/* \
@@ -26,7 +26,7 @@ RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
     /lib/systemd/system/systemd-update-utmp*
 
 RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
+ENV init=/lib/systemd/systemd
 
 RUN if [ $PUPPET_RELEASE -lt 8 ]; then \
       puppet module install puppetlabs-stdlib --version 4.24.0 && \

--- a/packaging/tests/deployments/puppet/images/rpm/Dockerfile.amazonlinux-2023
+++ b/packaging/tests/deployments/puppet/images/rpm/Dockerfile.amazonlinux-2023
@@ -1,6 +1,6 @@
 FROM amazonlinux:2023
 
-ENV container docker
+ENV container=docker
 
 RUN yum install -y systemd procps initscripts wget
 

--- a/packaging/tests/deployments/puppet/images/rpm/Dockerfile.centos-8
+++ b/packaging/tests/deployments/puppet/images/rpm/Dockerfile.centos-8
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream8
 
-ENV container docker
+ENV container=docker
 
 RUN echo 'fastestmirror=1' >> /etc/yum.conf
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*

--- a/packaging/tests/deployments/puppet/images/rpm/Dockerfile.centos-9
+++ b/packaging/tests/deployments/puppet/images/rpm/Dockerfile.centos-9
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream9
 
-ENV container docker
+ENV container=docker
 
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 RUN echo 'fastestmirror=1' >> /etc/yum.conf

--- a/packaging/tests/deployments/puppet/images/rpm/Dockerfile.opensuse-15
+++ b/packaging/tests/deployments/puppet/images/rpm/Dockerfile.opensuse-15
@@ -2,7 +2,7 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM opensuse/leap:15
 
-ENV container docker
+ENV container=docker
 
 # RUN sed -i 's|download.opensuse.org|provo-mirror.opensuse.org|' /etc/zypp/repos.d/*.repo
 RUN zypper -n install -l curl dbus-1 systemd-sysvinit tar wget gzip

--- a/packaging/tests/deployments/puppet/images/rpm/Dockerfile.oraclelinux-8
+++ b/packaging/tests/deployments/puppet/images/rpm/Dockerfile.oraclelinux-8
@@ -1,6 +1,6 @@
 FROM oraclelinux:8
 
-ENV container docker
+ENV container=docker
 
 RUN dnf install -y systemd procps initscripts wget
 

--- a/packaging/tests/images/deb/Dockerfile.debian-bookworm
+++ b/packaging/tests/images/deb/Dockerfile.debian-bookworm
@@ -2,12 +2,12 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM debian:bookworm
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
     apt-get install -yq ca-certificates curl procps systemd wget
 
-ENV container docker
+ENV container=docker
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
     rm -f /lib/systemd/system/multi-user.target.wants/*;\
@@ -17,7 +17,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
+ENV init=/lib/systemd/systemd
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/packaging/tests/images/deb/Dockerfile.debian-bullseye
+++ b/packaging/tests/images/deb/Dockerfile.debian-bullseye
@@ -2,12 +2,12 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM debian:bullseye
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
     apt-get install -yq ca-certificates curl procps systemd wget
 
-ENV container docker
+ENV container=docker
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
     rm -f /lib/systemd/system/multi-user.target.wants/*;\
@@ -17,7 +17,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
+ENV init=/lib/systemd/systemd
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/packaging/tests/images/deb/Dockerfile.ubuntu-focal
+++ b/packaging/tests/images/deb/Dockerfile.ubuntu-focal
@@ -2,12 +2,12 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM ubuntu:focal
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
     apt-get install -yq ca-certificates curl procps systemd wget
 
-ENV container docker
+ENV container=docker
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
     rm -f /lib/systemd/system/multi-user.target.wants/*;\
@@ -17,7 +17,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
+ENV init=/lib/systemd/systemd
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/packaging/tests/images/deb/Dockerfile.ubuntu-jammy
+++ b/packaging/tests/images/deb/Dockerfile.ubuntu-jammy
@@ -2,12 +2,12 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM ubuntu:jammy
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
     apt-get install -yq ca-certificates curl procps systemd wget
 
-ENV container docker
+ENV container=docker
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
     rm -f /lib/systemd/system/multi-user.target.wants/*;\
@@ -17,7 +17,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
+ENV init=/lib/systemd/systemd
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/packaging/tests/images/deb/Dockerfile.ubuntu-noble
+++ b/packaging/tests/images/deb/Dockerfile.ubuntu-noble
@@ -1,11 +1,11 @@
 FROM ubuntu:noble
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
     apt-get install -yq ca-certificates curl procps systemd wget
 
-ENV container docker
+ENV container=docker
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
     rm -f /lib/systemd/system/multi-user.target.wants/*;\
@@ -15,7 +15,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
+ENV init=/lib/systemd/systemd
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/packaging/tests/images/rpm/Dockerfile.amazonlinux-2023
+++ b/packaging/tests/images/rpm/Dockerfile.amazonlinux-2023
@@ -2,7 +2,7 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM amazonlinux:2023
 
-ENV container docker
+ENV container=docker
 
 RUN yum install -y procps initscripts systemd wget tar
 

--- a/packaging/tests/images/rpm/Dockerfile.centos-8
+++ b/packaging/tests/images/rpm/Dockerfile.centos-8
@@ -2,7 +2,7 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM quay.io/centos/centos:stream8
 
-ENV container docker
+ENV container=docker
 
 RUN echo 'fastestmirror=1' >> /etc/yum.conf
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*

--- a/packaging/tests/images/rpm/Dockerfile.centos-9
+++ b/packaging/tests/images/rpm/Dockerfile.centos-9
@@ -2,7 +2,7 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM quay.io/centos/centos:stream9
 
-ENV container docker
+ENV container=docker
 
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 RUN echo 'fastestmirror=1' >> /etc/yum.conf

--- a/packaging/tests/images/rpm/Dockerfile.opensuse-15
+++ b/packaging/tests/images/rpm/Dockerfile.opensuse-15
@@ -2,7 +2,7 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM opensuse/leap:15
 
-ENV container docker
+ENV container=docker
 
 # RUN sed -i 's|download.opensuse.org|provo-mirror.opensuse.org|' /etc/zypp/repos.d/*.repo
 RUN zypper -n install -l curl dbus-1 systemd-sysvinit tar wget

--- a/packaging/tests/images/rpm/Dockerfile.oraclelinux-8
+++ b/packaging/tests/images/rpm/Dockerfile.oraclelinux-8
@@ -2,7 +2,7 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM oraclelinux:8
 
-ENV container docker
+ENV container=docker
 
 RUN dnf install -y curl procps initscripts systemd wget
 

--- a/packaging/tests/images/rpm/Dockerfile.oraclelinux-9
+++ b/packaging/tests/images/rpm/Dockerfile.oraclelinux-9
@@ -2,7 +2,7 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM oraclelinux:9
 
-ENV container docker
+ENV container=docker
 
 RUN dnf install -y curl procps initscripts systemd wget
 

--- a/packaging/tests/images/rpm/Dockerfile.rockylinux-8
+++ b/packaging/tests/images/rpm/Dockerfile.rockylinux-8
@@ -2,7 +2,7 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM quay.io/rockylinux/rockylinux:8
 
-ENV container docker
+ENV container=docker
 
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial
 RUN echo 'fastestmirror=1' >> /etc/yum.conf

--- a/packaging/tests/images/rpm/Dockerfile.rockylinux-9
+++ b/packaging/tests/images/rpm/Dockerfile.rockylinux-9
@@ -2,7 +2,7 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM quay.io/rockylinux/rockylinux:9
 
-ENV container docker
+ENV container=docker
 
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9
 RUN echo 'fastestmirror=1' >> /etc/yum.conf

--- a/packaging/tests/images/tar/Dockerfile.rockylinux-8
+++ b/packaging/tests/images/tar/Dockerfile.rockylinux-8
@@ -2,7 +2,7 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM quay.io/rockylinux/rockylinux:8
 
-ENV container docker
+ENV container=docker
 
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial
 RUN echo 'fastestmirror=1' >> /etc/yum.conf

--- a/packaging/tests/images/tar/Dockerfile.rockylinux-9
+++ b/packaging/tests/images/tar/Dockerfile.rockylinux-9
@@ -2,7 +2,7 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM quay.io/rockylinux/rockylinux:9
 
-ENV container docker
+ENV container=docker
 
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9
 RUN echo 'fastestmirror=1' >> /etc/yum.conf

--- a/packaging/tests/instrumentation/images/deb/Dockerfile.debian-bookworm
+++ b/packaging/tests/instrumentation/images/deb/Dockerfile.debian-bookworm
@@ -6,12 +6,12 @@ FROM debian:bookworm
 
 ARG TARGETARCH
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
     apt-get install -yq ca-certificates curl procps python3 systemd wget
 
-ENV container docker
+ENV container=docker
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
     rm -f /lib/systemd/system/multi-user.target.wants/*;\
@@ -37,7 +37,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi
 
 RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
+ENV init=/lib/systemd/systemd
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/packaging/tests/instrumentation/images/deb/Dockerfile.debian-bullseye
+++ b/packaging/tests/instrumentation/images/deb/Dockerfile.debian-bullseye
@@ -6,12 +6,12 @@ FROM debian:bullseye
 
 ARG TARGETARCH
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
     apt-get install -yq ca-certificates curl procps python3 systemd wget
 
-ENV container docker
+ENV container=docker
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
     rm -f /lib/systemd/system/multi-user.target.wants/*;\
@@ -37,7 +37,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi
 
 RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
+ENV init=/lib/systemd/systemd
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/packaging/tests/instrumentation/images/deb/Dockerfile.ubuntu-focal
+++ b/packaging/tests/instrumentation/images/deb/Dockerfile.ubuntu-focal
@@ -6,12 +6,12 @@ FROM ubuntu:focal
 
 ARG TARGETARCH
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
     apt-get install -yq ca-certificates curl procps python3 systemd wget
 
-ENV container docker
+ENV container=docker
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
     rm -f /lib/systemd/system/multi-user.target.wants/*;\
@@ -37,7 +37,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi
 
 RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
+ENV init=/lib/systemd/systemd
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/packaging/tests/instrumentation/images/deb/Dockerfile.ubuntu-jammy
+++ b/packaging/tests/instrumentation/images/deb/Dockerfile.ubuntu-jammy
@@ -6,12 +6,12 @@ FROM ubuntu:jammy
 
 ARG TARGETARCH
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
     apt-get install -yq ca-certificates curl procps python3 systemd wget
 
-ENV container docker
+ENV container=docker
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
     rm -f /lib/systemd/system/multi-user.target.wants/*;\
@@ -37,7 +37,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi
 
 RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
+ENV init=/lib/systemd/systemd
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/packaging/tests/instrumentation/images/deb/Dockerfile.ubuntu-noble
+++ b/packaging/tests/instrumentation/images/deb/Dockerfile.ubuntu-noble
@@ -6,12 +6,12 @@ FROM ubuntu:noble
 
 ARG TARGETARCH
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
     apt-get install -yq ca-certificates curl procps python3 systemd wget
 
-ENV container docker
+ENV container=docker
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
     "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
     rm -f /lib/systemd/system/multi-user.target.wants/*;\
@@ -37,7 +37,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi
 
 RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
+ENV init=/lib/systemd/systemd
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/packaging/tests/instrumentation/images/rpm/Dockerfile.amazonlinux-2023
+++ b/packaging/tests/instrumentation/images/rpm/Dockerfile.amazonlinux-2023
@@ -6,7 +6,7 @@ FROM amazonlinux:2023
 
 ARG TARGETARCH
 
-ENV container docker
+ENV container=docker
 
 RUN yum install -y procps initscripts python3 systemd systemd-udev wget tar
 

--- a/packaging/tests/instrumentation/images/rpm/Dockerfile.centos-8
+++ b/packaging/tests/instrumentation/images/rpm/Dockerfile.centos-8
@@ -6,7 +6,7 @@ FROM quay.io/centos/centos:stream8
 
 ARG TARGETARCH
 
-ENV container docker
+ENV container=docker
 
 RUN echo 'fastestmirror=1' >> /etc/yum.conf
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*

--- a/packaging/tests/instrumentation/images/rpm/Dockerfile.centos-9
+++ b/packaging/tests/instrumentation/images/rpm/Dockerfile.centos-9
@@ -6,7 +6,7 @@ FROM quay.io/centos/centos:stream9
 
 ARG TARGETARCH
 
-ENV container docker
+ENV container=docker
 
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 RUN echo 'fastestmirror=1' >> /etc/yum.conf

--- a/packaging/tests/instrumentation/images/rpm/Dockerfile.opensuse-15
+++ b/packaging/tests/instrumentation/images/rpm/Dockerfile.opensuse-15
@@ -6,7 +6,7 @@ FROM opensuse/leap:15
 
 ARG TARGETARCH
 
-ENV container docker
+ENV container=docker
 
 # RUN sed -i 's|download.opensuse.org|provo-mirror.opensuse.org|' /etc/zypp/repos.d/*.repo
 RUN zypper -n install -l curl dbus-1 gzip python3 systemd-sysvinit tar wget

--- a/packaging/tests/instrumentation/images/rpm/Dockerfile.oraclelinux-8
+++ b/packaging/tests/instrumentation/images/rpm/Dockerfile.oraclelinux-8
@@ -6,7 +6,7 @@ FROM oraclelinux:8
 
 ARG TARGETARCH
 
-ENV container docker
+ENV container=docker
 
 RUN dnf install -y curl procps initscripts python3 systemd wget
 

--- a/packaging/tests/instrumentation/images/rpm/Dockerfile.oraclelinux-9
+++ b/packaging/tests/instrumentation/images/rpm/Dockerfile.oraclelinux-9
@@ -6,7 +6,7 @@ FROM oraclelinux:9
 
 ARG TARGETARCH
 
-ENV container docker
+ENV container=docker
 
 RUN dnf install -y curl procps initscripts python3 systemd wget
 

--- a/packaging/tests/instrumentation/images/rpm/Dockerfile.rockylinux-8
+++ b/packaging/tests/instrumentation/images/rpm/Dockerfile.rockylinux-8
@@ -6,7 +6,7 @@ FROM quay.io/rockylinux/rockylinux:8
 
 ARG TARGETARCH
 
-ENV container docker
+ENV container=docker
 
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial
 RUN echo 'fastestmirror=1' >> /etc/yum.conf

--- a/packaging/tests/instrumentation/images/rpm/Dockerfile.rockylinux-9
+++ b/packaging/tests/instrumentation/images/rpm/Dockerfile.rockylinux-9
@@ -6,7 +6,7 @@ FROM quay.io/rockylinux/rockylinux:9
 
 ARG TARGETARCH
 
-ENV container docker
+ENV container=docker
 
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9
 RUN echo 'fastestmirror=1' >> /etc/yum.conf


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
I recently noticed in [build logs](https://github.com/signalfx/splunk-otel-collector/actions/runs/17162859603/job/48696142382?pr=6625) we're getting errors about deprecated functionality:
```
 7 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 61)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 212)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 213)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 214)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 218)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 390)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 31)
```
This PR is meant to fix all usages of the format `ENV key value` -> `ENV key=value`