### PR TITLE
[chore] Align OTLP integration test endpoint handling with contrib

### DIFF
--- a/tests/testutils/endpoint.go
+++ b/tests/testutils/endpoint.go
@@ -32,12 +32,12 @@ type portpair struct {
 	last  string
 }
 
-// getAvailableLocalAddress finds an available local port and returns an endpoint
-// describing it. The port is available for opening when this function returns
-// provided that there is no race by some other code to grab the same port
-// immediately.
+// getAvailableLocalAddress finds an available IPv4 local port and returns an
+// endpoint describing it. The port is available for opening when this function
+// returns provided that there is no race by some other code to grab the same
+// port immediately.
 func getAvailableLocalAddress(tb testing.TB) string {
-	ln, err := net.Listen("tcp", "localhost:0")
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
 	require.NoError(tb, err, "Failed to get a free local port")
 	// There is a possible race if something else takes this same port before
 	// the test uses it, however, that is unlikely in practice.

--- a/tests/testutils/endpoint_test.go
+++ b/tests/testutils/endpoint_test.go
@@ -33,7 +33,7 @@ func TestGetAvailablePort(t *testing.T) {
 	portStr := strconv.Itoa(int(GetAvailablePort(t)))
 	require.NotEqual(t, "", portStr)
 
-	testEndpointAvailable(t, "localhost:"+portStr)
+	testEndpointAvailable(t, "127.0.0.1:"+portStr)
 }
 
 func testEndpointAvailable(t *testing.T, endpoint string) {

--- a/tests/testutils/testcase.go
+++ b/tests/testutils/testcase.go
@@ -95,9 +95,10 @@ func NewHECTestcase(tb testing.TB) *Testcase {
 
 func (t *Testcase) setOTLPEndpoint() {
 	otlpPort := GetAvailablePort(t)
-	otlpHost := "localhost"
-	t.OTLPEndpoint = fmt.Sprintf("%s:%d", otlpHost, otlpPort)
-	t.OTLPEndpointForCollector = t.OTLPEndpoint
+	t.OTLPEndpoint = fmt.Sprintf("localhost:%d", otlpPort)
+	// Use IPv4 loopback for collector clients so Linux host-networked containers
+	// don't resolve localhost to ::1 while the in-memory sink only listens on IPv4.
+	t.OTLPEndpointForCollector = fmt.Sprintf("127.0.0.1:%d", otlpPort)
 }
 
 func (t *Testcase) setHECEndpoint() {

--- a/tests/testutils/testcase.go
+++ b/tests/testutils/testcase.go
@@ -95,8 +95,6 @@ func NewHECTestcase(tb testing.TB) *Testcase {
 
 func (t *Testcase) setOTLPEndpoint() {
 	otlpPort := GetAvailablePort(t)
-	// Bind the sink on all interfaces so containerized collectors can reach it via
-	// an explicit host address instead of relying on localhost resolution.
 	t.OTLPEndpoint = fmt.Sprintf("0.0.0.0:%d", otlpPort)
 	t.OTLPEndpointForCollector = fmt.Sprintf("127.0.0.1:%d", otlpPort)
 }

--- a/tests/testutils/testcase.go
+++ b/tests/testutils/testcase.go
@@ -95,9 +95,9 @@ func NewHECTestcase(tb testing.TB) *Testcase {
 
 func (t *Testcase) setOTLPEndpoint() {
 	otlpPort := GetAvailablePort(t)
-	t.OTLPEndpoint = fmt.Sprintf("localhost:%d", otlpPort)
-	// Use IPv4 loopback for collector clients so Linux host-networked containers
-	// don't resolve localhost to ::1 while the in-memory sink only listens on IPv4.
+	// Bind the sink on all interfaces so containerized collectors can reach it via
+	// an explicit host address instead of relying on localhost resolution.
+	t.OTLPEndpoint = fmt.Sprintf("0.0.0.0:%d", otlpPort)
 	t.OTLPEndpointForCollector = fmt.Sprintf("127.0.0.1:%d", otlpPort)
 }
 


### PR DESCRIPTION
Align OTLP integration test endpoint handling with contrib by making the sink bind address explicit IPv4 for containerized collector tests. This help to avoid ocassional failures like `dial tcp [::1]:... connect: connection refused`