### PR TITLE
[chore][docker] Update bitnami images to bitnamilegacy

### DIFF
--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kafka:3.9.0
+FROM bitnamilegacy/kafka:3.9.0
 
 ENV JMX_PORT=7099
 EXPOSE 7099

--- a/tests/receivers/smartagent/collectd-spark/testdata/server/Dockerfile
+++ b/tests/receivers/smartagent/collectd-spark/testdata/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/spark:3.1.3
+FROM bitnamilegacy/spark:3.1.3
 
 EXPOSE 8080
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
[Context here](https://hub.docker.com/r/bitnami/kafka#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog), bitnami is no longer offering the same level of free containers. Legacy images are the same `bitnami`, but won't receive updates.