### PR TITLE
[chore][config server test] Fix flakiness by waiting for common port

### DIFF
--- a/internal/configconverter/config_server_test.go
+++ b/internal/configconverter/config_server_test.go
@@ -246,7 +246,7 @@ func waitForRequiredPort(t *testing.T, port string) {
 	const waitTime = 60 * time.Second
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		require.True(c, isPortAvailable(port))
-	}, waitTime, 500*time.Millisecond)
+	}, waitTime, 100*time.Millisecond)
 }
 
 func isPortAvailable(port string) bool {

--- a/internal/configconverter/config_server_test.go
+++ b/internal/configconverter/config_server_test.go
@@ -45,7 +45,7 @@ func TestConfigServer_RequireEnvVar(t *testing.T) {
 	cs.OnNew()
 	t.Cleanup(func() {
 		cs.OnShutdown()
-		assert.True(t, isPortAvailable(defaultConfigServerPort))
+		waitForRequiredPort(t, defaultConfigServerPort)
 	})
 	require.NoError(t, cs.Convert(context.Background(), confmap.NewFromStringMap(initial)))
 
@@ -108,7 +108,7 @@ func TestConfigServer_EnvVar(t *testing.T) {
 			cs.OnNew()
 			defer func() {
 				cs.OnShutdown()
-				assert.True(t, isPortAvailable(actualConfigServerPort))
+				waitForRequiredPort(t, actualConfigServerPort)
 			}()
 
 			require.NoError(t, cs.Convert(context.Background(), confmap.NewFromStringMap(initial)))
@@ -168,7 +168,7 @@ func TestConfigServer_Serve(t *testing.T) {
 	cs.OnNew()
 	t.Cleanup(func() {
 		cs.OnShutdown()
-		assert.True(t, isPortAvailable(defaultConfigServerPort))
+		waitForRequiredPort(t, defaultConfigServerPort)
 	})
 
 	cs.OnRetrieve("scheme", initial)
@@ -244,8 +244,8 @@ func TestSimpleRedact(t *testing.T) {
 func waitForRequiredPort(t *testing.T, port string) {
 	// Wait for a relatively long time for the port to be available, given that other package tests might be using it.
 	const waitTime = 60 * time.Second
-	require.Eventually(t, func() bool {
-		return isPortAvailable(port)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.True(c, isPortAvailable(port))
 	}, waitTime, 500*time.Millisecond)
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The tests are pretty flaky with failures such as:
```
=== RUN   TestConfigServer_RequireEnvVar
    config_server_test.go:48: 
        	Error Trace:	/Users/runner/work/splunk-otel-collector/splunk-otel-collector/internal/configconverter/config_server_test.go:48
        	            				/Users/runner/hostedtoolcache/go/1.23.10/arm64/src/testing/testing.go:1176
        	            				/Users/runner/hostedtoolcache/go/1.23.10/arm64/src/testing/testing.go:1354
        	            				/Users/runner/hostedtoolcache/go/1.23.10/arm64/src/testing/testing.go:1684
        	Error:      	Should be true
        	Test:       	TestConfigServer_RequireEnvVar
```
The line failing:
```
		assert.True(t, isPortAvailable(defaultConfigServerPort))
```
Tests are running in parallel, and many tests are using the default port. Each check waiting for required port to be available should be able to reduce flakiness.