### PR TITLE
feat: add log and metrics support for Windows

### DIFF
--- a/cmd/otelcol/config/collector/logs_windows_config.yaml
+++ b/cmd/otelcol/config/collector/logs_windows_config.yaml
@@ -1,0 +1,327 @@
+receivers:
+  windowseventlog:
+    channel: Application
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+    # Excludes events from providers whose metadata DLL is not accessible
+    # to the collector process (e.g. Tenable Nessus Agent).
+    # Remove entries below if you want to collect those events despite the error.
+    exclude_providers:
+      - "Tenable Nessus Agent"
+      - "XENAGENT"
+
+  windowseventlog/security:
+    channel: Security
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+    # NOTE: Splunk blacklists the following with a message-body regex condition:
+    #   EventCode 4662 where Object Type != groupPolicyContainer
+    #   EventCode 566  where Object Type != groupPolicyContainer
+    # The exclude_events filter below drops ALL 4662/566 events — it cannot
+    # replicate the groupPolicyContainer exception. Use a filterprocessor
+    # with OTTL if you need conditional filtering.
+    #
+    # exclude_events:
+    #   - event_ids: [4662, 566]
+
+  windowseventlog/system:
+    channel: System
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  windowseventlog/printservice:
+    channel: Microsoft-Windows-PrintService/Operational
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  # --- Disabled in inputs.conf -------------------------------------------
+
+  # ForwardedEvents exists but is disabled — enable on WEF collectors only
+  windowseventlog/forwardedevents:
+    channel: ForwardedEvents
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  # DC-only channels — will silently no-op on non-DC machines due to ignore_channel_errors
+  windowseventlog/dfs_replication:
+    channel: DFS Replication
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  windowseventlog/directory_service:
+    channel: Directory Service
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  windowseventlog/file_replication:
+    channel: File Replication Service
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  windowseventlog/dns_server:
+    channel: DNS Server
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  windowseventlog/key_management:
+    channel: Key Management Service
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  windowseventlog/defender:
+    channel: Microsoft-Windows-Windows Defender/Operational
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  filelog/dhcp:
+    include:
+      - 'C:\Windows\System32\DHCP\DhcpSrvLog*'
+    start_at: beginning
+    include_file_path: true
+    operators:
+      - type: move
+        from: attributes["log.file.path"]
+        to: resource["com.splunk.source"]
+      - type: add
+        field: resource["com.splunk.sourcetype"]
+        value: DhcpSrvLog
+    storage: file_storage/filelogs
+
+  filelog/windowsupdate_legacy:
+    # For Windows 8 / Server 2008R2 / Server 2012 / Server 2012R2
+    include:
+      - 'C:\Windows\WindowsUpdate.log'
+    start_at: beginning
+    include_file_path: true
+    operators:
+      - type: move
+        from: attributes["log.file.path"]
+        to: resource["com.splunk.source"]
+      - type: add
+        field: resource["com.splunk.sourcetype"]
+        value: WindowsUpdateLog
+    storage: file_storage/filelogs
+
+  filelog/netlogon:
+    include:
+      - 'C:\Windows\debug\netlogon.log'
+    start_at: beginning
+    include_file_path: true
+    operators:
+      - type: move
+        from: attributes["log.file.path"]
+        to: resource["com.splunk.source"]
+      - type: add
+        field: resource["com.splunk.sourcetype"]
+        value: MSAD:NT6:Netlogon
+    storage: file_storage/filelogs
+
+  filelog/firewall:
+    include:
+      - 'C:\Windows\System32\LogFiles\Firewall\*'
+    start_at: beginning
+    include_file_path: true
+    operators:
+      - type: move
+        from: attributes["log.file.path"]
+        to: resource["com.splunk.source"]
+      - type: add
+        field: resource["com.splunk.sourcetype"]
+        value: WindowsFirewallLog
+    storage: file_storage/filelogs
+
+  #   --- GAP: dns.log (MonitorNoHandle) ------------------------------------
+  #   [MonitorNoHandle://$WINDIR\System32\Dns\dns.log]
+  #   The live DNS debug log is held open with an exclusive lock by the DNS
+  #   service. filelogreceiver cannot reliably read exclusively locked files.
+  #   Workaround: use a scheduled task to periodically copy dns.log to a
+  #   staging path, then monitor that path with filelog.
+
+  filelog/dns_debug:
+    include:
+      - 'C:\dns_log_copy\dns.log'
+    start_at: beginning
+    include_file_path: true
+    operators:
+      - type: move
+        from: attributes["log.file.path"]
+        to: resource["com.splunk.source"]
+      - type: add
+        field: resource["com.splunk.sourcetype"]
+        value: MSAD:NT6:DNS
+    storage: file_storage/filelogs
+
+processors:
+  batch:
+  resourcedetection:
+    detectors: [ system, env ]
+    system:
+      hostname_sources: [ "os" ]
+  # WinEventLog://Application -> sourcetype=XmlWinEventLog  source=WinEventLog:Application
+  transform/application:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:Application")
+  # WinEventLog://Security -> sourcetype=XmlWinEventLog  source=WinEventLog:Security
+  transform/security:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:Security")
+  # WinEventLog://System -> sourcetype=XmlWinEventLog  source=WinEventLog:System
+  transform/system:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:System")
+  # WinEventLog://Microsoft-Windows-PrintService/Operational
+  # No renderXml in inputs.conf -> sourcetype=WinEventLog
+  transform/printservice:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "WinEventLog")
+          - set(attributes["com.splunk.source"], "WinEventLog:Microsoft-Windows-PrintService/Operational")
+  # transform/forwardedevents — uncomment if enabling ForwardedEvents receiver
+  transform/forwardedevents:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:ForwardedEvents")
+  transform/dfs_replication:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:DFS Replication")
+  transform/directory_service:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:Directory Service")
+  transform/file_replication:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:File Replication Service")
+  transform/dns_server:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:DNS Server")
+  transform/key_management:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:Key Management Service")
+  transform/defender:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:Microsoft-Windows-Windows Defender/Operational")
+
+
+exporters:
+  splunk_hec/logs:
+    endpoint: "${SPLUNK_HEC_URL}"
+    token: "${SPLUNK_HEC_TOKEN}"
+    source: "otel"
+    sourcetype: "otel"
+    index: "${SPLUNK_PLATFORM_LOGS_INDEX}"
+
+extensions:
+  file_storage/filelogs:
+    directory: "${ProgramData}/Splunk/OpenTelemetry Collector/FileStorage"
+    compaction:
+      on_start: true
+      directory: /tmp/
+    create_directory: true
+
+service:
+  extensions: [file_storage/filelogs]
+  pipelines:
+    logs/application:
+      receivers: [windowseventlog]
+      processors: [transform/application, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/security:
+      receivers: [windowseventlog/security]
+      processors: [transform/security, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/system:
+      receivers: [windowseventlog/system]
+      processors: [transform/system, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/printservice:
+      receivers: [windowseventlog/printservice]
+      processors: [transform/printservice, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/forwardedevents:
+      receivers: [windowseventlog/forwardedevents]
+      processors: [transform/forwardedevents, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/dfs_replication:
+      receivers: [windowseventlog/dfs_replication]
+      processors: [transform/dfs_replication, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/directory_service:
+      receivers: [windowseventlog/directory_service]
+      processors: [transform/directory_service, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/file_replication:
+      receivers: [windowseventlog/file_replication]
+      processors: [transform/file_replication, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/dns_server:
+      receivers: [windowseventlog/dns_server]
+      processors: [transform/dns_server, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/key_management:
+      receivers: [windowseventlog/key_management]
+      processors: [transform/key_management, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/defender:
+      receivers: [windowseventlog/defender]
+      processors: [transform/defender, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/dhcp:
+      receivers: [filelog/dhcp]
+      processors: [batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/windowsupdate:
+      receivers: [filelog/windowsupdate_legacy]
+      processors: [batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/netlogon:
+      receivers: [filelog/netlogon]
+      processors: [batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/firewall:
+      receivers: [filelog/firewall]
+      processors: [batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/dns_debug:
+      receivers: [filelog/dns_debug]
+      processors: [batch, resourcedetection]
+      exporters: [splunk_hec/logs]

--- a/cmd/otelcol/config/collector/metrics_windows_config.yaml
+++ b/cmd/otelcol/config/collector/metrics_windows_config.yaml
@@ -1,0 +1,312 @@
+receivers:
+  windowsperfcounters/cpu:
+    collection_interval: 10s
+    perfcounters:
+      - object: Processor
+        instances: ["*"]
+        counters:
+          - name: "% Processor Time"
+          - name: "% User Time"
+          - name: "% Privileged Time"
+          - name: "Interrupts/sec"
+          - name: "% DPC Time"
+          - name: "% Interrupt Time"
+          - name: "DPCs Queued/sec"
+          - name: "DPC Rate"
+          - name: "% Idle Time"
+          - name: "% C1 Time"
+          - name: "% C2 Time"
+          - name: "% C3 Time"
+          - name: "C1 Transitions/sec"
+          - name: "C2 Transitions/sec"
+          - name: "C3 Transitions/sec"
+  windowsperfcounters/processor_information:
+    collection_interval: 10s
+    perfcounters:
+      - object: Processor Information
+        instances: ["*"]
+        counters:
+          - name: "% Processor Time"
+          - name: "Processor Frequency"
+  windowsperfcounters/logical_disk:
+    collection_interval: 10s
+    perfcounters:
+      - object: LogicalDisk
+        instances: ["*"]
+        counters:
+          - name: "% Free Space"
+          - name: "Free Megabytes"
+          - name: "Current Disk Queue Length"
+          - name: "% Disk Time"
+          - name: "Avg. Disk Queue Length"
+          - name: "% Disk Read Time"
+          - name: "Avg. Disk Read Queue Length"
+          - name: "% Disk Write Time"
+          - name: "Avg. Disk Write Queue Length"
+          - name: "Avg. Disk sec/Transfer"
+          - name: "Avg. Disk sec/Read"
+          - name: "Avg. Disk sec/Write"
+          - name: "Disk Transfers/sec"
+          - name: "Disk Reads/sec"
+          - name: "Disk Writes/sec"
+          - name: "Disk Bytes/sec"
+          - name: "Disk Read Bytes/sec"
+          - name: "Disk Write Bytes/sec"
+          - name: "% Idle Time"
+  windowsperfcounters/physical_disk:
+    collection_interval: 10s
+    perfcounters:
+      - object: PhysicalDisk
+        instances: ["*"]
+        counters:
+          - name: "Current Disk Queue Length"
+          - name: "% Disk Time"
+          - name: "Disk Transfers/sec"
+          - name: "Disk Reads/sec"
+          - name: "Disk Writes/sec"
+          - name: "Disk Bytes/sec"
+          - name: "Disk Read Bytes/sec"
+          - name: "Disk Write Bytes/sec"
+          - name: "% Idle Time"
+  windowsperfcounters/memory:
+    collection_interval: 10s
+    perfcounters:
+      - object: Memory
+        counters:
+          - name: "Page Faults/sec"
+          - name: "Available Bytes"
+          - name: "Committed Bytes"
+          - name: "Commit Limit"
+          - name: "Pages/sec"
+          - name: "Pages Input/sec"
+          - name: "Page Reads/sec"
+          - name: "Pages Output/sec"
+          - name: "Pool Paged Bytes"
+          - name: "Pool Nonpaged Bytes"
+          - name: "Page Writes/sec"
+          - name: "Available KBytes"
+          - name: "Available MBytes"
+  windowsperfcounters/network:
+    collection_interval: 10s
+    perfcounters:
+      - object: Network Interface
+        instances: ["*"]
+        counters:
+          - name: "Bytes Total/sec"
+          - name: "Packets/sec"
+          - name: "Packets Received/sec"
+          - name: "Packets Sent/sec"
+          - name: "Current Bandwidth"
+          - name: "Bytes Received/sec"
+          - name: "Bytes Sent/sec"
+          - name: "Packets Received Discarded"
+          - name: "Packets Received Errors"
+          - name: "Packets Outbound Discarded"
+          - name: "Packets Outbound Errors"
+          - name: "Output Queue Length"
+  windowsperfcounters/process:
+    collection_interval: 10s
+    perfcounters:
+      - object: Process
+        instances: ["*"]
+        counters:
+          - name: "% Processor Time"
+          - name: "% User Time"
+          - name: "% Privileged Time"
+          - name: "Virtual Bytes"
+          - name: "Working Set"
+          - name: "Page File Bytes"
+          - name: "Private Bytes"
+          - name: "Thread Count"
+          - name: "ID Process"
+          - name: "IO Read Operations/sec"
+          - name: "IO Write Operations/sec"
+          - name: "IO Read Bytes/sec"
+          - name: "IO Write Bytes/sec"
+  windowsperfcounters/system:
+    collection_interval: 10s
+    perfcounters:
+      - object: System
+        counters:
+          - name: "File Read Operations/sec"
+          - name: "File Write Operations/sec"
+          - name: "Context Switches/sec"
+          - name: "System Calls/sec"
+          - name: "System Up Time"
+          - name: "Processor Queue Length"
+          - name: "Processes"
+          - name: "Threads"
+  windowsperfcounters/dfs_replicated_folders:
+    collection_interval: 30s
+    perfcounters:
+      - object: DFS Replicated Folders
+        instances: ["*"]
+        counters:
+          - name: "Bandwidth Savings Using DFS Replication"
+          - name: "RDC Bytes Received"
+          - name: "Total Files Received"
+          - name: "Conflict Files Generated"
+          - name: "Staging Files Generated"
+          - name: "Updates Dropped"
+  windowsperfcounters/ntds:
+    collection_interval: 10s
+    perfcounters:
+      - object: NTDS
+        counters:
+          - name: "DRA Inbound Objects/sec"
+          - name: "DRA Outbound Objects/sec"
+          - name: "LDAP Client Sessions"
+          - name: "LDAP Searches/sec"
+          - name: "LDAP Writes/sec"
+          - name: "LDAP Successful Binds/sec"
+          - name: "LDAP Bind Time"
+          - name: "DS Directory Reads/sec"
+          - name: "DS Directory Writes/sec"
+          - name: "DS Directory Searches/sec"
+          - name: "DRA Pending Replication Synchronizations"
+  windowsperfcounters/dns:
+    collection_interval: 10s
+    perfcounters:
+      - object: DNS
+        counters:
+          - name: "Total Query Received"
+          - name: "Total Query Received/sec"
+          - name: "UDP Query Received/sec"
+          - name: "TCP Query Received/sec"
+          - name: "Total Response Sent/sec"
+          - name: "Recursive Queries/sec"
+          - name: "Recursive Query Failure/sec"
+          - name: "Dynamic Update Received/sec"
+          - name: "Dynamic Update Rejected"
+          - name: "Zone Transfer Request Received"
+          - name: "Zone Transfer Success"
+          - name: "Zone Transfer Failure"
+
+
+processors:
+  batch:
+  resourcedetection:
+    detectors: [ system, env ]
+    system:
+      hostname_sources: [ "os" ]
+  transform/perfcounters_cpu:
+    metric_statements:
+      - context: resource
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "PerfmonMk:CPU")
+          - set(attributes["com.splunk.source"], "PerfmonMk:CPU")
+  transform/perfcounters_processor_information:
+    metric_statements:
+      - context: resource
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "PerfmonMk:ProcessorInformation")
+          - set(attributes["com.splunk.source"], "PerfmonMk:ProcessorInformation")
+  transform/perfcounters_logical_disk:
+    metric_statements:
+      - context: resource
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "PerfmonMk:LogicalDisk")
+          - set(attributes["com.splunk.source"], "PerfmonMk:LogicalDisk")
+  transform/perfcounters_physical_disk:
+    metric_statements:
+      - context: resource
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "PerfmonMk:PhysicalDisk")
+          - set(attributes["com.splunk.source"], "PerfmonMk:PhysicalDisk")
+  transform/perfcounters_memory:
+    metric_statements:
+      - context: resource
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "PerfmonMk:Memory")
+          - set(attributes["com.splunk.source"], "PerfmonMk:Memory")
+  transform/perfcounters_network:
+    metric_statements:
+      - context: resource
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "PerfmonMk:Network")
+          - set(attributes["com.splunk.source"], "PerfmonMk:Network")
+  transform/perfcounters_process:
+    metric_statements:
+      - context: resource
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "PerfmonMk:Process")
+          - set(attributes["com.splunk.source"], "PerfmonMk:Process")
+  transform/perfcounters_system:
+    metric_statements:
+      - context: resource
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "PerfmonMk:System")
+          - set(attributes["com.splunk.source"], "PerfmonMk:System")
+  transform/perfcounters_dfs_replicated_folders:
+    metric_statements:
+      - context: resource
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "PerfmonMk:DFS_Replicated_Folders")
+          - set(attributes["com.splunk.source"], "PerfmonMk:DFS_Replicated_Folders")
+  transform/perfcounters_ntds:
+    metric_statements:
+      - context: resource
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "PerfmonMk:NTDS")
+          - set(attributes["com.splunk.source"], "PerfmonMk:NTDS")
+  transform/perfcounters_dns:
+    metric_statements:
+      - context: resource
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "PerfmonMk:DNS")
+          - set(attributes["com.splunk.source"], "PerfmonMk:DNS")
+
+exporters:
+  splunk_hec/metrics:
+    endpoint: "${SPLUNK_HEC_URL}"
+    token: "${SPLUNK_HEC_TOKEN}"
+    source: "otel"
+    sourcetype: "otel"
+    index: "${SPLUNK_PLATFORM_METRICS_INDEX}"
+
+service:
+  pipelines:
+    metrics/cpu:
+      receivers: [windowsperfcounters/cpu]
+      processors: [transform/perfcounters_cpu, batch, resourcedetection]
+      exporters: [splunk_hec/metrics]
+    metrics/processor_information:
+      receivers: [windowsperfcounters/processor_information]
+      processors: [transform/perfcounters_processor_information, batch, resourcedetection]
+      exporters: [splunk_hec/metrics]
+    metrics/logical_disk:
+      receivers: [windowsperfcounters/logical_disk]
+      processors: [transform/perfcounters_logical_disk, batch, resourcedetection]
+      exporters: [splunk_hec/metrics]
+    metrics/physical_disk:
+      receivers: [windowsperfcounters/physical_disk]
+      processors: [transform/perfcounters_physical_disk, batch, resourcedetection]
+      exporters: [splunk_hec/metrics]
+    metrics/memory:
+      receivers: [windowsperfcounters/memory]
+      processors: [transform/perfcounters_memory, batch, resourcedetection]
+      exporters: [splunk_hec/metrics]
+    metrics/network:
+      receivers: [windowsperfcounters/network]
+      processors: [transform/perfcounters_network, batch, resourcedetection]
+      exporters: [splunk_hec/metrics]
+    metrics/process:
+      receivers: [windowsperfcounters/process]
+      processors: [transform/perfcounters_process, batch, resourcedetection]
+      exporters: [splunk_hec/metrics]
+    metrics/system:
+      receivers: [windowsperfcounters/system]
+      processors: [transform/perfcounters_system, batch, resourcedetection]
+      exporters: [splunk_hec/metrics]
+    metrics/dfs_replicated_folders:
+      receivers: [windowsperfcounters/dfs_replicated_folders]
+      processors: [transform/perfcounters_dfs_replicated_folders, batch, resourcedetection]
+      exporters: [splunk_hec/metrics]
+    metrics/ntds:
+      receivers: [windowsperfcounters/ntds]
+      processors: [transform/perfcounters_ntds, batch, resourcedetection]
+      exporters: [splunk_hec/metrics]
+    metrics/dns:
+      receivers: [windowsperfcounters/dns]
+      processors: [transform/perfcounters_dns, batch, resourcedetection]
+      exporters: [splunk_hec/metrics]

--- a/packaging/msi/msi-builder/build.sh
+++ b/packaging/msi/msi-builder/build.sh
@@ -24,6 +24,8 @@ PROJECT_DIR=${PROJECT_DIR:-"${REPO_DIR}"}
 MSI_SRC_DIR=${MSI_SRC_DIR:-"${REPO_DIR}/packaging/msi"}
 WXS_PATH="${MSI_SRC_DIR}/splunk-otel-collector.wxs"
 AGENT_CONFIG="${REPO_DIR}/cmd/otelcol/config/collector/agent_config.yaml"
+LOGS_CONFIG="${REPO_DIR}/cmd/otelcol/config/collector/logs_windows_config.yaml"
+METRICS_CONFIG="${REPO_DIR}/cmd/otelcol/config/collector/metrics_windows_config.yaml"
 GATEWAY_CONFIG="${REPO_DIR}/cmd/otelcol/config/collector/gateway_config.yaml"
 SUPPORT_BUNDLE_SCRIPT=${SUPPORT_BUNDLE_SCRIPT:-"${MSI_SRC_DIR}/splunk-support-bundle.ps1"}
 SPLUNK_ICON="${MSI_SRC_DIR}/splunk.ico"
@@ -62,6 +64,8 @@ parse_args_and_build() {
     local otelcol=""
     local agent_config="$AGENT_CONFIG"
     local gateway_config="$GATEWAY_CONFIG"
+    local logs_config="$LOGS_CONFIG"
+    local metrics_config="$METRICS_CONFIG"
     local support_bundle="$SUPPORT_BUNDLE_SCRIPT"
     local jmx_metric_gatherer_release="$JMX_METRIC_GATHERER_RELEASE"
     local splunk_icon="$SPLUNK_ICON"
@@ -159,6 +163,8 @@ parse_args_and_build() {
     mkdir -p "${files_dir}"
     cp "$support_bundle" "${files_dir}/splunk-support-bundle.ps1"
     cp "$agent_config" "${files_dir}/agent_config.yaml"
+    cp "$logs_config" "${files_dir}/logs_windows_config.yaml"
+    cp "$metrics_config" "${files_dir}/metrics_windows_config.yaml"
     cp "$gateway_config" "${files_dir}/gateway_config.yaml"
 
     if [ -z "$skip_build_dir_removal" ]; then

--- a/packaging/msi/splunk-otel-collector.wxs
+++ b/packaging/msi/splunk-otel-collector.wxs
@@ -40,13 +40,21 @@
       <!-- SPLUNK_*_URL properties required to start the collector -->
       <Property Id="SPLUNK_REALM" Value="us0" Secure="yes" />
 
-      <Property Id="SPLUNK_CONFIG" Secure="yes" />
       <Property Id="SPLUNK_API_URL" Secure="yes" />
       <Property Id="SPLUNK_INGEST_URL" Secure="yes" />
       <Property Id="SPLUNK_HEC_URL" Secure="yes" />
       <Property Id="SPLUNK_BUNDLE_DIR" Secure="yes" />
+      <Property Id="SPLUNK_PLATFORM_LOGS_INDEX" Secure="yes" />
+      <Property Id="SPLUNK_PLATFORM_METRICS_INDEX" Secure="yes" />
 
-      <CustomAction Id="Set_SPLUNK_CONFIG" Property="SPLUNK_CONFIG" Value="[CommonAppDataFolder]Splunk\OpenTelemetry Collector\[SPLUNK_SETUP_COLLECTOR_MODE]_config.yaml" />
+      <CustomAction Id="Set_SPLUNK_PLATFORM_LOGS_INDEX" Property="SPLUNK_PLATFORM_LOGS_INDEX" Value="[%SPLUNK_PLATFORM_LOGS_INDEX]" />
+      <CustomAction Id="Set_SPLUNK_PLATFORM_METRICS_INDEX" Property="SPLUNK_PLATFORM_METRICS_INDEX" Value="[%SPLUNK_PLATFORM_METRICS_INDEX]" />
+      <CustomAction Id="AppendDefaultConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="[COLLECTOR_SVC_ARGS] --config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\[SPLUNK_SETUP_COLLECTOR_MODE]_config.yaml&quot;" />
+      <CustomAction Id="SetDefaultConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="--config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\[SPLUNK_SETUP_COLLECTOR_MODE]_config.yaml&quot;" />
+      <CustomAction Id="AppendLogsConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="[COLLECTOR_SVC_ARGS] --config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\logs_windows_config.yaml&quot;" />
+      <CustomAction Id="SetLogsConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="--config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\logs_windows_config.yaml&quot;" />
+      <CustomAction Id="AppendMetricsConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="[COLLECTOR_SVC_ARGS] --config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\metrics_windows_config.yaml&quot;" />
+      <CustomAction Id="SetMetricsConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="--config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\metrics_windows_config.yaml&quot;" />
       <CustomAction Id="Set_SPLUNK_API_URL" Property="SPLUNK_API_URL" Value="https://api.[SPLUNK_REALM].observability.splunkcloud.com" />
       <CustomAction Id="Set_SPLUNK_INGEST_URL" Property="SPLUNK_INGEST_URL" Value="https://ingest.[SPLUNK_REALM].observability.splunkcloud.com" />
       <CustomAction Id="Set_SPLUNK_HEC_URL" Property="SPLUNK_HEC_URL" Value="[SPLUNK_INGEST_URL]/v1/log" />
@@ -55,7 +63,14 @@
       <InstallExecuteSequence>
          <Custom Action="CheckLaunchConditions" After="LaunchConditions" />
          <Custom Action="Set_SPLUNK_HEC_TOKEN" After="LaunchConditions" Condition="NOT SPLUNK_HEC_TOKEN" />
-         <Custom Action="Set_SPLUNK_CONFIG" After="LaunchConditions" Condition="NOT SPLUNK_CONFIG" />
+         <Custom Action="Set_SPLUNK_PLATFORM_LOGS_INDEX" After="CheckLaunchConditions" Condition="NOT SPLUNK_PLATFORM_LOGS_INDEX AND %SPLUNK_PLATFORM_LOGS_INDEX" />
+         <Custom Action="Set_SPLUNK_PLATFORM_METRICS_INDEX" After="Set_SPLUNK_PLATFORM_LOGS_INDEX" Condition="NOT SPLUNK_PLATFORM_METRICS_INDEX AND %SPLUNK_PLATFORM_METRICS_INDEX" />
+         <Custom Action="AppendDefaultConfigTo_COLLECTOR_SVC_ARGS" After="Set_SPLUNK_PLATFORM_METRICS_INDEX" Condition="COLLECTOR_SVC_ARGS AND SPLUNK_ACCESS_TOKEN" />
+         <Custom Action="SetDefaultConfigTo_COLLECTOR_SVC_ARGS" After="AppendDefaultConfigTo_COLLECTOR_SVC_ARGS" Condition="NOT COLLECTOR_SVC_ARGS AND SPLUNK_ACCESS_TOKEN" />
+         <Custom Action="AppendLogsConfigTo_COLLECTOR_SVC_ARGS" After="SetDefaultConfigTo_COLLECTOR_SVC_ARGS" Condition="COLLECTOR_SVC_ARGS AND SPLUNK_PLATFORM_LOGS_INDEX" />
+         <Custom Action="SetLogsConfigTo_COLLECTOR_SVC_ARGS" After="AppendLogsConfigTo_COLLECTOR_SVC_ARGS" Condition="NOT COLLECTOR_SVC_ARGS AND SPLUNK_PLATFORM_LOGS_INDEX" />
+         <Custom Action="AppendMetricsConfigTo_COLLECTOR_SVC_ARGS" After="SetLogsConfigTo_COLLECTOR_SVC_ARGS" Condition="COLLECTOR_SVC_ARGS AND SPLUNK_PLATFORM_METRICS_INDEX" />
+         <Custom Action="SetMetricsConfigTo_COLLECTOR_SVC_ARGS" After="AppendMetricsConfigTo_COLLECTOR_SVC_ARGS" Condition="NOT COLLECTOR_SVC_ARGS AND SPLUNK_PLATFORM_METRICS_INDEX" />
          <Custom Action="Set_SPLUNK_API_URL" After="LaunchConditions" Condition="NOT SPLUNK_API_URL" />
          <Custom Action="Set_SPLUNK_INGEST_URL" After="LaunchConditions" Condition="NOT SPLUNK_INGEST_URL" />
          <!-- The properties below depend on another properties and should be run only after all other properties are set -->
@@ -79,11 +94,12 @@
                <MultiStringValue Value="SPLUNK_ACCESS_TOKEN=[SPLUNK_ACCESS_TOKEN]" />
                <MultiStringValue Value="SPLUNK_API_URL=[SPLUNK_API_URL]" />
                <MultiStringValue Value="SPLUNK_BUNDLE_DIR=[SPLUNK_BUNDLE_DIR]" />
-               <MultiStringValue Value="SPLUNK_CONFIG=[SPLUNK_CONFIG]" />
                <MultiStringValue Value="SPLUNK_HEC_TOKEN=[SPLUNK_HEC_TOKEN]" />
                <MultiStringValue Value="SPLUNK_HEC_URL=[SPLUNK_HEC_URL]" />
                <MultiStringValue Value="SPLUNK_INGEST_URL=[SPLUNK_INGEST_URL]" />
                <MultiStringValue Value="SPLUNK_REALM=[SPLUNK_REALM]" />
+               <MultiStringValue Value="SPLUNK_PLATFORM_LOGS_INDEX=[SPLUNK_PLATFORM_LOGS_INDEX]" />
+               <MultiStringValue Value="SPLUNK_PLATFORM_METRICS_INDEX=[SPLUNK_PLATFORM_METRICS_INDEX]" />
             </RegistryValue>
          </RegistryKey>
       </Component>


### PR DESCRIPTION
Adds new logs_windows_config.yaml to MSI distribution
Adds new metrics_windows_config.yaml to MSI distribution

OTEL is run with following files depending on presence of specified parameter:
agent_config.yaml  -> SPLUNK_ACCESS_TOKEN
logs_windows_config.yaml -> SPLUNK_PLATFORM_LOGS_INDEX
metrics_windows_config.yaml -> SPLUNK_PLATFORM_METRICS_INDEX


