### PR TITLE
[smartagent/memcached] deprecate the memcached monitor

### DIFF
--- a/.chloggen/deprecate_memcachedreceiver.yaml
+++ b/.chloggen/deprecate_memcachedreceiver.yaml
@@ -8,7 +8,7 @@ component: smartagent/memcached
 note: The memcached monitor is deprecated.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [7414]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/deprecate_memcachedreceiver.yaml
+++ b/.chloggen/deprecate_memcachedreceiver.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/memcached
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The memcached monitor is deprecated.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Please use the [memcached receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/memcachedreceiver) instead.

--- a/internal/signalfx-agent/pkg/monitors/collectd/memcached/memcached.go
+++ b/internal/signalfx-agent/pkg/monitors/collectd/memcached/memcached.go
@@ -35,5 +35,5 @@ type Monitor struct {
 
 // Configure configures and runs the plugin in collectd
 func (mm *Monitor) Configure(conf *Config) error {
-	return mm.SetConfigurationAndRun(conf)
+	return mm.SetConfigurationAndRun(conf, collectd.WithDeprecationWarningLog("memcached"))
 }

--- a/internal/signalfx-agent/pkg/monitors/collectd/memcached/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/collectd/memcached/metadata.yaml
@@ -1,6 +1,9 @@
 monitors:
 - dimensions:
   doc: |
+    ** The memcached monitor is deprecated and will be removed by end of April 2026.
+    Please use the memcached receiver instead.**
+    
     Monitors an instance of memcached using the [collectd memcached
     plugin](https://collectd.org/wiki/index.php/Plugin:memcached).  Requires
     Memcached 1.1 or later.


### PR DESCRIPTION
Deprecate the memcached monitor, preparing for a short removal cycle by end of April 2026.