### PR TITLE
add Splunk Platform metrics collection support

### DIFF
--- a/.chloggen/support-metrics-to-splunk-platform.yaml
+++ b/.chloggen/support-metrics-to-splunk-platform.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: installer
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add Splunk Platform log collection support to the Linux installer script.
+note: Add Splunk Platform metrics collection support to the Linux installer script.
 
 # One or more tracking issues related to the change
 issues: [7575]

--- a/.chloggen/support-metrics-to-splunk-platform.yaml
+++ b/.chloggen/support-metrics-to-splunk-platform.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: installer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add Splunk Platform log collection support to the Linux installer script.
+
+# One or more tracking issues related to the change
+issues: [7575]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  New flags `--splunk-platform-metrics-index` enable forwarding basic host metrics to Splunk Platform via HEC.

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -278,6 +278,8 @@ jobs:
                 docker_args+=(--network ecs-mock-net -e ECS_CONTAINER_METADATA_URI_V4=http://ecs-mock) ;;
               splunk_logs_config_linux.yaml)
                 docker_args+=(-e SPLUNK_PLATFORM_TOKEN=fake-token -e SPLUNK_PLATFORM_URL=https://fake-hec.splunkcloud.com/services/collector -e SPLUNK_PLATFORM_LOGS_INDEX=fake-index -e SPLUNK_LISTEN_INTERFACE=127.0.0.1 -e SPLUNK_FILE_STORAGE_EXTENSION_PATH=/tmp/filelogs) ;;
+              splunk_metrics_config_linux.yaml)
+                docker_args+=(-e SPLUNK_PLATFORM_TOKEN=fake-token -e SPLUNK_PLATFORM_URL=http://fake-hec.splunkcloud.com/services/collector -e SPLUNK_PLATFORM_METRICS_INDEX=fake-index -e SPLUNK_LISTEN_INTERFACE=127.0.0.1) ;;
             esac
             # TODO: set fake-token back to 12345 once https://github.com/open-telemetry/opentelemetry-collector/issues/10937 is resolved
             docker_args+=(-e "SPLUNK_CONFIG=/etc/otel/collector/${config}" -e SPLUNK_ACCESS_TOKEN=fake-token -e SPLUNK_REALM=fake-realm --name otelcol otelcol:latest)

--- a/cmd/otelcol/Dockerfile
+++ b/cmd/otelcol/Dockerfile
@@ -45,6 +45,7 @@ COPY --chown=999 config/collector/agent_config.yaml /etc/otel/collector/agent_co
 COPY --chown=999 config/collector/fargate_config.yaml /etc/otel/collector/fargate_config.yaml
 COPY --chown=999 config/collector/ecs_ec2_config.yaml /etc/otel/collector/ecs_ec2_config.yaml
 COPY --chown=999 config/collector/splunk_logs_config_linux.yaml /etc/otel/collector/splunk_logs_config_linux.yaml
+COPY --chown=999 config/collector/splunk_metrics_config_linux.yaml /etc/otel/collector/splunk_metrics_config_linux.yaml
 
 USER splunk-otel-collector
 ENTRYPOINT ["/otelcol"]

--- a/cmd/otelcol/config/collector/splunk_metrics_config_linux.yaml
+++ b/cmd/otelcol/config/collector/splunk_metrics_config_linux.yaml
@@ -1,0 +1,86 @@
+# Default configuration file for metrics collection on Linux, sending to Splunk Platform via HEC.
+#
+# If the collector is installed without the Linux installer script, the following
+# environment variables are required to be manually defined or configured below:
+# - SPLUNK_PLATFORM_TOKEN: The Splunk HEC authentication token
+# - SPLUNK_PLATFORM_URL: The Splunk HEC endpoint URL, e.g. https://http-inputs-acme.splunkcloud.com/services/collector
+# - SPLUNK_MEMORY_LIMIT_MIB: 90% of memory allocated
+#
+# The following environment variables are optional:
+# - SPLUNK_PLATFORM_METRICS_INDEX: Splunk index to send metrics to. If not set, the default index
+#   configured on the HEC token will be used.
+
+extensions:
+  health_check:
+    endpoint: "${SPLUNK_LISTEN_INTERFACE}:13133"
+  zpages:
+    expvar:
+      enabled: true
+
+receivers:
+
+  host_metrics/platform:
+    collection_interval: 10s
+    scrapers:
+      cpu:
+      disk:
+      filesystem:
+      memory:
+      network:
+      # System load average metrics https://en.wikipedia.org/wiki/Load_(computing)
+      load:
+      # Paging/Swap space utilization and I/O metrics
+      paging:
+      # Aggregated system process count metrics
+      processes:
+      # System processes metrics, disabled by default
+      # process:
+
+processors:
+  memory_limiter:
+    check_interval: 2s
+    limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+
+  resourcedetection:
+    detectors: [gcp, ecs, ec2, azure, system]
+    override: true
+
+exporters:
+  splunk_hec/metrics:
+    token: "${SPLUNK_PLATFORM_TOKEN}"
+    endpoint: "${SPLUNK_PLATFORM_URL}"
+    index: "${SPLUNK_PLATFORM_METRICS_INDEX}"
+    log_data_enabled: false
+    disable_compression: true
+    use_multi_metric_format: true
+    timeout: 10s
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_elapsed_time: 300s
+      max_interval: 30s
+    sending_queue:
+      enabled: true
+      num_consumers: 10
+      queue_size: 10000
+      batch:
+    tls:
+      insecure_skip_verify: false
+
+service:
+  telemetry:
+    logs:
+      level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '127.0.0.1'
+                port: 8888
+  extensions: [health_check, zpages]
+  pipelines:
+    metrics/platform:
+      receivers: [host_metrics/platform]
+      processors: [memory_limiter, resourcedetection]
+      exporters: [splunk_hec/metrics]

--- a/cmd/otelcol/config/collector/splunk_metrics_config_linux.yaml
+++ b/cmd/otelcol/config/collector/splunk_metrics_config_linux.yaml
@@ -49,7 +49,9 @@ exporters:
   splunk_hec/metrics:
     token: "${SPLUNK_PLATFORM_TOKEN}"
     endpoint: "${SPLUNK_PLATFORM_URL}"
+    source: "otel"
     index: "${SPLUNK_PLATFORM_METRICS_INDEX}"
+    splunk_app_name: "splunk-otel-collector"
     log_data_enabled: false
     disable_compression: true
     use_multi_metric_format: true

--- a/cmd/otelcol/main_test.go
+++ b/cmd/otelcol/main_test.go
@@ -41,7 +41,7 @@ func TestRunFromCmdLine(t *testing.T) {
 
 	configFiles, err = filepath.Glob(filepath.Join("config", "collector", "*.yaml"))
 	require.NoError(t, err)
-	require.Len(t, configFiles, 9, "A new test case must be added to TestRunFromCmdLine to validate default configurations")
+	require.Len(t, configFiles, 10, "A new test case must be added to TestRunFromCmdLine to validate default configurations")
 
 	tests := []struct {
 		extraEnvVars map[string]string

--- a/cmd/otelcol/main_test.go
+++ b/cmd/otelcol/main_test.go
@@ -149,6 +149,18 @@ func TestRunFromCmdLine(t *testing.T) {
 			skipWindows:  true,
 		},
 		{
+			name: "splunk_metrics_linux",
+			args: []string{"otelcol", "--config=config/collector/splunk_metrics_config_linux.yaml"},
+			extraEnvVars: map[string]string{
+				"SPLUNK_PLATFORM_TOKEN":         "test-token",
+				"SPLUNK_PLATFORM_URL":           "https://localhost:8088/services/collector",
+				"SPLUNK_PLATFORM_METRICS_INDEX": "metrics",
+			},
+			timeout:      15 * time.Second,
+			validateOnly: true,
+			skipWindows:  true,
+		},
+		{
 			name:    "default_discovery",
 			args:    []string{"otelcol", "--discovery", "--config=config/collector/agent_config.yaml"},
 			timeout: 30 * time.Second,

--- a/packaging/fpm/common.sh
+++ b/packaging/fpm/common.sh
@@ -37,6 +37,8 @@ GATEWAY_CONFIG_REPO_PATH="$REPO_DIR/cmd/otelcol/config/collector/gateway_config.
 GATEWAY_CONFIG_INSTALL_PATH="/etc/otel/collector/gateway_config.yaml"
 LOGS_CONFIG_REPO_PATH="$REPO_DIR/cmd/otelcol/config/collector/splunk_logs_config_linux.yaml"
 LOGS_CONFIG_INSTALL_PATH="/etc/otel/collector/splunk_logs_config_linux.yaml"
+METRICS_CONFIG_REPO_PATH="$REPO_DIR/cmd/otelcol/config/collector/splunk_metrics_config_linux.yaml"
+METRICS_CONFIG_INSTALL_PATH="/etc/otel/collector/splunk_metrics_config_linux.yaml"
 SERVICE_REPO_PATH="$FPM_DIR/$SERVICE_NAME.service"
 SERVICE_INSTALL_PATH="/lib/systemd/system/$SERVICE_NAME.service"
 
@@ -92,6 +94,7 @@ setup_files_and_permissions() {
     cp -f "$AGENT_CONFIG_REPO_PATH" "$buildroot/$AGENT_CONFIG_INSTALL_PATH"
     cp -f "$GATEWAY_CONFIG_REPO_PATH" "$buildroot/$GATEWAY_CONFIG_INSTALL_PATH"
     cp -f "$LOGS_CONFIG_REPO_PATH" "$buildroot/$LOGS_CONFIG_INSTALL_PATH"
+    cp -f "$METRICS_CONFIG_REPO_PATH" "$buildroot/$METRICS_CONFIG_INSTALL_PATH"
     sudo chown -R $SERVICE_USER:$SERVICE_GROUP "$buildroot/etc/otel"
     sudo chmod -R 755 "$buildroot/etc/otel"
     sudo chmod 600 "$buildroot/etc/otel/collector/$SERVICE_NAME.conf.example"

--- a/packaging/fpm/deb/build.sh
+++ b/packaging/fpm/deb/build.sh
@@ -61,6 +61,7 @@ sudo fpm -s dir -t deb -n "$PKG_NAME" -v "$VERSION" -f -p "$OUTPUT_DIR" \
     --config-files "$AGENT_CONFIG_INSTALL_PATH" \
     --config-files "$GATEWAY_CONFIG_INSTALL_PATH" \
     --config-files "$LOGS_CONFIG_INSTALL_PATH" \
+    --config-files "$METRICS_CONFIG_INSTALL_PATH" \
     "$buildroot/"=/
 
 dpkg -c "${OUTPUT_DIR}/${PKG_NAME}_${VERSION}_${ARCH}.deb"

--- a/packaging/fpm/rpm/build.sh
+++ b/packaging/fpm/rpm/build.sh
@@ -67,6 +67,7 @@ sudo fpm -s dir -t rpm -n "$PKG_NAME" -v "$VERSION" -f -p "$OUTPUT_DIR" \
     --config-files "$AGENT_CONFIG_INSTALL_PATH" \
     --config-files "$GATEWAY_CONFIG_INSTALL_PATH" \
     --config-files "$LOGS_CONFIG_INSTALL_PATH" \
+    --config-files "$METRICS_CONFIG_INSTALL_PATH" \
     "$buildroot/"=/
 
 rpm -qpli "${OUTPUT_DIR}/${PKG_NAME}-${VERSION}*.${ARCH}.rpm"

--- a/packaging/installer/install.sh
+++ b/packaging/installer/install.sh
@@ -1662,10 +1662,13 @@ parse_args_and_install() {
       exit 0
   fi
 
-  # Log collection is enabled when --splunk-platform-url is provided.
-  # --splunk-platform-token is required alongside it.
-  # --splunk-platform-logs-index is optional; if omitted, the index defaults to whatever is
-  # configured on the HEC token.
+  # When --splunk-platform-url is provided, the following rules determine what is collected:
+  # - If only --splunk-platform-metrics-index is set: only metrics collection is enabled.
+  # - If neither index is set: log collection is enabled by default.
+  # - If both indexes are set: both logs and metrics collection are enabled.
+  # --splunk-platform-token is required alongside --splunk-platform-url.
+  # --splunk-platform-logs-index is optional when logs are enabled; if omitted, the index
+  # defaults to whatever is configured on the HEC token.
   # Validate before prompting for access token to avoid blocking on interactive input.
   if [ -n "$splunk_platform_token" ] || [ -n "$splunk_platform_logs_index" ] || [ -n "$splunk_platform_metrics_index" ]; then
     if [ -z "$splunk_platform_url" ]; then
@@ -1686,7 +1689,8 @@ parse_args_and_install() {
     if [ -n "$splunk_platform_metrics_index" ]; then
       with_metrics="true"
     fi
-    if [ -n "$splunk_platform_logs_index" ]; then
+    # Enable logs by default unless only metrics index was specified.
+    if [ -n "$splunk_platform_logs_index" ] || [ -z "$splunk_platform_metrics_index" ]; then
       with_logs="true"
     fi
   fi

--- a/packaging/installer/install.sh
+++ b/packaging/installer/install.sh
@@ -63,6 +63,7 @@ agent_config_path="${collector_config_dir}/agent_config.yaml"
 gateway_config_path="${collector_config_dir}/gateway_config.yaml"
 logs_config_path="${collector_config_dir}/splunk_logs_config_linux.yaml"
 logs_file_storage_path="/var/lib/otelcol/filelogs"
+metrics_config_path="${collector_config_dir}/splunk_metrics_config_linux.yaml"
 old_config_path="${collector_config_dir}/splunk_config_linux.yaml"
 collector_env_path="${collector_config_dir}/splunk-otel-collector.conf"
 collector_env_old_path="${collector_config_dir}/splunk_env"
@@ -1124,6 +1125,9 @@ Splunk Platform:
   --splunk-platform-url <url>           Set the Splunk Platform HEC endpoint URL.
   --splunk-platform-logs-index <index>  Set the Splunk index to send logs to.
                                         Optional: if omitted, the index defaults to the one configured on the HEC token.
+  --splunk-platform-metrics-index <index>  Set the Splunk index to send metrics to. This option enables Splunk Platform
+                                        metrics collection and must be specified when configuring metrics via this
+                                        installer.
 
 Auto Instrumentation:
   --with[out]-instrumentation           Whether to install the splunk-otel-auto-instrumentation package and add the
@@ -1397,6 +1401,8 @@ parse_args_and_install() {
   local splunk_platform_url=
   local splunk_platform_logs_index=
   local with_logs="false"
+  local splunk_platform_metrics_index=
+  local with_metrics="false"
   local godebug=
   local ingest_url=
   local insecure=
@@ -1463,6 +1469,10 @@ parse_args_and_install() {
         ;;
       --splunk-platform-logs-index)
         splunk_platform_logs_index="$2"
+        shift 1
+        ;;
+      --splunk-platform-metrics-index)
+        splunk_platform_metrics_index="$2"
         shift 1
         ;;
       --godebug)
@@ -1657,9 +1667,9 @@ parse_args_and_install() {
   # --splunk-platform-logs-index is optional; if omitted, the index defaults to whatever is
   # configured on the HEC token.
   # Validate before prompting for access token to avoid blocking on interactive input.
-  if [ -n "$splunk_platform_token" ] || [ -n "$splunk_platform_logs_index" ]; then
+  if [ -n "$splunk_platform_token" ] || [ -n "$splunk_platform_logs_index" ] || [ -n "$splunk_platform_metrics_index" ]; then
     if [ -z "$splunk_platform_url" ]; then
-      echo "[ERROR] --splunk-platform-url is required when --splunk-platform-token or --splunk-platform-logs-index is set." >&2
+      echo "[ERROR] --splunk-platform-url is required when --splunk-platform-token or --splunk-platform-logs-index or --splunk-platform-metrics-index is set." >&2
       exit 1
     fi
   fi
@@ -1670,10 +1680,15 @@ parse_args_and_install() {
       exit 1
     fi
     if [ "$mode" = "gateway" ]; then
-      echo "[ERROR] Splunk Platform log collection is not supported in gateway mode." >&2
+      echo "[ERROR] Splunk Platform ingestion is not supported in gateway mode." >&2
       exit 1
     fi
-    with_logs="true"
+    if [ -n "$splunk_platform_metrics_index" ]; then
+      with_metrics="true"
+    fi
+    if [ -n "$splunk_platform_logs_index" ]; then
+      with_logs="true"
+    fi
   fi
 
   if [ -z "$access_token" ] && [ -z "$splunk_platform_url" ]; then
@@ -1933,9 +1948,9 @@ parse_args_and_install() {
     configure_env_file "SPLUNK_INGEST_URL" "$ingest_url" "$collector_env_path"
     configure_env_file "SPLUNK_HEC_URL" "$hec_url" "$collector_env_path"
     configure_env_file "SPLUNK_HEC_TOKEN" "$hec_token" "$collector_env_path"
-     if [ "${with_logs:-false}" != "true" ]; then
-       configure_env_file "SPLUNK_CONFIG" "$collector_config_path" "$collector_env_path"
-     fi
+    if [ "${with_logs:-false}" != "true" ] && [ "${with_metrics:-false}" != "true" ]; then
+      configure_env_file "SPLUNK_CONFIG" "$collector_config_path" "$collector_env_path"
+    fi
   fi
   configure_env_file "GODEBUG" "$godebug" "$collector_env_path"
   configure_env_file "SPLUNK_MEMORY_TOTAL_MIB" "$memory" "$collector_env_path"
@@ -1945,20 +1960,34 @@ parse_args_and_install() {
     otelcol_options="--discovery"
   fi
 
-  if [ "$with_logs" = "true" ]; then
-    mkdir -p "$logs_file_storage_path"
-    chown -R $service_user:$service_group "$logs_file_storage_path"
-    chmod 700 "$logs_file_storage_path"
+  if [ "$with_logs" = "true" ] || [ "$with_metrics" = "true" ]; then
     configure_env_file "SPLUNK_PLATFORM_URL" "$splunk_platform_url" "$collector_env_path"
     configure_env_file "SPLUNK_PLATFORM_TOKEN" "$splunk_platform_token" "$collector_env_path"
-    configure_env_file "SPLUNK_FILE_STORAGE_EXTENSION_PATH" "$logs_file_storage_path" "$collector_env_path"
-    if [ -n "$splunk_platform_logs_index" ]; then
-      configure_env_file "SPLUNK_PLATFORM_LOGS_INDEX" "$splunk_platform_logs_index" "$collector_env_path"
+    if [ "$with_logs" = "true" ]; then
+      mkdir -p "$logs_file_storage_path"
+      chown -R $service_user:$service_group "$logs_file_storage_path"
+      chmod 700 "$logs_file_storage_path"
+      configure_env_file "SPLUNK_FILE_STORAGE_EXTENSION_PATH" "$logs_file_storage_path" "$collector_env_path"
+      if [ -n "$splunk_platform_logs_index" ]; then
+        configure_env_file "SPLUNK_PLATFORM_LOGS_INDEX" "$splunk_platform_logs_index" "$collector_env_path"
+      fi
+    fi
+    if [ "$with_metrics" = "true" ]; then
+      configure_env_file "SPLUNK_PLATFORM_METRICS_INDEX" "$splunk_platform_metrics_index" "$collector_env_path"
+    fi
+    local platform_configs=
+    if [ "$with_logs" = "true" ]; then
+      platform_configs="$platform_configs --config $logs_config_path"
+    fi
+    if [ "$with_metrics" = "true" ]; then
+      platform_configs="$platform_configs --config $metrics_config_path"
     fi
     if [ -n "$access_token" ]; then
-      otelcol_options="$otelcol_options --config $collector_config_path --config $logs_config_path --feature-gates=confmap.enableMergeAppendOption"
+      otelcol_options="$otelcol_options --config $collector_config_path$platform_configs --feature-gates=confmap.enableMergeAppendOption"
+    elif [ "$with_logs" = "true" ] && [ "$with_metrics" = "true" ]; then
+      otelcol_options="$otelcol_options$platform_configs --feature-gates=confmap.enableMergeAppendOption"
     else
-      otelcol_options="$otelcol_options --config $logs_config_path"
+      otelcol_options="$otelcol_options$platform_configs"
     fi
   fi
 
@@ -2005,8 +2034,13 @@ EOH
 EOH
   fi
 
-  cat <<EOH
+  if [ "$with_metrics" = "true" ]; then
+    cat <<EOH
+  Splunk Platform metrics config:   $metrics_config_path
+EOH
+  fi
 
+  cat <<EOH
 You can modify any of the above configuration files to customize the collector's behavior.
 To apply changes, restart the collector:
 

--- a/packaging/tests/installer_test.py
+++ b/packaging/tests/installer_test.py
@@ -682,6 +682,7 @@ def test_installer_with_obi(distro, arch):
 SPLUNK_PLATFORM_TOKEN = os.environ.get("SPLUNK_PLATFORM_TOKEN", "test-hec-token")
 SPLUNK_PLATFORM_URL = os.environ.get("SPLUNK_PLATFORM_URL", "https://splunk.example.com:8088/services/collector")
 SPLUNK_PLATFORM_LOGS_INDEX = "test-logs-index"
+SPLUNK_PLATFORM_METRICS_INDEX = "test-metrics-index"
 
 
 def get_platform_installer_cmd():
@@ -767,7 +768,7 @@ def test_installer_splunk_platform_logs_missing_token(distro, arch):
 )
 @pytest.mark.parametrize("arch", ["amd64", "arm64"])
 def test_installer_splunk_platform_logs_missing_url(distro, arch):
-    """Verify installer errors when --splunk-platform-token is provided without --splunk-platform-url."""
+    """Verify installer errors when --splunk-platform-token and --splunk-platform-logs-index is provided without --splunk-platform-url."""
     install_cmd = " ".join((
         get_platform_installer_cmd(),
         f"--splunk-platform-token {SPLUNK_PLATFORM_TOKEN}",
@@ -795,11 +796,11 @@ def test_installer_splunk_platform_logs_missing_url(distro, arch):
 )
 @pytest.mark.parametrize("arch", ["amd64", "arm64"])
 def test_installer_splunk_platform_metrics_missing_url(distro, arch):
-    """Verify installer errors when --splunk-metrics-token is provided without --splunk-platform-url."""
+    """Verify installer errors when --splunk-platform-token and --splunk-platform-metrics-index is provided without --splunk-platform-url."""
     install_cmd = " ".join((
         get_platform_installer_cmd(),
         f"--splunk-platform-token {SPLUNK_PLATFORM_TOKEN}",
-        f"--splunk-platform-metrics-index {SPLUNK_PLATFORM_LOGS_INDEX}",
+        f"--splunk-platform-metrics-index {SPLUNK_PLATFORM_METRICS_INDEX}",
     ))
 
     print(f"Testing Splunk Platform metrics missing url on {distro} ({arch}) ...")

--- a/packaging/tests/installer_test.py
+++ b/packaging/tests/installer_test.py
@@ -785,3 +785,31 @@ def test_installer_splunk_platform_logs_missing_url(distro, arch):
         _, output = run_container_cmd(container, f"{install_cmd} 2>&1", exit_code=1, timeout=INSTALLER_TIMEOUT)
         assert "--splunk-platform-url is required when --splunk-platform-token or --splunk-platform-logs-index or --splunk-platform-metrics-index is set" in output.decode("utf-8"), \
             f"Expected missing url error message, got: {output.decode('utf-8')}"
+
+
+@pytest.mark.installer
+@pytest.mark.parametrize(
+    "distro",
+    [pytest.param(distro, marks=pytest.mark.deb) for distro in DEB_DISTROS]
+    + [pytest.param(distro, marks=pytest.mark.rpm) for distro in RPM_DISTROS],
+)
+@pytest.mark.parametrize("arch", ["amd64", "arm64"])
+def test_installer_splunk_platform_metrics_missing_url(distro, arch):
+    """Verify installer errors when --splunk-metrics-token is provided without --splunk-platform-url."""
+    install_cmd = " ".join((
+        get_platform_installer_cmd(),
+        f"--splunk-platform-token {SPLUNK_PLATFORM_TOKEN}",
+        f"--splunk-platform-metrics-index {SPLUNK_PLATFORM_LOGS_INDEX}",
+    ))
+
+    print(f"Testing Splunk Platform metrics missing url on {distro} ({arch}) ...")
+    with run_distro_container(distro, arch) as container:
+        copy_file_into_container(container, INSTALLER_PATH, "/test/install.sh")
+        if LOCAL_COLLECTOR_PACKAGE:
+            copy_file_into_container(container, LOCAL_COLLECTOR_PACKAGE, "/test/collector.pkg")
+            if distro in DEB_DISTROS:
+                run_container_cmd(container, "apt-get install -y libcap2-bin")
+
+        _, output = run_container_cmd(container, f"{install_cmd} 2>&1", exit_code=1, timeout=INSTALLER_TIMEOUT)
+        assert "--splunk-platform-url is required when --splunk-platform-token or --splunk-platform-logs-index or --splunk-platform-metrics-index is set" in output.decode("utf-8"), \
+            f"Expected missing url error message, got: {output.decode('utf-8')}"

--- a/packaging/tests/installer_test.py
+++ b/packaging/tests/installer_test.py
@@ -783,5 +783,5 @@ def test_installer_splunk_platform_logs_missing_url(distro, arch):
                 run_container_cmd(container, "apt-get install -y libcap2-bin")
 
         _, output = run_container_cmd(container, f"{install_cmd} 2>&1", exit_code=1, timeout=INSTALLER_TIMEOUT)
-        assert "--splunk-platform-url is required when --splunk-platform-token or --splunk-platform-logs-index is set" in output.decode("utf-8"), \
+        assert "--splunk-platform-url is required when --splunk-platform-token or --splunk-platform-logs-index or --splunk-platform-metrics-index is set" in output.decode("utf-8"), \
             f"Expected missing url error message, got: {output.decode('utf-8')}"

--- a/tests/general/splunk_platform_metrics_test.go
+++ b/tests/general/splunk_platform_metrics_test.go
@@ -1,0 +1,315 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/signalfx/splunk-otel-collector/tests/testutils"
+)
+
+func TestSplunkPlatformMetricsEffectiveConfig(t *testing.T) {
+	tc := testutils.NewTestcase(t)
+	defer tc.PrintLogsOnFailure()
+	defer tc.ShutdownOTLPReceiverSink()
+
+	collector, shutdown := tc.SplunkOtelCollectorContainer(
+		"",
+		func(collector testutils.Collector) testutils.Collector {
+			return collector.WithArgs(
+				"--config", "/etc/otel/collector/splunk_metrics_config_linux.yaml",
+			).WithEnv(map[string]string{
+				"SPLUNK_PLATFORM_TOKEN":         "test-token",
+				"SPLUNK_PLATFORM_URL":           "https://http-inputs-test.splunkcloud.com/services/collector",
+				"SPLUNK_PLATFORM_METRICS_INDEX": "main",
+				"SPLUNK_LISTEN_INTERFACE":       "127.0.0.1",
+			})
+		},
+	)
+	defer shutdown()
+
+	config := collector.EffectiveConfig(t)
+
+	// Only the platform metrics pipeline is present (no logs, no traces, no o11y components).
+	service, ok := config["service"].(map[string]any)
+	require.True(t, ok)
+	pipelines, ok := service["pipelines"].(map[string]any)
+	require.True(t, ok)
+
+	require.Contains(t, pipelines, "metrics/platform")
+	require.NotContains(t, pipelines, "logs")
+	require.NotContains(t, pipelines, "traces")
+	require.NotContains(t, pipelines, "metrics") // no o11y metrics pipeline
+
+	metricsPlatform, ok := pipelines["metrics/platform"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, []any{"host_metrics/platform"}, metricsPlatform["receivers"])
+	require.Equal(t, []any{"memory_limiter", "resourcedetection"}, metricsPlatform["processors"])
+	require.Equal(t, []any{"splunk_hec/metrics"}, metricsPlatform["exporters"])
+
+	// The platform HEC exporter points at the configured URL and index.
+	exporters, ok := config["exporters"].(map[string]any)
+	require.True(t, ok)
+	hecMetrics, ok := exporters["splunk_hec/metrics"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "https://http-inputs-test.splunkcloud.com/services/collector", hecMetrics["endpoint"])
+	require.Equal(t, "main", hecMetrics["index"])
+	require.Equal(t, "<redacted>", hecMetrics["token"])
+
+	// Only health_check and zpages extensions are present (no file_storage, no smartagent, etc.).
+	extensions, ok := config["extensions"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, extensions, "health_check")
+	require.Contains(t, extensions, "zpages")
+	require.NotContains(t, extensions, "file_storage/filelogs")
+	require.NotContains(t, extensions, "smartagent")
+
+	serviceExtensions, ok := service["extensions"].([]any)
+	require.True(t, ok)
+	require.ElementsMatch(t, []any{"health_check", "zpages", "config_source_telemetry"}, serviceExtensions)
+
+	// Only the platform metrics processors are present.
+	processors, ok := config["processors"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, map[string]any{
+		"memory_limiter": map[string]any{
+			"check_interval": "2s",
+			"limit_mib":      460,
+		},
+		"resourcedetection": map[string]any{
+			"detectors": []any{"gcp", "ecs", "ec2", "azure", "system"},
+			"override":  true,
+		},
+	}, processors)
+}
+
+func TestSplunkPlatformMetricsWithO11yEffectiveConfig(t *testing.T) {
+	tc := testutils.NewTestcase(t)
+	defer tc.PrintLogsOnFailure()
+	defer tc.ShutdownOTLPReceiverSink()
+
+	collector, shutdown := tc.SplunkOtelCollectorContainer(
+		"",
+		func(collector testutils.Collector) testutils.Collector {
+			return collector.WithArgs(
+				"--config", "/etc/otel/collector/agent_config.yaml",
+				"--config", "/etc/otel/collector/splunk_metrics_config_linux.yaml",
+				"--feature-gates=confmap.enableMergeAppendOption",
+			).WithEnv(map[string]string{
+				"SPLUNK_ACCESS_TOKEN":           "not.real",
+				"SPLUNK_REALM":                  "not.real",
+				"SPLUNK_HEC_TOKEN":              "not.real",
+				"SPLUNK_INGEST_URL":             "http://127.0.0.1:0",
+				"SPLUNK_API_URL":                "http://127.0.0.1:0",
+				"SPLUNK_HEC_URL":                "http://127.0.0.1:0",
+				"SPLUNK_PLATFORM_TOKEN":         "test-token",
+				"SPLUNK_PLATFORM_URL":           "https://http-inputs-test.splunkcloud.com/services/collector",
+				"SPLUNK_PLATFORM_METRICS_INDEX": "main",
+				"SPLUNK_LISTEN_INTERFACE":       "127.0.0.1",
+			})
+		},
+	)
+	defer shutdown()
+
+	config := collector.EffectiveConfig(t)
+
+	// Verify both o11y pipelines from agent_config.yaml and the platform metrics pipeline are present.
+	service, ok := config["service"].(map[string]any)
+	require.True(t, ok)
+	pipelines, ok := service["pipelines"].(map[string]any)
+	require.True(t, ok)
+
+	// agent_config.yaml pipelines are present.
+	require.Contains(t, pipelines, "metrics")
+	require.Contains(t, pipelines, "traces")
+	require.Contains(t, pipelines, "logs")
+
+	// splunk_metrics_config_linux.yaml pipeline is present.
+	require.Contains(t, pipelines, "metrics/platform")
+
+	metricsPlatform, ok := pipelines["metrics/platform"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, []any{"host_metrics/platform"}, metricsPlatform["receivers"])
+	require.Equal(t, []any{"splunk_hec/metrics"}, metricsPlatform["exporters"])
+
+	// splunk_hec/metrics exporter is present in the merged config.
+	exporters, ok := config["exporters"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, exporters, "splunk_hec/metrics")
+
+	// All extensions from agent_config.yaml plus health_check from metrics config are present.
+	serviceExtensions, ok := service["extensions"].([]any)
+	require.True(t, ok)
+	require.Contains(t, serviceExtensions, "health_check")
+	require.Contains(t, serviceExtensions, "headers_setter")
+	require.Contains(t, serviceExtensions, "http_forwarder")
+	require.Contains(t, serviceExtensions, "http_forwarder/opamp_splunk_o11y")
+	require.Contains(t, serviceExtensions, "zpages")
+
+	extensions, ok := config["extensions"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, extensions, "health_check")
+	require.Contains(t, extensions, "headers_setter")
+	require.Contains(t, extensions, "http_forwarder")
+	require.Contains(t, extensions, "http_forwarder/opamp_splunk_o11y")
+	require.Contains(t, extensions, "zpages")
+
+	// Processors from both configs are present in the merged config.
+	processors, ok := config["processors"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, map[string]any{
+		"batch": map[string]any{
+			"metadata_keys": []any{"X-SF-Token"},
+		},
+		"memory_limiter": map[string]any{
+			"check_interval": "2s",
+			"limit_mib":      460,
+		},
+		"resourcedetection": map[string]any{
+			"detectors": []any{"gcp", "ecs", "ec2", "azure", "system"},
+			"override":  true,
+		},
+		"resource/add_mode": map[string]any{
+			"attributes": []any{
+				map[string]any{
+					"action": "insert",
+					"value":  "agent",
+					"key":    "otelcol.service.mode",
+				},
+			},
+		},
+	}, processors)
+}
+
+func TestSplunkPlatformMetricsConfig(t *testing.T) {
+	tc := testutils.NewHECTestcase(t)
+	defer tc.PrintLogsOnFailure()
+	defer tc.ShutdownHECReceiverSink()
+
+	path, err := filepath.Abs("../../cmd/otelcol/config/collector/splunk_metrics_config_linux.yaml")
+	require.NoError(t, err)
+
+	_, shutdown := tc.SplunkOtelCollectorProcess(path,
+		func(collector testutils.Collector) testutils.Collector {
+			return collector.WithEnv(map[string]string{
+				"SPLUNK_PLATFORM_TOKEN":         "test-token",
+				"SPLUNK_PLATFORM_URL":           tc.HECEndpointForCollector,
+				"SPLUNK_PLATFORM_METRICS_INDEX": "test-index",
+				"SPLUNK_MEMORY_LIMIT_MIB":       "256",
+				"SPLUNK_LISTEN_INTERFACE":       "127.0.0.1",
+			})
+		},
+	)
+	defer shutdown()
+
+	assertHostMetricsReceived(t, tc.HECReceiverSink)
+}
+
+// TestSplunkPlatformMetricsWithO11yDataFlow verifies that when both the agent and platform metrics configs
+// are loaded together, the platform metrics pipeline delivers host metrics to the HEC sink and the o11y
+// metrics pipeline (host_metrics → otlp_grpc/gateway) delivers metrics to the OTLP sink.
+func TestSplunkPlatformMetricsWithO11yDataFlow(t *testing.T) {
+	// Use NewTestcase for the OTLP sink (o11y metrics) and create a separate HEC sink for platform metrics.
+	tc := testutils.NewTestcase(t)
+	defer tc.PrintLogsOnFailure()
+	defer tc.ShutdownOTLPReceiverSink()
+
+	hecSink, err := testutils.NewHECReceiverSink().WithEndpoint(fmt.Sprintf("0.0.0.0:%d", testutils.GetAvailablePort(t))).Build()
+	require.NoError(t, err)
+	require.NoError(t, hecSink.Start())
+	defer func() { require.NoError(t, hecSink.Shutdown()) }()
+	hecEndpointForCollector := "http://127.0.0.1:" + strings.Split(hecSink.Endpoint, ":")[1]
+
+	agentPath, err := filepath.Abs("../../cmd/otelcol/config/collector/agent_config.yaml")
+	require.NoError(t, err)
+	metricsPath, err := filepath.Abs("../../cmd/otelcol/config/collector/splunk_metrics_config_linux.yaml")
+	require.NoError(t, err)
+
+	// Write an override config that points otlp_grpc/gateway at the test OTLP sink.
+	overrideContent := "exporters:\n  otlp_grpc/gateway:\n    endpoint: " + tc.OTLPEndpointForCollector + "\n    tls:\n      insecure: true\nservice:\n  pipelines:\n    metrics:\n      exporters: [otlp_grpc/gateway]\n"
+	overrideFile, err := os.CreateTemp(t.TempDir(), "otlp-override-*.yaml")
+	require.NoError(t, err)
+	_, err = overrideFile.WriteString(overrideContent)
+	require.NoError(t, err)
+	require.NoError(t, overrideFile.Close())
+
+	_, shutdown := tc.SplunkOtelCollectorProcess("",
+		func(collector testutils.Collector) testutils.Collector {
+			return collector.
+				WithArgs(
+					"--set=service.telemetry.logs.level=debug",
+					"--config", agentPath,
+					"--config", metricsPath,
+					"--config", overrideFile.Name(),
+					"--feature-gates=confmap.enableMergeAppendOption",
+					"--set=service.telemetry.metrics.level=none",
+				).
+				WithEnv(map[string]string{
+					"SPLUNK_ACCESS_TOKEN":           "not.real",
+					"SPLUNK_REALM":                  "not.real",
+					"SPLUNK_HEC_TOKEN":              "not.real",
+					"SPLUNK_INGEST_URL":             "http://127.0.0.1:0",
+					"SPLUNK_API_URL":                "http://127.0.0.1:0",
+					"SPLUNK_HEC_URL":                "http://127.0.0.1:0",
+					"SPLUNK_GATEWAY_URL":            "127.0.0.1",
+					"SPLUNK_PLATFORM_TOKEN":         "test-token",
+					"SPLUNK_PLATFORM_URL":           hecEndpointForCollector,
+					"SPLUNK_PLATFORM_METRICS_INDEX": "test-index",
+					"SPLUNK_MEMORY_LIMIT_MIB":       "256",
+					"SPLUNK_LISTEN_INTERFACE":       "127.0.0.1",
+				})
+		},
+	)
+	defer shutdown()
+
+	// Verify platform metrics flow: host_metrics/platform data points arrive at the HEC sink.
+	assertHostMetricsReceived(t, hecSink)
+
+	// Verify o11y metrics flow: host_metrics (system.cpu.time) arrives at the OTLP sink.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		found := false
+		for _, metrics := range tc.OTLPReceiverSink.AllMetrics() {
+			for i := range metrics.ResourceMetrics().Len() {
+				rm := metrics.ResourceMetrics().At(i)
+				for j := range rm.ScopeMetrics().Len() {
+					for k := range rm.ScopeMetrics().At(j).Metrics().Len() {
+						if rm.ScopeMetrics().At(j).Metrics().At(k).Name() == "system.cpu.time" {
+							found = true
+						}
+					}
+				}
+			}
+		}
+		require.True(c, found, "host metric system.cpu.time not found in OTLP sink")
+	}, 60*time.Second, 500*time.Millisecond)
+}
+
+func assertHostMetricsReceived(t *testing.T, sink *testutils.HECReceiverSink) {
+	t.Helper()
+	// splunk_hec/metrics sends metrics as HEC metric events; verify data points arrive.
+	require.Eventually(t, func() bool {
+		return sink.DataPointCount() > 0
+	}, 60*time.Second, 500*time.Millisecond)
+}

--- a/tests/general/splunk_platform_metrics_test.go
+++ b/tests/general/splunk_platform_metrics_test.go
@@ -191,15 +191,6 @@ func TestSplunkPlatformMetricsWithO11yEffectiveConfig(t *testing.T) {
 			"detectors": []any{"gcp", "ecs", "ec2", "azure", "system"},
 			"override":  true,
 		},
-		"resource/add_mode": map[string]any{
-			"attributes": []any{
-				map[string]any{
-					"action": "insert",
-					"value":  "agent",
-					"key":    "otelcol.service.mode",
-				},
-			},
-		},
 	}, processors)
 }
 

--- a/tests/testutils/hec_receiver_sink.go
+++ b/tests/testutils/hec_receiver_sink.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
 	mnoop "go.opentelemetry.io/otel/metric/noop"
 	tnoop "go.opentelemetry.io/otel/trace/noop"
@@ -35,13 +36,15 @@ const (
 )
 
 // To be used as a builder whose Build() method provides the actual instance capable of starting the HEC receiver
-// providing received metrics to test cases.
+// providing received logs and metrics to test cases.
 type HECReceiverSink struct {
-	Host         component.Host
-	logsReceiver *receiver.Logs
-	logsSink     *consumertest.LogsSink
-	Logger       *zap.Logger
-	Endpoint     string
+	Host            component.Host
+	logsReceiver    *receiver.Logs
+	logsSink        *consumertest.LogsSink
+	metricsReceiver *receiver.Metrics
+	metricsSink     *consumertest.MetricsSink
+	Logger          *zap.Logger
+	Endpoint        string
 }
 
 func NewHECReceiverSink() HECReceiverSink {
@@ -54,7 +57,7 @@ func (hec HECReceiverSink) WithEndpoint(endpoint string) HECReceiverSink {
 	return hec
 }
 
-// Build will create, configure, and start an HECReceiver with GRPC listener and associated metric and log sinks
+// Build will create and configure an HECReceiver with associated log and metric sinks.
 func (hec HECReceiverSink) Build() (*HECReceiverSink, error) {
 	if hec.Endpoint == "" {
 		return nil, errors.New("must provide an Endpoint for HECReceiverSink")
@@ -63,6 +66,7 @@ func (hec HECReceiverSink) Build() (*HECReceiverSink, error) {
 	hec.Host = componenttest.NewNopHost()
 
 	hec.logsSink = new(consumertest.LogsSink)
+	hec.metricsSink = new(consumertest.MetricsSink)
 
 	hecFactory := splunkhecreceiver.NewFactory()
 	hecConfig := hecFactory.CreateDefaultConfig().(*splunkhecreceiver.Config)
@@ -83,11 +87,17 @@ func (hec HECReceiverSink) Build() (*HECReceiverSink, error) {
 	}
 	hec.logsReceiver = &logsReceiver
 
+	metricsReceiver, err := hecFactory.CreateMetrics(context.Background(), params, hecConfig, hec.metricsSink)
+	if err != nil {
+		return nil, err
+	}
+	hec.metricsReceiver = &metricsReceiver
+
 	return &hec, nil
 }
 
 func (hec *HECReceiverSink) assertBuilt(operation string) error {
-	if hec.logsReceiver == nil || hec.logsSink == nil {
+	if hec.logsReceiver == nil || hec.logsSink == nil || hec.metricsReceiver == nil || hec.metricsSink == nil {
 		return fmt.Errorf("cannot invoke %s() on an HECReceiverSink that hasn't been built", operation)
 	}
 	return nil
@@ -97,14 +107,21 @@ func (hec *HECReceiverSink) Start() error {
 	if err := hec.assertBuilt("Start"); err != nil {
 		return err
 	}
-	return (*hec.logsReceiver).Start(context.Background(), hec.Host)
+	logsErr := (*hec.logsReceiver).Start(context.Background(), hec.Host)
+	metricsErr := (*hec.metricsReceiver).Start(context.Background(), hec.Host)
+	if logsErr != nil || metricsErr != nil {
+		return errors.Join(logsErr, metricsErr)
+	}
+	return nil
 }
 
 func (hec *HECReceiverSink) Shutdown() error {
 	if err := hec.assertBuilt("Shutdown"); err != nil {
 		return err
 	}
-	return (*hec.logsReceiver).Shutdown(context.Background())
+	logsErr := (*hec.logsReceiver).Shutdown(context.Background())
+	metricsErr := (*hec.metricsReceiver).Shutdown(context.Background())
+	return errors.Join(logsErr, metricsErr)
 }
 
 func (hec *HECReceiverSink) LogRecordCount() int {
@@ -119,4 +136,18 @@ func (hec *HECReceiverSink) AllLogs() []plog.Logs {
 		return nil
 	}
 	return hec.logsSink.AllLogs()
+}
+
+func (hec *HECReceiverSink) AllMetrics() []pmetric.Metrics {
+	if err := hec.assertBuilt("AllMetrics"); err != nil {
+		return nil
+	}
+	return hec.metricsSink.AllMetrics()
+}
+
+func (hec *HECReceiverSink) DataPointCount() int {
+	if err := hec.assertBuilt("DataPointCount"); err != nil {
+		return 0
+	}
+	return hec.metricsSink.DataPointCount()
 }

--- a/tests/testutils/hec_receiver_sink.go
+++ b/tests/testutils/hec_receiver_sink.go
@@ -107,21 +107,14 @@ func (hec *HECReceiverSink) Start() error {
 	if err := hec.assertBuilt("Start"); err != nil {
 		return err
 	}
-	logsErr := (*hec.logsReceiver).Start(context.Background(), hec.Host)
-	metricsErr := (*hec.metricsReceiver).Start(context.Background(), hec.Host)
-	if logsErr != nil || metricsErr != nil {
-		return errors.Join(logsErr, metricsErr)
-	}
-	return nil
+	return (*hec.logsReceiver).Start(context.Background(), hec.Host)
 }
 
 func (hec *HECReceiverSink) Shutdown() error {
 	if err := hec.assertBuilt("Shutdown"); err != nil {
 		return err
 	}
-	logsErr := (*hec.logsReceiver).Shutdown(context.Background())
-	metricsErr := (*hec.metricsReceiver).Shutdown(context.Background())
-	return errors.Join(logsErr, metricsErr)
+	return (*hec.logsReceiver).Shutdown(context.Background())
 }
 
 func (hec *HECReceiverSink) LogRecordCount() int {

--- a/tests/testutils/hec_receiver_sink_test.go
+++ b/tests/testutils/hec_receiver_sink_test.go
@@ -31,6 +31,8 @@ func TestNewHECReceiverSink(t *testing.T) {
 	require.Nil(t, hec.Logger)
 	require.Nil(t, hec.logsReceiver)
 	require.Nil(t, hec.logsSink)
+	require.Nil(t, hec.metricsReceiver)
+	require.Nil(t, hec.metricsSink)
 }
 
 func TestHECReceiverNotBuilt(t *testing.T) {
@@ -40,6 +42,8 @@ func TestHECReceiverNotBuilt(t *testing.T) {
 	require.Error(t, hec.Shutdown())
 	require.Zero(t, hec.LogRecordCount())
 	require.Nil(t, hec.AllLogs())
+	require.Zero(t, hec.DataPointCount())
+	require.Nil(t, hec.AllMetrics())
 }
 
 func TestHECBuilderMethods(t *testing.T) {
@@ -62,4 +66,6 @@ func TestHECBuildDefaults(t *testing.T) {
 	assert.NotNil(t, hec.Logger)
 	assert.NotNil(t, hec.logsReceiver)
 	assert.NotNil(t, hec.logsSink)
+	assert.NotNil(t, hec.metricsReceiver)
+	assert.NotNil(t, hec.metricsSink)
 }

--- a/tests/testutils/hec_receiver_sink_test.go
+++ b/tests/testutils/hec_receiver_sink_test.go
@@ -17,6 +17,7 @@
 package testutils
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -68,4 +69,27 @@ func TestHECBuildDefaults(t *testing.T) {
 	assert.NotNil(t, hec.logsSink)
 	assert.NotNil(t, hec.metricsReceiver)
 	assert.NotNil(t, hec.metricsSink)
+}
+
+func TestHECStartAndShutdown(t *testing.T) {
+	endpoint := fmt.Sprintf("127.0.0.1:%d", GetAvailablePort(t))
+	hec, err := NewHECReceiverSink().WithEndpoint(endpoint).Build()
+	require.NoError(t, err)
+
+	require.NoError(t, hec.Start())
+	require.NoError(t, hec.Shutdown())
+}
+
+func TestHECAccessorsOnBuiltEmptySink(t *testing.T) {
+	endpoint := fmt.Sprintf("127.0.0.1:%d", GetAvailablePort(t))
+	hec, err := NewHECReceiverSink().WithEndpoint(endpoint).Build()
+	require.NoError(t, err)
+
+	require.NoError(t, hec.Start())
+	defer func() { require.NoError(t, hec.Shutdown()) }()
+
+	assert.Zero(t, hec.LogRecordCount())
+	assert.Empty(t, hec.AllLogs())
+	assert.Zero(t, hec.DataPointCount())
+	assert.Empty(t, hec.AllMetrics())
 }


### PR DESCRIPTION
**Description:**   

**Summary**

Adds support for collecting host metrics and forwarding them to Splunk Platform (HEC) via the install.sh installer.
  - New --splunk-platform-metrics-index flag on install.sh — enables metrics collection when provided
  - New splunk_metrics_config_linux.yaml collector config with hostmetrics receiver (cpu, disk, filesystem, memory, network, load, paging, processes)
  - --splunk-platform-token and --splunk-platform-url are required alongside --splunk-platform-metrics-index
  - When both logs and metrics are enabled together, the confmap.enableMergeAppendOption feature gate is enabled to union-merge service.extensions across the two config files
- When both o11y (--realm + access token) and platform metrics are enabled simultaneously, agent_config.yaml is explicitly added to --config flags (since SPLUNK_CONFIG is ignored when --config flags are present) and the feature gate is enabled
- Packaged into deb/rpm via packaging/fpm
 Post-install notice lists all active configuration files
