### PR TITLE
[chore] Fix TA v2 publication script

### DIFF
--- a/.gitlab/publish-ta-v2-to-splunkbase.sh
+++ b/.gitlab/publish-ta-v2-to-splunkbase.sh
@@ -50,7 +50,7 @@ for package in "${packages[@]}"; do
     fi
     echo "Uploaded ${file_name} with id: ${id}"
 
-    # Step 2: Poll until result is "pass" or timeout after 5 minutes
+    # Step 2: Poll until result is "pass" or timeout after 10 minutes
     echo "Step 2: Waiting for id ${id} to pass validation..."
     start_time=$(date +%s)
     release_file=""

--- a/.gitlab/publish-ta-v2-to-splunkbase.sh
+++ b/.gitlab/publish-ta-v2-to-splunkbase.sh
@@ -8,18 +8,13 @@
 #   TA_PACKAGES_PATH    - Path to the directory containing .tgz packages
 #   VERSION_TAG         - Version tag for release notes (e.g. v0.148.0)
 
-set -euo pipefail
+set -uo pipefail
 
 SPLUNK_VERSIONS="8.0,8.1,8.2,9.0,9.1,9.2,9.3,9.4,10.0,10.1,10.2,10.3,10.4"
 AUTH="srv-prod-gdi-otel:${SPLUNKBASE_PASSWORD}"
-MAX_WAIT_SECONDS=300
+MAX_WAIT_SECONDS=600
 POLL_INTERVAL=10
 
-declare -a ids=()
-declare -a release_files=()
-
-# Step 1: Upload each .tgz package and capture the returned id
-echo "Step 1: Uploading packages to Splunk Base..."
 shopt -s nullglob
 packages=("${TA_PACKAGES_PATH}"/*.tgz)
 shopt -u nullglob
@@ -29,35 +24,37 @@ if [ "${#packages[@]}" -eq 0 ]; then
     exit 1
 fi
 
+failed=0
+
 for package in "${packages[@]}"; do
     abs_path=$(realpath "$package")
     file_name=$(basename "$package")
 
-    echo "Uploading ${file_name}..."
+    echo "--- Processing ${file_name} ---"
+
+    # Step 1: Upload package and capture the returned id
+    echo "Step 1: Uploading ${file_name}..."
     response=$(curl -u "${AUTH}" \
         --request POST "https://splunkbase.splunk.com/api/v1/app/${APP_ID}/new_release" \
         -F "files[]=@${abs_path}" \
         -F "filename=${file_name}" \
         -F "splunk_versions=${SPLUNK_VERSIONS}" \
         -F "visibility=false" \
-        -fSs)
+        -fSs) || { echo "Upload request failed for ${file_name}"; failed=1; continue; }
 
     id=$(echo "$response" | jq -r '.id')
     if [ -z "$id" ] || [ "$id" = "null" ]; then
         echo "Failed to get id from response: ${response}"
-        exit 1
+        failed=1
+        continue
     fi
-
     echo "Uploaded ${file_name} with id: ${id}"
-    ids+=("$id")
-done
 
-# Step 2: Poll each id until result is "pass" or timeout after 5 minutes
-echo "Step 2: Waiting for package validation..."
-for id in "${ids[@]}"; do
-    echo "Waiting for id ${id} to pass validation..."
+    # Step 2: Poll until result is "pass" or timeout after 5 minutes
+    echo "Step 2: Waiting for id ${id} to pass validation..."
     start_time=$(date +%s)
     release_file=""
+    validation_ok=1
 
     while true; do
         current_time=$(date +%s)
@@ -65,7 +62,8 @@ for id in "${ids[@]}"; do
 
         if [ "$elapsed" -ge "$MAX_WAIT_SECONDS" ]; then
             echo "Timeout waiting for id ${id} after ${MAX_WAIT_SECONDS} seconds"
-            exit 1
+            validation_ok=0
+            break
         fi
 
         response=$(curl -u "${AUTH}" \
@@ -79,10 +77,10 @@ for id in "${ids[@]}"; do
             release_file=$(echo "$response" | jq -r '.message.release_file')
             if [ -z "$release_file" ] || [ "$release_file" = "null" ]; then
                 echo "Failed to get release_file from response: ${response}"
-                exit 1
+                validation_ok=0
+            else
+                echo "  id ${id}: passed, release_file=${release_file}"
             fi
-            echo "  id ${id}: passed, release_file=${release_file}"
-            release_files+=("$release_file")
             break
         fi
 
@@ -95,23 +93,33 @@ for id in "${ids[@]}"; do
                     error_details="$response"
                 fi
                 echo "Validation failed for id ${id}: ${error_details}"
-                exit 1
+                validation_ok=0
+                break
                 ;;
         esac
 
         sleep "$POLL_INTERVAL"
     done
-done
 
-# Step 3: Update release notes for each release_file
-echo "Step 3: Updating release notes..."
-for release_file in "${release_files[@]}"; do
-    echo "Updating release notes for release_file ${release_file}..."
+    if [ "$validation_ok" -eq 0 ]; then
+        failed=1
+        continue
+    fi
+
+    # Step 3: Update release notes
+    echo "Step 3: Updating release notes for release_file ${release_file}..."
     curl -u "${AUTH}" \
         --request PUT "https://splunkbase.splunk.com/api/v2/apps/${APP_ID}/releases/${release_file}/" \
-        --json "{\"release_notes\": \"Add-On with Splunk OpenTelemetry Collector ${VERSION_TAG}\\n\\n[Release Notes](https://github.com/signalfx/splunk-otel-collector/releases/tag/${VERSION_TAG})\"}"
+        --json "{\"release_notes\": \"Add-On with Splunk OpenTelemetry Collector ${VERSION_TAG}\\n\\n[Release Notes](https://github.com/signalfx/splunk-otel-collector/releases/tag/${VERSION_TAG})\"}" \
+        || { echo "Failed to update release notes for ${file_name}"; failed=1; continue; }
     echo ""
-    echo "Updated release notes for release_file ${release_file}"
+    echo "Updated release notes for ${file_name} (release_file: ${release_file})"
+    echo "--- Done with ${file_name} ---"
 done
+
+if [ "$failed" -ne 0 ]; then
+    echo "One or more packages failed to publish."
+    exit 1
+fi
 
 echo "Done!"

--- a/.gitlab/publish-ta-v2-to-splunkbase.sh
+++ b/.gitlab/publish-ta-v2-to-splunkbase.sh
@@ -8,7 +8,7 @@
 #   TA_PACKAGES_PATH    - Path to the directory containing .tgz packages
 #   VERSION_TAG         - Version tag for release notes (e.g. v0.148.0)
 
-set -uo pipefail
+set -euo pipefail
 
 SPLUNK_VERSIONS="8.0,8.1,8.2,9.0,9.1,9.2,9.3,9.4,10.0,10.1,10.2,10.3,10.4"
 AUTH="srv-prod-gdi-otel:${SPLUNKBASE_PASSWORD}"
@@ -27,7 +27,11 @@ fi
 failed=0
 
 for package in "${packages[@]}"; do
-    abs_path=$(realpath "$package")
+    if ! abs_path=$(realpath "$package"); then
+        echo "Failed to resolve path for ${package}"
+        failed=1
+        continue
+    fi
     file_name=$(basename "$package")
 
     echo "--- Processing ${file_name} ---"
@@ -42,7 +46,11 @@ for package in "${packages[@]}"; do
         -F "visibility=false" \
         -fSs) || { echo "Upload request failed for ${file_name}"; failed=1; continue; }
 
-    id=$(echo "$response" | jq -r '.id')
+    if ! id=$(echo "$response" | jq -r '.id'); then
+        echo "Failed to parse upload response for ${file_name}: ${response}"
+        failed=1
+        continue
+    fi
     if [ -z "$id" ] || [ "$id" = "null" ]; then
         echo "Failed to get id from response: ${response}"
         failed=1
@@ -66,15 +74,27 @@ for package in "${packages[@]}"; do
             break
         fi
 
-        response=$(curl -u "${AUTH}" \
+        if ! response=$(curl -u "${AUTH}" \
             --request GET "https://splunkbase.splunk.com/api/v1/package/${id}/" \
-            -s)
+            -fSs); then
+            echo "Polling request failed for id ${id}"
+            validation_ok=0
+            break
+        fi
 
-        result=$(echo "$response" | jq -r '.result')
+        if ! result=$(echo "$response" | jq -r '.result'); then
+            echo "Failed to parse validation response for id ${id}: ${response}"
+            validation_ok=0
+            break
+        fi
         echo "  id ${id}: result=${result} (${elapsed}s elapsed)"
 
         if [ "$result" = "pass" ]; then
-            release_file=$(echo "$response" | jq -r '.message.release_file')
+            if ! release_file=$(echo "$response" | jq -r '.message.release_file'); then
+                echo "Failed to parse release_file for id ${id}: ${response}"
+                validation_ok=0
+                break
+            fi
             if [ -z "$release_file" ] || [ "$release_file" = "null" ]; then
                 echo "Failed to get release_file from response: ${response}"
                 validation_ok=0
@@ -86,9 +106,11 @@ for package in "${packages[@]}"; do
 
         case "$result" in
             fail|failed|error)
-                error_details=$(echo "$response" | jq -r '
+                if ! error_details=$(echo "$response" | jq -r '
                     .message.error? // .message.details? // .message? // .error? // .details? // empty
-                ' 2>/dev/null)
+                ' 2>/dev/null); then
+                    error_details="$response"
+                fi
                 if [ -z "$error_details" ] || [ "$error_details" = "null" ]; then
                     error_details="$response"
                 fi
@@ -111,6 +133,7 @@ for package in "${packages[@]}"; do
     curl -u "${AUTH}" \
         --request PUT "https://splunkbase.splunk.com/api/v2/apps/${APP_ID}/releases/${release_file}/" \
         --json "{\"release_notes\": \"Add-On with Splunk OpenTelemetry Collector ${VERSION_TAG}\\n\\n[Release Notes](https://github.com/signalfx/splunk-otel-collector/releases/tag/${VERSION_TAG})\"}" \
+        -fSs \
         || { echo "Failed to update release notes for ${file_name}"; failed=1; continue; }
     echo ""
     echo "Updated release notes for ${file_name} (release_file: ${release_file})"


### PR DESCRIPTION
The REST API just supports publishing one version at time. This change simply makes the script do all the 3 steps for a single tgz file before moving to the next.

Manually tested with version 0.150.0