### PR TITLE
[chore] Git ignore `/instrumentation/tests/dotnet/obj/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ deployments/heroku/test/node_modules
 /instrumentation/obj/
 /instrumentation/so/
 /instrumentation/tests/dotnet/libsplunk.so
+/instrumentation/tests/dotnet/obj/
 /instrumentation/tests/java/libsplunk.so
 /instrumentation/tests/nodejs/libsplunk.so
 


### PR DESCRIPTION
This is motivated by changes on the VSCode plugin that is now building the project out of the box and showing those object files as changes.