### PR TITLE
Remove redundant service attribute relabels from internal metrics scrape configs

### DIFF
--- a/.chloggen/remove-service-relabels.yaml
+++ b/.chloggen/remove-service-relabels.yaml
@@ -1,0 +1,7 @@
+change_type: bug_fix
+
+component: config
+
+note: Remove redundant service attribute relabels from internal metrics scrape configs
+
+issues: [7481]

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -85,14 +85,6 @@ receivers:
         static_configs:
         - targets: ["0.0.0.0:8888"]
         metric_relabel_configs:
-          - source_labels: [ service_name ]
-            target_label: service.name
-          - source_labels: [ service_instance_id ]
-            target_label: service.instance.id
-          - source_labels: [ service_version ]
-            target_label: service.version
-          - regex: service_name|service_instance_id|service_version
-            action: labeldrop
           - source_labels: [ __name__ ]
             regex: 'promhttp_metric_handler_errors.*'
             action: drop

--- a/cmd/otelcol/config/collector/ecs_ec2_config.yaml
+++ b/cmd/otelcol/config/collector/ecs_ec2_config.yaml
@@ -71,14 +71,6 @@ receivers:
           static_configs:
             - targets: ['0.0.0.0:8888']
           metric_relabel_configs:
-            - source_labels: [ service_name ]
-              target_label: service.name
-            - source_labels: [ service_instance_id ]
-              target_label: service.instance.id
-            - source_labels: [ service_version ]
-              target_label: service.version
-            - regex: service_name|service_instance_id|service_version
-              action: labeldrop
             - source_labels: [ __name__ ]
               regex: 'promhttp_metric_handler_errors.*'
               action: drop

--- a/cmd/otelcol/config/collector/fargate_config.yaml
+++ b/cmd/otelcol/config/collector/fargate_config.yaml
@@ -46,14 +46,6 @@ receivers:
           static_configs:
             - targets: ['0.0.0.0:8888']
           metric_relabel_configs:
-            - source_labels: [ service_name ]
-              target_label: service.name
-            - source_labels: [ service_instance_id ]
-              target_label: service.instance.id
-            - source_labels: [ service_version ]
-              target_label: service.version
-            - regex: service_name|service_instance_id|service_version
-              action: labeldrop
             - source_labels: [ __name__ ]
               regex: 'promhttp_metric_handler_errors.*'
               action: drop

--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -130,14 +130,6 @@ receivers:
         static_configs:
         - targets: ['0.0.0.0:8888']
         metric_relabel_configs:
-          - source_labels: [ service_name ]
-            target_label: service.name
-          - source_labels: [ service_instance_id ]
-            target_label: service.instance.id
-          - source_labels: [ service_version ]
-            target_label: service.version
-          - regex: service_name|service_instance_id|service_version
-            action: labeldrop
           - source_labels: [ __name__ ]
             regex: 'promhttp_metric_handler_errors.*'
             action: drop

--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -59,14 +59,6 @@ receivers:
         static_configs:
         - targets: ['0.0.0.0:8888']
         metric_relabel_configs:
-          - source_labels: [ service_name ]
-            target_label: service.name
-          - source_labels: [ service_instance_id ]
-            target_label: service.instance.id
-          - source_labels: [ service_version ]
-            target_label: service.version
-          - regex: service_name|service_instance_id|service_version
-            action: labeldrop
           - source_labels: [ __name__ ]
             regex: 'promhttp_metric_handler_errors.*'
             action: drop

--- a/cmd/otelcol/config/collector/otlp_config_linux.yaml
+++ b/cmd/otelcol/config/collector/otlp_config_linux.yaml
@@ -32,14 +32,6 @@ receivers:
         static_configs:
         - targets: ['0.0.0.0:8888']
         metric_relabel_configs:
-          - source_labels: [ service_name ]
-            target_label: service.name
-          - source_labels: [ service_instance_id ]
-            target_label: service.instance.id
-          - source_labels: [ service_version ]
-            target_label: service.version
-          - regex: service_name|service_instance_id|service_version
-            action: labeldrop
           - source_labels: [ __name__ ]
             regex: 'promhttp_metric_handler_errors.*'
             action: drop

--- a/cmd/otelcol/config/collector/upstream_agent_config.yaml
+++ b/cmd/otelcol/config/collector/upstream_agent_config.yaml
@@ -83,14 +83,6 @@ receivers:
         static_configs:
         - targets: ['0.0.0.0:8888']
         metric_relabel_configs:
-          - source_labels: [ service_name ]
-            target_label: service.name
-          - source_labels: [ service_instance_id ]
-            target_label: service.instance.id
-          - source_labels: [ service_version ]
-            target_label: service.version
-          - regex: service_name|service_instance_id|service_version
-            action: labeldrop
           - source_labels: [ __name__ ]
             regex: 'promhttp_metric_handler_errors.*'
             action: drop

--- a/cmd/otelcol/fips/config/agent_config.yaml
+++ b/cmd/otelcol/fips/config/agent_config.yaml
@@ -79,14 +79,6 @@ receivers:
         static_configs:
         - targets: ["0.0.0.0:8888"]
         metric_relabel_configs:
-          - source_labels: [ service_name ]
-            target_label: service.name
-          - source_labels: [ service_instance_id ]
-            target_label: service.instance.id
-          - source_labels: [ service_version ]
-            target_label: service.version
-          - regex: service_name|service_instance_id|service_version
-            action: labeldrop
           - source_labels: [ __name__ ]
             regex: 'promhttp_metric_handler_errors.*'
             action: drop

--- a/cmd/otelcol/fips/config/ecs_ec2_config.yaml
+++ b/cmd/otelcol/fips/config/ecs_ec2_config.yaml
@@ -70,14 +70,6 @@ receivers:
           static_configs:
             - targets: ['0.0.0.0:8888']
           metric_relabel_configs:
-            - source_labels: [ service_name ]
-              target_label: service.name
-            - source_labels: [ service_instance_id ]
-              target_label: service.instance.id
-            - source_labels: [ service_version ]
-              target_label: service.version
-            - regex: service_name|service_instance_id|service_version
-              action: labeldrop
             - source_labels: [ __name__ ]
               regex: 'promhttp_metric_handler_errors.*'
               action: drop

--- a/cmd/otelcol/fips/config/fargate_config.yaml
+++ b/cmd/otelcol/fips/config/fargate_config.yaml
@@ -46,14 +46,6 @@ receivers:
           static_configs:
             - targets: ['0.0.0.0:8888']
           metric_relabel_configs:
-            - source_labels: [ service_name ]
-              target_label: service.name
-            - source_labels: [ service_instance_id ]
-              target_label: service.instance.id
-            - source_labels: [ service_version ]
-              target_label: service.version
-            - regex: service_name|service_instance_id|service_version
-              action: labeldrop
             - source_labels: [ __name__ ]
               regex: 'promhttp_metric_handler_errors.*'
               action: drop

--- a/cmd/otelcol/fips/config/gateway_config.yaml
+++ b/cmd/otelcol/fips/config/gateway_config.yaml
@@ -59,14 +59,6 @@ receivers:
         static_configs:
         - targets: ['0.0.0.0:8888']
         metric_relabel_configs:
-          - source_labels: [ service_name ]
-            target_label: service.name
-          - source_labels: [ service_instance_id ]
-            target_label: service.instance.id
-          - source_labels: [ service_version ]
-            target_label: service.version
-          - regex: service_name|service_instance_id|service_version
-            action: labeldrop
           - source_labels: [ __name__ ]
             regex: 'promhttp_metric_handler_errors.*'
             action: drop

--- a/cmd/otelcol/fips/config/otlp_config_linux.yaml
+++ b/cmd/otelcol/fips/config/otlp_config_linux.yaml
@@ -32,14 +32,6 @@ receivers:
         static_configs:
         - targets: ['0.0.0.0:8888']
         metric_relabel_configs:
-          - source_labels: [ service_name ]
-            target_label: service.name
-          - source_labels: [ service_instance_id ]
-            target_label: service.instance.id
-          - source_labels: [ service_version ]
-            target_label: service.version
-          - regex: service_name|service_instance_id|service_version
-            action: labeldrop
           - source_labels: [ __name__ ]
             regex: 'promhttp_metric_handler_errors.*'
             action: drop

--- a/tests/general/default_config_test.go
+++ b/tests/general/default_config_test.go
@@ -185,22 +185,6 @@ func TestDefaultGatewayConfig(t *testing.T) {
 									"job_name": "otel-collector",
 									"metric_relabel_configs": []any{
 										map[string]any{
-											"source_labels": []any{"service_name"},
-											"target_label":  "service.name",
-										},
-										map[string]any{
-											"source_labels": []any{"service_instance_id"},
-											"target_label":  "service.instance.id",
-										},
-										map[string]any{
-											"source_labels": []any{"service_version"},
-											"target_label":  "service.version",
-										},
-										map[string]any{
-											"regex":  "service_name|service_instance_id|service_version",
-											"action": "labeldrop",
-										},
-										map[string]any{
 											"action":        "drop",
 											"regex":         "promhttp_metric_handler_errors.*",
 											"source_labels": []any{"__name__"},
@@ -467,22 +451,6 @@ func TestDefaultAgentConfig(t *testing.T) {
 								map[string]any{
 									"job_name": "otel-collector",
 									"metric_relabel_configs": []any{
-										map[string]any{
-											"source_labels": []any{"service_name"},
-											"target_label":  "service.name",
-										},
-										map[string]any{
-											"source_labels": []any{"service_instance_id"},
-											"target_label":  "service.instance.id",
-										},
-										map[string]any{
-											"source_labels": []any{"service_version"},
-											"target_label":  "service.version",
-										},
-										map[string]any{
-											"regex":  "service_name|service_instance_id|service_version",
-											"action": "labeldrop",
-										},
 										map[string]any{
 											"action":        "drop",
 											"regex":         "promhttp_metric_handler_errors.*",


### PR DESCRIPTION
This reverts commit 525a4ad9f62ad3183c771f98e47047a1e97e2a88.

It's not needed anymore given that github.com/open-telemetry/opentelemetry-collector/issues/14814 was fixed upstream