### PR TITLE
Pass Collector resource attributes to OpAMP in default configs

### DIFF
--- a/.chloggen/opamp-resource-v0-3-0.yaml
+++ b/.chloggen/opamp-resource-v0-3-0.yaml
@@ -1,0 +1,24 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: agent, gateway
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Pass Collector resource attributes to the OpAMP extension and adopt the declarative `service::telemetry::resource` (SDK API v0.3) shape in the default agent and gateway configs.
+
+# One or more tracking issues related to the change
+issues: [4251]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - Enable `agent_description.include_resource_attributes: true` on `opamp/splunk_o11y` so the
+    Collector's resource attributes (e.g. `otelcol.service.mode`, `host.name`, `cloud.*`) are
+    reported as OpAMP non-identifying attributes.
+  - Move `otelcol.service.mode` from the `resource/add_mode` processor into
+    `service.telemetry.resource.attributes` and remove `resource/add_mode` from the default
+    agent and gateway configurations.
+  - The shape of the existing internal telemetry resource is preserved; resource attributes set
+    by the `resourcedetection` processor are not migrated in this change.

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -37,6 +37,9 @@ extensions:
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:
+    agent_description:
+      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
+      include_resource_attributes: true
     server:
       http:
         endpoint: "${SPLUNK_INGEST_URL}/v1/opamp"
@@ -146,13 +149,6 @@ processors:
         #value: staging/production/...
         #key: deployment.environment
 
-  # The following processor is used to add "otelcol.service.mode" attribute to the internal metrics
-  resource/add_mode:
-    attributes:
-      - action: insert
-        value: "agent"
-        key: otelcol.service.mode
-
 exporters:
   # Traces
   otlp_http:
@@ -205,6 +201,13 @@ service:
   telemetry:
     logs:
       level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+    # Resource attributes attached to the Collector's internal telemetry. These
+    # are also exposed via OpAMP when the opamp/splunk_o11y extension is enabled
+    # with agent_description.include_resource_attributes set to true.
+    resource:
+      attributes:
+        - name: otelcol.service.mode
+          value: agent
     metrics:
       readers:
         - pull:
@@ -232,7 +235,7 @@ service:
       #exporters: [otlp_grpc/gateway]
     metrics/internal:
       receivers: [prometheus/internal]
-      processors: [memory_limiter, batch, resourcedetection, resource/add_mode]
+      processors: [memory_limiter, batch, resourcedetection]
       # When sending to gateway, at least one metrics pipeline needs
       # to use signalfx exporter so host metadata gets emitted
       exporters: [signalfx]

--- a/cmd/otelcol/config/collector/ecs_ec2_config.yaml
+++ b/cmd/otelcol/config/collector/ecs_ec2_config.yaml
@@ -27,6 +27,9 @@ extensions:
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:
+    agent_description:
+      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
+      include_resource_attributes: true
     server:
       http:
         endpoint: "${SPLUNK_INGEST_URL}/v1/opamp"

--- a/cmd/otelcol/config/collector/fargate_config.yaml
+++ b/cmd/otelcol/config/collector/fargate_config.yaml
@@ -22,6 +22,9 @@ extensions:
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:
+    agent_description:
+      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
+      include_resource_attributes: true
     server:
       http:
         endpoint: "${SPLUNK_INGEST_URL}/v1/opamp"

--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -706,6 +706,9 @@ extensions:
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:
+    agent_description:
+      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
+      include_resource_attributes: true
     server:
       http:
         endpoint: "https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com/v1/opamp"

--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -31,6 +31,9 @@ extensions:
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:
+    agent_description:
+      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
+      include_resource_attributes: true
     server:
       http:
         endpoint: "${SPLUNK_INGEST_URL}/v1/opamp"
@@ -103,13 +106,6 @@ processors:
         #value: staging/production/...
         #key: deployment.environment
 
-  # The following processor is used to add "otelcol.service.mode" attribute to the internal metrics
-  resource/add_mode:
-    attributes:
-      - action: insert
-        value: "gateway"
-        key: otelcol.service.mode
-
   # Detect if the collector is running on a cloud system. Overrides resource attributes set by receivers.
   # Detector order is important: the `system` detector goes last so it can't preclude cloud detectors from setting host/os info.
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#ordering
@@ -174,6 +170,13 @@ service:
   telemetry:
     logs:
       level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+    # Resource attributes attached to the Collector's internal telemetry. These
+    # are also exposed via OpAMP when the opamp/splunk_o11y extension is enabled
+    # with agent_description.include_resource_attributes set to true.
+    resource:
+      attributes:
+        - name: otelcol.service.mode
+          value: gateway
     metrics:
       readers:
         - pull:
@@ -195,7 +198,7 @@ service:
       exporters: [signalfx]
     metrics/internal:
       receivers: [prometheus/internal]
-      processors: [memory_limiter, batch, resourcedetection/internal, resource/add_mode]
+      processors: [memory_limiter, batch, resourcedetection/internal]
       exporters: [signalfx/internal]
     logs:
       receivers: [routing/logs]

--- a/cmd/otelcol/config/collector/otlp_config_linux.yaml
+++ b/cmd/otelcol/config/collector/otlp_config_linux.yaml
@@ -108,6 +108,9 @@ extensions:
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:
+    agent_description:
+      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
+      include_resource_attributes: true
     server:
       http:
         endpoint: "https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com/v1/opamp"

--- a/cmd/otelcol/config/collector/upstream_agent_config.yaml
+++ b/cmd/otelcol/config/collector/upstream_agent_config.yaml
@@ -37,6 +37,9 @@ extensions:
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:
+    agent_description:
+      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
+      include_resource_attributes: true
     server:
       http:
         endpoint: "${SPLUNK_INGEST_URL}/v1/opamp"

--- a/cmd/otelcol/fips/config/agent_config.yaml
+++ b/cmd/otelcol/fips/config/agent_config.yaml
@@ -35,6 +35,9 @@ extensions:
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:
+    agent_description:
+      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
+      include_resource_attributes: true
     server:
       http:
         endpoint: "${SPLUNK_INGEST_URL}/v1/opamp"
@@ -193,6 +196,13 @@ service:
   telemetry:
     logs:
       level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+    # Resource attributes attached to the Collector's internal telemetry. These
+    # are also exposed via OpAMP when the opamp/splunk_o11y extension is enabled
+    # with agent_description.include_resource_attributes set to true.
+    resource:
+      attributes:
+        - name: otelcol.service.mode
+          value: agent
     metrics:
       readers:
         - pull:

--- a/cmd/otelcol/fips/config/ecs_ec2_config.yaml
+++ b/cmd/otelcol/fips/config/ecs_ec2_config.yaml
@@ -27,6 +27,9 @@ extensions:
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:
+    agent_description:
+      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
+      include_resource_attributes: true
     server:
       http:
         endpoint: "${SPLUNK_INGEST_URL}/v1/opamp"

--- a/cmd/otelcol/fips/config/fargate_config.yaml
+++ b/cmd/otelcol/fips/config/fargate_config.yaml
@@ -22,6 +22,9 @@ extensions:
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:
+    agent_description:
+      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
+      include_resource_attributes: true
     server:
       http:
         endpoint: "${SPLUNK_INGEST_URL}/v1/opamp"

--- a/cmd/otelcol/fips/config/gateway_config.yaml
+++ b/cmd/otelcol/fips/config/gateway_config.yaml
@@ -31,6 +31,9 @@ extensions:
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:
+    agent_description:
+      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
+      include_resource_attributes: true
     server:
       http:
         endpoint: "${SPLUNK_INGEST_URL}/v1/opamp"
@@ -151,6 +154,13 @@ service:
   telemetry:
     logs:
       level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+    # Resource attributes attached to the Collector's internal telemetry. These
+    # are also exposed via OpAMP when the opamp/splunk_o11y extension is enabled
+    # with agent_description.include_resource_attributes set to true.
+    resource:
+      attributes:
+        - name: otelcol.service.mode
+          value: gateway
     metrics:
       readers:
         - pull:

--- a/cmd/otelcol/fips/config/otlp_config_linux.yaml
+++ b/cmd/otelcol/fips/config/otlp_config_linux.yaml
@@ -108,6 +108,9 @@ extensions:
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:
+    agent_description:
+      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
+      include_resource_attributes: true
     server:
       http:
         endpoint: "https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com/v1/opamp"

--- a/tests/general/default_config_test.go
+++ b/tests/general/default_config_test.go
@@ -144,6 +144,9 @@ func TestDefaultGatewayConfig(t *testing.T) {
 						},
 					},
 					"opamp/splunk_o11y": map[string]any{
+						"agent_description": map[string]any{
+							"include_resource_attributes": true,
+						},
 						"server": map[string]any{
 							"http": map[string]any{
 								"endpoint": "https://ingest.not.real.observability.splunkcloud.com/v1/opamp",
@@ -172,15 +175,6 @@ func TestDefaultGatewayConfig(t *testing.T) {
 					"resourcedetection/internal": map[string]any{
 						"detectors": []any{"gcp", "ecs", "ec2", "azure", "system"},
 						"override":  true,
-					},
-					"resource/add_mode": map[string]any{
-						"attributes": []any{
-							map[string]any{
-								"action": "insert",
-								"value":  "gateway",
-								"key":    "otelcol.service.mode",
-							},
-						},
 					},
 				},
 				"receivers": map[string]any{
@@ -243,6 +237,14 @@ func TestDefaultGatewayConfig(t *testing.T) {
 				},
 				"service": map[string]any{
 					"telemetry": map[string]any{
+						"resource": map[string]any{
+							"attributes": []any{
+								map[string]any{
+									"name":  "otelcol.service.mode",
+									"value": "gateway",
+								},
+							},
+						},
 						"metrics": map[string]any{
 							"readers": []any{
 								map[string]any{
@@ -284,7 +286,7 @@ func TestDefaultGatewayConfig(t *testing.T) {
 						},
 						"metrics/internal": map[string]any{
 							"exporters":  []any{"signalfx/internal"},
-							"processors": []any{"memory_limiter", "batch", "resourcedetection/internal", "resource/add_mode"},
+							"processors": []any{"memory_limiter", "batch", "resourcedetection/internal"},
 							"receivers":  []any{"prometheus/internal"},
 						},
 						"traces": map[string]any{
@@ -412,6 +414,9 @@ func TestDefaultAgentConfig(t *testing.T) {
 						},
 					},
 					"opamp/splunk_o11y": map[string]any{
+						"agent_description": map[string]any{
+							"include_resource_attributes": true,
+						},
 						"server": map[string]any{
 							"http": map[string]any{
 								"endpoint": "https://ingest.not.real.observability.splunkcloud.com/v1/opamp",
@@ -445,15 +450,6 @@ func TestDefaultAgentConfig(t *testing.T) {
 					"resourcedetection": map[string]any{
 						"detectors": []any{"gcp", "ecs", "ec2", "azure", "system"},
 						"override":  true,
-					},
-					"resource/add_mode": map[string]any{
-						"attributes": []any{
-							map[string]any{
-								"action": "insert",
-								"value":  "agent",
-								"key":    "otelcol.service.mode",
-							},
-						},
 					},
 				},
 				"receivers": map[string]any{
@@ -536,7 +532,7 @@ func TestDefaultAgentConfig(t *testing.T) {
 						},
 						"metrics/internal": map[string]any{
 							"exporters":  []any{"signalfx"},
-							"processors": []any{"memory_limiter", "batch", "resourcedetection", "resource/add_mode"},
+							"processors": []any{"memory_limiter", "batch", "resourcedetection"},
 							"receivers":  []any{"prometheus/internal"},
 						},
 						"traces": map[string]any{
@@ -551,6 +547,14 @@ func TestDefaultAgentConfig(t *testing.T) {
 						},
 					},
 					"telemetry": map[string]any{
+						"resource": map[string]any{
+							"attributes": []any{
+								map[string]any{
+									"name":  "otelcol.service.mode",
+									"value": "agent",
+								},
+							},
+						},
 						"metrics": map[string]any{
 							"readers": []any{
 								map[string]any{


### PR DESCRIPTION
**Description:**

Update the default hosted collector configurations so resource attributes attached to the Collector's internal telemetry are also exposed to the OpAMP extension, using the new declarative `service::telemetry::resource` (SDK API v0.3) shape. Tracked by OTL-4251.

**Changes:**

- Enable `agent_description.include_resource_attributes: true` on `opamp/splunk_o11y` in the `agent`, `gateway`, `fargate`, `ecs/ec2`, `otlp`, `upstream-agent`, `full` and FIPS variants so the Collector's resource attributes (e.g. `otelcol.service.mode`, `host.name`, `cloud.*`) are reported as OpAMP non-identifying attributes.
- Move `otelcol.service.mode` from the `resource/add_mode` processor into `service.telemetry.resource.attributes` for the agent and gateway configs (regular and FIPS), and drop the now-unused processor from the `metrics/internal` pipeline. The shape of the existing internal telemetry resource is preserved.
- Update `tests/general/default_config_test.go` and the `discoverymode` testdata fixtures to match the new shape.
- Add test cases to `internal/configconverter/discovery_test.go` covering: legacy inline-map attribute migration via `MigrateTelemetryResourceAttributes` + `SetupDiscovery`, preservation of existing v0.3 attributes lists, and creation of the telemetry block when absent.

Resource attributes set by the `resourcedetection` processor are intentionally not migrated in this change (out of scope for OTL-4251).

> **Note:** The `discovery.go` migration logic originally included in this PR was superseded by #7559, which introduced the shared `MigrateTelemetryResourceAttributes` converter and `AddDeclarativeTelemetryResourceAttribute` helper. Our changes are fully compatible with and build on that infrastructure.

Related: signalfx/splunk-otel-collector-chart#2418 (sibling change for the Helm chart).



**Testing:**

- Unit tests: `go test ./internal/configconverter/...` and `go build ./...` — all pass.
- Updated integration test expectations in `tests/general/default_config_test.go` (`TestDefaultAgentConfig`, `TestDefaultGatewayConfig`) to assert:
  - `agent_description.include_resource_attributes: true` is present on `opamp/splunk_o11y`
  - `service.telemetry.resource.attributes` contains `otelcol.service.mode` with the correct value (`agent` / `gateway`)
  - `resource/add_mode` is no longer declared as a processor or referenced in the `metrics/internal` pipeline
- End-to-end smoke test against a local cosmos OpAMP server with `--feature-gates=+splunk.opamp.enabled`:
  - Verified the new agent appears in cosmos with the expected non-identifying attributes:
    ```
    tags: [
      "host.arch=arm64",
      "host.name=ROSONAWA-M-HP4Y",
      "os.description=macOS 26.4.1",
      "os.type=darwin",
      "otelcol.service.mode=agent"
    ]
    ```
  - The reported effective config shows `service.telemetry.resource.attributes` populated with `otelcol.service.mode=agent` (v0.3 shape) and no `resource/add_mode` processor anywhere.
  - Confirmed internal telemetry shape is preserved: `target_info{otelcol_service_mode="agent", ...}` still present on `:8888/metrics`.

**Documentation:**

- `chloggen` entry added at `.chloggen/opamp-resource-v0-3-0.yaml` (component `agent, gateway`, change type `enhancement`, issue `4251`).
- Inline YAML comments added next to `agent_description.include_resource_attributes` and `service.telemetry.resource` in the touched configs.