### PR TITLE
[smartagent] Deprecate subset of Kubernetes related monitors

### DIFF
--- a/.chloggen/deprecate_apiserver.yaml
+++ b/.chloggen/deprecate_apiserver.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/kubernetes-apiserver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The `kubernetes-apiserver` Smart Agent monitor has been deprecated and will be removed by the end of April 2026.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Please use the native [Prometheus receiver](https://help.splunk.com/en/splunk-observability-cloud/manage-data/splunk-distribution-of-the-opentelemetry-collector/get-started-with-the-splunk-distribution-of-the-opentelemetry-collector/collector-components/receivers/prometheus-receiver)
+  instead.

--- a/.chloggen/deprecate_apiserver.yaml
+++ b/.chloggen/deprecate_apiserver.yaml
@@ -8,7 +8,7 @@ component: smartagent/kubernetes-apiserver
 note: The `kubernetes-apiserver` Smart Agent monitor has been deprecated and will be removed by the end of April 2026.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [7298]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/deprecate_coredns.yaml
+++ b/.chloggen/deprecate_coredns.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/coredns
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The `coredns` Smart Agent monitor has been deprecated and will be removed by the end of April 2026.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Please use the native [Prometheus receiver](https://help.splunk.com/en/splunk-observability-cloud/manage-data/splunk-distribution-of-the-opentelemetry-collector/get-started-with-the-splunk-distribution-of-the-opentelemetry-collector/collector-components/receivers/prometheus-receiver)
+  instead.

--- a/.chloggen/deprecate_coredns.yaml
+++ b/.chloggen/deprecate_coredns.yaml
@@ -8,7 +8,7 @@ component: smartagent/coredns
 note: The `coredns` Smart Agent monitor has been deprecated and will be removed by the end of April 2026.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [7298]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/deprecate_kube-controller-manager.yaml
+++ b/.chloggen/deprecate_kube-controller-manager.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/kube-controller-manager
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The `kube-controller-manager` Smart Agent monitor has been deprecated and will be removed by the end of April 2026.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Please use the native [Prometheus receiver](https://help.splunk.com/en/splunk-observability-cloud/manage-data/splunk-distribution-of-the-opentelemetry-collector/get-started-with-the-splunk-distribution-of-the-opentelemetry-collector/collector-components/receivers/prometheus-receiver)
+  instead.

--- a/.chloggen/deprecate_kube-controller-manager.yaml
+++ b/.chloggen/deprecate_kube-controller-manager.yaml
@@ -8,7 +8,7 @@ component: smartagent/kube-controller-manager
 note: The `kube-controller-manager` Smart Agent monitor has been deprecated and will be removed by the end of April 2026.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [7298]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/deprecate_kubernetes-proxy.yaml
+++ b/.chloggen/deprecate_kubernetes-proxy.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/kubernetes-proxy
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The `kubernetes-proxy` Smart Agent monitor has been deprecated and will be removed by the end of April 2026.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Please use the native [Prometheus receiver](https://help.splunk.com/en/splunk-observability-cloud/manage-data/splunk-distribution-of-the-opentelemetry-collector/get-started-with-the-splunk-distribution-of-the-opentelemetry-collector/collector-components/receivers/prometheus-receiver)
+  instead.

--- a/.chloggen/deprecate_kubernetes-proxy.yaml
+++ b/.chloggen/deprecate_kubernetes-proxy.yaml
@@ -8,7 +8,7 @@ component: smartagent/kubernetes-proxy
 note: The `kubernetes-proxy` Smart Agent monitor has been deprecated and will be removed by the end of April 2026.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [7298]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/deprecate_kubernetes-scheduler.yaml
+++ b/.chloggen/deprecate_kubernetes-scheduler.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/kubernetes-scheduler
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The `kubernetes-scheduler` Smart Agent monitor has been deprecated and will be removed by the end of April 2026.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Please use the native [Prometheus receiver](https://help.splunk.com/en/splunk-observability-cloud/manage-data/splunk-distribution-of-the-opentelemetry-collector/get-started-with-the-splunk-distribution-of-the-opentelemetry-collector/collector-components/receivers/prometheus-receiver)
+  instead.

--- a/.chloggen/deprecate_kubernetes-scheduler.yaml
+++ b/.chloggen/deprecate_kubernetes-scheduler.yaml
@@ -8,7 +8,7 @@ component: smartagent/kubernetes-scheduler
 note: The `kubernetes-scheduler` Smart Agent monitor has been deprecated and will be removed by the end of April 2026.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [7298]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/internal/signalfx-agent/pkg/monitors/coredns/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/coredns/metadata.yaml
@@ -2,6 +2,9 @@ monitors:
 - monitorType: coredns
   dimensions:
   doc: |-
+      **This plugin is deprecated and will be removed by the end of April 2026.
+      Please use the Prometheus receiver instead.**
+
       This monitor scrapes prometheus metrics exposed by CoreDNS. The default port for these metrics
       are exposed on port 9153, at the /metrics path. For more information about CoreDNS prometheus
       metrics, check out their [documentation](https://coredns.io/plugins/metrics/).

--- a/internal/signalfx-agent/pkg/monitors/kubernetes/apiserver/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/kubernetes/apiserver/metadata.yaml
@@ -1,6 +1,9 @@
 monitors:
 - monitorType: kubernetes-apiserver
   doc: |
+    **This plugin is deprecated and will be removed by the end of April 2026.
+    Please use the Prometheus receiver instead.**
+
     This monitor queries the Kubernetes API server for kube-apiserver metrics in Prometheus format.
     The monitor queries path `/metrics` by default when no path is configured. The monitor converts
     the Prometheus metric types to SignalFx metric types as described [here](prometheus-exporter.md)

--- a/internal/signalfx-agent/pkg/monitors/kubernetes/controllermanager/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/kubernetes/controllermanager/metadata.yaml
@@ -1,5 +1,8 @@
 monitors:
 - doc: |
+    **This plugin is deprecated and will be removed by the end of April 2026.
+    Please use the Prometheus receiver instead.**
+
     Exports Prometheus metrics from the [kube-controller-manager]
     (https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/).
     The monitor queries path `/metrics` by default when no path is configured. The monitor converts

--- a/internal/signalfx-agent/pkg/monitors/kubernetes/proxy/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/kubernetes/proxy/metadata.yaml
@@ -1,5 +1,8 @@
 monitors:
 - doc: |
+    **This plugin is deprecated and will be removed by the end of April 2026.
+    Please use the Prometheus receiver instead.**
+
     Exports Prometheus metrics from the [kube-proxy](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy)
     metrics in Prometheus format. The monitor queries path `/metrics` by default when no path is configured. The monitor converts
     the Prometheus metric types to SignalFx metric types as described [here](prometheus-exporter.md)

--- a/internal/signalfx-agent/pkg/monitors/kubernetes/scheduler/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/kubernetes/scheduler/metadata.yaml
@@ -1,5 +1,8 @@
 monitors:
 - doc: |
+    **This plugin is deprecated and will be removed by the end of April 2026.
+    Please use the Prometheus receiver instead.**
+
     Exports Prometheus metrics from the [kube-scheduler](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler).
   monitorType: kubernetes-scheduler
   metrics:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
These monitors are removed from default chart configurations in https://github.com/signalfx/splunk-otel-collector-chart/pull/2266, so they can now be marked as deprecated.