### PR TITLE
[Do not merge] Example showing how to sample profiles

### DIFF
--- a/examples/profiling-sampling/docker-compose.yml
+++ b/examples/profiling-sampling/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  tomcat:
+    image: "tomcat:8-jdk8-corretto"
+    container_name: tomcat
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./splunk-otel-javaagent.jar:/var/splunk-otel-javaagent.jar
+    environment:
+      JAVA_TOOL_OPTIONS: "-javaagent:/var/splunk-otel-javaagent.jar"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otelcollector:4318"
+      SPLUNK_PROFILER_ENABLED: "true"
+      OTEL_SERVICE_NAME: tomcat
+  # OpenTelemetry Collector
+  otelcollector:
+    image: quay.io/signalfx/splunk-otel-collector:latest
+    container_name: otelcollector
+    command: [ "--config=/etc/otel-collector-config.yml" ]
+    volumes:
+      - ./otel-collector-config.yml:/etc/otel-collector-config.yml

--- a/examples/profiling-sampling/otel-collector-config.yml
+++ b/examples/profiling-sampling/otel-collector-config.yml
@@ -1,0 +1,41 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"
+      http:
+        endpoint: "0.0.0.0:4318"
+exporters:
+  debug:
+    verbosity: detailed
+  nop:
+
+processors:
+  transform/add_uuid:
+    log_statements:
+      - set(log.attributes["uuid"], UUID())
+  transform/remove_uuid:
+    log_statements:
+      - delete_matching_keys(log.attributes, "uuid")
+  probabilistic_sampler:
+    sampling_percentage: 50
+    attribute_source: record
+    from_attribute: uuid
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [ health_check ]
+  pipelines:
+    logs/profiling:
+      receivers: [ otlp ]
+      processors: [ transform/add_uuid, probabilistic_sampler, transform/remove_uuid ]
+      exporters: [ debug ]
+    metrics:
+      receivers: [ otlp ]
+      exporters: [ nop ]
+    traces:
+      receivers: [ otlp ]
+      exporters: [ nop ]


### PR DESCRIPTION
This example is showing how to deploy the collector against a Java app instrumented by the Java agent, sending profiles to the collector. The example concentrates on the ability of the collector to sample profiles by using a random uuid associated with each log representing a profile.