### PR TITLE
[chore] update-deps: handle go.opentelemetry.io/collector/semcov special case

### DIFF
--- a/update-deps
+++ b/update-deps
@@ -40,10 +40,10 @@ update_gomod() {
 
     pushd "$( dirname "$gomod" )" >/dev/null
 
-    if [ -n "$(go list -f '{{if not .Indirect}}{{.Path}}{{end}}' -m ${pkgs}/... 2>/dev/null)" ]; then
-        echo "Updating ${pkgs}/... in $gomod to $version"
-        go get ${pkgs}/...@${version}
-    fi
+    for mod in $( go list -f '{{if not .Indirect}}{{.Path}}{{end}}' -m ${pkgs}/... 2>/dev/null | grep -v go.opentelemetry.io/collector/semconv ); do
+        echo "Updating ${mod} in $gomod to $version"
+        go get ${mod}@${version}
+    done
 
     popd >/dev/null
 }


### PR DESCRIPTION
`update-deps` is failing because `go.opentelemetry.io/collector/semconv` is deprecated and doesn't have a version on the same bulk upgrade done by the script, i.e.: `go get go.opentelemetry.io/...@{version}` - at this point we don't want the upgrade for this module to happen since contrib still points to the same version as us. When contrib migrates to the replacement for this package we can remove the exception. The fix here just excludes the offending module and upgrades the remaining modules individually