### PR TITLE
[ta-v2] Add gateway config to the package

### DIFF
--- a/packaging/ta-v2/CHANGELOG.md
+++ b/packaging/ta-v2/CHANGELOG.md
@@ -1,3 +1,0 @@
-# Changelog
-
-## Unreleased

--- a/packaging/ta-v2/Makefile
+++ b/packaging/ta-v2/Makefile
@@ -29,6 +29,7 @@ sync-configs:
 	@echo "Syncing configuration files ..."
 	@if [ ! -d ./assets/configs/ ]; then mkdir -p ./assets/configs/; fi
 	cp $(SRC_ROOT)/cmd/otelcol/config/collector/agent_config.yaml ./assets/configs/agent_config.yaml
+	cp $(SRC_ROOT)/cmd/otelcol/config/collector/gateway_config.yaml ./assets/configs/gateway_config.yaml
 
 .PHONY: ta-inputs-conf
 ta-inputs-conf:

--- a/packaging/ta-v2/Splunk_TA_otel.fileslist.txt
+++ b/packaging/ta-v2/Splunk_TA_otel.fileslist.txt
@@ -1,8 +1,9 @@
+Splunk_TA_otel/configs/agent_config.yaml
+Splunk_TA_otel/configs/gateway_config.yaml
 Splunk_TA_otel/default/app.conf
 Splunk_TA_otel/default/inputs.conf
-Splunk_TA_otel/README/inputs.conf.spec
 Splunk_TA_otel/linux_x86_64/bin/Splunk_TA_otel
-Splunk_TA_otel/static/appIcon.png
+Splunk_TA_otel/README/inputs.conf.spec
 Splunk_TA_otel/static/appIcon_2x.png
-Splunk_TA_otel/configs/agent_config.yaml
+Splunk_TA_otel/static/appIcon.png
 Splunk_TA_otel/windows_x86_64/bin/Splunk_TA_otel.exe

--- a/packaging/ta-v2/Splunk_TA_otel_linux_x86_64.fileslist.txt
+++ b/packaging/ta-v2/Splunk_TA_otel_linux_x86_64.fileslist.txt
@@ -1,7 +1,8 @@
+Splunk_TA_otel/configs/agent_config.yaml
+Splunk_TA_otel/configs/gateway_config.yaml
 Splunk_TA_otel/default/app.conf
 Splunk_TA_otel/default/inputs.conf
-Splunk_TA_otel/README/inputs.conf.spec
 Splunk_TA_otel/linux_x86_64/bin/Splunk_TA_otel
-Splunk_TA_otel/static/appIcon.png
+Splunk_TA_otel/README/inputs.conf.spec
 Splunk_TA_otel/static/appIcon_2x.png
-Splunk_TA_otel/configs/agent_config.yaml
+Splunk_TA_otel/static/appIcon.png

--- a/packaging/ta-v2/Splunk_TA_otel_windows_x86_64.fileslist.txt
+++ b/packaging/ta-v2/Splunk_TA_otel_windows_x86_64.fileslist.txt
@@ -1,7 +1,8 @@
+Splunk_TA_otel/configs/agent_config.yaml
+Splunk_TA_otel/configs/gateway_config.yaml
 Splunk_TA_otel/default/app.conf
 Splunk_TA_otel/default/inputs.conf
 Splunk_TA_otel/README/inputs.conf.spec
-Splunk_TA_otel/static/appIcon.png
 Splunk_TA_otel/static/appIcon_2x.png
-Splunk_TA_otel/configs/agent_config.yaml
+Splunk_TA_otel/static/appIcon.png
 Splunk_TA_otel/windows_x86_64/bin/Splunk_TA_otel.exe

--- a/packaging/ta-v2/tests/package_test.go
+++ b/packaging/ta-v2/tests/package_test.go
@@ -216,6 +216,7 @@ func TestPackageMandatoryFiles(t *testing.T) {
 
 			mandatoryPaths := []string{
 				modularInputName + "/configs/agent_config.yaml",
+				modularInputName + "/configs/gateway_config.yaml",
 				modularInputName + "/default/app.conf",
 				modularInputName + "/default/inputs.conf",
 				modularInputName + "/README/inputs.conf.spec",


### PR DESCRIPTION
Adds the gateway config to the TA v2 package given that there are customers using gateway config with the TA v1.
