### PR TITLE
[chore] update ansible assertions

### DIFF
--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/default_install_remote_version/verify.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/default_install_remote_version/verify.yml
@@ -17,6 +17,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert SPLUNK_REALM env var is set
       ansible.builtin.lineinfile:
@@ -24,6 +26,8 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert SPLUNK_INGEST_URL env var is set
       ansible.builtin.lineinfile:
@@ -31,13 +35,17 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert SPLUNK_API_URL env var is set
       ansible.builtin.lineinfile:
-        line: SPLUNK_INGEST_URL=https://api.fake-realm.signalfx.com
+        line: SPLUNK_API_URL=https://api.fake-realm.signalfx.com
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert SPLUNK_HEC_URL env var is set
       ansible.builtin.lineinfile:
@@ -45,3 +53,5 @@
         dest: /etc/otel/collector/splunk-otel-collector.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/with_instrumentation_systemd_custom/verify.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/with_instrumentation_systemd_custom/verify.yml
@@ -112,6 +112,8 @@
         dest: /usr/lib/systemd/system.conf.d/00-splunk-otel-auto-instrumentation.conf
         state: present
       check_mode: yes
+      register: config
+      failed_when: config is changed
 
     - name: Assert instrumentation config contains SPLUNK_PROFILER_MEMORY_ENABLED
       ansible.builtin.lineinfile:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Spotted during review of [#7419](https://github.com/signalfx/splunk-otel-collector/pull/7419#discussion_r3075527072): molecule verify files use `lineinfile` + `check_mode: yes` to assert env var values, but without `register / failed_when: config is changed` the tasks always succeed because Ansible treats a changed result (line not found) as success, not failure, making every assertion a no-op.

Updated files -

- default_install_remote_version/verify.yml - updated 5 assertions. One also had the wrong variable name (SPLUNK_INGEST_URL instead of SPLUNK_API_URL).

- with_instrumentation_systemd_custom/verify.yml 
