### PR TITLE
[chore] Use GH standard runner for `dotnet-zeroconfig-e2e-test` workflow

### DIFF
--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -59,7 +59,7 @@ jobs:
       OS: ${{ matrix.OS }}
 
   dotnet-zeroconfig-e2e-test:
-    runs-on: otel-windows
+    runs-on: windows-2022 # windows-2022 comes preloaded with the Docker image used in the test
     needs: [msi-build]
     steps:
       - name: Check out the codebase.


### PR DESCRIPTION
Previously I switched to the larger runner, but after that problems in the test code were fixed. Switching back to the standard GH runner since the original issue was caused by the test code itself.

I will retry a few runs to see if all is good before merging this one.