### PR TITLE
[chore][dependabot] Group pyyaml bumps together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,9 @@ updates:
       boto3:
         patterns:
           - "boto3"
+      pyyaml:
+        patterns:
+          - "pyyaml"
   - package-ecosystem: "docker"
     directories:
       - "**/*"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Two identical PRs are open currently from dependabot, updating the exact same line of code: https://github.com/signalfx/splunk-otel-collector/pull/6725 and https://github.com/signalfx/splunk-otel-collector/pull/6728. I believe this would be solved by grouping pyyaml dependency bumps together.