### PR TITLE
chore: update RHEL repository URL configuration

### DIFF
--- a/deployments/chef/attributes/default.rb
+++ b/deployments/chef/attributes/default.rb
@@ -4,8 +4,8 @@ default['splunk_otel_collector']['package_stage'] = 'release'
 default['splunk_otel_collector']['debian_repo_url'] = "#{node['splunk_otel_collector']['repo_base_url']}/otel-collector-deb"
 default['splunk_otel_collector']['debian_gpg_key_url'] = "#{node['splunk_otel_collector']['debian_repo_url']}/splunk-B3CD4420.gpg"
 
-default['splunk_otel_collector']['rhel_repo_url'] = "#{node['splunk_otel_collector']['repo_base_url']}/otel-collector-rpm"
-default['splunk_otel_collector']['rhel_gpg_key_url'] = "#{node['splunk_otel_collector']['rhel_repo_url']}/splunk-B3CD4420.pub"
+default['splunk_otel_collector']['rhel_repo_url'] = "#{node['splunk_otel_collector']['repo_base_url']}/otel-collector-rpm/#{node['splunk_otel_collector']['package_stage']}/$basearch/"
+default['splunk_otel_collector']['rhel_gpg_key_url'] = "#{node['splunk_otel_collector']['repo_base_url']}/otel-collector-rpm/splunk-B3CD4420.pub"
 
 default['splunk_otel_collector']['windows_repo_url'] = "https://dl.signalfx.com/splunk-otel-collector/msi/#{node['splunk_otel_collector']['package_stage']}"
 

--- a/deployments/chef/recipes/collector_yum_repo.rb
+++ b/deployments/chef/recipes/collector_yum_repo.rb
@@ -3,7 +3,7 @@
 
 yum_repository 'splunk-otel-collector' do
   description 'Splunk OpenTelemetry Collector Repository'
-  baseurl "#{node['splunk_otel_collector']['rhel_repo_url']}/#{node['splunk_otel_collector']['package_stage']}/$basearch/"
+  baseurl node['splunk_otel_collector']['rhel_repo_url']
   gpgcheck true
   gpgkey node['splunk_otel_collector']['rhel_gpg_key_url']
   enabled true

--- a/deployments/chef/recipes/collector_zypper_repo.rb
+++ b/deployments/chef/recipes/collector_zypper_repo.rb
@@ -3,7 +3,7 @@
 
 zypper_repository 'splunk-otel-collector' do
   description 'Splunk OpenTelemetry Collector Repository'
-  baseurl "#{node['splunk_otel_collector']['rhel_repo_url']}/#{node['splunk_otel_collector']['package_stage']}/$basearch/"
+  baseurl node['splunk_otel_collector']['rhel_repo_url']
   gpgcheck true
   gpgkey node['splunk_otel_collector']['rhel_gpg_key_url']
   type 'yum'


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Change how the rhel_repo_url is handled in chef allowing for full override on the user side.

We have an internal fork of the upstream repository and would like to point to it properly, having some logic in the actual yum_repository/zypper_repository resource removes the ability to do so

**Testing:** <Describe what testing was performed and which tests were added.>

Tested only the yum side, but these are virtually identical in the implementation

