### PR TITLE
[chore] Install go as a pre-req for update dep PRs in GitLab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -285,6 +285,7 @@ update-otel-deps-nightly:
 update-openjdk:
   only:
     - schedules
+  extends: .go-cache
   stage: update-deps
   needs: []
   dependencies: []
@@ -295,6 +296,7 @@ update-openjdk:
 update-javaagent:
   only:
     - schedules
+  extends: .go-cache
   stage: update-deps
   needs: []
   dependencies: []
@@ -305,6 +307,7 @@ update-javaagent:
 update-jmx-metrics-gatherer:
   only:
     - schedules
+  extends: .go-cache
   stage: update-deps
   needs: []
   dependencies: []
@@ -315,6 +318,7 @@ update-jmx-metrics-gatherer:
 update-nodejs-agent:
   only:
     - schedules
+  extends: .go-cache
   stage: update-deps
   needs: []
   dependencies: []
@@ -325,6 +329,7 @@ update-nodejs-agent:
 update-dotnet-agent:
   only:
     - schedules
+  extends: .go-cache
   stage: update-deps
   needs: []
   dependencies: []


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This was missed in https://github.com/signalfx/splunk-otel-collector/pull/6703. `make chlog-new` requires `go` to be installed, otherwise the jobs will fail with an error saying `find: 'go': No such file or directory`, and no PR will be created.