### PR TITLE
[logs config] Use env variable for file storage extension path

### DIFF
--- a/.chloggen/use_default_path_logs_config.yaml
+++ b/.chloggen/use_default_path_logs_config.yaml
@@ -8,7 +8,7 @@ component: logs
 note: Added a new optional environment variable to the default Linux logs configuration file
 
 # One or more tracking issues related to the change
-issues: []
+issues: [6656]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/use_default_path_logs_config.yaml
+++ b/.chloggen/use_default_path_logs_config.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: logs
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added a new optional environment variable to the default Linux logs configuration file
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The new variable is `SPLUNK_FILE_STORAGE_EXTENSION_PATH`, which is used for 
+  setting where the filelog receiver's checkpoint files are stored. The default value
+  for this flag is `/var/lib/otelcol/filelogs`. This is only relevant for the
+  `logs_config_linux.yaml` configuration file at this time.

--- a/cmd/otelcol/config/collector/logs_config_linux.yaml
+++ b/cmd/otelcol/config/collector/logs_config_linux.yaml
@@ -9,8 +9,7 @@
 # - SPLUNK_LISTEN_INTERFACE: The network interface the agent receivers listen on.
 # - SPLUNK_MEMORY_LIMIT_MIB: 90% of memory allocated
 
-# If the collector is installed without the Linux installer script, the following
-# environment variables are optional:
+# The following environment variables are optional:
 
 # - SPLUNK_FILE_STORAGE_EXTENSION_PATH: Path to directory that will be used to
 #   contain file offsets used by the filelog receivers. This allows the receivers

--- a/cmd/otelcol/config/collector/logs_config_linux.yaml
+++ b/cmd/otelcol/config/collector/logs_config_linux.yaml
@@ -1,6 +1,6 @@
 # Example configuration file for logs collection.
 
-# If the collector is installed without the Linux/Windows installer script, the following
+# If the collector is installed without the Linux installer script, the following
 # environment variables are required to be manually defined or configured below:
 # - SPLUNK_ACCESS_TOKEN: The Splunk access token to authenticate requests
 # - SPLUNK_HEC_TOKEN: The Splunk HEC authentication token
@@ -8,6 +8,15 @@
 # - SPLUNK_INGEST_URL: The Splunk ingest URL, e.g. https://ingest.us0.signalfx.com
 # - SPLUNK_LISTEN_INTERFACE: The network interface the agent receivers listen on.
 # - SPLUNK_MEMORY_LIMIT_MIB: 90% of memory allocated
+
+# If the collector is installed without the Linux installer script, the following
+# environment variables are optional:
+
+# - SPLUNK_FILE_STORAGE_EXTENSION_PATH: Path to directory that will be used to
+#   contain file offsets used by the filelog receivers. This allows the receivers
+#   to pick up where they left off in case of a collector restart. This directory
+#   must be writable by the collector.
+#   default: `/var/lib/otelcol/filelogs`
 
 receivers:
   # Receivers for tailing and parsing log files coming from various services.
@@ -683,22 +692,21 @@ exporters:
     log_data_enabled: false
 
 
-
 extensions:
   health_check:
     endpoint: "${SPLUNK_LISTEN_INTERFACE}:13133"
-
 
   # Storage extension for storing filelog checkpoints.
   # Checkpoints allow the receiver to pick up where it left off in the case of a
   # collector restart.
   file_storage/filelogs:
-    # Location where checkpoint files are stored. This directory must exist and
-    # must be writable by the collector..
-    directory: /var/lib/otelcol/filelogs
+    # Location where checkpoint files are stored. This directory must be writable
+    # by the collector.
+    directory: "${SPLUNK_FILE_STORAGE_EXTENSION_PATH}"
     compaction:
       on_start: true
       directory: /tmp/
+    create_directory: true
 
 
 service:

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -38,15 +38,16 @@ import (
 type envVarWarnings map[string]string
 
 const (
-	APIURLEnvVar              = "SPLUNK_API_URL"
-	ConfigEnvVar              = "SPLUNK_CONFIG"
-	ConfigDirEnvVar           = "SPLUNK_CONFIG_DIR"
-	ConfigServerEnabledEnvVar = "SPLUNK_DEBUG_CONFIG_SERVER"
-	ConfigYamlEnvVar          = "SPLUNK_CONFIG_YAML"
-	HecLogIngestURLEnvVar     = "SPLUNK_HEC_URL"
-	ListenInterfaceEnvVar     = "SPLUNK_LISTEN_INTERFACE"
-	GoMemLimitEnvVar          = "GOMEMLIMIT"
-	GoGCEnvVar                = "GOGC"
+	APIURLEnvVar                   = "SPLUNK_API_URL"
+	ConfigEnvVar                   = "SPLUNK_CONFIG"
+	ConfigDirEnvVar                = "SPLUNK_CONFIG_DIR"
+	ConfigServerEnabledEnvVar      = "SPLUNK_DEBUG_CONFIG_SERVER"
+	ConfigYamlEnvVar               = "SPLUNK_CONFIG_YAML"
+	FileStorageExtensionPathEnvVar = "SPLUNK_FILE_STORAGE_EXTENSION_PATH"
+	HecLogIngestURLEnvVar          = "SPLUNK_HEC_URL"
+	ListenInterfaceEnvVar          = "SPLUNK_LISTEN_INTERFACE"
+	GoMemLimitEnvVar               = "GOMEMLIMIT"
+	GoGCEnvVar                     = "GOGC"
 	// nolint:gosec
 	HecTokenEnvVar    = "SPLUNK_HEC_TOKEN" // this isn't a hardcoded token
 	IngestURLEnvVar   = "SPLUNK_INGEST_URL"
@@ -396,6 +397,10 @@ func setDefaultEnvVars(s *Settings) error {
 
 	if token, ok := os.LookupEnv(TokenEnvVar); ok {
 		defaultEnvVars[HecTokenEnvVar] = token
+	}
+
+	if _, ok := os.LookupEnv(FileStorageExtensionPathEnvVar); !ok {
+		defaultEnvVars[FileStorageExtensionPathEnvVar] = "/var/lib/otelcol/filelogs"
 	}
 
 	for e, v := range defaultEnvVars {

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -673,6 +673,26 @@ func TestDiscoveryPropertiesMustExist(t *testing.T) {
 	require.Nil(t, settings)
 }
 
+func TestSetDefaultEnvVarsFileStorageExtension(t *testing.T) {
+	t.Cleanup(clearEnv(t))
+	_, ok := os.LookupEnv("SPLUNK_FILE_STORAGE_EXTENSION_PATH")
+	require.False(t, ok)
+	require.NoError(t, setDefaultEnvVars(nil))
+	path, ok := os.LookupEnv("SPLUNK_FILE_STORAGE_EXTENSION_PATH")
+	require.True(t, ok, "Expected SPLUNK_FILE_STORAGE_EXTENSION_PATH set by default")
+	require.Equal(t, path, "/var/lib/otelcol/filelogs")
+}
+
+func TestSetNonDefaultEnvVarsFileStorageExtension(t *testing.T) {
+	t.Cleanup(clearEnv(t))
+	nonDefaultPath := "/var/non/default/path"
+	err := os.Setenv("SPLUNK_FILE_STORAGE_EXTENSION_PATH", nonDefaultPath)
+	require.NoError(t, err)
+	path, ok := os.LookupEnv("SPLUNK_FILE_STORAGE_EXTENSION_PATH")
+	require.True(t, ok, "Expected SPLUNK_FILE_STORAGE_EXTENSION_PATH set by default")
+	require.Equal(t, path, nonDefaultPath)
+}
+
 // to satisfy Settings generation
 func setRequiredEnvVars(t *testing.T) func() {
 	cleanup := clearEnv(t)

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -688,8 +688,9 @@ func TestSetNonDefaultEnvVarsFileStorageExtension(t *testing.T) {
 	nonDefaultPath := "/var/non/default/path"
 	err := os.Setenv("SPLUNK_FILE_STORAGE_EXTENSION_PATH", nonDefaultPath)
 	require.NoError(t, err)
+	require.NoError(t, setDefaultEnvVars(nil))
 	path, ok := os.LookupEnv("SPLUNK_FILE_STORAGE_EXTENSION_PATH")
-	require.True(t, ok, "Expected SPLUNK_FILE_STORAGE_EXTENSION_PATH set by default")
+	require.True(t, ok, "Expected SPLUNK_FILE_STORAGE_EXTENSION_PATH to be set")
 	require.Equal(t, path, nonDefaultPath)
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Added a new optional environment variable to the default Linux logs configuration file. If not set by the user, it's set by default upon collector startup to `/var/lib/otelcol/filelogs`.

This PR also changes the configuration to enable `create_directory` by default on the file storage extension as it helps new installation startup proceed more smoothly. When running in a new test or production environment without this option being enabled, users have to manually create the directory or the collector will fail on startup.

This is a pre-req to https://github.com/signalfx/splunk-otel-collector/pull/6625