### PR TITLE
[chore] TA test flakiness: free disk space

### DIFF
--- a/.github/workflows/splunk-ta-otel.yml
+++ b/.github/workflows/splunk-ta-otel.yml
@@ -83,6 +83,9 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-environment
 
+      - name: Free up disk space for next step
+        uses: jlumbroso/free-disk-space@v1.3.1
+
       - name: Build & Package TA
         run: |
           set -o pipefail


### PR DESCRIPTION
Two instances of `test` job failing due to lack of free disk space:

- https://github.com/signalfx/splunk-otel-collector/actions/runs/18114820572/job/51548426693#step:4:86
- https://github.com/signalfx/splunk-otel-collector/actions/runs/18116463255/job/51552801403?pr=6812#step:4:86
