### PR TITLE
[configconverter] Drops SignalFx exporter from trace pipelines

### DIFF
--- a/.chloggen/traces_correlation_feature_gate.yaml
+++ b/.chloggen/traces_correlation_feature_gate.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: config
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The `signalfx` exporter is now removed from trace pipelines by default on collector startup
+
+# One or more tracking issues related to the change
+issues: [7516]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The SignalFx exporter was historically included in trace pipelines for the sole purpose of
+  trace correlation. This is no longer required. A config converter is used on collector startup
+  to remove every `signalfx` exporter from every traces pipeline. To disable this functionality, disable
+  the newly introduced feature gate `splunk.dropSignalFxTracesCorrelationPipeline.enabled`

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -107,6 +107,7 @@ func runFromCmdLine(args []string) {
 		configconverter.ConverterFactoryFromConverter(dryRun),
 		configconverter.ConverterFactoryFromFunc(configconverter.InjectConfigSourceTelemetryExtension),
 		configconverter.ConverterFactoryFromFunc(configconverter.RemoveSplunkOpAMPIfFeatureGateDisabled),
+		configconverter.ConverterFactoryFromFunc(configconverter.DropSignalFxTracesExporterIfFeatureGateEnabled),
 		configconverter.ConverterFactoryFromConverter(expvarConverter)) // `expvarConverter` must be last to expose the effective config correctly
 
 	configSourceProvider := configsource.New(zap.NewNop(), []configsource.Hook{expvarConverter, dryRun, telemetryHook})

--- a/internal/configconverter/common.go
+++ b/internal/configconverter/common.go
@@ -51,7 +51,9 @@ func ConverterFactoryFromConverter(conv confmap.Converter) confmap.ConverterFact
 func getMetricsPipelineAndReceivers(pipelines map[string]any) (map[string]any, []any, error) {
 	metricsPipeline := map[string]any{}
 	if mp, ok := pipelines["metrics"]; ok && mp != nil {
-		metricsPipeline = mp.(map[string]any)
+		if metricsPipeline, ok = mp.(map[string]any); !ok {
+			return nil, nil, fmt.Errorf("metrics pipeline is of unexpected form (%T): %v", mp, mp)
+		}
 	}
 	pipelines["metrics"] = metricsPipeline
 

--- a/internal/configconverter/common.go
+++ b/internal/configconverter/common.go
@@ -99,11 +99,11 @@ func getExtensionsFromService(service map[string]any) ([]any, error) {
 }
 
 func isSignalFxExporter(exporter string) bool {
-	return strings.ToLower(exporter) == "signalfx" || strings.HasPrefix(strings.ToLower(exporter), "signalfx/")
+	return strings.EqualFold(exporter, "signalfx") || strings.HasPrefix(strings.ToLower(exporter), "signalfx/")
 }
 
 func isTracePipeline(pipeline string) bool {
-	return strings.ToLower(pipeline) == "traces" || strings.HasPrefix(strings.ToLower(pipeline), "traces/")
+	return strings.EqualFold(pipeline, "traces") || strings.HasPrefix(strings.ToLower(pipeline), "traces/")
 }
 
 func toAnySlice(s any) ([]any, error) {

--- a/internal/configconverter/common.go
+++ b/internal/configconverter/common.go
@@ -16,6 +16,8 @@ package configconverter
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"go.opentelemetry.io/collector/confmap"
 )
@@ -44,4 +46,77 @@ func ConverterFactoryFromFunc(f func(context.Context, *confmap.Conf) error) conf
 // ConverterFactoryFromConverter creates a ConverterFactory from a Converter.
 func ConverterFactoryFromConverter(conv confmap.Converter) confmap.ConverterFactory {
 	return &convFact{conv: conv}
+}
+
+func getMetricsPipelineAndReceivers(pipelines map[string]any) (map[string]any, []any, error) {
+	metricsPipeline := map[string]any{}
+	if mp, ok := pipelines["metrics"]; ok && mp != nil {
+		metricsPipeline = mp.(map[string]any)
+	}
+	pipelines["metrics"] = metricsPipeline
+
+	var metricsReceivers []any
+	if mr, ok := metricsPipeline["receivers"]; ok && mr != nil {
+		var err error
+		if metricsReceivers, err = toAnySlice(mr); err != nil {
+			return nil, nil, fmt.Errorf("cannot determine metrics pipeline receivers: %w", err)
+		}
+	}
+	return metricsPipeline, metricsReceivers, nil
+}
+
+func getPipelinesFromService(service map[string]any) (map[string]any, error) {
+	pipelines := map[string]any{}
+	if s, hasPipelines := service["pipelines"]; hasPipelines && s != nil {
+		var ok bool
+		if pipelines, ok = s.(map[string]any); !ok {
+			return nil, fmt.Errorf("pipelines is of unexpected form (%T): %v", s, s)
+		}
+	}
+	return pipelines, nil
+}
+
+func getService(out map[string]any) (map[string]any, error) {
+	service := map[string]any{}
+	if s, hasService := out["service"]; hasService && s != nil {
+		var ok bool
+		if service, ok = s.(map[string]any); !ok {
+			return nil, fmt.Errorf("service is of unexpected form (%T): %v", s, s)
+		}
+	}
+	return service, nil
+}
+
+func getExtensionsFromService(service map[string]any) ([]any, error) {
+	var serviceExtensions []any
+	if ses, hasExtensions := service["extensions"]; hasExtensions && ses != nil {
+		var err error
+		if serviceExtensions, err = toAnySlice(ses); err != nil {
+			return nil, fmt.Errorf("cannot determine service extensions: %w", err)
+		}
+	}
+	return serviceExtensions, nil
+}
+
+func isSignalFxExporter(exporter string) bool {
+	return strings.ToLower(exporter) == "signalfx" || strings.HasPrefix(strings.ToLower(exporter), "signalfx/")
+}
+
+func isTracePipeline(pipeline string) bool {
+	return strings.ToLower(pipeline) == "traces" || strings.HasPrefix(strings.ToLower(pipeline), "traces/")
+}
+
+func toAnySlice(s any) ([]any, error) {
+	var out []any
+	switch v := s.(type) {
+	case []any:
+		out = v
+	case []string:
+		for _, i := range v {
+			out = append(out, i)
+		}
+	default:
+		return nil, fmt.Errorf("unexpected form %T", s)
+	}
+	return out, nil
 }

--- a/internal/configconverter/configsourcetelemetry.go
+++ b/internal/configconverter/configsourcetelemetry.go
@@ -32,7 +32,11 @@ func InjectConfigSourceTelemetryExtension(_ context.Context, in *confmap.Conf) e
 
 	out := in.ToStringMap()
 
-	service, serviceExtensions, err := getServiceExtensions(out)
+	service, err := getService(out)
+	if err != nil {
+		return err
+	}
+	serviceExtensions, err := getExtensionsFromService(service)
 	if err != nil {
 		return err
 	}

--- a/internal/configconverter/configsourcetelemetry_test.go
+++ b/internal/configconverter/configsourcetelemetry_test.go
@@ -26,7 +26,9 @@ import (
 
 func serviceExtensionsFromConf(t *testing.T, conf *confmap.Conf) []any {
 	t.Helper()
-	_, exts, err := getServiceExtensions(conf.ToStringMap())
+	service, err := getService(conf.ToStringMap())
+	require.NoError(t, err)
+	exts, err := getExtensionsFromService(service)
 	require.NoError(t, err)
 	return exts
 }

--- a/internal/configconverter/discovery.go
+++ b/internal/configconverter/discovery.go
@@ -34,7 +34,11 @@ func SetupDiscovery(_ context.Context, in *confmap.Conf) error {
 	}
 
 	out := in.ToStringMap()
-	service, serviceExtensions, err := getServiceExtensions(out)
+	service, err := getService(out)
+	if err != nil {
+		return err
+	}
+	serviceExtensions, err := getExtensionsFromService(service)
 	if err != nil {
 		return err
 	}
@@ -98,24 +102,6 @@ func setAutoDiscoveryResourceAttribute(service map[string]any) {
 	resAttrs["splunk_autodiscovery"] = "true"
 }
 
-func getServiceExtensions(out map[string]any) (map[string]any, []any, error) {
-	service := map[string]any{}
-	var serviceExtensions []any
-	if s, hasService := out["service"]; hasService && s != nil {
-		var ok bool
-		if service, ok = s.(map[string]any); !ok {
-			return nil, nil, fmt.Errorf("service is of unexpected form (%T): %v", s, s)
-		}
-		if ses, hasExtensions := service["extensions"]; hasExtensions && ses != nil {
-			var err error
-			if serviceExtensions, err = toAnySlice(ses); err != nil {
-				return nil, nil, fmt.Errorf("cannot determine service extensions: %w", err)
-			}
-		}
-	}
-	return service, serviceExtensions, nil
-}
-
 func getDiscoExtensions(service map[string]any) (bool, []any, error) {
 	var isSet bool
 	var extensions []any
@@ -142,23 +128,6 @@ func getDiscoReceivers(service map[string]any) (bool, []any, error) {
 		}
 	}
 	return isSet, receivers, nil
-}
-
-func getMetricsPipelineAndReceivers(pipelines map[string]any) (map[string]any, []any, error) {
-	metricsPipeline := map[string]any{}
-	if mp, ok := pipelines["metrics"]; ok && mp != nil {
-		metricsPipeline = mp.(map[string]any)
-	}
-	pipelines["metrics"] = metricsPipeline
-
-	var metricsReceivers []any
-	if mr, ok := metricsPipeline["receivers"]; ok && mr != nil {
-		var err error
-		if metricsReceivers, err = toAnySlice(mr); err != nil {
-			return nil, nil, fmt.Errorf("cannot determine metrics pipeline receivers: %w", err)
-		}
-	}
-	return metricsPipeline, metricsReceivers, nil
 }
 
 func setEntitiesPipelineReceivers(pipelines map[string]any, discoReceivers []any) {
@@ -191,19 +160,4 @@ func appendUnique(serviceComponents, discoComponents []any) []any {
 		}
 	}
 	return serviceComponents
-}
-
-func toAnySlice(s any) ([]any, error) {
-	var out []any
-	switch v := s.(type) {
-	case []any:
-		out = v
-	case []string:
-		for _, i := range v {
-			out = append(out, i)
-		}
-	default:
-		return nil, fmt.Errorf("unexpected form %T", s)
-	}
-	return out, nil
 }

--- a/internal/configconverter/drop_signalfx_trace_correlation.go
+++ b/internal/configconverter/drop_signalfx_trace_correlation.go
@@ -1,0 +1,107 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configconverter
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/featuregate"
+)
+
+const (
+	dropTraceCorrelationPipelineFeatureGateID = "splunk.dropSignalFxTracesCorrelationPipeline.enabled"
+)
+
+var dropTraceCorrelationPipelineFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	dropTraceCorrelationPipelineFeatureGateID,
+	featuregate.StageBeta,
+	featuregate.WithRegisterDescription("When enabled (default), the SignalFx Exporter will be removed from all trace pipelines. "+
+		"This functionality is no longer needed for trace correlation."),
+	featuregate.WithRegisterFromVersion("v0.151.0"),
+)
+
+func DropSignalFxTracesExporterIfFeatureGateEnabled(_ context.Context, in *confmap.Conf) error {
+	if in == nil || !dropTraceCorrelationPipelineFeatureGate.IsEnabled() {
+		return nil
+	}
+
+	out := in.ToStringMap()
+
+	service, err := getService(out)
+	if err != nil {
+		return err
+	}
+
+	pipelines, err := getPipelinesFromService(service)
+	if err != nil {
+		return err
+	}
+	if len(pipelines) == 0 {
+		return nil
+	}
+
+	removeSignalFxExportersFromTracePipelines(pipelines)
+
+	*in = *confmap.NewFromStringMap(out)
+	return nil
+}
+
+func removeSignalFxExportersFromTracePipelines(pipelines map[string]any) {
+	filteredPipelines := make(map[string]any, len(pipelines))
+
+	for pipelineName, rawPipeline := range pipelines {
+		if !isTracePipeline(pipelineName) {
+			filteredPipelines[pipelineName] = rawPipeline
+			continue
+		}
+
+		pipeline, ok := rawPipeline.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		rawExporters, ok := pipeline["exporters"]
+		if !ok || rawExporters == nil {
+			continue
+		}
+
+		exporters, err := toAnySlice(rawExporters)
+		if err != nil {
+			continue
+		}
+
+		filtered := make([]any, 0, len(exporters))
+		for _, exporter := range exporters {
+			exporterName, ok := exporter.(string)
+			if !ok || isSignalFxExporter(exporterName) {
+				continue
+			}
+			filtered = append(filtered, exporter)
+		}
+
+		if len(filtered) == 0 {
+			continue
+		}
+		pipeline["exporters"] = filtered
+		filteredPipelines[pipelineName] = pipeline
+	}
+	for pipelineName := range pipelines {
+		delete(pipelines, pipelineName)
+	}
+	for pipelineName, pipeline := range filteredPipelines {
+		pipelines[pipelineName] = pipeline
+	}
+}

--- a/internal/configconverter/drop_signalfx_trace_correlation.go
+++ b/internal/configconverter/drop_signalfx_trace_correlation.go
@@ -73,6 +73,7 @@ func removeSignalFxExportersFromTracePipelines(pipelines map[string]any) {
 
 		pipeline, ok := rawPipeline.(map[string]any)
 		if !ok {
+			pipelinesToKeep[pipelineName] = rawPipeline
 			continue
 		}
 
@@ -84,6 +85,7 @@ func removeSignalFxExportersFromTracePipelines(pipelines map[string]any) {
 
 		exporters, err := toAnySlice(rawExporters)
 		if err != nil {
+			pipelinesToKeep[pipelineName] = rawPipeline
 			continue
 		}
 
@@ -103,7 +105,7 @@ func removeSignalFxExportersFromTracePipelines(pipelines map[string]any) {
 		}
 
 		if len(filtered) == 0 {
-			log.Printf("INFO: The trace pipeline '%s' was removed as there no exporters remaining after config conversion.", pipelineName)
+			log.Printf("INFO: The trace pipeline '%s' was removed as there are no exporters remaining after config conversion.", pipelineName)
 			continue
 		}
 		pipeline["exporters"] = filtered

--- a/internal/configconverter/drop_signalfx_trace_correlation.go
+++ b/internal/configconverter/drop_signalfx_trace_correlation.go
@@ -16,6 +16,7 @@ package configconverter
 
 import (
 	"context"
+	"log"
 
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/featuregate"
@@ -59,12 +60,14 @@ func DropSignalFxTracesExporterIfFeatureGateEnabled(_ context.Context, in *confm
 	return nil
 }
 
+// This function does not provide user-facing config validation. Any config validation
+// that fails will simply leaves the given object as-is.
 func removeSignalFxExportersFromTracePipelines(pipelines map[string]any) {
-	filteredPipelines := make(map[string]any, len(pipelines))
+	pipelinesToKeep := make(map[string]any, len(pipelines))
 
 	for pipelineName, rawPipeline := range pipelines {
 		if !isTracePipeline(pipelineName) {
-			filteredPipelines[pipelineName] = rawPipeline
+			pipelinesToKeep[pipelineName] = rawPipeline
 			continue
 		}
 
@@ -75,7 +78,7 @@ func removeSignalFxExportersFromTracePipelines(pipelines map[string]any) {
 
 		rawExporters, ok := pipeline["exporters"]
 		if !ok || rawExporters == nil {
-			filteredPipelines[pipelineName] = pipeline
+			pipelinesToKeep[pipelineName] = pipeline
 			continue
 		}
 
@@ -87,22 +90,29 @@ func removeSignalFxExportersFromTracePipelines(pipelines map[string]any) {
 		filtered := make([]any, 0, len(exporters))
 		for _, exporter := range exporters {
 			exporterName, ok := exporter.(string)
-			if !ok || isSignalFxExporter(exporterName) {
+			if !ok {
+				continue
+			}
+			exporterToDrop := isSignalFxExporter(exporterName)
+			if exporterToDrop {
+				log.Printf("DEPRECATION: The SignalFx exporter no longer needs to be in trace pipelines. "+
+					"Dropping '%s' exporter from '%s' pipeline", exporterName, pipelineName)
 				continue
 			}
 			filtered = append(filtered, exporter)
 		}
 
 		if len(filtered) == 0 {
+			log.Printf("INFO: The trace pipeline '%s' was removed as there no exporters remaining after config conversion.", pipelineName)
 			continue
 		}
 		pipeline["exporters"] = filtered
-		filteredPipelines[pipelineName] = pipeline
+		pipelinesToKeep[pipelineName] = pipeline
 	}
 	for pipelineName := range pipelines {
 		delete(pipelines, pipelineName)
 	}
-	for pipelineName, pipeline := range filteredPipelines {
+	for pipelineName, pipeline := range pipelinesToKeep {
 		pipelines[pipelineName] = pipeline
 	}
 }

--- a/internal/configconverter/drop_signalfx_trace_correlation.go
+++ b/internal/configconverter/drop_signalfx_trace_correlation.go
@@ -75,6 +75,7 @@ func removeSignalFxExportersFromTracePipelines(pipelines map[string]any) {
 
 		rawExporters, ok := pipeline["exporters"]
 		if !ok || rawExporters == nil {
+			filteredPipelines[pipelineName] = pipeline
 			continue
 		}
 

--- a/internal/configconverter/drop_signalfx_trace_correlation_test.go
+++ b/internal/configconverter/drop_signalfx_trace_correlation_test.go
@@ -23,217 +23,6 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 )
 
-func TestDropSignalFxTracesExporterIfFeatureGateEnabled(t *testing.T) {
-	tests := []struct {
-		name               string
-		input              string
-		expected           string
-		featureGateEnabled bool
-	}{
-		{
-			name:               "feature_gate_enabled",
-			input:              "testdata/drop_signalfx_exporter_traces_pipelines/input_config.yaml",
-			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/expected_config.yaml",
-			featureGateEnabled: true,
-		},
-		{
-			name:               "feature_gate_disabled",
-			input:              "testdata/drop_signalfx_exporter_traces_pipelines/input_config.yaml",
-			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/input_config.yaml",
-			featureGateEnabled: false,
-		},
-		{
-			name:               "agent_config_feature_gate_enabled",
-			input:              "../../cmd/otelcol/config/collector/agent_config.yaml",
-			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/agent_config_expected.yaml",
-			featureGateEnabled: true,
-		},
-		{
-			name:               "agent_config_feature_gate_disabled",
-			input:              "../../cmd/otelcol/config/collector/agent_config.yaml",
-			expected:           "../../cmd/otelcol/config/collector/agent_config.yaml",
-			featureGateEnabled: false,
-		},
-		{
-			name:               "ecs_ec2_config_feature_gate_enabled",
-			input:              "../../cmd/otelcol/config/collector/ecs_ec2_config.yaml",
-			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/ecs_ec2_config_expected.yaml",
-			featureGateEnabled: true,
-		},
-		{
-			name:               "ecs_ec2_config_feature_gate_disabled",
-			input:              "../../cmd/otelcol/config/collector/ecs_ec2_config.yaml",
-			expected:           "../../cmd/otelcol/config/collector/ecs_ec2_config.yaml",
-			featureGateEnabled: false,
-		},
-		{
-			name:               "fargate_config_feature_gate_enabled",
-			input:              "../../cmd/otelcol/config/collector/fargate_config.yaml",
-			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/fargate_config_expected.yaml",
-			featureGateEnabled: true,
-		},
-		{
-			name:               "fargate_config_feature_gate_disabled",
-			input:              "../../cmd/otelcol/config/collector/fargate_config.yaml",
-			expected:           "../../cmd/otelcol/config/collector/fargate_config.yaml",
-			featureGateEnabled: false,
-		},
-		{
-			name:               "gateway_config_feature_gate_enabled",
-			input:              "../../cmd/otelcol/config/collector/gateway_config.yaml",
-			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/gateway_config_expected.yaml",
-			featureGateEnabled: true,
-		},
-		{
-			name:               "gateway_config_feature_gate_disabled",
-			input:              "../../cmd/otelcol/config/collector/gateway_config.yaml",
-			expected:           "../../cmd/otelcol/config/collector/gateway_config.yaml",
-			featureGateEnabled: false,
-		},
-		{
-			name:               "upstream_agent_config_feature_gate_enabled",
-			input:              "../../cmd/otelcol/config/collector/upstream_agent_config.yaml",
-			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/upstream_agent_config_expected.yaml",
-			featureGateEnabled: true,
-		},
-		{
-			name:               "upstream_agent_config_feature_gate_disabled",
-			input:              "../../cmd/otelcol/config/collector/upstream_agent_config.yaml",
-			expected:           "../../cmd/otelcol/config/collector/upstream_agent_config.yaml",
-			featureGateEnabled: false,
-		},
-		{
-			name:               "full_config_linux_feature_gate_enabled",
-			input:              "../../cmd/otelcol/config/collector/full_config_linux.yaml",
-			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/full_config_linux_expected.yaml",
-			featureGateEnabled: true,
-		},
-		{
-			name:               "full_config_linux_feature_gate_disabled",
-			input:              "../../cmd/otelcol/config/collector/full_config_linux.yaml",
-			expected:           "../../cmd/otelcol/config/collector/full_config_linux.yaml",
-			featureGateEnabled: false,
-		},
-		{
-			name:               "logs_config_linux_feature_gate_enabled",
-			input:              "../../cmd/otelcol/config/collector/logs_config_linux.yaml",
-			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/logs_config_linux_expected.yaml",
-			featureGateEnabled: true,
-		},
-		{
-			name:               "logs_config_linux_feature_gate_disabled",
-			input:              "../../cmd/otelcol/config/collector/logs_config_linux.yaml",
-			expected:           "../../cmd/otelcol/config/collector/logs_config_linux.yaml",
-			featureGateEnabled: false,
-		},
-		{
-			name:               "otlp_config_linux_feature_gate_enabled",
-			input:              "../../cmd/otelcol/config/collector/otlp_config_linux.yaml",
-			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/otlp_config_linux_expected.yaml",
-			featureGateEnabled: true,
-		},
-		{
-			name:               "otlp_config_linux_feature_gate_disabled",
-			input:              "../../cmd/otelcol/config/collector/otlp_config_linux.yaml",
-			expected:           "../../cmd/otelcol/config/collector/otlp_config_linux.yaml",
-			featureGateEnabled: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.NoError(t, featuregate.GlobalRegistry().Set(dropTraceCorrelationPipelineFeatureGateID, tt.featureGateEnabled))
-
-			cfgMap, err := confmaptest.LoadConf(tt.input)
-			require.NoError(t, err)
-			require.NotNil(t, cfgMap)
-
-			expectedCfgMap, err := confmaptest.LoadConf(tt.expected)
-			require.NoError(t, err)
-			require.NotNil(t, expectedCfgMap)
-
-			require.NoError(t, DropSignalFxTracesExporterIfFeatureGateEnabled(t.Context(), cfgMap))
-
-			require.Equal(t, expectedCfgMap, cfgMap)
-		})
-	}
-}
-
-func TestIsTracePipeline(t *testing.T) {
-	tests := []struct {
-		name     string
-		pipeline string
-		expected bool
-	}{
-		{
-			name:     "traces_pipeline",
-			pipeline: "traces",
-			expected: true,
-		},
-		{
-			name:     "alternate_traces_pipeline",
-			pipeline: "traces/alternate",
-			expected: true,
-		},
-		{
-			name:     "metrics_pipeline",
-			pipeline: "metrics",
-			expected: false,
-		},
-		{
-			name:     "internal_metrics_pipeline",
-			pipeline: "metrics/internal",
-			expected: false,
-		},
-		{
-			name:     "logs_pipeline",
-			pipeline: "logs",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, isTracePipeline(tt.pipeline))
-		})
-	}
-}
-
-func TestIsSignalFxExporter(t *testing.T) {
-	tests := []struct {
-		name     string
-		exporter string
-		expected bool
-	}{
-		{
-			name:     "default_signalfx_exporter",
-			exporter: "signalfx",
-			expected: true,
-		},
-		{
-			name:     "alternate_signalfx_exporter",
-			exporter: "signalfx/alternate",
-			expected: true,
-		},
-		{
-			name:     "otlp_http_exporter",
-			exporter: "otlp_http",
-			expected: false,
-		},
-		{
-			name:     "splunk_hec_exporter",
-			exporter: "splunk_hec",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, isSignalFxExporter(tt.exporter))
-		})
-	}
-}
-
 func TestNoOpConfigs(t *testing.T) {
 	tests := []struct {
 		config        *confmap.Conf
@@ -319,6 +108,166 @@ func TestNoOpConfigs(t *testing.T) {
 				require.NoError(t, err)
 			}
 			require.Equal(t, original, config)
+		})
+	}
+}
+
+func TestDropSignalFxTracesExporterIfFeatureGateEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "drop_signalfx_exporter_traces_pipelines",
+			input:    "testdata/drop_signalfx_exporter_traces_pipelines/input_config.yaml",
+			expected: "testdata/drop_signalfx_exporter_traces_pipelines/expected_config.yaml",
+		},
+		{
+			name:     "drop_traces_pipelines",
+			input:    "testdata/drop_signalfx_exporter_traces_pipelines/drop_traces_pipeline_input.yaml",
+			expected: "testdata/drop_signalfx_exporter_traces_pipelines/drop_traces_pipeline_expected.yaml",
+		},
+		{
+			name:     "agent_config",
+			input:    "../../cmd/otelcol/config/collector/agent_config.yaml",
+			expected: "testdata/drop_signalfx_exporter_traces_pipelines/agent_config_expected.yaml",
+		},
+		{
+			name:     "ecs_ec2_config",
+			input:    "../../cmd/otelcol/config/collector/ecs_ec2_config.yaml",
+			expected: "testdata/drop_signalfx_exporter_traces_pipelines/ecs_ec2_config_expected.yaml",
+		},
+		{
+			name:     "fargate_config",
+			input:    "../../cmd/otelcol/config/collector/fargate_config.yaml",
+			expected: "testdata/drop_signalfx_exporter_traces_pipelines/fargate_config_expected.yaml",
+		},
+		{
+			name:     "gateway_config",
+			input:    "../../cmd/otelcol/config/collector/gateway_config.yaml",
+			expected: "testdata/drop_signalfx_exporter_traces_pipelines/gateway_config_expected.yaml",
+		},
+		{
+			name:     "upstream_agent_config",
+			input:    "../../cmd/otelcol/config/collector/upstream_agent_config.yaml",
+			expected: "testdata/drop_signalfx_exporter_traces_pipelines/upstream_agent_config_expected.yaml",
+		},
+		{
+			name:     "full_config_linux",
+			input:    "../../cmd/otelcol/config/collector/full_config_linux.yaml",
+			expected: "testdata/drop_signalfx_exporter_traces_pipelines/full_config_linux_expected.yaml",
+		},
+		{
+			name:     "logs_config_linux",
+			input:    "../../cmd/otelcol/config/collector/logs_config_linux.yaml",
+			expected: "testdata/drop_signalfx_exporter_traces_pipelines/logs_config_linux_expected.yaml",
+		},
+		{
+			name:     "otlp_config_linux",
+			input:    "../../cmd/otelcol/config/collector/otlp_config_linux.yaml",
+			expected: "testdata/drop_signalfx_exporter_traces_pipelines/otlp_config_linux_expected.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputCfgMap, err := confmaptest.LoadConf(tt.input)
+			require.NoError(t, err)
+			require.NotNil(t, inputCfgMap)
+
+			require.NoError(t, featuregate.GlobalRegistry().Set(dropTraceCorrelationPipelineFeatureGateID, false))
+			disabledCfgMap, err := confmaptest.LoadConf(tt.input)
+			require.NoError(t, err)
+			require.NotNil(t, disabledCfgMap)
+			require.NoError(t, DropSignalFxTracesExporterIfFeatureGateEnabled(t.Context(), disabledCfgMap))
+			require.Equal(t, inputCfgMap, disabledCfgMap)
+
+			expectedCfgMap, err := confmaptest.LoadConf(tt.expected)
+			require.NoError(t, err)
+			require.NotNil(t, expectedCfgMap)
+
+			require.NoError(t, featuregate.GlobalRegistry().Set(dropTraceCorrelationPipelineFeatureGateID, true))
+			enabledCfgMap, err := confmaptest.LoadConf(tt.input)
+			require.NoError(t, err)
+			require.NotNil(t, enabledCfgMap)
+			require.NoError(t, DropSignalFxTracesExporterIfFeatureGateEnabled(t.Context(), enabledCfgMap))
+			require.Equal(t, expectedCfgMap, enabledCfgMap)
+		})
+	}
+}
+
+func TestIsTracePipeline(t *testing.T) {
+	tests := []struct {
+		name     string
+		pipeline string
+		expected bool
+	}{
+		{
+			name:     "traces_pipeline",
+			pipeline: "traces",
+			expected: true,
+		},
+		{
+			name:     "alternate_traces_pipeline",
+			pipeline: "traces/alternate",
+			expected: true,
+		},
+		{
+			name:     "metrics_pipeline",
+			pipeline: "metrics",
+			expected: false,
+		},
+		{
+			name:     "internal_metrics_pipeline",
+			pipeline: "metrics/internal",
+			expected: false,
+		},
+		{
+			name:     "logs_pipeline",
+			pipeline: "logs",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, isTracePipeline(tt.pipeline))
+		})
+	}
+}
+
+func TestIsSignalFxExporter(t *testing.T) {
+	tests := []struct {
+		name     string
+		exporter string
+		expected bool
+	}{
+		{
+			name:     "default_signalfx_exporter",
+			exporter: "signalfx",
+			expected: true,
+		},
+		{
+			name:     "alternate_signalfx_exporter",
+			exporter: "signalfx/alternate",
+			expected: true,
+		},
+		{
+			name:     "otlp_http_exporter",
+			exporter: "otlp_http",
+			expected: false,
+		},
+		{
+			name:     "splunk_hec_exporter",
+			exporter: "splunk_hec",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, isSignalFxExporter(tt.exporter))
 		})
 	}
 }

--- a/internal/configconverter/drop_signalfx_trace_correlation_test.go
+++ b/internal/configconverter/drop_signalfx_trace_correlation_test.go
@@ -1,3 +1,17 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package configconverter
 
 import (

--- a/internal/configconverter/drop_signalfx_trace_correlation_test.go
+++ b/internal/configconverter/drop_signalfx_trace_correlation_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/featuregate"
 )
@@ -142,9 +143,6 @@ func TestDropSignalFxTracesExporterIfFeatureGateEnabled(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.NoError(t, featuregate.GlobalRegistry().Set(dropTraceCorrelationPipelineFeatureGateID, tt.featureGateEnabled))
-			t.Cleanup(func() {
-				_ = featuregate.GlobalRegistry().Set(dropTraceCorrelationPipelineFeatureGateID, false)
-			})
 
 			cfgMap, err := confmaptest.LoadConf(tt.input)
 			require.NoError(t, err)
@@ -232,6 +230,95 @@ func TestIsSignalFxExporter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.expected, isSignalFxExporter(tt.exporter))
+		})
+	}
+}
+
+func TestInvalidConfigs(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        *confmap.Conf
+		errorExpected bool
+	}{
+		{
+			name: "nil",
+		},
+		{
+			name:          "empty",
+			config:        confmap.New(),
+			errorExpected: false,
+		},
+		{
+			name: "invalid_service",
+			config: confmap.NewFromStringMap(map[string]any{
+				"service": "not-a-map",
+			}),
+			errorExpected: true,
+		},
+		{
+			name: "invalid_pipelines",
+			config: confmap.NewFromStringMap(map[string]any{
+				"service": map[string]any{
+					"pipelines": "not-a-map",
+				},
+			}),
+			errorExpected: true,
+		},
+		{
+			name: "no_service",
+			config: confmap.NewFromStringMap(map[string]any{
+				"receivers": map[string]any{
+					"otlp": map[string]any{},
+				},
+			}),
+			errorExpected: false,
+		},
+		{
+			name: "no_traces_pipeline",
+			config: confmap.NewFromStringMap(map[string]any{
+				"service": map[string]any{
+					"pipelines": map[string]any{
+						"metrics": map[string]any{
+							"exporters": []any{"signalfx"},
+						},
+					},
+				},
+			}),
+			errorExpected: false,
+		},
+		{
+			name: "no_exporters",
+			config: confmap.NewFromStringMap(map[string]any{
+				"service": map[string]any{
+					"pipelines": map[string]any{
+						"traces": map[string]any{
+							"receivers": []any{"otlp"},
+						},
+					},
+				},
+			}),
+			errorExpected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, featuregate.GlobalRegistry().Set(dropTraceCorrelationPipelineFeatureGateID, true))
+
+			var original *confmap.Conf
+			config := tt.config
+			if config != nil {
+				original = confmap.NewFromStringMap(config.ToStringMap())
+				config = confmap.NewFromStringMap(config.ToStringMap())
+			}
+
+			err := DropSignalFxTracesExporterIfFeatureGateEnabled(t.Context(), config)
+			if tt.errorExpected {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, original, config)
 		})
 	}
 }

--- a/internal/configconverter/drop_signalfx_trace_correlation_test.go
+++ b/internal/configconverter/drop_signalfx_trace_correlation_test.go
@@ -1,0 +1,127 @@
+package configconverter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+	"go.opentelemetry.io/collector/featuregate"
+)
+
+func TestDropSignalFxTracesExporterIfFeatureGateEnabled(t *testing.T) {
+	tests := []struct {
+		name               string
+		featureGateEnabled bool
+		input              string
+		expected           string
+	}{
+		{
+			name:               "feature_gate_enabled",
+			featureGateEnabled: true,
+			input:              "testdata/drop_signalfx_exporter_traces_pipelines/input_config.yaml",
+			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/expected_config.yaml",
+		},
+		{
+			name:               "feature_gate_disabled",
+			featureGateEnabled: false,
+			input:              "testdata/drop_signalfx_exporter_traces_pipelines/input_config.yaml",
+			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/input_config.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, featuregate.GlobalRegistry().Set(dropTraceCorrelationPipelineFeatureGateID, tt.featureGateEnabled))
+			t.Cleanup(func() {
+				_ = featuregate.GlobalRegistry().Set(dropTraceCorrelationPipelineFeatureGateID, false)
+			})
+
+			cfgMap, err := confmaptest.LoadConf(tt.input)
+			require.NoError(t, err)
+			require.NotNil(t, cfgMap)
+
+			expectedCfgMap, err := confmaptest.LoadConf(tt.expected)
+			require.NoError(t, err)
+			require.NotNil(t, expectedCfgMap)
+
+			require.NoError(t, DropSignalFxTracesExporterIfFeatureGateEnabled(t.Context(), cfgMap))
+
+			require.Equal(t, expectedCfgMap, cfgMap)
+		})
+	}
+}
+
+func TestIsTracePipeline(t *testing.T) {
+	tests := []struct {
+		name     string
+		pipeline string
+		expected bool
+	}{
+		{
+			name:     "traces_pipeline",
+			pipeline: "traces",
+			expected: true,
+		},
+		{
+			name:     "alternate_traces_pipeline",
+			pipeline: "traces/alternate",
+			expected: true,
+		},
+		{
+			name:     "metrics_pipeline",
+			pipeline: "metrics",
+			expected: false,
+		},
+		{
+			name:     "internal_metrics_pipeline",
+			pipeline: "metrics/internal",
+			expected: false,
+		},
+		{
+			name:     "logs_pipeline",
+			pipeline: "logs",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, isTracePipeline(tt.pipeline))
+		})
+	}
+}
+
+func TestIsSignalFxExporter(t *testing.T) {
+	tests := []struct {
+		name     string
+		exporter string
+		expected bool
+	}{
+		{
+			name:     "default_signalfx_exporter",
+			exporter: "signalfx",
+			expected: true,
+		},
+		{
+			name:     "alternate_signalfx_exporter",
+			exporter: "signalfx/alternate",
+			expected: true,
+		},
+		{
+			name:     "otlp_http_exporter",
+			exporter: "otlp_http",
+			expected: false,
+		},
+		{
+			name:     "splunk_hec_exporter",
+			exporter: "splunk_hec",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, isSignalFxExporter(tt.exporter))
+		})
+	}
+}

--- a/internal/configconverter/drop_signalfx_trace_correlation_test.go
+++ b/internal/configconverter/drop_signalfx_trace_correlation_test.go
@@ -25,21 +25,21 @@ import (
 func TestDropSignalFxTracesExporterIfFeatureGateEnabled(t *testing.T) {
 	tests := []struct {
 		name               string
-		featureGateEnabled bool
 		input              string
 		expected           string
+		featureGateEnabled bool
 	}{
 		{
 			name:               "feature_gate_enabled",
-			featureGateEnabled: true,
 			input:              "testdata/drop_signalfx_exporter_traces_pipelines/input_config.yaml",
 			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/expected_config.yaml",
+			featureGateEnabled: true,
 		},
 		{
 			name:               "feature_gate_disabled",
-			featureGateEnabled: false,
 			input:              "testdata/drop_signalfx_exporter_traces_pipelines/input_config.yaml",
 			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/input_config.yaml",
+			featureGateEnabled: false,
 		},
 	}
 

--- a/internal/configconverter/drop_signalfx_trace_correlation_test.go
+++ b/internal/configconverter/drop_signalfx_trace_correlation_test.go
@@ -234,7 +234,7 @@ func TestIsSignalFxExporter(t *testing.T) {
 	}
 }
 
-func TestInvalidConfigs(t *testing.T) {
+func TestNoOpConfigs(t *testing.T) {
 	tests := []struct {
 		name          string
 		config        *confmap.Conf

--- a/internal/configconverter/drop_signalfx_trace_correlation_test.go
+++ b/internal/configconverter/drop_signalfx_trace_correlation_test.go
@@ -41,6 +41,102 @@ func TestDropSignalFxTracesExporterIfFeatureGateEnabled(t *testing.T) {
 			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/input_config.yaml",
 			featureGateEnabled: false,
 		},
+		{
+			name:               "agent_config_feature_gate_enabled",
+			input:              "../../cmd/otelcol/config/collector/agent_config.yaml",
+			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/agent_config_expected.yaml",
+			featureGateEnabled: true,
+		},
+		{
+			name:               "agent_config_feature_gate_disabled",
+			input:              "../../cmd/otelcol/config/collector/agent_config.yaml",
+			expected:           "../../cmd/otelcol/config/collector/agent_config.yaml",
+			featureGateEnabled: false,
+		},
+		{
+			name:               "ecs_ec2_config_feature_gate_enabled",
+			input:              "../../cmd/otelcol/config/collector/ecs_ec2_config.yaml",
+			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/ecs_ec2_config_expected.yaml",
+			featureGateEnabled: true,
+		},
+		{
+			name:               "ecs_ec2_config_feature_gate_disabled",
+			input:              "../../cmd/otelcol/config/collector/ecs_ec2_config.yaml",
+			expected:           "../../cmd/otelcol/config/collector/ecs_ec2_config.yaml",
+			featureGateEnabled: false,
+		},
+		{
+			name:               "fargate_config_feature_gate_enabled",
+			input:              "../../cmd/otelcol/config/collector/fargate_config.yaml",
+			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/fargate_config_expected.yaml",
+			featureGateEnabled: true,
+		},
+		{
+			name:               "fargate_config_feature_gate_disabled",
+			input:              "../../cmd/otelcol/config/collector/fargate_config.yaml",
+			expected:           "../../cmd/otelcol/config/collector/fargate_config.yaml",
+			featureGateEnabled: false,
+		},
+		{
+			name:               "gateway_config_feature_gate_enabled",
+			input:              "../../cmd/otelcol/config/collector/gateway_config.yaml",
+			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/gateway_config_expected.yaml",
+			featureGateEnabled: true,
+		},
+		{
+			name:               "gateway_config_feature_gate_disabled",
+			input:              "../../cmd/otelcol/config/collector/gateway_config.yaml",
+			expected:           "../../cmd/otelcol/config/collector/gateway_config.yaml",
+			featureGateEnabled: false,
+		},
+		{
+			name:               "upstream_agent_config_feature_gate_enabled",
+			input:              "../../cmd/otelcol/config/collector/upstream_agent_config.yaml",
+			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/upstream_agent_config_expected.yaml",
+			featureGateEnabled: true,
+		},
+		{
+			name:               "upstream_agent_config_feature_gate_disabled",
+			input:              "../../cmd/otelcol/config/collector/upstream_agent_config.yaml",
+			expected:           "../../cmd/otelcol/config/collector/upstream_agent_config.yaml",
+			featureGateEnabled: false,
+		},
+		{
+			name:               "full_config_linux_feature_gate_enabled",
+			input:              "../../cmd/otelcol/config/collector/full_config_linux.yaml",
+			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/full_config_linux_expected.yaml",
+			featureGateEnabled: true,
+		},
+		{
+			name:               "full_config_linux_feature_gate_disabled",
+			input:              "../../cmd/otelcol/config/collector/full_config_linux.yaml",
+			expected:           "../../cmd/otelcol/config/collector/full_config_linux.yaml",
+			featureGateEnabled: false,
+		},
+		{
+			name:               "logs_config_linux_feature_gate_enabled",
+			input:              "../../cmd/otelcol/config/collector/logs_config_linux.yaml",
+			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/logs_config_linux_expected.yaml",
+			featureGateEnabled: true,
+		},
+		{
+			name:               "logs_config_linux_feature_gate_disabled",
+			input:              "../../cmd/otelcol/config/collector/logs_config_linux.yaml",
+			expected:           "../../cmd/otelcol/config/collector/logs_config_linux.yaml",
+			featureGateEnabled: false,
+		},
+		{
+			name:               "otlp_config_linux_feature_gate_enabled",
+			input:              "../../cmd/otelcol/config/collector/otlp_config_linux.yaml",
+			expected:           "testdata/drop_signalfx_exporter_traces_pipelines/otlp_config_linux_expected.yaml",
+			featureGateEnabled: true,
+		},
+		{
+			name:               "otlp_config_linux_feature_gate_disabled",
+			input:              "../../cmd/otelcol/config/collector/otlp_config_linux.yaml",
+			expected:           "../../cmd/otelcol/config/collector/otlp_config_linux.yaml",
+			featureGateEnabled: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/configconverter/drop_signalfx_trace_correlation_test.go
+++ b/internal/configconverter/drop_signalfx_trace_correlation_test.go
@@ -236,8 +236,8 @@ func TestIsSignalFxExporter(t *testing.T) {
 
 func TestNoOpConfigs(t *testing.T) {
 	tests := []struct {
-		name          string
 		config        *confmap.Conf
+		name          string
 		errorExpected bool
 	}{
 		{

--- a/internal/configconverter/opamp.go
+++ b/internal/configconverter/opamp.go
@@ -42,7 +42,11 @@ func RemoveSplunkOpAMPIfFeatureGateDisabled(_ context.Context, in *confmap.Conf)
 
 	out := in.ToStringMap()
 
-	service, serviceExtensions, err := getServiceExtensions(out)
+	service, err := getService(out)
+	if err != nil {
+		return err
+	}
+	serviceExtensions, err := getExtensionsFromService(service)
 	if err != nil {
 		return err
 	}

--- a/internal/configconverter/opamp_test.go
+++ b/internal/configconverter/opamp_test.go
@@ -61,7 +61,9 @@ func TestRemoveOpAMP_GateDisabled_OpAMPInConfig_IsRemoved(t *testing.T) {
 	assert.Contains(t, extensions, "opamp/splunk_o11y")
 	assert.Contains(t, extensions, "health_check")
 
-	_, serviceExts, err := getServiceExtensions(out)
+	service, err := getService(out)
+	require.NoError(t, err)
+	serviceExts, err := getExtensionsFromService(service)
 	require.NoError(t, err)
 	assert.NotContains(t, serviceExts, "opamp/splunk_o11y")
 	assert.Contains(t, serviceExts, "health_check")
@@ -107,7 +109,9 @@ func TestRemoveOpAMP_GateDisabled_OtherOpAMPVariants_NotRemoved(t *testing.T) {
 	assert.Contains(t, extensions, "opamp/splunk_o11y")
 	assert.Contains(t, extensions, "health_check")
 
-	_, serviceExts, err := getServiceExtensions(out)
+	service, err := getService(out)
+	require.NoError(t, err)
+	serviceExts, err := getExtensionsFromService(service)
 	require.NoError(t, err)
 	// Only opamp/splunk_o11y should be removed from service.extensions
 	assert.Contains(t, serviceExts, "opamp")

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/agent_config_expected.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/agent_config_expected.yaml
@@ -89,9 +89,9 @@ processors:
             - system
         override: true
 receivers:
-    fluentforward:
+    fluent_forward:
         endpoint: ${SPLUNK_LISTEN_INTERFACE}:8006
-    hostmetrics:
+    host_metrics:
         collection_interval: 10s
         scrapers:
             cpu: null
@@ -159,7 +159,7 @@ service:
                 - batch
                 - resourcedetection
             receivers:
-                - fluentforward
+                - fluent_forward
                 - otlp
         logs/entities:
             exporters:
@@ -187,7 +187,7 @@ service:
                 - batch
                 - resourcedetection
             receivers:
-                - hostmetrics
+                - host_metrics
                 - otlp
         metrics/internal:
             exporters:

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/agent_config_expected.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/agent_config_expected.yaml
@@ -1,0 +1,222 @@
+exporters:
+    debug:
+        verbosity: detailed
+    otlp_grpc/gateway:
+        auth:
+            authenticator: headers_setter
+        endpoint: ${SPLUNK_GATEWAY_URL}:4317
+        tls:
+            insecure: true
+    otlp_http:
+        auth:
+            authenticator: headers_setter
+        headers:
+            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        traces_endpoint: ${SPLUNK_INGEST_URL}/v2/trace/otlp
+    otlp_http/entities:
+        auth:
+            authenticator: headers_setter
+        headers:
+            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        logs_endpoint: ${SPLUNK_INGEST_URL}/v3/event
+    signalfx:
+        access_token: ${SPLUNK_ACCESS_TOKEN}
+        api_url: ${SPLUNK_API_URL}
+        correlation: null
+        ingest_url: ${SPLUNK_INGEST_URL}
+        sync_host_metadata: true
+    splunk_hec:
+        endpoint: ${SPLUNK_HEC_URL}
+        profiling_data_enabled: false
+        source: otel
+        sourcetype: otel
+        token: ${SPLUNK_HEC_TOKEN}
+    splunk_hec/profiling:
+        endpoint: ${SPLUNK_INGEST_URL}/v1/log
+        log_data_enabled: false
+        token: ${SPLUNK_ACCESS_TOKEN}
+extensions:
+    headers_setter:
+        headers:
+            - action: upsert
+              default_value: ${SPLUNK_ACCESS_TOKEN}
+              from_context: X-SF-TOKEN
+              key: X-SF-TOKEN
+    health_check:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:13133
+    http_forwarder:
+        egress:
+            endpoint: ${SPLUNK_API_URL}
+        ingress:
+            endpoint: ${SPLUNK_LISTEN_INTERFACE}:6060
+    http_forwarder/opamp_splunk_o11y:
+        egress:
+            endpoint: ${SPLUNK_INGEST_URL}
+        ingress:
+            endpoint: ${SPLUNK_LISTEN_INTERFACE}:4320
+    opamp/splunk_o11y:
+        server:
+            http:
+                endpoint: ${SPLUNK_INGEST_URL}/v1/opamp
+                headers:
+                    X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+                polling_interval: 30s
+    smartagent:
+        bundleDir: ${SPLUNK_BUNDLE_DIR}
+        collectd:
+            configDir: ${SPLUNK_COLLECTD_DIR}
+    zpages:
+        expvar:
+            enabled: true
+processors:
+    batch:
+        metadata_keys:
+            - X-SF-Token
+    memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+    resource/add_mode:
+        attributes:
+            - action: insert
+              key: otelcol.service.mode
+              value: agent
+    resourcedetection:
+        detectors:
+            - gcp
+            - ecs
+            - ec2
+            - azure
+            - system
+        override: true
+receivers:
+    fluentforward:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:8006
+    hostmetrics:
+        collection_interval: 10s
+        scrapers:
+            cpu: null
+            disk: null
+            filesystem: null
+            load: null
+            memory: null
+            network: null
+            paging: null
+            processes: null
+    jaeger:
+        protocols:
+            grpc:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:14250
+            thrift_binary:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:6832
+            thrift_compact:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:6831
+            thrift_http:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:14268
+    nop: null
+    otlp:
+        protocols:
+            grpc:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:4317
+            http:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:4318
+    prometheus/internal:
+        config:
+            scrape_configs:
+                - job_name: otel-collector
+                  metric_relabel_configs:
+                    - action: drop
+                      regex: promhttp_metric_handler_errors.*
+                      source_labels:
+                        - __name__
+                    - action: drop
+                      regex: otelcol_processor_batch_.*
+                      source_labels:
+                        - __name__
+                  scrape_interval: 10s
+                  static_configs:
+                    - targets:
+                        - 0.0.0.0:8888
+    smartagent/processlist:
+        type: processlist
+    zipkin:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:9411
+service:
+    extensions:
+        - headers_setter
+        - health_check
+        - http_forwarder
+        - http_forwarder/opamp_splunk_o11y
+        - opamp/splunk_o11y
+        - zpages
+        - smartagent
+    pipelines:
+        logs:
+            exporters:
+                - splunk_hec
+                - splunk_hec/profiling
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - fluentforward
+                - otlp
+        logs/entities:
+            exporters:
+                - otlp_http/entities
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - nop
+        logs/signalfx:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - smartagent/processlist
+        metrics:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - hostmetrics
+                - otlp
+        metrics/internal:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+                - resource/add_mode
+            receivers:
+                - prometheus/internal
+        traces:
+            exporters:
+                - otlp_http
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - jaeger
+                - otlp
+                - zipkin
+    telemetry:
+        logs:
+            level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+        metrics:
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 127.0.0.1
+                            port: 8888

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/drop_traces_pipeline_expected.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/drop_traces_pipeline_expected.yaml
@@ -1,0 +1,426 @@
+exporters:
+    debug:
+        verbosity: detailed
+    file:
+        path: ./filename.json
+    jaeger:
+        endpoint: jaeger-all-in-one:14250
+        tls:
+            insecure: true
+    otlp_grpc:
+        auth:
+            authenticator: headers_setter
+        endpoint: otelcol2:4317
+    otlp_http:
+        auth:
+            authenticator: headers_setter
+        compression: gzip
+        endpoint: otelcol2:4318
+        headers:
+            X-SF-TOKEN: ${SPLUNK_ACCESS_TOKEN}
+    prometheus:
+        const_labels:
+            another label: spaced value
+            label1: value1
+        endpoint: 1.2.3.4:1234
+        namespace: test-space
+        send_timestamps: true
+    prometheusremotewrite:
+        endpoint: http://some.url:9411/api/prom/push
+    signalfx:
+        access_token: ${SPLUNK_ACCESS_TOKEN}
+        realm: ${SPLUNK_REALM}
+    splunk_hec:
+        disable_compression: false
+        endpoint: https://${SPLUNK_ENDPOINT}:8088/services/collector
+        index: metrics
+        insecure_skip_verify: false
+        max_connections: 200
+        profiling_data_enabled: false
+        source: otel
+        sourcetype: otel
+        timeout: 10s
+        token: ${SPLUNK_HEC_TOKEN}
+    splunk_hec/profiling:
+        endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com/v1/log
+        log_data_enabled: false
+        token: ${SPLUNK_ACCESS_TOKEN}
+    zipkin:
+        endpoint: http://some.url:9411/api/v2/spans
+        tls:
+            insecure: true
+extensions:
+    headers_setter:
+        headers:
+            - action: upsert
+              default_value: ${SPLUNK_ACCESS_TOKEN}
+              from_context: X-SF-TOKEN
+              key: X-SF-TOKEN
+    health_check:
+        endpoint: 0.0.0.0:13133
+    host_observer: null
+    http_forwarder:
+        egress:
+            endpoint: https://api.${SPLUNK_REALM}.observability.splunkcloud.com
+        ingress:
+            endpoint: 0.0.0.0:6060
+    http_forwarder/opamp_splunk_o11y:
+        egress:
+            endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com
+        ingress:
+            endpoint: 0.0.0.0:4320
+    k8s_observer: null
+    opamp/splunk_o11y:
+        server:
+            http:
+                endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com/v1/opamp
+                headers:
+                    X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+                polling_interval: 30s
+    pprof: null
+    zpages:
+        expvar:
+            enabled: true
+processors:
+    attributes:
+        actions:
+            - action: insert
+              key: environment
+              value: test
+    attributes/example:
+        actions:
+            - action: delete
+              key: db.statement
+            - action: extract
+              key: http.url
+              pattern: ^(?P<http_protocol>.*):\/\/(?P<http_domain>.*)\/(?P<http_path>.*)(\?|\&)(?P<http_query_params>.*)
+            - action: hash
+              key: email
+            - action: insert
+              key: build_num
+              value: 1.5.7
+            - action: update
+              from_attribute: foo
+              key: bar
+            - action: upsert
+              key: region
+              value: planet-earth
+    batch:
+        metadata_keys:
+            - X-SF-Token
+    filter/1:
+        metrics:
+            exclude:
+                match_type: strict
+                metric_names:
+                    - hello_world
+                    - hello/world
+            include:
+                match_type: regexp
+                metric_names:
+                    - prefix/.*
+                    - prefix_.*
+                resource_attributes:
+                    - Key: container.name
+                      Value: app_container_1
+    memory_limiter:
+        check_interval: 2s
+        limit_mib: 1800
+    resource:
+        attributes:
+            - action: upsert
+              key: cloud.zone
+              value: zone-1
+            - action: insert
+              from_attribute: k8s-cluster
+              key: k8s.cluster.name
+            - action: delete
+              key: redundant-attribute
+    resourcedetection/internal:
+        detectors:
+            - gcp
+            - ecs
+            - ec2
+            - azure
+            - system
+        override: true
+    span/from_attributes:
+        name:
+            from_attributes:
+                - db.svc
+                - operation
+            separator: '::'
+    span/to_attributes:
+        name:
+            to_attributes:
+                rules:
+                    - ^\/api\/v1\/document\/(?P<documentId>.*)\/update$
+receivers:
+    file_log:
+        exclude:
+            - /var/log/*lastlog*
+            - /var/log/*anaconda.syslog*
+        include:
+            - /Library/Logs/*
+            - /var/log/*.log*
+            - /var/log/*log
+            - /var/log/*messages*
+            - /var/log/*secure*
+            - /var/log/*auth*
+            - /var/log/*mesg
+            - /var/log/*cron
+            - /var/log/*acpid
+            - /var/log/*.out*
+            - /var/adm/*.log*
+            - /var/adm/*log
+            - /var/adm/*messages*
+            - /etc/*.conf*
+            - /etc/*.cfg*
+            - /etc/*config
+            - /etc/*.ini*
+            - /etc/*.init*
+            - /etc/*.cf*
+            - /etc/*.cnf*
+            - /etc/*shrc
+            - /etc/ifcfg*
+            - /etc/*.profile*
+            - /etc/*.rc*
+            - /etc/*.rules*
+            - /etc/*.tab*
+            - /etc/*tab
+            - /etc/*.login*
+            - /etc/*policy
+            - /root/.bash_history
+            - /home/*/.bash_history
+        include_file_name: false
+        include_file_path: true
+    fluentforward:
+        endpoint: 0.0.0.0:8006
+    hostmetrics:
+        collection_interval: 10s
+        scrapers:
+            cpu: null
+            disk: null
+            filesystem: null
+            load: null
+            memory: null
+            network: null
+            paging: null
+            processes: null
+    jaeger:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:14250
+            thrift_binary:
+                endpoint: 0.0.0.0:6832
+            thrift_compact:
+                endpoint: 0.0.0.0:6831
+            thrift_http:
+                endpoint: 0.0.0.0:14268
+    k8s_cluster: null
+    kafka:
+        protocol_version: 2.0.0
+    kubeletstats:
+        auth_type: serviceAccount
+        insecure_skip_verify: true
+    otlp:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:4317
+            http:
+                endpoint: 0.0.0.0:4318
+    prometheus/internal:
+        config:
+            scrape_configs:
+                - job_name: otel-collector
+                  metric_relabel_configs:
+                    - action: drop
+                      regex: promhttp_metric_handler_errors.*
+                      source_labels:
+                        - __name__
+                    - action: drop
+                      regex: otelcol_processor_batch_.*
+                      source_labels:
+                        - __name__
+                  scrape_interval: 10s
+                  static_configs:
+                    - targets:
+                        - 0.0.0.0:8888
+    prometheus_simple: null
+    scripted_inputs/bandwidth:
+        collection_interval: 60s
+        script_name: bandwidth
+        source: bandwidth
+        sourcetype: bandwidth
+    scripted_inputs/cpu:
+        collection_interval: 30s
+        script_name: cpu
+        source: cpu
+        sourcetype: cpu
+    scripted_inputs/df:
+        collection_interval: 10s
+        script_name: df
+        source: df
+        sourcetype: df
+    scripted_inputs/hardware:
+        collection_interval: 36000s
+        script_name: hardware
+        source: hardware
+        sourcetype: hardware
+    scripted_inputs/interfaces:
+        collection_interval: 60s
+        script_name: interfaces
+        source: interfaces
+        sourcetype: interfaces
+    scripted_inputs/iostat:
+        collection_interval: 60s
+        script_name: iostat
+        source: iostat
+        sourcetype: iostat
+    scripted_inputs/lastlog:
+        collection_interval: 300s
+        script_name: lastlog
+        source: lastlog
+        sourcetype: lastlog
+    scripted_inputs/lsof:
+        collection_interval: 600s
+        script_name: lsof
+        source: lsof
+        sourcetype: lsof
+    scripted_inputs/netstat:
+        collection_interval: 60s
+        script_name: netstat
+        source: netstat
+        sourcetype: netstat
+    scripted_inputs/nfsiostat:
+        collection_interval: 60s
+        script_name: nfsiostat
+        source: nfsiostat
+        sourcetype: nfsiostat
+    scripted_inputs/openPorts:
+        collection_interval: 300s
+        script_name: openPorts
+        source: openPorts
+        sourcetype: openPorts
+    scripted_inputs/openPortsEnhanced:
+        collection_interval: 3600s
+        script_name: openPortsEnhanced
+        source: openPortsEnhanced
+        sourcetype: openPortsEnhanced
+    scripted_inputs/package:
+        collection_interval: 3600s
+        script_name: package
+        source: package
+        sourcetype: package
+    scripted_inputs/passwd:
+        collection_interval: 3600s
+        script_name: passwd
+        source: passwd
+        sourcetype: passwd
+    scripted_inputs/protocol:
+        collection_interval: 60s
+        script_name: protocol
+        source: protocol
+        sourcetype: protocol
+    scripted_inputs/ps:
+        collection_interval: 30s
+        script_name: ps
+        source: ps
+        sourcetype: ps
+    scripted_inputs/rlog:
+        collection_interval: 60s
+        script_name: rlog
+        source: rlog
+        sourcetype: rlog
+    scripted_inputs/selinuxChecker:
+        collection_interval: 3600s
+        script_name: selinuxChecker
+        source: selinuxChecker
+        sourcetype: selinuxChecker
+    scripted_inputs/service:
+        collection_interval: 3600s
+        script_name: service
+        source: service
+        sourcetype: service
+    scripted_inputs/sshdChecker:
+        collection_interval: 3600s
+        script_name: sshdChecker
+        source: sshdChecker
+        sourcetype: sshdChecker
+    scripted_inputs/time:
+        collection_interval: 21600s
+        script_name: time
+        source: time
+        sourcetype: time
+    scripted_inputs/top:
+        collection_interval: 60s
+        script_name: top
+        source: top
+        sourcetype: top
+    scripted_inputs/update:
+        collection_interval: 86400s
+        script_name: update
+        source: update
+        sourcetype: update
+    scripted_inputs/uptime:
+        collection_interval: 86400s
+        script_name: uptime
+        source: uptime
+        sourcetype: uptime
+    scripted_inputs/usersWithLoginPrivs:
+        collection_interval: 3600s
+        script_name: usersWithLoginPrivs
+        source: usersWithLoginPrivs
+        sourcetype: usersWithLoginPrivs
+    scripted_inputs/version:
+        collection_interval: 86400s
+        script_name: version
+        source: version
+        sourcetype: version
+    scripted_inputs/vmstat:
+        collection_interval: 60s
+        script_name: vmstat
+        source: vmstat
+        sourcetype: vmstat
+    scripted_inputs/vsftpdChecker:
+        collection_interval: 86400s
+        script_name: vsftpdChecker
+        source: vsftpdChecker
+        sourcetype: vsftpdChecker
+    scripted_inputs/who:
+        collection_interval: 150s
+        script_name: who
+        source: who
+        sourcetype: who
+    splunk_hec: null
+    zipkin:
+        endpoint: 0.0.0.0:9411
+service:
+    extensions:
+        - headers_setter
+        - health_check
+        - http_forwarder
+        - http_forwarder/opamp_splunk_o11y
+        - opamp/splunk_o11y
+        - zpages
+    pipelines:
+        traces/otlp:
+            exporters:
+                - otlp_http
+            processors:
+                - memory_limiter
+                - batch
+            receivers:
+                - jaeger
+                - otlp
+                - zipkin
+    telemetry:
+        logs:
+            level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+        metrics:
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 127.0.0.1
+                            port: 8888

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/drop_traces_pipeline_input.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/drop_traces_pipeline_input.yaml
@@ -1,0 +1,436 @@
+exporters:
+    debug:
+        verbosity: detailed
+    file:
+        path: ./filename.json
+    jaeger:
+        endpoint: jaeger-all-in-one:14250
+        tls:
+            insecure: true
+    otlp_grpc:
+        auth:
+            authenticator: headers_setter
+        endpoint: otelcol2:4317
+    otlp_http:
+        auth:
+            authenticator: headers_setter
+        compression: gzip
+        endpoint: otelcol2:4318
+        headers:
+            X-SF-TOKEN: ${SPLUNK_ACCESS_TOKEN}
+    prometheus:
+        const_labels:
+            another label: spaced value
+            label1: value1
+        endpoint: 1.2.3.4:1234
+        namespace: test-space
+        send_timestamps: true
+    prometheusremotewrite:
+        endpoint: http://some.url:9411/api/prom/push
+    signalfx:
+        access_token: ${SPLUNK_ACCESS_TOKEN}
+        realm: ${SPLUNK_REALM}
+    splunk_hec:
+        disable_compression: false
+        endpoint: https://${SPLUNK_ENDPOINT}:8088/services/collector
+        index: metrics
+        insecure_skip_verify: false
+        max_connections: 200
+        profiling_data_enabled: false
+        source: otel
+        sourcetype: otel
+        timeout: 10s
+        token: ${SPLUNK_HEC_TOKEN}
+    splunk_hec/profiling:
+        endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com/v1/log
+        log_data_enabled: false
+        token: ${SPLUNK_ACCESS_TOKEN}
+    zipkin:
+        endpoint: http://some.url:9411/api/v2/spans
+        tls:
+            insecure: true
+extensions:
+    headers_setter:
+        headers:
+            - action: upsert
+              default_value: ${SPLUNK_ACCESS_TOKEN}
+              from_context: X-SF-TOKEN
+              key: X-SF-TOKEN
+    health_check:
+        endpoint: 0.0.0.0:13133
+    host_observer: null
+    http_forwarder:
+        egress:
+            endpoint: https://api.${SPLUNK_REALM}.observability.splunkcloud.com
+        ingress:
+            endpoint: 0.0.0.0:6060
+    http_forwarder/opamp_splunk_o11y:
+        egress:
+            endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com
+        ingress:
+            endpoint: 0.0.0.0:4320
+    k8s_observer: null
+    opamp/splunk_o11y:
+        server:
+            http:
+                endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com/v1/opamp
+                headers:
+                    X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+                polling_interval: 30s
+    pprof: null
+    zpages:
+        expvar:
+            enabled: true
+processors:
+    attributes:
+        actions:
+            - action: insert
+              key: environment
+              value: test
+    attributes/example:
+        actions:
+            - action: delete
+              key: db.statement
+            - action: extract
+              key: http.url
+              pattern: ^(?P<http_protocol>.*):\/\/(?P<http_domain>.*)\/(?P<http_path>.*)(\?|\&)(?P<http_query_params>.*)
+            - action: hash
+              key: email
+            - action: insert
+              key: build_num
+              value: 1.5.7
+            - action: update
+              from_attribute: foo
+              key: bar
+            - action: upsert
+              key: region
+              value: planet-earth
+    batch:
+        metadata_keys:
+            - X-SF-Token
+    filter/1:
+        metrics:
+            exclude:
+                match_type: strict
+                metric_names:
+                    - hello_world
+                    - hello/world
+            include:
+                match_type: regexp
+                metric_names:
+                    - prefix/.*
+                    - prefix_.*
+                resource_attributes:
+                    - Key: container.name
+                      Value: app_container_1
+    memory_limiter:
+        check_interval: 2s
+        limit_mib: 1800
+    resource:
+        attributes:
+            - action: upsert
+              key: cloud.zone
+              value: zone-1
+            - action: insert
+              from_attribute: k8s-cluster
+              key: k8s.cluster.name
+            - action: delete
+              key: redundant-attribute
+    resourcedetection/internal:
+        detectors:
+            - gcp
+            - ecs
+            - ec2
+            - azure
+            - system
+        override: true
+    span/from_attributes:
+        name:
+            from_attributes:
+                - db.svc
+                - operation
+            separator: '::'
+    span/to_attributes:
+        name:
+            to_attributes:
+                rules:
+                    - ^\/api\/v1\/document\/(?P<documentId>.*)\/update$
+receivers:
+    file_log:
+        exclude:
+            - /var/log/*lastlog*
+            - /var/log/*anaconda.syslog*
+        include:
+            - /Library/Logs/*
+            - /var/log/*.log*
+            - /var/log/*log
+            - /var/log/*messages*
+            - /var/log/*secure*
+            - /var/log/*auth*
+            - /var/log/*mesg
+            - /var/log/*cron
+            - /var/log/*acpid
+            - /var/log/*.out*
+            - /var/adm/*.log*
+            - /var/adm/*log
+            - /var/adm/*messages*
+            - /etc/*.conf*
+            - /etc/*.cfg*
+            - /etc/*config
+            - /etc/*.ini*
+            - /etc/*.init*
+            - /etc/*.cf*
+            - /etc/*.cnf*
+            - /etc/*shrc
+            - /etc/ifcfg*
+            - /etc/*.profile*
+            - /etc/*.rc*
+            - /etc/*.rules*
+            - /etc/*.tab*
+            - /etc/*tab
+            - /etc/*.login*
+            - /etc/*policy
+            - /root/.bash_history
+            - /home/*/.bash_history
+        include_file_name: false
+        include_file_path: true
+    fluentforward:
+        endpoint: 0.0.0.0:8006
+    hostmetrics:
+        collection_interval: 10s
+        scrapers:
+            cpu: null
+            disk: null
+            filesystem: null
+            load: null
+            memory: null
+            network: null
+            paging: null
+            processes: null
+    jaeger:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:14250
+            thrift_binary:
+                endpoint: 0.0.0.0:6832
+            thrift_compact:
+                endpoint: 0.0.0.0:6831
+            thrift_http:
+                endpoint: 0.0.0.0:14268
+    k8s_cluster: null
+    kafka:
+        protocol_version: 2.0.0
+    kubeletstats:
+        auth_type: serviceAccount
+        insecure_skip_verify: true
+    otlp:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:4317
+            http:
+                endpoint: 0.0.0.0:4318
+    prometheus/internal:
+        config:
+            scrape_configs:
+                - job_name: otel-collector
+                  metric_relabel_configs:
+                    - action: drop
+                      regex: promhttp_metric_handler_errors.*
+                      source_labels:
+                        - __name__
+                    - action: drop
+                      regex: otelcol_processor_batch_.*
+                      source_labels:
+                        - __name__
+                  scrape_interval: 10s
+                  static_configs:
+                    - targets:
+                        - 0.0.0.0:8888
+    prometheus_simple: null
+    scripted_inputs/bandwidth:
+        collection_interval: 60s
+        script_name: bandwidth
+        source: bandwidth
+        sourcetype: bandwidth
+    scripted_inputs/cpu:
+        collection_interval: 30s
+        script_name: cpu
+        source: cpu
+        sourcetype: cpu
+    scripted_inputs/df:
+        collection_interval: 10s
+        script_name: df
+        source: df
+        sourcetype: df
+    scripted_inputs/hardware:
+        collection_interval: 36000s
+        script_name: hardware
+        source: hardware
+        sourcetype: hardware
+    scripted_inputs/interfaces:
+        collection_interval: 60s
+        script_name: interfaces
+        source: interfaces
+        sourcetype: interfaces
+    scripted_inputs/iostat:
+        collection_interval: 60s
+        script_name: iostat
+        source: iostat
+        sourcetype: iostat
+    scripted_inputs/lastlog:
+        collection_interval: 300s
+        script_name: lastlog
+        source: lastlog
+        sourcetype: lastlog
+    scripted_inputs/lsof:
+        collection_interval: 600s
+        script_name: lsof
+        source: lsof
+        sourcetype: lsof
+    scripted_inputs/netstat:
+        collection_interval: 60s
+        script_name: netstat
+        source: netstat
+        sourcetype: netstat
+    scripted_inputs/nfsiostat:
+        collection_interval: 60s
+        script_name: nfsiostat
+        source: nfsiostat
+        sourcetype: nfsiostat
+    scripted_inputs/openPorts:
+        collection_interval: 300s
+        script_name: openPorts
+        source: openPorts
+        sourcetype: openPorts
+    scripted_inputs/openPortsEnhanced:
+        collection_interval: 3600s
+        script_name: openPortsEnhanced
+        source: openPortsEnhanced
+        sourcetype: openPortsEnhanced
+    scripted_inputs/package:
+        collection_interval: 3600s
+        script_name: package
+        source: package
+        sourcetype: package
+    scripted_inputs/passwd:
+        collection_interval: 3600s
+        script_name: passwd
+        source: passwd
+        sourcetype: passwd
+    scripted_inputs/protocol:
+        collection_interval: 60s
+        script_name: protocol
+        source: protocol
+        sourcetype: protocol
+    scripted_inputs/ps:
+        collection_interval: 30s
+        script_name: ps
+        source: ps
+        sourcetype: ps
+    scripted_inputs/rlog:
+        collection_interval: 60s
+        script_name: rlog
+        source: rlog
+        sourcetype: rlog
+    scripted_inputs/selinuxChecker:
+        collection_interval: 3600s
+        script_name: selinuxChecker
+        source: selinuxChecker
+        sourcetype: selinuxChecker
+    scripted_inputs/service:
+        collection_interval: 3600s
+        script_name: service
+        source: service
+        sourcetype: service
+    scripted_inputs/sshdChecker:
+        collection_interval: 3600s
+        script_name: sshdChecker
+        source: sshdChecker
+        sourcetype: sshdChecker
+    scripted_inputs/time:
+        collection_interval: 21600s
+        script_name: time
+        source: time
+        sourcetype: time
+    scripted_inputs/top:
+        collection_interval: 60s
+        script_name: top
+        source: top
+        sourcetype: top
+    scripted_inputs/update:
+        collection_interval: 86400s
+        script_name: update
+        source: update
+        sourcetype: update
+    scripted_inputs/uptime:
+        collection_interval: 86400s
+        script_name: uptime
+        source: uptime
+        sourcetype: uptime
+    scripted_inputs/usersWithLoginPrivs:
+        collection_interval: 3600s
+        script_name: usersWithLoginPrivs
+        source: usersWithLoginPrivs
+        sourcetype: usersWithLoginPrivs
+    scripted_inputs/version:
+        collection_interval: 86400s
+        script_name: version
+        source: version
+        sourcetype: version
+    scripted_inputs/vmstat:
+        collection_interval: 60s
+        script_name: vmstat
+        source: vmstat
+        sourcetype: vmstat
+    scripted_inputs/vsftpdChecker:
+        collection_interval: 86400s
+        script_name: vsftpdChecker
+        source: vsftpdChecker
+        sourcetype: vsftpdChecker
+    scripted_inputs/who:
+        collection_interval: 150s
+        script_name: who
+        source: who
+        sourcetype: who
+    splunk_hec: null
+    zipkin:
+        endpoint: 0.0.0.0:9411
+service:
+    extensions:
+        - headers_setter
+        - health_check
+        - http_forwarder
+        - http_forwarder/opamp_splunk_o11y
+        - opamp/splunk_o11y
+        - zpages
+    pipelines:
+        traces/otlp:
+            exporters:
+                - otlp_http
+            processors:
+                - memory_limiter
+                - batch
+            receivers:
+                - jaeger
+                - otlp
+                - zipkin
+        traces/signalfx:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+            receivers:
+                - jaeger
+                - otlp
+                - zipkin
+    telemetry:
+        logs:
+            level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+        metrics:
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 127.0.0.1
+                            port: 8888

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/ecs_ec2_config_expected.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/ecs_ec2_config_expected.yaml
@@ -1,0 +1,183 @@
+config_sources:
+    env:
+        defaults:
+            METRICS_TO_EXCLUDE: []
+exporters:
+    otlp_http:
+        auth:
+            authenticator: headers_setter
+        headers:
+            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        traces_endpoint: ${SPLUNK_INGEST_URL}/v2/trace/otlp
+    signalfx:
+        access_token: ${SPLUNK_ACCESS_TOKEN}
+        correlation: null
+        realm: ${SPLUNK_REALM}
+    splunk_hec:
+        endpoint: ${SPLUNK_HEC_URL}
+        profiling_data_enabled: false
+        source: otel
+        sourcetype: otel
+        token: ${SPLUNK_HEC_TOKEN}
+    splunk_hec/profiling:
+        endpoint: ${SPLUNK_INGEST_URL}/v1/log
+        log_data_enabled: false
+        token: ${SPLUNK_ACCESS_TOKEN}
+extensions:
+    headers_setter:
+        headers:
+            - action: upsert
+              default_value: ${SPLUNK_ACCESS_TOKEN}
+              from_context: X-SF-TOKEN
+              key: X-SF-TOKEN
+    health_check:
+        endpoint: 0.0.0.0:13133
+    http_forwarder:
+        egress:
+            endpoint: https://api.${SPLUNK_REALM}.observability.splunkcloud.com
+        ingress:
+            endpoint: 0.0.0.0:6060
+    http_forwarder/opamp_splunk_o11y:
+        egress:
+            endpoint: ${SPLUNK_INGEST_URL}
+        ingress:
+            endpoint: ${SPLUNK_LISTEN_INTERFACE}:4320
+    opamp/splunk_o11y:
+        server:
+            http:
+                endpoint: ${SPLUNK_INGEST_URL}/v1/opamp
+                headers:
+                    X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+                polling_interval: 30s
+    zpages:
+        endpoint: 0.0.0.0:55679
+        expvar:
+            enabled: true
+processors:
+    batch:
+        metadata_keys:
+            - X-SF-Token
+    filter:
+        metrics:
+            exclude:
+                match_type: regexp
+                metric_names: ${env:METRICS_TO_EXCLUDE}
+    memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+    resourcedetection:
+        detectors:
+            - ecs
+        override: false
+    resourcedetection/internal:
+        detectors:
+            - ecs
+        override: true
+receivers:
+    awsecscontainermetrics: null
+    fluentforward:
+        endpoint: 0.0.0.0:8006
+    hostmetrics:
+        collection_interval: 10s
+        scrapers:
+            cpu: null
+            disk: null
+            load: null
+            memory: null
+            network: null
+            paging: null
+            processes: null
+    jaeger:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:14250
+            thrift_http:
+                endpoint: 0.0.0.0:14268
+    otlp:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:4317
+            http:
+                endpoint: 0.0.0.0:4318
+    prometheus/internal:
+        config:
+            scrape_configs:
+                - job_name: otel-collector
+                  metric_relabel_configs:
+                    - action: drop
+                      regex: promhttp_metric_handler_errors.*
+                      source_labels:
+                        - __name__
+                    - action: drop
+                      regex: otelcol_processor_batch_.*
+                      source_labels:
+                        - __name__
+                  scrape_interval: 10s
+                  static_configs:
+                    - targets:
+                        - 0.0.0.0:8888
+    zipkin:
+        endpoint: 0.0.0.0:9411
+service:
+    extensions:
+        - headers_setter
+        - health_check
+        - http_forwarder
+        - http_forwarder/opamp_splunk_o11y
+        - opamp/splunk_o11y
+        - zpages
+    pipelines:
+        logs:
+            exporters:
+                - splunk_hec
+                - splunk_hec/profiling
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - otlp
+                - fluentforward
+        metrics:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - filter
+                - resourcedetection
+            receivers:
+                - hostmetrics
+                - otlp
+                - awsecscontainermetrics
+        metrics/internal:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - filter
+                - resourcedetection/internal
+            receivers:
+                - prometheus/internal
+        traces:
+            exporters:
+                - otlp_http
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - jaeger
+                - otlp
+                - zipkin
+    telemetry:
+        logs:
+            level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+        metrics:
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 127.0.0.1
+                            port: 8888

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/ecs_ec2_config_expected.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/ecs_ec2_config_expected.yaml
@@ -75,9 +75,9 @@ processors:
         override: true
 receivers:
     awsecscontainermetrics: null
-    fluentforward:
+    fluent_forward:
         endpoint: 0.0.0.0:8006
-    hostmetrics:
+    host_metrics:
         collection_interval: 10s
         scrapers:
             cpu: null
@@ -137,7 +137,7 @@ service:
                 - resourcedetection
             receivers:
                 - otlp
-                - fluentforward
+                - fluent_forward
         metrics:
             exporters:
                 - signalfx
@@ -147,7 +147,7 @@ service:
                 - filter
                 - resourcedetection
             receivers:
-                - hostmetrics
+                - host_metrics
                 - otlp
                 - awsecscontainermetrics
         metrics/internal:

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/expected_config.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/expected_config.yaml
@@ -12,6 +12,6 @@ service:
     traces/signalfx_exporter_first_alternate_name:
       exporters: [otlp_http]
     traces/signalfx_exporter_second_alternate_name:
-      exporters: [oltp_http,]
+      exporters: [oltp_http]
     traces/signalfx_exporter_middle_alternate_name:
       exporters: [ oltp_http, zipkin]

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/expected_config.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/expected_config.yaml
@@ -1,0 +1,17 @@
+service:
+  pipelines:
+    metrics:
+    traces:
+      exporters: [otlp_http]
+    traces/signalfx_exporter_first:
+      exporters: [otlp_http]
+    traces/signalfx_exporter_second:
+      exporters: [oltp_http]
+    traces/signalfx_exporter_middle:
+      exporters: [ oltp_http, zipkin]
+    traces/signalfx_exporter_first_alternate_name:
+      exporters: [otlp_http]
+    traces/signalfx_exporter_second_alternate_name:
+      exporters: [oltp_http,]
+    traces/signalfx_exporter_middle_alternate_name:
+      exporters: [ oltp_http, zipkin]

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/fargate_config_expected.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/fargate_config_expected.yaml
@@ -1,0 +1,146 @@
+exporters:
+    otlp_http:
+        auth:
+            authenticator: headers_setter
+        headers:
+            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        traces_endpoint: ${SPLUNK_INGEST_URL}/v2/trace/otlp
+    signalfx:
+        access_token: ${SPLUNK_ACCESS_TOKEN}
+        correlation: null
+        realm: ${SPLUNK_REALM}
+    splunk_hec:
+        endpoint: ${SPLUNK_HEC_URL}
+        profiling_data_enabled: false
+        source: otel
+        sourcetype: otel
+        token: ${SPLUNK_HEC_TOKEN}
+    splunk_hec/profiling:
+        endpoint: ${SPLUNK_INGEST_URL}/v1/log
+        log_data_enabled: false
+        token: ${SPLUNK_ACCESS_TOKEN}
+extensions:
+    headers_setter:
+        headers:
+            - action: upsert
+              default_value: ${SPLUNK_ACCESS_TOKEN}
+              from_context: X-SF-TOKEN
+              key: X-SF-TOKEN
+    health_check:
+        endpoint: 0.0.0.0:13133
+    http_forwarder:
+        egress:
+            endpoint: https://api.${SPLUNK_REALM}.observability.splunkcloud.com
+        ingress:
+            endpoint: 0.0.0.0:6060
+    http_forwarder/opamp_splunk_o11y:
+        egress:
+            endpoint: ${SPLUNK_INGEST_URL}
+        ingress:
+            endpoint: ${SPLUNK_LISTEN_INTERFACE}:4320
+    opamp/splunk_o11y:
+        server:
+            http:
+                endpoint: ${SPLUNK_INGEST_URL}/v1/opamp
+                headers:
+                    X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+                polling_interval: 30s
+    zpages:
+        endpoint: 0.0.0.0:55679
+        expvar:
+            enabled: true
+processors:
+    batch:
+        metadata_keys:
+            - X-SF-Token
+    memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+    resourcedetection:
+        detectors:
+            - ecs
+        override: false
+receivers:
+    awsecscontainermetrics: null
+    jaeger:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:14250
+            thrift_http:
+                endpoint: 0.0.0.0:14268
+    otlp:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:4317
+            http:
+                endpoint: 0.0.0.0:4318
+    prometheus/internal:
+        config:
+            scrape_configs:
+                - job_name: otel-collector
+                  metric_relabel_configs:
+                    - action: drop
+                      regex: promhttp_metric_handler_errors.*
+                      source_labels:
+                        - __name__
+                    - action: drop
+                      regex: otelcol_processor_batch_.*
+                      source_labels:
+                        - __name__
+                  scrape_interval: 10s
+                  static_configs:
+                    - targets:
+                        - 0.0.0.0:8888
+    zipkin:
+        endpoint: 0.0.0.0:9411
+service:
+    extensions:
+        - headers_setter
+        - health_check
+        - http_forwarder
+        - http_forwarder/opamp_splunk_o11y
+        - opamp/splunk_o11y
+        - zpages
+    pipelines:
+        logs:
+            exporters:
+                - splunk_hec
+                - splunk_hec/profiling
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - otlp
+        metrics:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - otlp
+                - awsecscontainermetrics
+                - prometheus/internal
+        traces:
+            exporters:
+                - otlp_http
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - jaeger
+                - otlp
+                - zipkin
+    telemetry:
+        logs:
+            level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+        metrics:
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 127.0.0.1
+                            port: 8888

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/full_config_linux_expected.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/full_config_linux_expected.yaml
@@ -194,9 +194,9 @@ receivers:
             - /home/*/.bash_history
         include_file_name: false
         include_file_path: true
-    fluentforward:
+    fluent_forward:
         endpoint: 0.0.0.0:8006
-    hostmetrics:
+    host_metrics:
         collection_interval: 10s
         scrapers:
             cpu: null
@@ -412,7 +412,7 @@ service:
                 - memory_limiter
                 - batch
             receivers:
-                - fluentforward
+                - fluent_forward
                 - otlp
                 - scripted_inputs/bandwidth
                 - scripted_inputs/cpu

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/full_config_linux_expected.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/full_config_linux_expected.yaml
@@ -1,0 +1,482 @@
+exporters:
+    debug:
+        verbosity: detailed
+    file:
+        path: ./filename.json
+    jaeger:
+        endpoint: jaeger-all-in-one:14250
+        tls:
+            insecure: true
+    otlp_grpc:
+        auth:
+            authenticator: headers_setter
+        endpoint: otelcol2:4317
+    otlp_http:
+        auth:
+            authenticator: headers_setter
+        compression: gzip
+        endpoint: otelcol2:4318
+        headers:
+            X-SF-TOKEN: ${SPLUNK_ACCESS_TOKEN}
+    prometheus:
+        const_labels:
+            another label: spaced value
+            label1: value1
+        endpoint: 1.2.3.4:1234
+        namespace: test-space
+        send_timestamps: true
+    prometheusremotewrite:
+        endpoint: http://some.url:9411/api/prom/push
+    signalfx:
+        access_token: ${SPLUNK_ACCESS_TOKEN}
+        realm: ${SPLUNK_REALM}
+    splunk_hec:
+        disable_compression: false
+        endpoint: https://${SPLUNK_ENDPOINT}:8088/services/collector
+        index: metrics
+        insecure_skip_verify: false
+        max_connections: 200
+        profiling_data_enabled: false
+        source: otel
+        sourcetype: otel
+        timeout: 10s
+        token: ${SPLUNK_HEC_TOKEN}
+    splunk_hec/profiling:
+        endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com/v1/log
+        log_data_enabled: false
+        token: ${SPLUNK_ACCESS_TOKEN}
+    zipkin:
+        endpoint: http://some.url:9411/api/v2/spans
+        tls:
+            insecure: true
+extensions:
+    headers_setter:
+        headers:
+            - action: upsert
+              default_value: ${SPLUNK_ACCESS_TOKEN}
+              from_context: X-SF-TOKEN
+              key: X-SF-TOKEN
+    health_check:
+        endpoint: 0.0.0.0:13133
+    host_observer: null
+    http_forwarder:
+        egress:
+            endpoint: https://api.${SPLUNK_REALM}.observability.splunkcloud.com
+        ingress:
+            endpoint: 0.0.0.0:6060
+    http_forwarder/opamp_splunk_o11y:
+        egress:
+            endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com
+        ingress:
+            endpoint: 0.0.0.0:4320
+    k8s_observer: null
+    opamp/splunk_o11y:
+        server:
+            http:
+                endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com/v1/opamp
+                headers:
+                    X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+                polling_interval: 30s
+    pprof: null
+    zpages:
+        expvar:
+            enabled: true
+processors:
+    attributes:
+        actions:
+            - action: insert
+              key: environment
+              value: test
+    attributes/example:
+        actions:
+            - action: delete
+              key: db.statement
+            - action: extract
+              key: http.url
+              pattern: ^(?P<http_protocol>.*):\/\/(?P<http_domain>.*)\/(?P<http_path>.*)(\?|\&)(?P<http_query_params>.*)
+            - action: hash
+              key: email
+            - action: insert
+              key: build_num
+              value: 1.5.7
+            - action: update
+              from_attribute: foo
+              key: bar
+            - action: upsert
+              key: region
+              value: planet-earth
+    batch:
+        metadata_keys:
+            - X-SF-Token
+    filter/1:
+        metrics:
+            exclude:
+                match_type: strict
+                metric_names:
+                    - hello_world
+                    - hello/world
+            include:
+                match_type: regexp
+                metric_names:
+                    - prefix/.*
+                    - prefix_.*
+                resource_attributes:
+                    - Key: container.name
+                      Value: app_container_1
+    memory_limiter:
+        check_interval: 2s
+        limit_mib: 1800
+    resource:
+        attributes:
+            - action: upsert
+              key: cloud.zone
+              value: zone-1
+            - action: insert
+              from_attribute: k8s-cluster
+              key: k8s.cluster.name
+            - action: delete
+              key: redundant-attribute
+    resourcedetection/internal:
+        detectors:
+            - gcp
+            - ecs
+            - ec2
+            - azure
+            - system
+        override: true
+    span/from_attributes:
+        name:
+            from_attributes:
+                - db.svc
+                - operation
+            separator: '::'
+    span/to_attributes:
+        name:
+            to_attributes:
+                rules:
+                    - ^\/api\/v1\/document\/(?P<documentId>.*)\/update$
+receivers:
+    file_log:
+        exclude:
+            - /var/log/*lastlog*
+            - /var/log/*anaconda.syslog*
+        include:
+            - /Library/Logs/*
+            - /var/log/*.log*
+            - /var/log/*log
+            - /var/log/*messages*
+            - /var/log/*secure*
+            - /var/log/*auth*
+            - /var/log/*mesg
+            - /var/log/*cron
+            - /var/log/*acpid
+            - /var/log/*.out*
+            - /var/adm/*.log*
+            - /var/adm/*log
+            - /var/adm/*messages*
+            - /etc/*.conf*
+            - /etc/*.cfg*
+            - /etc/*config
+            - /etc/*.ini*
+            - /etc/*.init*
+            - /etc/*.cf*
+            - /etc/*.cnf*
+            - /etc/*shrc
+            - /etc/ifcfg*
+            - /etc/*.profile*
+            - /etc/*.rc*
+            - /etc/*.rules*
+            - /etc/*.tab*
+            - /etc/*tab
+            - /etc/*.login*
+            - /etc/*policy
+            - /root/.bash_history
+            - /home/*/.bash_history
+        include_file_name: false
+        include_file_path: true
+    fluentforward:
+        endpoint: 0.0.0.0:8006
+    hostmetrics:
+        collection_interval: 10s
+        scrapers:
+            cpu: null
+            disk: null
+            filesystem: null
+            load: null
+            memory: null
+            network: null
+            paging: null
+            processes: null
+    jaeger:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:14250
+            thrift_binary:
+                endpoint: 0.0.0.0:6832
+            thrift_compact:
+                endpoint: 0.0.0.0:6831
+            thrift_http:
+                endpoint: 0.0.0.0:14268
+    k8s_cluster: null
+    kafka:
+        protocol_version: 2.0.0
+    kubeletstats:
+        auth_type: serviceAccount
+        insecure_skip_verify: true
+    otlp:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:4317
+            http:
+                endpoint: 0.0.0.0:4318
+    prometheus/internal:
+        config:
+            scrape_configs:
+                - job_name: otel-collector
+                  metric_relabel_configs:
+                    - action: drop
+                      regex: promhttp_metric_handler_errors.*
+                      source_labels:
+                        - __name__
+                    - action: drop
+                      regex: otelcol_processor_batch_.*
+                      source_labels:
+                        - __name__
+                  scrape_interval: 10s
+                  static_configs:
+                    - targets:
+                        - 0.0.0.0:8888
+    prometheus_simple: null
+    scripted_inputs/bandwidth:
+        collection_interval: 60s
+        script_name: bandwidth
+        source: bandwidth
+        sourcetype: bandwidth
+    scripted_inputs/cpu:
+        collection_interval: 30s
+        script_name: cpu
+        source: cpu
+        sourcetype: cpu
+    scripted_inputs/df:
+        collection_interval: 10s
+        script_name: df
+        source: df
+        sourcetype: df
+    scripted_inputs/hardware:
+        collection_interval: 36000s
+        script_name: hardware
+        source: hardware
+        sourcetype: hardware
+    scripted_inputs/interfaces:
+        collection_interval: 60s
+        script_name: interfaces
+        source: interfaces
+        sourcetype: interfaces
+    scripted_inputs/iostat:
+        collection_interval: 60s
+        script_name: iostat
+        source: iostat
+        sourcetype: iostat
+    scripted_inputs/lastlog:
+        collection_interval: 300s
+        script_name: lastlog
+        source: lastlog
+        sourcetype: lastlog
+    scripted_inputs/lsof:
+        collection_interval: 600s
+        script_name: lsof
+        source: lsof
+        sourcetype: lsof
+    scripted_inputs/netstat:
+        collection_interval: 60s
+        script_name: netstat
+        source: netstat
+        sourcetype: netstat
+    scripted_inputs/nfsiostat:
+        collection_interval: 60s
+        script_name: nfsiostat
+        source: nfsiostat
+        sourcetype: nfsiostat
+    scripted_inputs/openPorts:
+        collection_interval: 300s
+        script_name: openPorts
+        source: openPorts
+        sourcetype: openPorts
+    scripted_inputs/openPortsEnhanced:
+        collection_interval: 3600s
+        script_name: openPortsEnhanced
+        source: openPortsEnhanced
+        sourcetype: openPortsEnhanced
+    scripted_inputs/package:
+        collection_interval: 3600s
+        script_name: package
+        source: package
+        sourcetype: package
+    scripted_inputs/passwd:
+        collection_interval: 3600s
+        script_name: passwd
+        source: passwd
+        sourcetype: passwd
+    scripted_inputs/protocol:
+        collection_interval: 60s
+        script_name: protocol
+        source: protocol
+        sourcetype: protocol
+    scripted_inputs/ps:
+        collection_interval: 30s
+        script_name: ps
+        source: ps
+        sourcetype: ps
+    scripted_inputs/rlog:
+        collection_interval: 60s
+        script_name: rlog
+        source: rlog
+        sourcetype: rlog
+    scripted_inputs/selinuxChecker:
+        collection_interval: 3600s
+        script_name: selinuxChecker
+        source: selinuxChecker
+        sourcetype: selinuxChecker
+    scripted_inputs/service:
+        collection_interval: 3600s
+        script_name: service
+        source: service
+        sourcetype: service
+    scripted_inputs/sshdChecker:
+        collection_interval: 3600s
+        script_name: sshdChecker
+        source: sshdChecker
+        sourcetype: sshdChecker
+    scripted_inputs/time:
+        collection_interval: 21600s
+        script_name: time
+        source: time
+        sourcetype: time
+    scripted_inputs/top:
+        collection_interval: 60s
+        script_name: top
+        source: top
+        sourcetype: top
+    scripted_inputs/update:
+        collection_interval: 86400s
+        script_name: update
+        source: update
+        sourcetype: update
+    scripted_inputs/uptime:
+        collection_interval: 86400s
+        script_name: uptime
+        source: uptime
+        sourcetype: uptime
+    scripted_inputs/usersWithLoginPrivs:
+        collection_interval: 3600s
+        script_name: usersWithLoginPrivs
+        source: usersWithLoginPrivs
+        sourcetype: usersWithLoginPrivs
+    scripted_inputs/version:
+        collection_interval: 86400s
+        script_name: version
+        source: version
+        sourcetype: version
+    scripted_inputs/vmstat:
+        collection_interval: 60s
+        script_name: vmstat
+        source: vmstat
+        sourcetype: vmstat
+    scripted_inputs/vsftpdChecker:
+        collection_interval: 86400s
+        script_name: vsftpdChecker
+        source: vsftpdChecker
+        sourcetype: vsftpdChecker
+    scripted_inputs/who:
+        collection_interval: 150s
+        script_name: who
+        source: who
+        sourcetype: who
+    splunk_hec: null
+    zipkin:
+        endpoint: 0.0.0.0:9411
+service:
+    extensions:
+        - headers_setter
+        - health_check
+        - http_forwarder
+        - http_forwarder/opamp_splunk_o11y
+        - opamp/splunk_o11y
+        - zpages
+    pipelines:
+        logs:
+            exporters:
+                - splunk_hec
+                - splunk_hec/profiling
+            processors:
+                - memory_limiter
+                - batch
+            receivers:
+                - fluentforward
+                - otlp
+                - scripted_inputs/bandwidth
+                - scripted_inputs/cpu
+                - scripted_inputs/df
+                - scripted_inputs/hardware
+                - scripted_inputs/interfaces
+                - scripted_inputs/iostat
+                - scripted_inputs/lastlog
+                - scripted_inputs/lsof
+                - scripted_inputs/netstat
+                - scripted_inputs/nfsiostat
+                - scripted_inputs/openPorts
+                - scripted_inputs/openPortsEnhanced
+                - scripted_inputs/package
+                - scripted_inputs/passwd
+                - scripted_inputs/protocol
+                - scripted_inputs/ps
+                - scripted_inputs/rlog
+                - scripted_inputs/selinuxChecker
+                - scripted_inputs/service
+                - scripted_inputs/sshdChecker
+                - scripted_inputs/time
+                - scripted_inputs/top
+                - scripted_inputs/update
+                - scripted_inputs/uptime
+                - scripted_inputs/usersWithLoginPrivs
+                - scripted_inputs/version
+                - scripted_inputs/vmstat
+                - scripted_inputs/vsftpdChecker
+                - scripted_inputs/who
+        metrics:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+            receivers:
+                - otlp
+        metrics/internal:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection/internal
+            receivers:
+                - prometheus/internal
+        traces:
+            exporters:
+                - otlp_http
+            processors:
+                - memory_limiter
+                - batch
+            receivers:
+                - jaeger
+                - otlp
+                - zipkin
+    telemetry:
+        logs:
+            level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+        metrics:
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 127.0.0.1
+                            port: 8888

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/gateway_config_expected.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/gateway_config_expected.yaml
@@ -1,0 +1,204 @@
+connectors:
+    routing/logs:
+        default_pipelines:
+            - logs
+        table:
+            - condition: instrumentation_scope.attributes["otel.entity.event_as_log"] == true
+              context: log
+              pipelines:
+                - logs/entities
+exporters:
+    otlp_http:
+        auth:
+            authenticator: headers_setter
+        headers:
+            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        sending_queue:
+            num_consumers: 32
+        traces_endpoint: ${SPLUNK_INGEST_URL}/v2/trace/otlp
+    otlp_http/entities:
+        auth:
+            authenticator: headers_setter
+        headers:
+            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        logs_endpoint: ${SPLUNK_INGEST_URL}/v3/event
+    signalfx:
+        access_token: ${SPLUNK_ACCESS_TOKEN}
+        realm: ${SPLUNK_REALM}
+        sending_queue:
+            num_consumers: 32
+    signalfx/internal:
+        access_token: ${SPLUNK_ACCESS_TOKEN}
+        realm: ${SPLUNK_REALM}
+        sync_host_metadata: true
+    splunk_hec:
+        endpoint: ${SPLUNK_HEC_URL}
+        profiling_data_enabled: false
+        source: otel
+        sourcetype: otel
+        token: ${SPLUNK_HEC_TOKEN}
+    splunk_hec/profiling:
+        endpoint: ${SPLUNK_INGEST_URL}/v1/log
+        log_data_enabled: false
+        token: ${SPLUNK_ACCESS_TOKEN}
+extensions:
+    headers_setter:
+        headers:
+            - action: upsert
+              default_value: ${SPLUNK_ACCESS_TOKEN}
+              from_context: X-SF-TOKEN
+              key: X-SF-TOKEN
+    health_check:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:13133
+    http_forwarder:
+        egress:
+            endpoint: https://api.${SPLUNK_REALM}.observability.splunkcloud.com
+        ingress:
+            endpoint: ${SPLUNK_LISTEN_INTERFACE}:6060
+    http_forwarder/opamp_splunk_o11y:
+        egress:
+            endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com
+        ingress:
+            endpoint: ${SPLUNK_LISTEN_INTERFACE}:4320
+    http_forwarder/signalfx:
+        egress:
+            endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com
+        ingress:
+            endpoint: ${SPLUNK_LISTEN_INTERFACE}:9943
+    opamp/splunk_o11y:
+        server:
+            http:
+                endpoint: ${SPLUNK_INGEST_URL}/v1/opamp
+                headers:
+                    X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+                polling_interval: 30s
+    zpages:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:55679
+        expvar:
+            enabled: true
+processors:
+    batch:
+        metadata_keys:
+            - X-SF-Token
+    memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+    resource/add_mode:
+        attributes:
+            - action: insert
+              key: otelcol.service.mode
+              value: gateway
+    resourcedetection/internal:
+        detectors:
+            - gcp
+            - ecs
+            - ec2
+            - azure
+            - system
+        override: true
+receivers:
+    jaeger:
+        protocols:
+            grpc:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:14250
+            thrift_binary:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:6832
+            thrift_compact:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:6831
+            thrift_http:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:14268
+    otlp:
+        protocols:
+            grpc:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:4317
+            http:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:4318
+    prometheus/internal:
+        config:
+            scrape_configs:
+                - job_name: otel-collector
+                  metric_relabel_configs:
+                    - action: drop
+                      regex: promhttp_metric_handler_errors.*
+                      source_labels:
+                        - __name__
+                    - action: drop
+                      regex: otelcol_processor_batch_.*
+                      source_labels:
+                        - __name__
+                  scrape_interval: 10s
+                  static_configs:
+                    - targets:
+                        - 0.0.0.0:8888
+    zipkin:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:9411
+service:
+    extensions:
+        - headers_setter
+        - health_check
+        - http_forwarder
+        - http_forwarder/opamp_splunk_o11y
+        - http_forwarder/signalfx
+        - opamp/splunk_o11y
+        - zpages
+    pipelines:
+        logs:
+            exporters:
+                - splunk_hec
+                - splunk_hec/profiling
+            processors:
+                - memory_limiter
+                - batch
+            receivers:
+                - routing/logs
+        logs/entities:
+            exporters:
+                - otlp_http/entities
+            processors:
+                - memory_limiter
+                - batch
+            receivers:
+                - routing/logs
+        logs/split:
+            exporters:
+                - routing/logs
+            receivers:
+                - otlp
+        metrics:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+            receivers:
+                - otlp
+        metrics/internal:
+            exporters:
+                - signalfx/internal
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection/internal
+                - resource/add_mode
+            receivers:
+                - prometheus/internal
+        traces:
+            exporters:
+                - otlp_http
+            processors:
+                - memory_limiter
+                - batch
+            receivers:
+                - jaeger
+                - otlp
+                - zipkin
+    telemetry:
+        logs:
+            level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+        metrics:
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 127.0.0.1
+                            port: 8888

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/input_config.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/input_config.yaml
@@ -1,0 +1,21 @@
+service:
+  pipelines:
+    metrics:
+    traces:
+      exporters: [signalfx, otlp_http]
+    traces/only_signalfx_exporter:
+      exporters: [signalfx]
+    traces/signalfx_exporter_first:
+      exporters: [signalfx, otlp_http]
+    traces/signalfx_exporter_second:
+      exporters: [oltp_http, signalfx]
+    traces/signalfx_exporter_middle:
+      exporters: [ oltp_http, signalfx, zipkin]
+    traces/only_signalfx_exporter_alternate_name:
+      exporters: [signalfx/traces]
+    traces/signalfx_exporter_first_alternate_name:
+      exporters: [signalfx/traces, otlp_http]
+    traces/signalfx_exporter_second_alternate_name:
+      exporters: [oltp_http, signalfx/traces]
+    traces/signalfx_exporter_middle_alternate_name:
+      exporters: [ oltp_http, signalfx/traces, zipkin]

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/logs_config_linux_expected.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/logs_config_linux_expected.yaml
@@ -1,0 +1,593 @@
+exporters:
+    splunk_hec:
+        endpoint: ${SPLUNK_HEC_URL}
+        profiling_data_enabled: false
+        source: otel
+        sourcetype: otel
+        token: ${SPLUNK_HEC_TOKEN}
+    splunk_hec/profiling:
+        endpoint: ${SPLUNK_INGEST_URL}/v1/log
+        log_data_enabled: false
+        token: ${SPLUNK_ACCESS_TOKEN}
+extensions:
+    file_storage/filelogs:
+        compaction:
+            directory: /tmp/
+            on_start: true
+        create_directory: true
+        directory: ${SPLUNK_FILE_STORAGE_EXTENSION_PATH}
+    health_check:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:13133
+processors:
+    batch:
+        metadata_keys:
+            - X-SF-Token
+    memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+receivers:
+    file_log/apache-access:
+        include:
+            - /var/log/apache*/access.log
+            - /var/log/apache*/access_log
+            - /var/log/httpd/access.log
+            - /var/log/httpd/access_log
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - regex: ^(?P<host>.+) (?P<remote_logname>.+) (?P<user>.+) \[(?P<time>.+)\] "(?P<method>.+) (?P<path>.+) (?P<protocol>.+)" (?P<code>\d+) (?P<size>\d+) "(?P<referer>.+)" "(?P<agent>.+)"$
+              timestamp:
+                layout: '%d/%b/%Y:%H:%M:%S %z'
+                parse_from: attributes.time
+              type: regex_parser
+        storage: file_storage/filelogs
+    file_log/apache-error:
+        include:
+            - /var/log/apache*/error.log
+            - /var/log/apache*/error_log
+            - /var/log/httpd/error.log
+            - /var/log/httpd/error_log
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - regex: ^\[(?P<time>.+?)\] \[(?P<module>\w+):(?P<level>\w+)\] \[pid (?P<pid>\d+):tid (?P<tid>\d+)\] (?P<log>.*)$
+              severity:
+                mapping:
+                    error2: crit
+                    error3: alert
+                    fatal: emerg
+                    info2: notice
+                parse_from: attributes.level
+              timestamp:
+                layout: '%c'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes.module
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/cassandra:
+        include:
+            - /var/log/cassandra/cassandra.log
+            - /var/log/cassandra/system.log
+        include_file_name: false
+        include_file_path: true
+        multiline:
+            line_start_pattern: ^[A-Z]+\s+\[[\w:]+\]\s\d
+        operators:
+            - regex: ^(?P<level>\w+) +\[(?P<thread>[\w:]+)\] (?P<time>.+) (?P<source_file>\S+):(?P<source_line>\d+) - (?P<log>[\s\S]*)$
+              severity:
+                parse_from: attributes.level
+              timestamp:
+                layout: '%Y-%m-%d %H:%M:%S'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes.thread
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/cassandra-debug:
+        include:
+            - /var/log/cassandra/debug.log
+        include_file_name: false
+        include_file_path: true
+        multiline:
+            line_start_pattern: ^[A-Z]+\s+\[[\w:]+\]\s\d
+        operators:
+            - regex: ^(?P<level>\w+) +\[(?P<thread>[\w:]+)\] (?P<time>.+) (?P<source_file>\S+):(?P<source_line>\d+) - (?P<log>[\s\S]*)$
+              severity:
+                parse_from: attributes.level
+              timestamp:
+                layout: '%Y-%m-%d %H:%M:%S'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes.thread
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/cassandra-output:
+        include:
+            - /var/log/cassandra/output.log
+        include_file_name: false
+        include_file_path: true
+        storage: file_storage/filelogs
+    file_log/docker:
+        include:
+            - /var/lib/docker/containers/*/*-json.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - timestamp:
+                layout: '%Y-%m-%dT%H:%M:%S.%fZ'
+                parse_from: attributes.time
+              type: json_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes.stream
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/etcd:
+        include:
+            - /var/log/etcd.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - regex: ^(?P<time>.+?) (?P<level>\w) \| (?P<log>.*)$
+              severity:
+                mapping:
+                    debug: D
+                    error: E
+                    fatal: C
+                    info: I
+                    info2: "N"
+                    trace: T
+                    warning: W
+                parse_from: attributes.level
+              timestamp:
+                layout: '%Y-%m-%d %H:%M:%S'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/jetty9:
+        include:
+            - /var/log/jetty9/*.jetty.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - regex: '^(?P<time>[\d-]{10} [\d:.]{12}):(?P<level>\w+):(?P<class>[\w.]+):(?P<thread>[\w:]+?): (?P<log>.*)$'
+              severity:
+                parse_from: attributes.level
+              timestamp:
+                layout: '%Y-%m-%d %H:%M:%S.%L'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/jetty9-debug:
+        include:
+            - /var/log/jetty9/*.debug.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - regex: ^(?P<time>\d{2}:\d{2}:\d{2}\.\d{3}):(?P<log>.*)$
+              timestamp:
+                layout: '%H:%M:%S.%L'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/jetty9-request:
+        include:
+            - /var/log/jetty9/*.request.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - regex: ^(?P<host>.+) (?P<remote_logname>.+) (?P<user>.+) \[(?P<time>.+)\] "(?P<method>.+) (?P<path>.+) (?P<protocol>.+)" (?P<code>\d+) (?P<size>\d+)$
+              timestamp:
+                layout: '%d/%b/%Y:%H:%M:%S %z'
+                parse_from: attributes.time
+              type: regex_parser
+        storage: file_storage/filelogs
+    file_log/memcached:
+        include:
+            - /var/log/memcached.log
+        include_file_name: false
+        include_file_path: true
+        storage: file_storage/filelogs
+    file_log/mongodb:
+        include:
+            - /var/log/mongodb/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - severity:
+                mapping:
+                    debug: D1
+                    debug2: D2
+                    debug3: D3
+                    debug4: D4
+                    error: E
+                    fatal: F
+                    info: I
+                    warning: W
+                parse_from: attributes.s
+              timestamp:
+                layout: '%Y-%m-%dT%H:%M:%S.%L%z'
+                parse_from: attributes.t.$$date
+              type: json_parser
+            - from: attributes.msg
+              to: body
+              type: move
+            - fields:
+                - attributes.ctx
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/mysql-error:
+        include:
+            - /var/log/mysql/error.log
+        include_file_name: false
+        include_file_path: true
+        multiline:
+            line_start_pattern: ^[\w-]+ [\d:.]+ \w+ \[\w+\]
+        operators:
+            - regex: ^(?P<time>.+?) \d+ \[(?P<level>\w+)\] (?P<log>[\s\S]*)$
+              severity:
+                parse_from: attributes.level
+              timestamp:
+                layout: '%Y-%m-%d %H:%M:%S'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/mysql-query:
+        include:
+            - /var/log/mysql.log
+            - /var/log/mysql/mysql.log
+        include_file_name: false
+        include_file_path: true
+        multiline:
+            line_start_pattern: ^\d{6} [\d:.]+
+        operators:
+            - routes:
+                - expr: body matches "^\\d+"
+                  output: parse_query_log
+              type: router
+            - id: parse_query_log
+              regex: ^(?P<time>\d{6} [\d:.]+)\s+(?P<log>[\s\S]*)$
+              timestamp:
+                layout: '%y%m%d %H:%M:%S'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/mysql-slow_query:
+        include:
+            - /var/log/mysql/mysql-slow.log
+            - /var/log/mysql/mariadb-slow.log
+        include_file_name: false
+        include_file_path: true
+        multiline:
+            line_start_pattern: '^# Time: '
+        storage: file_storage/filelogs
+    file_log/nginx-access:
+        include:
+            - /var/log/nginx/access.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - regex: ^(?P<host>.+) (?P<remote_logname>.+) (?P<user>.+) \[(?P<time>.+)\] "(?P<method>.+) (?P<path>.+) (?P<protocol>.+)" (?P<code>\d+) (?P<size>\d+) "(?P<referer>.+)" "(?P<agent>.+)"$
+              timestamp:
+                layout: '%d/%b/%Y:%H:%M:%S %z'
+                parse_from: attributes.time
+              type: regex_parser
+        storage: file_storage/filelogs
+    file_log/nginx-error:
+        include:
+            - /var/log/nginx/error.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - regex: '^(?P<time>.+?) \[(?P<level>\w+)\] (?P<pid>\d+)#(?P<tid>\d+): (?P<log>.*)$'
+              severity:
+                mapping:
+                    error2: crit
+                    error3: alert
+                    fatal: emerg
+                    info2: notice
+                parse_from: attributes.level
+              timestamp:
+                layout: '%Y/%m/%d %H:%M:%S'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/postgresql:
+        include:
+            - /var/log/postgres*/*.log
+            - /var/log/pgsql/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - regex: ^(?P<time>.+?) \[(?P<pid>\d+)\] (?P<log>.*)$
+              timestamp:
+                layout: '%Y-%m-%d %H:%M:%S.%L %Z'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/rabbitmq:
+        include:
+            - /var/log/rabbitmq/rabbit@*.log
+        include_file_name: false
+        include_file_path: true
+        multiline:
+            line_start_pattern: ^[\w-]+ [\d:.]+ \[\w+\]
+        operators:
+            - regex: ^(?P<time>.+?) \[(?P<level>\w+)\] <(?P<erlang_pid>[\d.]+)> (?P<log>[\s\S]*)$
+              severity:
+                parse_from: attributes.level
+              timestamp:
+                layout: '%Y-%m-%d %H:%M:%S.%L'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/rabbitmq-startup:
+        include:
+            - /var/log/rabbitmq/startup_log
+            - /var/log/rabbitmq/rabbitmq-server.log
+        include_file_name: false
+        include_file_path: true
+        storage: file_storage/filelogs
+    file_log/rabbitmq-startup_err:
+        include:
+            - /var/log/rabbitmq/startup_err
+            - /var/log/rabbitmq/rabbitmq-server.error.log
+        include_file_name: false
+        include_file_path: true
+        storage: file_storage/filelogs
+    file_log/redis:
+        include:
+            - /var/log/redis*.log
+            - /var/log/redis/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - routes:
+                - expr: body matches "^[0-9]+:[\\w-]+ \\([0-9]+\\) .*$"
+                  output: parse_handler_log
+                - expr: body matches "^[0-9]+:[A-Z] .*$"
+                  output: parse_server_log
+              type: router
+            - id: parse_server_log
+              output: move_log
+              regex: ^(?P<pid>\d+):(?P<role>\S*) (?P<time>.+?) (?P<level>.) (?P<log>.*)$
+              severity:
+                mapping:
+                    debug: .
+                    info: '*'
+                    info2: '-'
+                    warning: '#'
+                parse_from: attributes.level
+              timestamp:
+                layout: '%d %b %Y %H:%M:%S.%L'
+                parse_from: attributes.time
+              type: regex_parser
+            - id: parse_handler_log
+              regex: ^(?P<pid>\d+):(?P<role>\S*) \((?P<time>\d+)\) (?P<log>.*)$
+              timestamp:
+                layout: s
+                layout_type: epoch
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              id: move_log
+              to: body
+              type: move
+            - fields:
+                - attributes.role
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/syslog:
+        include:
+            - /var/log/syslog
+            - /var/log/messages
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - regex: '^(?P<time>.+?) (?P<hostname>\S+) (?P<program>[^ :\[]+)\[?(?P<pid>\d+)?\]?: (?P<log>.*)$'
+              timestamp:
+                layout: '%b %e %H:%M:%S'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes.program
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/tomcat:
+        include:
+            - /var/log/tomcat*/catalina.*.log
+            - /var/log/tomcat*/localhost.*.log
+        include_file_name: false
+        include_file_path: true
+        multiline:
+            line_start_pattern: ^[\w-]+ [\d:.]+ \w+ \[[\w:-]+\]
+        operators:
+            - regex: ^(?P<time>.+?) (?P<level>\w+) \[(?P<thread>[\w:-]+)\] (?P<function>\S+) (?P<log>[\s\S]*)$
+              severity:
+                parse_from: attributes.level
+              timestamp:
+                layout: '%d-%b-%Y %H:%M:%S'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes.thread
+                - attributes.function
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/tomcat-localhost_access_log:
+        include:
+            - /var/log/tomcat*/localhost_access_log.*.txt
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - regex: ^(?P<host>.+) (?P<remote_logname>.+) (?P<user>.+) \[(?P<time>.+)\] "(?P<method>.+) (?P<path>.+) (?P<protocol>.+)" (?P<code>\d+) (?P<size>\d+)$
+              timestamp:
+                layout: '%d/%b/%Y:%H:%M:%S %z'
+                parse_from: attributes.time
+              type: regex_parser
+        storage: file_storage/filelogs
+    file_log/tomcat-out:
+        include:
+            - /var/log/tomcat*/catalina.out
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - regex: ^\[(?P<time>.+?)\] \[(?P<level>\w+)\] (?P<log>.*)$
+              severity:
+                parse_from: attributes.level
+              timestamp:
+                layout: '%Y-%m-%d %H:%M:%S'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/zookeeper:
+        include:
+            - /var/log/zookeeper/zookeeper.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - regex: ^(?P<time>.+?) - (?P<level>\w+) +\[(?P<thread>[\w:]+?):(?P<class>\w+)@(?P<line>\d+|\?)\] - (?P<log>.*)$
+              severity:
+                parse_from: attributes.level
+              timestamp:
+                layout: '%Y-%m-%d %H:%M:%S'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes.thread
+                - attributes.class
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+    file_log/zookeeper-trace:
+        include:
+            - /var/log/zookeeper/zookeeper_trace.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+            - regex: ^(?P<time>.+?) - (?P<level>\w+) +\[(?P<thread>[\w:]+?):(?P<class>\w+)@(?P<line>\d+|\?)\]\[(?P<context>.+?)?\] - (?P<log>.*)$
+              severity:
+                parse_from: attributes.level
+              timestamp:
+                layout: '%Y-%m-%d %H:%M:%S'
+                parse_from: attributes.time
+              type: regex_parser
+            - from: attributes.log
+              to: body
+              type: move
+            - fields:
+                - attributes.thread
+                - attributes.class
+                - attributes["log.file.path"]
+              type: retain
+        storage: file_storage/filelogs
+service:
+    extensions:
+        - health_check
+        - file_storage/filelogs
+    pipelines:
+        logs:
+            exporters:
+                - splunk_hec
+                - splunk_hec/profiling
+            processors:
+                - memory_limiter
+                - batch
+            receivers:
+                - file_log/syslog
+    telemetry:
+        logs:
+            level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+        metrics:
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 127.0.0.1
+                            port: 8888

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/otlp_config_linux_expected.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/otlp_config_linux_expected.yaml
@@ -1,0 +1,138 @@
+exporters:
+    otlp_http:
+        auth:
+            authenticator: headers_setter
+        compression: gzip
+        headers:
+            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        traces_endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com/v2/trace/otlp
+    signalfx:
+        access_token: ${SPLUNK_ACCESS_TOKEN}
+        realm: ${SPLUNK_REALM}
+extensions:
+    headers_setter:
+        headers:
+            - action: upsert
+              default_value: ${SPLUNK_ACCESS_TOKEN}
+              from_context: X-SF-TOKEN
+              key: X-SF-TOKEN
+    health_check:
+        endpoint: 0.0.0.0:13133
+    http_forwarder:
+        egress:
+            endpoint: https://api.${SPLUNK_REALM}.observability.splunkcloud.com
+        ingress:
+            endpoint: 0.0.0.0:6060
+    http_forwarder/opamp_splunk_o11y:
+        egress:
+            endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com
+        ingress:
+            endpoint: ${SPLUNK_LISTEN_INTERFACE}:4320
+    opamp/splunk_o11y:
+        server:
+            http:
+                endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com/v1/opamp
+                headers:
+                    X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+                polling_interval: 30s
+    zpages:
+        endpoint: 0.0.0.0:55679
+        expvar:
+            enabled: true
+processors:
+    batch:
+        metadata_keys:
+            - X-SF-Token
+    memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+    resourcedetection/internal:
+        detectors:
+            - gcp
+            - ecs
+            - ec2
+            - azure
+            - system
+        override: true
+receivers:
+    jaeger:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:14250
+            thrift_binary:
+                endpoint: 0.0.0.0:6832
+            thrift_compact:
+                endpoint: 0.0.0.0:6831
+            thrift_http:
+                endpoint: 0.0.0.0:14268
+    otlp:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:4317
+            http:
+                endpoint: 0.0.0.0:4318
+    prometheus/internal:
+        config:
+            scrape_configs:
+                - job_name: otel-collector
+                  metric_relabel_configs:
+                    - action: drop
+                      regex: promhttp_metric_handler_errors.*
+                      source_labels:
+                        - __name__
+                    - action: drop
+                      regex: otelcol_processor_batch_.*
+                      source_labels:
+                        - __name__
+                  scrape_interval: 10s
+                  static_configs:
+                    - targets:
+                        - 0.0.0.0:8888
+    zipkin:
+        endpoint: 0.0.0.0:9411
+service:
+    extensions:
+        - headers_setter
+        - health_check
+        - http_forwarder
+        - http_forwarder/opamp_splunk_o11y
+        - opamp/splunk_o11y
+        - zpages
+    pipelines:
+        metrics:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+            receivers:
+                - otlp
+        metrics/internal:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection/internal
+            receivers:
+                - prometheus/internal
+        traces:
+            exporters:
+                - otlp_http
+            processors:
+                - memory_limiter
+                - batch
+            receivers:
+                - jaeger
+                - otlp
+                - zipkin
+    telemetry:
+        logs:
+            level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+        metrics:
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 127.0.0.1
+                            port: 8888

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/upstream_agent_config_expected.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/upstream_agent_config_expected.yaml
@@ -1,0 +1,192 @@
+exporters:
+    debug:
+        verbosity: detailed
+    otlp_grpc/gateway:
+        auth:
+            authenticator: headers_setter
+        endpoint: ${SPLUNK_GATEWAY_URL}:4317
+        tls:
+            insecure: true
+    otlp_http:
+        auth:
+            authenticator: headers_setter
+        headers:
+            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        traces_endpoint: ${SPLUNK_INGEST_URL}/v2/trace/otlp
+    otlp_http/entities:
+        auth:
+            authenticator: headers_setter
+        headers:
+            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        logs_endpoint: ${SPLUNK_INGEST_URL}/v3/event
+    signalfx:
+        access_token: ${SPLUNK_ACCESS_TOKEN}
+        api_url: ${SPLUNK_API_URL}
+        correlation: null
+        ingest_url: ${SPLUNK_INGEST_URL}
+        sync_host_metadata: true
+    splunk_hec/profiling:
+        endpoint: https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com/v1/log
+        log_data_enabled: false
+        token: ${SPLUNK_ACCESS_TOKEN}
+extensions:
+    headers_setter:
+        headers:
+            - action: upsert
+              default_value: ${SPLUNK_ACCESS_TOKEN}
+              from_context: X-SF-TOKEN
+              key: X-SF-TOKEN
+    health_check:
+        endpoint: 0.0.0.0:13133
+    http_forwarder:
+        egress:
+            endpoint: ${SPLUNK_API_URL}
+        ingress:
+            endpoint: 0.0.0.0:6060
+    http_forwarder/opamp_splunk_o11y:
+        egress:
+            endpoint: ${SPLUNK_INGEST_URL}
+        ingress:
+            endpoint: ${SPLUNK_LISTEN_INTERFACE}:4320
+    opamp/splunk_o11y:
+        server:
+            http:
+                endpoint: ${SPLUNK_INGEST_URL}/v1/opamp
+                headers:
+                    X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+                polling_interval: 30s
+    zpages:
+        expvar:
+            enabled: true
+processors:
+    batch:
+        metadata_keys:
+            - X-SF-Token
+    memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+    resourcedetection:
+        detectors:
+            - gcp
+            - ecs
+            - ec2
+            - azure
+            - system
+        override: true
+receivers:
+    fluentforward:
+        endpoint: 127.0.0.1:8006
+    hostmetrics:
+        collection_interval: 10s
+        scrapers:
+            cpu: null
+            disk: null
+            filesystem: null
+            load: null
+            memory: null
+            network: null
+            paging: null
+            processes: null
+    jaeger:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:14250
+            thrift_binary:
+                endpoint: 0.0.0.0:6832
+            thrift_compact:
+                endpoint: 0.0.0.0:6831
+            thrift_http:
+                endpoint: 0.0.0.0:14268
+    nop: null
+    otlp:
+        protocols:
+            grpc:
+                endpoint: 0.0.0.0:4317
+            http:
+                endpoint: 0.0.0.0:4318
+    prometheus/internal:
+        config:
+            scrape_configs:
+                - job_name: otel-collector
+                  metric_relabel_configs:
+                    - action: drop
+                      regex: promhttp_metric_handler_errors.*
+                      source_labels:
+                        - __name__
+                    - action: drop
+                      regex: otelcol_processor_batch_.*
+                      source_labels:
+                        - __name__
+                  scrape_interval: 10s
+                  static_configs:
+                    - targets:
+                        - 0.0.0.0:8888
+    zipkin:
+        endpoint: 0.0.0.0:9411
+service:
+    extensions:
+        - headers_setter
+        - health_check
+        - http_forwarder
+        - http_forwarder/opamp_splunk_o11y
+        - opamp/splunk_o11y
+        - zpages
+    pipelines:
+        logs:
+            exporters:
+                - splunk_hec/profiling
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - otlp
+        logs/entities:
+            exporters:
+                - otlp_http/entities
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - nop
+        metrics:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - hostmetrics
+                - otlp
+        metrics/internal:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - prometheus/internal
+        traces:
+            exporters:
+                - otlp_http
+            processors:
+                - memory_limiter
+                - batch
+                - resourcedetection
+            receivers:
+                - jaeger
+                - otlp
+                - zipkin
+    telemetry:
+        logs:
+            level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+        metrics:
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 127.0.0.1
+                            port: 8888

--- a/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/upstream_agent_config_expected.yaml
+++ b/internal/configconverter/testdata/drop_signalfx_exporter_traces_pipelines/upstream_agent_config_expected.yaml
@@ -74,9 +74,9 @@ processors:
             - system
         override: true
 receivers:
-    fluentforward:
+    fluent_forward:
         endpoint: 127.0.0.1:8006
-    hostmetrics:
+    host_metrics:
         collection_interval: 10s
         scrapers:
             cpu: null
@@ -158,7 +158,7 @@ service:
                 - batch
                 - resourcedetection
             receivers:
-                - hostmetrics
+                - host_metrics
                 - otlp
         metrics/internal:
             exporters:

--- a/tests/general/default_config_test.go
+++ b/tests/general/default_config_test.go
@@ -540,7 +540,7 @@ func TestDefaultAgentConfig(t *testing.T) {
 							"receivers":  []any{"prometheus/internal"},
 						},
 						"traces": map[string]any{
-							"exporters":  []any{"otlp_http", "signalfx"},
+							"exporters":  []any{"otlp_http"},
 							"processors": []any{"memory_limiter", "batch", "resourcedetection"},
 							"receivers":  []any{"jaeger", "otlp", "zipkin"},
 						},


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
- Add a new feature gate (enabled by default) that drops the `signalfx` exporter from all trace pipelines.
- Any trace pipeline that no longer has any exporters will be dropped as well.
- Log deprecation/info notices when exporter/pipeline is removed.