### PR TITLE
[chore] OTL-4045 Update README.md with more accurate explaination

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,60 +163,73 @@ as a reference.
 
 ### From 0.149.0 to 0.150.0
 
-The default API and ingest endpoint URLs have been updated across **all components** from
-`*.signalfx.com` to `*.observability.splunkcloud.com`. See the
-[official domain transition guide](https://help.splunk.com/en/splunk-observability-cloud/reference/splunk-observability-cloud-domain-transition-guide)
-for background.
+Default endpoint URLs have changed from *.signalfx.com to *.observability.splunkcloud.com. The legacy endpoints remaim functional but migrating to the new domain is highly recommended. See the domain transition guide for background.
 
-**URL changes applied across all components:**
-- `https://api.<realm>.signalfx.com` → `https://api.<realm>.observability.splunkcloud.com`
-- `https://ingest.<realm>.signalfx.com` → `https://ingest.<realm>.observability.splunkcloud.com`
-- `https://ingest.<realm>.signalfx.com/v2/trace` → `https://ingest.<realm>.observability.splunkcloud.com/v2/trace`
-- `https://ingest.<realm>.signalfx.com/v1/log` → `https://ingest.<realm>.observability.splunkcloud.com/v1/log`
+| Variable | Old default | New default |
+| --- | --- | --- |
+| `SPLUNK_API_URL` | `https://api.<realm>.signalfx.com` | `https://api.<realm>.observability.splunkcloud.com` |
+| `SPLUNK_INGEST_URL` | `https://ingest.<realm>.signalfx.com` | `https://ingest.<realm>.observability.splunkcloud.com` |
+| `SPLUNK_TRACE_URL` | `https://ingest.<realm>.signalfx.com/v2/trace` | `https://ingest.<realm>.observability.splunkcloud.com/v2/trace` |
+| `SPLUNK_HEC_URL` | `https://ingest.<realm>.signalfx.com/v1/log` | `https://ingest.<realm>.observability.splunkcloud.com/v1/log` |
 
-**Migration Notes — Proxy and Firewall Configuration:**
-If you have firewall rules or proxy allowlists scoped to `*.signalfx.com`, update them to also allow
-`*.observability.splunkcloud.com`, or the specific realm-scoped hostnames:
-- `api.<realm>.observability.splunkcloud.com`
-- `ingest.<realm>.observability.splunkcloud.com`
+    Note: If you have firewall rules or proxy allowlists scoped to *.signalfx.com, add
+    *.observability.splunkcloud.com (or the realm-specific hostnames
+    api.<realm>.observability.splunkcloud.com and ingest.<realm>.observability.splunkcloud.com)
+    before switching.
 
-If you already set `SPLUNK_API_URL`, `SPLUNK_INGEST_URL`, `SPLUNK_TRACE_URL`, or `SPLUNK_HEC_URL`
-explicitly in your deployment, no immediate action required but user should start using the new endpoints.
-The legacy `*.signalfx.com` endpoints remain available during the transition period. 
+###  Package manager upgrade (apt, yum, choco upgrade)
 
-#### Collector configuration and environment variable defaults
-
-The default values compiled into the collector binary and all bundled YAML config files have been
-updated. To keep the legacy endpoints, set these environment variables explicitly (replace `<realm>`
-with your realm, e.g. `us0`):
-
-```
-SPLUNK_API_URL=https://api.<realm>.signalfx.com
-SPLUNK_INGEST_URL=https://ingest.<realm>.signalfx.com
-SPLUNK_TRACE_URL=https://ingest.<realm>.signalfx.com/v2/trace
-SPLUNK_HEC_URL=https://ingest.<realm>.signalfx.com/v1/log
-```
-
-#### Installer scripts
-
-Linux (`install.sh`):
-```
---api-url https://api.<realm>.signalfx.com
---ingest-url https://ingest.<realm>.signalfx.com
---hec-url https://ingest.<realm>.signalfx.com/v1/log
-```
-
-Windows (`install.ps1`):
-```
--api_url https://api.<realm>.signalfx.com
--ingest_url https://ingest.<realm>.signalfx.com
--hec_url https://ingest.<realm>.signalfx.com/v1/log
-```
-
-Chocolatey:
-```
-choco install splunk-otel-collector --params "'/SPLUNK_API_URL:https://api.<realm>.signalfx.com /SPLUNK_INGEST_URL:https://ingest.<realm>.signalfx.com /SPLUNK_HEC_URL:https://ingest.<realm>.signalfx.com/v1/log'"
-```
+  Your existing environment configuration is preserved. The collector continues
+  to use the endpoints you previously configured.
+  
+  When you are ready to migrate, replace <realm> with your realm (e.g. us0):
+  
+  **Linux**: Edit `/etc/otel/collector/splunk-otel-collector.conf:`
+  
+    SPLUNK_API_URL=https://api.<realm>.observability.splunkcloud.com
+    SPLUNK_INGEST_URL=https://ingest.<realm>.observability.splunkcloud.com
+    SPLUNK_HEC_URL=https://ingest.<realm>.observability.splunkcloud.com/v1/log
+  
+  Then restart the service: `sudo systemctl restart splunk-otel-collector`
+  
+  **Windows**: Update the `Environment` value in the registry at
+  `HKLM:\SYSTEM\CurrentControlSet\Services\splunk-otel-collector` with the
+  same URLs, then restart the service.
+  
+  `SPLUNK_TRACE_URL` is derived automatically from `SPLUNK_INGEST_URL` at runtime
+  unless you have explicitly set it. If you have, update it as well.
+  
+  ### MSI upgrade (Windows)
+  
+  Upgrading via `msiexec` applies the new `*.observability.splunkcloud.com`
+  defaults. To keep the legacy endpoints, pass them as MSI properties:
+  
+    msiexec /i <path\to\msi> SPLUNK_API_URL=https://api.<realm>.signalfx.com SPLUNK_INGEST_URL=https://ingest.<realm>.signalfx.com SPLUNK_HEC_URL=https://ingest.<realm>.signalfx.com/v1/log
+  
+  ### New installation
+  
+  New installations default to `*.observability.splunkcloud.com`. If your
+  environment requires the legacy endpoints, pass them explicitly:
+  
+  `install.sh` (add these flags):
+  
+    --api-url https://api.<realm>.signalfx.com \
+    --ingest-url https://ingest.<realm>.signalfx.com \
+    --hec-url https://ingest.<realm>.signalfx.com/v1/log
+  
+  `install.ps1` (add these flags):
+  
+    -api_url https://api.<realm>.signalfx.com `
+    -ingest_url https://ingest.<realm>.signalfx.com `
+    -hec_url https://ingest.<realm>.signalfx.com/v1/log
+  
+  Chocolatey (add these params):
+  
+    choco install splunk-otel-collector --params "'/SPLUNK_API_URL:https://api.<realm>.signalfx.com /SPLUNK_INGEST_URL:https://ingest.<realm>.signalfx.com /SPLUNK_HEC_URL:https://ingest.<realm>.signalfx.com/v1/log'"
+    
+  `msiexec` (add these properties):
+  
+    SPLUNK_API_URL=https://api.<realm>.signalfx.com SPLUNK_INGEST_URL=https://ingest.<realm>.signalfx.com SPLUNK_HEC_URL=https://ingest.<realm>.signalfx.com/v1/log
 
 ### From 0.117.0 to 0.118.0
 


### PR DESCRIPTION
**Description:** 
From 0.149.0 to 0.150.0 upgrade guide section to accurately describe the migration behavior from the user's perspective:
                                                                                                                                                                                                                                                                                                                                            
  - Already-installed collector: existing signalfx.com URL overrides are honoured as-is (no breaking change, no urgent action required). Migration instructions with the new-domain env var block are provided for when the user is ready.                                    
  - New installation wanting legacy endpoints: new installs default to *.observability.splunkcloud.com via SPLUNK_REALM. Users who need to stay on signalfx.com must set the URL env vars explicitly; examples are provided for env vars and all three installer surfaces (Linux install.sh, Windows install.ps1, Chocolatey).              
  - Added a firewall/proxy callout note advising users to allow *.observability.splunkcloud.com before switching.

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
