### PR TITLE
Replace deprecated alias references

### DIFF
--- a/.chloggen/update_deprecated_aliases.yaml
+++ b/.chloggen/update_deprecated_aliases.yaml
@@ -8,7 +8,7 @@ component: config
 note: All default configuration references to `filelog` receiver have been updated to `file_log`
 
 # One or more tracking issues related to the change
-issues: []
+issues: [7484]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/update_deprecated_aliases.yaml
+++ b/.chloggen/update_deprecated_aliases.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: config
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: All default configuration references to `filelog` receiver have been updated to `file_log`
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `filelog` alias has been deprecated. Please update any existing references to `file_log`.

--- a/.chloggen/update_deprecated_aliases.yaml
+++ b/.chloggen/update_deprecated_aliases.yaml
@@ -15,3 +15,4 @@ issues: []
 # Use pipe (|) for multiline entries.
 subtext: |
   The `filelog` alias has been deprecated. Please update any existing references to `file_log`.
+  This is only relevant for users that have custom configuration dependent on the default config.

--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -328,7 +328,7 @@ receivers:
     sourcetype: who
 
   # Enables file_log receiver
-  # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/file_logreceiver
+  # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver
   file_log:
     include:
       - /Library/Logs/*
@@ -617,7 +617,7 @@ exporters:
   # Enables the otlp grpc exporter
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter
   # NOTE: These settings should be updated to the proper destination
-  # WARN: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com does NOT support gRPC at this time; use oltp_http exporter instead
+  # WARN: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com does NOT support gRPC at this time; use otlp_http exporter instead
   otlp_grpc:
     endpoint: otelcol2:4317
     auth:

--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -327,9 +327,9 @@ receivers:
     source: who
     sourcetype: who
 
-  # Enables filelog receiver
-  # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver
-  filelog:
+  # Enables file_log receiver
+  # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/file_logreceiver
+  file_log:
     include:
       - /Library/Logs/*
       - /var/log/*.log*
@@ -617,7 +617,7 @@ exporters:
   # Enables the otlp grpc exporter
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter
   # NOTE: These settings should be updated to the proper destination
-  # WARN: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com does NOT support gRPC at this time; use otlphttp exporter instead
+  # WARN: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com does NOT support gRPC at this time; use oltp_http exporter instead
   otlp_grpc:
     endpoint: otelcol2:4317
     auth:
@@ -657,8 +657,8 @@ exporters:
       "another label": spaced value
     send_timestamps: true
 
-  # Enables the prometheus exporter
-  # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter
+  # Enables the prometheus remote write exporter
+  # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter
   # NOTE: These settings should be updated to the proper destination
   prometheusremotewrite:
     endpoint: "http://some.url:9411/api/prom/push"

--- a/cmd/otelcol/config/collector/logs_config_linux.yaml
+++ b/cmd/otelcol/config/collector/logs_config_linux.yaml
@@ -54,7 +54,7 @@ receivers:
           layout: '%d/%b/%Y:%H:%M:%S %z'
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Apache error log.
   # Configured using the ErrorLogFormat directive.
@@ -84,7 +84,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Apache Cassandra default log.
   # Configured in /etc/cassandra/logback.xml, SYSTEMLOG appender section.
@@ -111,7 +111,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Apache Cassandra debug log. Contains additional debugging information.
   # Configured in /etc/cassandra/logback.xml, DEBUGLOG appender section.
@@ -138,7 +138,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # This file is written if Cassandra process' standard output stream (stdout)
   # is redirected to a file.
@@ -146,7 +146,7 @@ receivers:
     include: [ "/var/log/cassandra/output.log" ]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Docker container logs.
   # If the default json-file logging driver is used, Docker will store container
@@ -168,7 +168,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Etcd versions 3.4 and prior are loging using the capnslog library.
   # (https://etcd.io/docs/v3.4/dev-internal/logging/).
@@ -200,7 +200,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Jetty default log.
   # By default, Jetty will log to standard error stream (stderr). To redirect
@@ -227,7 +227,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Jetty debug log.
   # Enabled with the jetty-debuglog module.
@@ -247,7 +247,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Jetty request logs.
   # Enabled with the jetty-requestlog module.
@@ -262,14 +262,14 @@ receivers:
           layout: '%d/%b/%Y:%H:%M:%S %z'
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Memcached.
   file_log/memcached:
     include: [ "/var/log/memcached.log" ]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # MongoDB v4.4 and later outputs all log messages in a structured JSON format.
   # See https://www.mongodb.com/docs/manual/reference/log-messages/
@@ -300,7 +300,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # MySQL server error log. Contains critical errors that occurred during the
   # server's operation, table corruption, start and stop information.
@@ -328,7 +328,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # MySQL general query log. Contains a log of every SQL query received from a
   # client, as well as each client connect and disconnect.
@@ -357,7 +357,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # MySQL slow query log. Contains a log of SQL queries that took a long time to perform.
   # Disabled by default. To enable, use the slow_query_log variable.
@@ -368,7 +368,7 @@ receivers:
       line_start_pattern: '^# Time: '
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Nginx access log.
   # By default, client requests are logged in the standard NCSA Common Log Format.
@@ -383,7 +383,7 @@ receivers:
           layout: '%d/%b/%Y:%H:%M:%S %z'
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Nginx error log.
   # See https://docs.nginx.com/nginx/admin-guide/monitoring/logging/
@@ -410,7 +410,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # PostgreSQL server log.
   # See https://www.postgresql.org/docs/current/runtime-config-logging.html
@@ -430,7 +430,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # RabbitMQ broker node log.
   # See https://www.rabbitmq.com/logging.html
@@ -455,21 +455,21 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # RabbitMQ server startup log.
   file_log/rabbitmq-startup:
     include: [ "/var/log/rabbitmq/startup_log", "/var/log/rabbitmq/rabbitmq-server.log" ]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # RabbitMQ server startup error log.
   file_log/rabbitmq-startup_err:
     include: [ "/var/log/rabbitmq/startup_err", "/var/log/rabbitmq/rabbitmq-server.error.log" ]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Redis logging.
   # By default configured to log to a file (logfile directive in redis.conf).
@@ -513,7 +513,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Syslog and messages log files.
   # These are not in the RFC3164 format.
@@ -534,7 +534,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Apache Tomcat.
   # See https://tomcat.apache.org/tomcat-9.0-doc/logging.html
@@ -561,7 +561,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Apache Tomcat console output.
   # See https://tomcat.apache.org/tomcat-9.0-doc/logging.html#Console
@@ -583,7 +583,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Apache Tomcat access log.
   # Entries are in the standard NCSA Common Log Format.
@@ -599,7 +599,7 @@ receivers:
           layout: '%d/%b/%Y:%H:%M:%S %z'
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Zookeper log.
   # Configured in /etc/zookeeper/conf/log4j.properties
@@ -623,7 +623,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
   # Zookeeper tracefile.
   # Configured in /etc/zookeeper/conf/log4j.properties
@@ -647,7 +647,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/file_logs
+    storage: file_storage/filelogs
 
 
 processors:
@@ -698,7 +698,7 @@ extensions:
   # Storage extension for storing file_log checkpoints.
   # Checkpoints allow the receiver to pick up where it left off in the case of a
   # collector restart.
-  file_storage/file_logs:
+  file_storage/filelogs:
     # Location where checkpoint files are stored. This directory must be writable
     # by the collector.
     directory: "${SPLUNK_FILE_STORAGE_EXTENSION_PATH}"
@@ -709,7 +709,7 @@ extensions:
 
 
 service:
-  extensions: [health_check, file_storage/file_logs]
+  extensions: [health_check, file_storage/filelogs]
   telemetry:
     logs:
       level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}

--- a/cmd/otelcol/config/collector/logs_config_linux.yaml
+++ b/cmd/otelcol/config/collector/logs_config_linux.yaml
@@ -15,7 +15,7 @@
 #   contain file offsets used by the file_log receivers. This allows the receivers
 #   to pick up where they left off in case of a collector restart. This directory
 #   must be writable by the collector.
-#   default: `/var/lib/otelcol/file_logs`
+#   default: `/var/lib/otelcol/filelogs`
 
 receivers:
   # Receivers for tailing and parsing log files coming from various services.

--- a/cmd/otelcol/config/collector/logs_config_linux.yaml
+++ b/cmd/otelcol/config/collector/logs_config_linux.yaml
@@ -12,10 +12,10 @@
 # The following environment variables are optional:
 
 # - SPLUNK_FILE_STORAGE_EXTENSION_PATH: Path to directory that will be used to
-#   contain file offsets used by the filelog receivers. This allows the receivers
+#   contain file offsets used by the file_log receivers. This allows the receivers
 #   to pick up where they left off in case of a collector restart. This directory
 #   must be writable by the collector.
-#   default: `/var/lib/otelcol/filelogs`
+#   default: `/var/lib/otelcol/file_logs`
 
 receivers:
   # Receivers for tailing and parsing log files coming from various services.
@@ -37,14 +37,14 @@ receivers:
   # Attributes not listed will be removed from the log entry.
   # If the 'retain' operator is not used, then all attributes are kept.
   #
-  # For a filelog receiver to be enabled it must be listed in the 'service' block
+  # For a file_log receiver to be enabled it must be listed in the 'service' block
   # at the end of this file.
 
   # Apache access log.
   # Configured using the LogFormat directive.
   # By default, date and time are in the 'day/Month/year:hour:minute:second zone' format.
   # See https://httpd.apache.org/docs/current/mod/mod_log_config.html#logformat
-  filelog/apache-access:
+  file_log/apache-access:
     include: [ "/var/log/apache*/access.log", "/var/log/apache*/access_log", "/var/log/httpd/access.log", "/var/log/httpd/access_log" ]
     operators:
       - type: regex_parser
@@ -54,13 +54,13 @@ receivers:
           layout: '%d/%b/%Y:%H:%M:%S %z'
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Apache error log.
   # Configured using the ErrorLogFormat directive.
   # By default, date and time are in the locale-specific representation (%c in strftime).
   # See https://httpd.apache.org/docs/current/mod/core.html#errorlogformat
-  filelog/apache-error:
+  file_log/apache-error:
     include: [ "/var/log/apache*/error.log", "/var/log/apache*/error_log", "/var/log/httpd/error.log", "/var/log/httpd/error_log" ]
     operators:
       - type: regex_parser
@@ -84,13 +84,13 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Apache Cassandra default log.
   # Configured in /etc/cassandra/logback.xml, SYSTEMLOG appender section.
   # Default date and time format is ISO-8601 (year-month-day hour:minute:second).
   # See https://cassandra.apache.org/doc/latest/cassandra/troubleshooting/reading_logs.html
-  filelog/cassandra:
+  file_log/cassandra:
     include: [ "/var/log/cassandra/cassandra.log", "/var/log/cassandra/system.log" ]
     multiline:
       line_start_pattern: '^[A-Z]+\s+\[[\w:]+\]\s\d'
@@ -111,13 +111,13 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Apache Cassandra debug log. Contains additional debugging information.
   # Configured in /etc/cassandra/logback.xml, DEBUGLOG appender section.
   # Default date and time format is ISO-8601 (year-month-day hour:minute:second).
   # See https://cassandra.apache.org/doc/latest/cassandra/troubleshooting/reading_logs.html
-  filelog/cassandra-debug:
+  file_log/cassandra-debug:
     include: [ "/var/log/cassandra/debug.log" ]
     multiline:
       line_start_pattern: '^[A-Z]+\s+\[[\w:]+\]\s\d'
@@ -138,21 +138,21 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # This file is written if Cassandra process' standard output stream (stdout)
   # is redirected to a file.
-  filelog/cassandra-output:
+  file_log/cassandra-output:
     include: [ "/var/log/cassandra/output.log" ]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Docker container logs.
   # If the default json-file logging driver is used, Docker will store container
   # stdout and stderr output on the host filesystem as JSON files.
   # See https://docs.docker.com/config/containers/logging/configure
-  filelog/docker:
+  file_log/docker:
     include: [ "/var/lib/docker/containers/*/*-json.log" ]
     operators:
       - type: json_parser
@@ -168,13 +168,13 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Etcd versions 3.4 and prior are loging using the capnslog library.
   # (https://etcd.io/docs/v3.4/dev-internal/logging/).
   # Versions 3.5 and later are logging using the zap library
   # (https://etcd.io/docs/v3.5/dev-internal/logging/).
-  filelog/etcd:
+  file_log/etcd:
     include: [ "/var/log/etcd.log" ]
     operators:
       - type: regex_parser
@@ -200,7 +200,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Jetty default log.
   # By default, Jetty will log to standard error stream (stderr). To redirect
@@ -209,7 +209,7 @@ receivers:
   # (default is /var/log/jetty9/).
   # See https://eclipse.dev/jetty/documentation/jetty-9/index.html#configuring-logging
   # for more information on Jetty9 logging.
-  filelog/jetty9:
+  file_log/jetty9:
     include: [ "/var/log/jetty9/*.jetty.log" ]
     operators:
       - type: regex_parser
@@ -227,11 +227,11 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Jetty debug log.
   # Enabled with the jetty-debuglog module.
-  filelog/jetty9-debug:
+  file_log/jetty9-debug:
     include: [ "/var/log/jetty9/*.debug.log" ]
     operators:
       - type: regex_parser
@@ -247,12 +247,12 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Jetty request logs.
   # Enabled with the jetty-requestlog module.
   # Request logs are in standard NCSA Common Log Format.
-  filelog/jetty9-request:
+  file_log/jetty9-request:
     include: [ "/var/log/jetty9/*.request.log" ]
     operators:
       - type: regex_parser
@@ -262,18 +262,18 @@ receivers:
           layout: '%d/%b/%Y:%H:%M:%S %z'
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Memcached.
-  filelog/memcached:
+  file_log/memcached:
     include: [ "/var/log/memcached.log" ]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # MongoDB v4.4 and later outputs all log messages in a structured JSON format.
   # See https://www.mongodb.com/docs/manual/reference/log-messages/
-  filelog/mongodb:
+  file_log/mongodb:
     include: [ "/var/log/mongodb/*.log" ]
     operators:
       - type: json_parser
@@ -300,14 +300,14 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # MySQL server error log. Contains critical errors that occurred during the
   # server's operation, table corruption, start and stop information.
   # When running under Systemd, error logging goes to journald. To enable
   # logging to a file, use the log_error variable.
   # See https://mariadb.com/kb/en/error-log/
-  filelog/mysql-error:
+  file_log/mysql-error:
     include: [ "/var/log/mysql/error.log" ]
     multiline:
       # e.g. "2023-10-09 13:40:48 0 [Note] ..."
@@ -328,13 +328,13 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # MySQL general query log. Contains a log of every SQL query received from a
   # client, as well as each client connect and disconnect.
   # Disabled by default. To enable, use the general_log_file variable.
   # See https://mariadb.com/kb/en/general-query-log/
-  filelog/mysql-query:
+  file_log/mysql-query:
     include: [ "/var/log/mysql.log", "/var/log/mysql/mysql.log" ]
     multiline:
       line_start_pattern: '^\d{6} [\d:.]+'
@@ -357,23 +357,23 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # MySQL slow query log. Contains a log of SQL queries that took a long time to perform.
   # Disabled by default. To enable, use the slow_query_log variable.
   # See https://mariadb.com/kb/en/slow-query-log/
-  filelog/mysql-slow_query:
+  file_log/mysql-slow_query:
     include: [ "/var/log/mysql/mysql-slow.log", "/var/log/mysql/mariadb-slow.log" ]
     multiline:
       line_start_pattern: '^# Time: '
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Nginx access log.
   # By default, client requests are logged in the standard NCSA Common Log Format.
   # See https://docs.nginx.com/nginx/admin-guide/monitoring/logging/
-  filelog/nginx-access:
+  file_log/nginx-access:
     include: [ "/var/log/nginx/access.log" ]
     operators:
       - type: regex_parser
@@ -383,11 +383,11 @@ receivers:
           layout: '%d/%b/%Y:%H:%M:%S %z'
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Nginx error log.
   # See https://docs.nginx.com/nginx/admin-guide/monitoring/logging/
-  filelog/nginx-error:
+  file_log/nginx-error:
     include: [ "/var/log/nginx/error.log" ]
     operators:
       - type: regex_parser
@@ -410,11 +410,11 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # PostgreSQL server log.
   # See https://www.postgresql.org/docs/current/runtime-config-logging.html
-  filelog/postgresql:
+  file_log/postgresql:
     include: [ "/var/log/postgres*/*.log", "/var/log/pgsql/*.log" ]
     operators:
       - type: regex_parser
@@ -430,11 +430,11 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # RabbitMQ broker node log.
   # See https://www.rabbitmq.com/logging.html
-  filelog/rabbitmq:
+  file_log/rabbitmq:
     include: [ "/var/log/rabbitmq/rabbit@*.log" ]
     multiline:
       # e.g. "2023-10-16 13:00:19.461 [debug] <0.289.0> ..."
@@ -455,25 +455,25 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # RabbitMQ server startup log.
-  filelog/rabbitmq-startup:
+  file_log/rabbitmq-startup:
     include: [ "/var/log/rabbitmq/startup_log", "/var/log/rabbitmq/rabbitmq-server.log" ]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # RabbitMQ server startup error log.
-  filelog/rabbitmq-startup_err:
+  file_log/rabbitmq-startup_err:
     include: [ "/var/log/rabbitmq/startup_err", "/var/log/rabbitmq/rabbitmq-server.error.log" ]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Redis logging.
   # By default configured to log to a file (logfile directive in redis.conf).
-  filelog/redis:
+  file_log/redis:
     include: [ "/var/log/redis*.log", "/var/log/redis/*.log"]
     operators:
       - type: router
@@ -513,11 +513,11 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Syslog and messages log files.
   # These are not in the RFC3164 format.
-  filelog/syslog:
+  file_log/syslog:
     include: [ "/var/log/syslog", "/var/log/messages"]
     operators:
       - type: regex_parser
@@ -534,11 +534,11 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Apache Tomcat.
   # See https://tomcat.apache.org/tomcat-9.0-doc/logging.html
-  filelog/tomcat:
+  file_log/tomcat:
     include: [ "/var/log/tomcat*/catalina.*.log", "/var/log/tomcat*/localhost.*.log" ]
     multiline:
       # e.g. "11-Oct-2023 12:55:33.425 INFO [Thread-3] ..."
@@ -561,11 +561,11 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Apache Tomcat console output.
   # See https://tomcat.apache.org/tomcat-9.0-doc/logging.html#Console
-  filelog/tomcat-out:
+  file_log/tomcat-out:
     include: [ "/var/log/tomcat*/catalina.out" ]
     operators:
       - type: regex_parser
@@ -583,13 +583,13 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Apache Tomcat access log.
   # Entries are in the standard NCSA Common Log Format.
   # See https://tomcat.apache.org/tomcat-9.0-doc/logging.html#Access_logging and
   # https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Access_Logging
-  filelog/tomcat-localhost_access_log:
+  file_log/tomcat-localhost_access_log:
     include: [ "/var/log/tomcat*/localhost_access_log.*.txt" ]
     operators:
       - type: regex_parser
@@ -599,11 +599,11 @@ receivers:
           layout: '%d/%b/%Y:%H:%M:%S %z'
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Zookeper log.
   # Configured in /etc/zookeeper/conf/log4j.properties
-  filelog/zookeeper:
+  file_log/zookeeper:
     include: [ "/var/log/zookeeper/zookeeper.log" ]
     operators:
       - type: regex_parser
@@ -623,11 +623,11 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
   # Zookeeper tracefile.
   # Configured in /etc/zookeeper/conf/log4j.properties
-  filelog/zookeeper-trace:
+  file_log/zookeeper-trace:
     include: [ "/var/log/zookeeper/zookeeper_trace.log" ]
     operators:
       - type: regex_parser
@@ -647,7 +647,7 @@ receivers:
           - attributes["log.file.path"]
     include_file_name: false
     include_file_path: true
-    storage: file_storage/filelogs
+    storage: file_storage/file_logs
 
 
 processors:
@@ -695,10 +695,10 @@ extensions:
   health_check:
     endpoint: "${SPLUNK_LISTEN_INTERFACE}:13133"
 
-  # Storage extension for storing filelog checkpoints.
+  # Storage extension for storing file_log checkpoints.
   # Checkpoints allow the receiver to pick up where it left off in the case of a
   # collector restart.
-  file_storage/filelogs:
+  file_storage/file_logs:
     # Location where checkpoint files are stored. This directory must be writable
     # by the collector.
     directory: "${SPLUNK_FILE_STORAGE_EXTENSION_PATH}"
@@ -709,7 +709,7 @@ extensions:
 
 
 service:
-  extensions: [health_check, file_storage/filelogs]
+  extensions: [health_check, file_storage/file_logs]
   telemetry:
     logs:
       level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
@@ -723,32 +723,32 @@ service:
   pipelines:
     logs:
       receivers:
-        #- filelog/apache-access
-        #- filelog/apache-error
-        #- filelog/cassandra
-        #- filelog/cassandra-debug
-        #- filelog/cassandra-output
-        #- filelog/docker
-        #- filelog/etcd
-        #- filelog/jetty9
-        #- filelog/jetty9-debug
-        #- filelog/jetty9-request
-        #- filelog/mongodb
-        #- filelog/mysql-error
-        #- filelog/mysql-query
-        #- filelog/mysql-slow_query
-        #- filelog/nginx-access
-        #- filelog/nginx-error
-        #- filelog/postgresql
-        #- filelog/rabbitmq
-        #- filelog/rabbitmq-startup
-        #- filelog/rabbitmq-startup_err
-        #- filelog/redis
-        - filelog/syslog
-        #- filelog/tomcat
-        #- filelog/tomcat-out
-        #- filelog/tomcat-localhost_access_log
-        #- filelog/zookeeper
-        #- filelog/zookeeper-trace
+        #- file_log/apache-access
+        #- file_log/apache-error
+        #- file_log/cassandra
+        #- file_log/cassandra-debug
+        #- file_log/cassandra-output
+        #- file_log/docker
+        #- file_log/etcd
+        #- file_log/jetty9
+        #- file_log/jetty9-debug
+        #- file_log/jetty9-request
+        #- file_log/mongodb
+        #- file_log/mysql-error
+        #- file_log/mysql-query
+        #- file_log/mysql-slow_query
+        #- file_log/nginx-access
+        #- file_log/nginx-error
+        #- file_log/postgresql
+        #- file_log/rabbitmq
+        #- file_log/rabbitmq-startup
+        #- file_log/rabbitmq-startup_err
+        #- file_log/redis
+        - file_log/syslog
+        #- file_log/tomcat
+        #- file_log/tomcat-out
+        #- file_log/tomcat-localhost_access_log
+        #- file_log/zookeeper
+        #- file_log/zookeeper-trace
       processors: [memory_limiter, batch]
       exporters: [splunk_hec, splunk_hec/profiling]

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/custom_vars/custom_collector_config.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/custom_vars/custom_collector_config.yml
@@ -2,7 +2,7 @@
 # Custom collector config for test purposes
 
 receivers:
-  filelog:
+  file_log:
     include:
       - /var/log/app.log
   otlp:
@@ -35,6 +35,6 @@ service:
       processors: [memory_limiter]
       exporters: [debug/normal]
     logs:
-      receivers: [otlp, filelog]
+      receivers: [otlp, file_log]
       processors: [memory_limiter]
       exporters: [debug/detailed]

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/custom_vars/custom_collector_config_deprecated.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/custom_vars/custom_collector_config_deprecated.yml
@@ -2,7 +2,7 @@
 # Custom collector config for test purposes
 
 receivers:
-  filelog:
+  file_log:
     include:
       - /var/log/app.log
   otlp:
@@ -35,6 +35,6 @@ service:
       processors: [memory_limiter]
       exporters: [logging/info]
     logs:
-      receivers: [otlp, filelog]
+      receivers: [otlp, file_log]
       processors: [memory_limiter]
       exporters: [logging/debug]

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/custom_vars_install_old_version/custom_collector_config.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/custom_vars_install_old_version/custom_collector_config.yml
@@ -2,7 +2,7 @@
 # Custom collector config for test purposes
 
 receivers:
-  file_log:
+  filelog:
     include:
       - /var/log/app.log
   otlp:
@@ -35,6 +35,6 @@ service:
       processors: [memory_limiter]
       exporters: [debug/normal]
     logs:
-      receivers: [file_log, otlp]
+      receivers: [filelog, otlp]
       processors: [memory_limiter]
       exporters: [debug/detailed]

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/custom_vars_install_old_version/custom_collector_config.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/custom_vars_install_old_version/custom_collector_config.yml
@@ -2,7 +2,7 @@
 # Custom collector config for test purposes
 
 receivers:
-  filelog:
+  file_log:
     include:
       - /var/log/app.log
   otlp:
@@ -35,6 +35,6 @@ service:
       processors: [memory_limiter]
       exporters: [debug/normal]
     logs:
-      receivers: [filelog, otlp]
+      receivers: [file_log, otlp]
       processors: [memory_limiter]
       exporters: [debug/detailed]

--- a/docs/components.md
+++ b/docs/components.md
@@ -19,9 +19,9 @@ The distribution offers support for the following components.
 | [awscontainerinsights](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscontainerinsightreceiver)                           | [beta]           |
 | [awscloudwatch](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscloudwatchreceiver)                                        | [alpha]          |
 | [awsecscontainermetrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver)                      | [beta]           |
-| [azureblob](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azureblobreceiver)                                                | [alpha]          |
+| [azure_blob](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azureblobreceiver)                                               | [alpha]          |
 | [azure_event_hub](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azureeventhubreceiver)                                      | [alpha]          |
-| [azuremonitor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azuremonitorreceiver)                                          | [alpha]          |
+| [azure_monitor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azuremonitorreceiver)                                         | [alpha]          |
 | [carbon](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/carbonreceiver)                                                      | [alpha]          |
 | [chrony](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/chronyreceiver)                                                      | [beta]           |
 | [ciscoos](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/ciscoosreceiver)                                                    | [alpha]          |
@@ -30,13 +30,13 @@ The distribution offers support for the following components.
 | [discovery](../internal/receiver/discoveryreceiver)                                                                                                                | [in development] |
 | [docker_stats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dockerstatsreceiver)                                           | [alpha]          |
 | [elasticsearch](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/elasticsearchreceiver)                                        | [beta]           |
-| [filelog](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver)                                                    | [beta]           |
+| [file_log](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver)                                                   | [beta]           |
 | [filestats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filestatsreceiver)                                                | [beta]           |
 | [fluentforward](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/fluentforwardreceiver)                                        | [beta]           |
 | [googlecloudpubsub](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/googlecloudpubsubreceiver)                                | [beta]           |
 | [haproxy](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/haproxyreceiver)                                                    | [beta]           |
 | [hostmetrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver)                                            | [beta]           |
-| [httpcheck](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/httpcheckreceiver)                                                | [alpha]          |
+| [http_check](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/httpcheckreceiver)                                               | [alpha]          |
 | [icmpcheck](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/icmpcheckreceiver)                                                | [in development] |
 | [iis](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/iisreceiver)                                                            | [beta]           |
 | [influxdb](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/influxdbreceiver)                                                  | [beta]           |
@@ -61,7 +61,7 @@ The distribution offers support for the following components.
 | [otlp](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver)                                                                  | [stable]         |
 | [postgresql](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/postgresqlreceiver)                                              | [beta]           |
 | [prometheus](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)                                              | [beta]           |
-| [prometheusremotewrite](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusremotewritereceiver)                        | [alpha]          |
+| [prometheus_remote_write](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusremotewritereceiver)                      | [alpha]          |
 | [prometheus_simple](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/simpleprometheusreceiver)                                 | [beta]           |
 | [purefa](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/purefareceiver)                                                      | [alpha]          |
 | [rabbitmq](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/rabbitmqreceiver)                                                  | [beta]           |
@@ -84,15 +84,15 @@ The distribution offers support for the following components.
 | [syslog](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/syslogreceiver)                                                      | [alpha]          |
 | [systemd](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/systemdreceiver)                                                    | [alpha]          |
 | [tcpcheck](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/tcpcheckreceiver)                                                  | [alpha]          |
-| [tcplog](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/tcplogreceiver)                                                      | [alpha]          |
-| [tlscheck](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/tlscheckreceiver)                                                  | [alpha]          |
-| [udplog](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/udplogreceiver)                                                      | [alpha]          |
+| [tcp_log](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/tcplogreceiver)                                                     | [alpha]          |
+| [tls_check](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/tlscheckreceiver)                                                 | [alpha]          |
+| [udp_log](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/udplogreceiver)                                                     | [alpha]          |
 | [vcenter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/vcenterreceiver)                                                    | [alpha]          |
 | [wavefront](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/wavefrontreceiver)                                                | [beta]           |
-| [windowseventlog](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowseventlogreceiver)                                    | [alpha]          |
+| [windows_event_log](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowseventlogreceiver)                                  | [alpha]          |
 | [windowsperfcounters](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowsperfcountersreceiver)                            | [beta]           |
 | [windowsservice](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowsservicereceiver)                                      | [in development] |
-| [yanggrpc](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/yanggrpcreceiver)                                                  | [alpha]          |
+| [yang_grpc](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/yanggrpcreceiver)                                                 | [alpha]          |
 | [zipkin](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zipkinreceiver)                                                      | [beta]           |
 | [zookeeper](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zookeeperreceiver)                                                | [alpha]          |
 
@@ -130,7 +130,7 @@ The distribution offers support for the following components.
 | [awss3](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awss3exporter)                                 | [alpha]      |
 | [debug](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter)                                         | [alpha]      |
 | [file](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter)                                   | [alpha]      |
-| [googlecloudstorage](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudstorageexporter)       | [alpha]      |
+| [google_cloud_storage](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudstorageexporter)     | [alpha]      |
 | [kafka](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter)                                 | [beta]       |
 | [loadbalancing](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter)                 | [beta]       |
 | [nop](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/nopexporter)                                             | [beta]       |


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Cross referenced [expected aliases](https://github.com/signalfx/splunk-otel-collector/blob/3e4a13b9c4de90e0d2920b25e66e1b89f8f42916/internal/components/components_test.go#L132) against the rest of the repo to find references to deprecated aliases. Also, found what looked some incorrect copy+paste comments referencing the Prometheus exporter above a `prometheusremotewrite` exporter config block, so I updated that as well.