### PR TITLE
[chore] Clean up free space on runner for Windows FIPS build

### DIFF
--- a/.github/workflows/otelcol-fips.yml
+++ b/.github/workflows/otelcol-fips.yml
@@ -39,6 +39,9 @@ jobs:
             GOARCH: amd64
       fail-fast: false
     steps:
+      # Building FIPs for Windows is flaky due to out of space issues.
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        if: matrix.GOOS == 'windows'
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
I'm hitting a lot of failures in the job `otelcol-fips` for Windows/amd64 running on the `ubuntu-24.04` GitHub runner ([example](https://github.com/signalfx/splunk-otel-collector/actions/runs/17749508115/job/50502480445?pr=6763)):
```
362.5 /usr/bin/x86_64-w64-mingw32-ld: final link failed: No space left on device
362.5 collect2: error: ld returned 1 exit status
```
Cleaning up free space before building should help reduce the frequency of this error.
