### PR TITLE
[chore][Make] Simplify "for all" commands

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,9 +24,9 @@ jobs:
 
       - name: tidy
         run: |
-          make for-all CMD="make tidy"
+          make tidy-all
           if ! git diff --exit-code; then
-            echo "One or more Go files are not tidied. Run 'make for-all CMD=\"make tidy\"' and push the changes."
+            echo "One or more Go files are not tidied. Run 'make tidy-all' and push the changes."
             exit 1
           fi
 
@@ -39,9 +39,9 @@ jobs:
 
       - name: gofmt
         run: |
-          make for-all CMD="make fmt"
+          make fmt-all
           if ! git diff --exit-code; then
-            echo "One or more Go files are not formatted correctly. Run 'make for-all CMD=\"make fmt\"' and push the changes."
+            echo "One or more Go files are not formatted correctly. Run 'make fmt-all' and push the changes."
             exit 1
           fi
 
@@ -76,7 +76,7 @@ jobs:
 
       - name: Lint
         run: |
-          make for-all CMD="make lint"
+          make lint-all
 
   actionlint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/reusable-unit-test.yml
+++ b/.github/workflows/reusable-unit-test.yml
@@ -39,7 +39,7 @@ jobs:
           if ${{ inputs.COVERAGE }}; then
             make gotest-cover-without-race | tee unit-test-results-${{ inputs.OS }}/go-unit-tests.out
           else
-            make for-all CMD="make test" | tee unit-test-results/go-unit-tests.out
+            make test-all | tee unit-test-results/go-unit-tests.out
           fi
 
       - name: Uploading artifacts

--- a/.gitlab/tidy-dependabot-pr.sh
+++ b/.gitlab/tidy-dependabot-pr.sh
@@ -24,7 +24,7 @@ tidy_dependabot_pr() {
   git checkout "$branch"
 
   echo ">>> make tidy ..."
-  if make for-all CMD='make tidy'; then
+  if make tidy-all; then
     if ! git diff --exit-code >/dev/null 2>&1; then
       git commit -S -am "$message"
       git push -f "$repo_url" "$branch"

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,21 @@ tidy-all:
 	$(MAKE) for-all-target TARGET="tidy"
 	$(MAKE) tidy
 
+.PHONY: fmt-all
+fmt-all:
+	$(MAKE) for-all-target TARGET="fmt"
+	$(MAKE) fmt
+
+.PHONY: lint-all
+lint-all:
+	$(MAKE) for-all-target TARGET="lint"
+	$(MAKE) lint
+
+.PHONY: test-all
+test-all:
+	$(MAKE) for-all-target TARGET="test"
+	$(MAKE) test
+
 .PHONY: install-tools
 install-tools:
 	cd ./internal/tools && go install github.com/client9/misspell/cmd/misspell


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The current make commands for the `for-all` targets are longer and more complicated than necessary for our UX. I've added `lint-all`, `fmt-all` and `test-all` targets in place of the `make for-all CMD="make ..."` syntax we were using before.

Added targets follow the same naming scheme as `tidy-all`. We could instead move to match upstream, where all would be `go` prefixing the target (e.g. `gotidy`, `gofmt`, etc.)