### PR TITLE
[chore] Do not push codecov for dependabot

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -91,7 +91,7 @@ jobs:
         shell: bash
 
   test:
-    name: test-${{ matrix.OS }}-race_detection:${{ matrix.TEST_RACE }}-coverage:${{ !matrix.TEST_RACE }}
+    name: test-${{ matrix.OS }}-race_detection:${{ matrix.TEST_RACE }}-coverage:${{ !matrix.TEST_RACE && github.actor != 'dependabot[bot]' }}
     strategy:
       matrix:
         OS: [ "ubuntu-24.04", "macos-14", "macos-15", "windows-2025", "windows-11-arm" ]
@@ -102,11 +102,12 @@ jobs:
     uses: ./.github/workflows/reusable-unit-test.yml
     with:
       OS: ${{ matrix.OS }}
-      COVERAGE: ${{ !matrix.TEST_RACE }} # No coverage when running with race
+      COVERAGE: ${{ !matrix.TEST_RACE && github.actor != 'dependabot[bot]' }} # No coverage when running with race or Dependabot-triggered PRs
       TEST_RACE: ${{ matrix.TEST_RACE }}
     secrets: inherit
 
   coverage:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     name: coverage
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
This step is currently failing in CI because dependabot doesn't have access to the codecov token. Disabling it as there is no value in doing this anyway.
