### PR TITLE
[chore][puppet] Push releases to Splunk JFrog instance

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1815,7 +1815,12 @@ puppet-release:
     - bundle install
     - bundle exec rake module:clean
   script:
-    - bundle exec rake module:push
+    - |
+      export BLACKSMITH_FORGE_URL=https://splunk.jfrog.io/artifactory/puppet-splunk
+      export BLACKSMITH_FORGE_TYPE=artifactory
+      export BLACKSMITH_FORGE_USERNAME="${ARTIFACTORY_USERNAME}"
+      export BLACKSMITH_FORGE_PASSWORD="${ARTIFACTORY_TOKEN}"
+      bundle exec rake module:push
   artifacts:
     paths:
       - deployments/puppet/pkg/*.tar.gz


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The plan going forward is to push Puppet releases to [Splunk's artifactory instance](https://splunk.jfrog.io), rather than Puppet forge.

[Source](https://github.com/voxpupuli/puppet-blacksmith#configuring-to-push-a-module-to-a-jfrog-artifactory) for setting variables