### PR TITLE
[chore][dependabot] Group k8s dependencies together for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
     directories:
       - "**/*"
     groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/api"
+          - "k8s.io/apimachinery"
+          - "k8s.io/client-go"
+          - "k8s.io/kubelet"
       otelcol:
         patterns:
           - "go.opentelemetry.io/collector*"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Separate PRs are currently being opened by dependabot for each dependency. Every PR fails needing `go mod tidy` to be run, which ends up bumping the rest of the k8s dependencies since they all need to be bumped together.

Example: https://github.com/signalfx/splunk-otel-collector/pull/7498, running `make tidy-all` locally resulted in [bumping the rest of the k8s deps](https://github.com/signalfx/splunk-otel-collector/pull/7498/commits/7d8769a935228e0fe00c4288ae0184bdb79aeb08). (It didn't actually bump k8s.io/kubelet, but running `make tidy-all` against [that PR](https://github.com/signalfx/splunk-otel-collector/pull/7501) bumps at least `k8s.io/api`, so they're inter-dependent as well)