### PR TITLE
fix: 'occured' -> 'occurred' in installer error and rlog script

### DIFF
--- a/internal/receiver/scriptedinputsreceiver/scripts/rlog.sh
+++ b/internal/receiver/scriptedinputsreceiver/scripts/rlog.sh
@@ -56,7 +56,7 @@ if [ "$KERNEL" = "Linux" ] ; then
             echo "$CURRENT_TIME" > "$SEEK_FILE" # Checkpoint+
 
     else   # Added this condition to get error logs
-        echo "error occured while running 'service auditd status' command in rlog.sh script. Output : $(service auditd status). Command exited with exit code $?" 1>&2
+        echo "error occurred while running 'service auditd status' command in rlog.sh script. Output : $(service auditd status). Command exited with exit code $?" 1>&2
     fi
     # remove temporary error redirection file if it exists
     # shellcheck disable=SC2086

--- a/packaging/installer/install.ps1
+++ b/packaging/installer/install.ps1
@@ -518,7 +518,7 @@ if ($with_dotnet_instrumentation) {
         } catch {
             $err = $_.Exception.Message
             $message = "
-            An error occured when trying to download .NET Instrumentation installer from $download. This may be due to a network connectivity issue.
+            An error occurred when trying to download .NET Instrumentation installer from $download. This may be due to a network connectivity issue.
             $err
             "
             throw "$message"


### PR DESCRIPTION
Fix 2 user-visible error messages:

- `internal/receiver/scriptedinputsreceiver/scripts/rlog.sh` line 59: Error stderr message from auditd probe
- `packaging/installer/install.ps1` line 521: .NET instrumentation installer download error

String-literal-only change.