### PR TITLE
[chore][.NET e2e test] Do not crash on failed attempt to connect

### DIFF
--- a/tests/zeroconfig/windows/windows_iis_test.go
+++ b/tests/zeroconfig/windows/windows_iis_test.go
@@ -104,9 +104,18 @@ func assertHTTPGetRequestSuccess(t *testing.T, url string) {
 	httpClient := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	assert.NoError(t, err)
+	if err != nil {
+		t.Logf("Error creating HTTP request: %v", err)
+		return
+	}
+
 	resp, err := httpClient.Do(req)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Logf("Error making HTTP request: %v", err)
+		return
+	}
 	defer resp.Body.Close()
+
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 


### PR DESCRIPTION
The code is crashing on `nil` exception when the very 1st attempt to perform an HTTP request to IIS fails. The issue is that the helper function "asserts" that there were no errors but it doesn't bail out, so it crashes assuming that the `req` and `resp` are not `nil`. The fix is to simply bailout earlier.

```terminal
=== RUN   TestWindowsIISInstrumentation
    windows_iis_test.go:99: 
    windows_iis_test.go:108: 
        	Error Trace:	C:/a/splunk-otel-collector/splunk-otel-collector/tests/zeroconfig/windows/windows_iis_test.go:108
        	            				C:/a/splunk-otel-collector/splunk-otel-collector/tests/zeroconfig/windows/windows_iis_test.go:119
        	            				C:/hostedtoolcache/windows/go/1.24.7/x64/src/runtime/asm_amd64.s:1700
        	Error:      	Received unexpected error:
        	            	Get "http://localhost:8000/aspnetfxapp/api/values/4": dial tcp [::1]:8000: connectex: No connection could be made because the target machine actively refused it.
        	Test:       	TestWindowsIISInstrumentation
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x40 pc=0x141144b]

goroutine 45 [running]:
github.com/signalfx/splunk-otel-collector/tests/zeroconfig/windows.assertHTTPGetRequestSuccess(0xc000003340, {0x1710cec, 0x2e})
	C:/a/splunk-otel-collector/splunk-otel-collector/tests/zeroconfig/windows/windows_iis_test.go:109 +0xeb
github.com/signalfx/splunk-otel-collector/tests/zeroconfig/windows.testExpectedTracesForHTTPGetRequest.func1(0xc000091fc7?)
	C:/a/splunk-otel-collector/splunk-otel-collector/tests/zeroconfig/windows/windows_iis_test.go:119 +0x1f
github.com/stretchr/testify/assert.EventuallyWithT.func1()
	C:/Users/runneradmin/go/pkg/mod/github.com/stretchr/testify@v1.11.1/assert/assertions.go:2096 +0x70
created by github.com/stretchr/testify/assert.EventuallyWithT in goroutine 3
	C:/Users/runneradmin/go/pkg/mod/github.com/stretchr/testify@v1.11.1/assert/assertions.go:2108 +0x1a5
exit status 2
FAIL	github.com/signalfx/splunk-otel-collector/tests/zeroconfig/windows	4.009s
```