### PR TITLE
Add OpAMP Supervisor launcher core for remote configuration support

### DIFF
--- a/cmd/splunk-otel-collector-launcher/main.go
+++ b/cmd/splunk-otel-collector-launcher/main.go
@@ -1,0 +1,29 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/signalfx/splunk-otel-collector/internal/opampsupervisor/launcher"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Environ(), launcher.DefaultPaths()); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/splunk-otel-collector-launcher/main_others.go
+++ b/cmd/splunk-otel-collector-launcher/main_others.go
@@ -1,0 +1,33 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package main
+
+import (
+	"golang.org/x/sys/unix"
+
+	"github.com/signalfx/splunk-otel-collector/internal/opampsupervisor/launcher"
+)
+
+// run replaces the launcher process with the selected child process on POSIX
+// systems so systemd tracks the collector or supervisor directly.
+func run(args, env []string, paths launcher.Paths) error {
+	cmd, err := launcher.PrepareCommand(args, env, paths)
+	if err != nil {
+		return err
+	}
+	return unix.Exec(cmd.Path, append([]string{cmd.Path}, cmd.Args...), cmd.Env)
+}

--- a/cmd/splunk-otel-collector-launcher/main_windows.go
+++ b/cmd/splunk-otel-collector-launcher/main_windows.go
@@ -1,0 +1,27 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/signalfx/splunk-otel-collector/internal/opampsupervisor/launcher"
+)
+
+func run(_, _ []string, _ launcher.Paths) error {
+	return fmt.Errorf("windows launcher service support is not implemented")
+}

--- a/internal/opampsupervisor/launcher/config.go
+++ b/internal/opampsupervisor/launcher/config.go
@@ -1,0 +1,379 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package launcher
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	SupervisorEnabledEnvVar = "SPLUNK_OPAMP_SUPERVISOR_ENABLED"
+
+	CollectorConfigEnvVar = "SPLUNK_CONFIG"
+	GatewayURLEnvVar      = "SPLUNK_GATEWAY_URL"
+	IngestURLEnvVar       = "SPLUNK_INGEST_URL"
+
+	opampSplunkExtension  = "opamp/splunk_o11y"
+	opampFeatureGate      = "splunk.opamp.enabled"
+	collectorConfigEnvRef = "${" + CollectorConfigEnvVar + "}"
+)
+
+// Paths contains package installation paths and supervisor state paths.
+type Paths struct {
+	CollectorExecutable  string
+	SupervisorExecutable string
+	SupervisorConfig     string
+	StorageDirectory     string
+	UseHUPConfigReload   bool
+}
+
+// Command is the executable, arguments, and environment the launcher should run.
+type Command struct {
+	Path string
+	Args []string
+	Env  []string
+}
+
+// SupervisorConfig is the subset of the upstream opampsupervisor config this
+// launcher renders for package-managed supervisor mode.
+type SupervisorConfig struct {
+	Server       supervisorServer       `yaml:"server"`
+	Storage      supervisorStorage      `yaml:"storage"`
+	Agent        supervisorAgent        `yaml:"agent"`
+	Capabilities supervisorCapabilities `yaml:"capabilities"`
+}
+
+type supervisorServer struct {
+	TLS      any            `yaml:"tls,omitempty"`
+	Headers  map[string]any `yaml:"headers,omitempty"`
+	Endpoint string         `yaml:"endpoint"`
+}
+
+type supervisorCapabilities struct {
+	ReportsEffectiveConfig     bool `yaml:"reports_effective_config"`
+	ReportsHealth              bool `yaml:"reports_health"`
+	ReportsAvailableComponents bool `yaml:"reports_available_components"`
+	AcceptsRemoteConfig        bool `yaml:"accepts_remote_config"`
+	ReportsRemoteConfig        bool `yaml:"reports_remote_config"`
+	ReportsOwnMetrics          bool `yaml:"reports_own_metrics"`
+	ReportsHeartbeat           bool `yaml:"reports_heartbeat"`
+}
+
+type supervisorStorage struct {
+	Directory string `yaml:"directory"`
+}
+
+type supervisorAgent struct {
+	Env                map[string]string `yaml:"env,omitempty"`
+	Executable         string            `yaml:"executable"`
+	ConfigFiles        []string          `yaml:"config_files"`
+	Args               []string          `yaml:"args,omitempty"`
+	PassthroughLogs    bool              `yaml:"passthrough_logs"`
+	UseHUPConfigReload bool              `yaml:"use_hup_config_reload,omitempty"`
+	ValidateConfig     bool              `yaml:"validate_config"`
+}
+
+// SupervisorEnabled reports whether the persisted service-scoped supervisor
+// switch is enabled in the provided environment.
+func SupervisorEnabled(env map[string]string) bool {
+	return strings.EqualFold(strings.TrimSpace(env[SupervisorEnabledEnvVar]), "true")
+}
+
+// PrepareCommand builds the command the launcher should run. In direct mode this
+// is the collector, while supervisor mode ensures supervisor config exists
+// before returning the opampsupervisor command.
+func PrepareCommand(args, environ []string, paths Paths) (Command, error) {
+	env := environToMap(environ)
+	if !SupervisorEnabled(env) {
+		return Command{
+			Path: paths.CollectorExecutable,
+			Args: args,
+			Env:  environ,
+		}, nil
+	}
+
+	if err := PrepareSupervisor(args, env, paths); err != nil {
+		return Command{}, err
+	}
+
+	return Command{
+		Path: paths.SupervisorExecutable,
+		Args: []string{"--config", paths.SupervisorConfig},
+		Env:  environ,
+	}, nil
+}
+
+// PrepareSupervisor creates the supervisor directory and writes the initial
+// supervisor config only when it does not already exist. Existing supervisor
+// config is user-editable and is preserved across launcher restarts.
+func PrepareSupervisor(args []string, env map[string]string, paths Paths) error {
+	if err := prepareSupervisorStorageDir(paths); err != nil {
+		return err
+	}
+
+	_, err := os.Stat(paths.SupervisorConfig)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("stat supervisor config %q: %w", paths.SupervisorConfig, err)
+	}
+
+	agentArgs := filterSupervisorAgentArgs(args)
+
+	configPath := strings.TrimSpace(env[CollectorConfigEnvVar])
+	if configPath == "" {
+		return fmt.Errorf("%s must be set in supervisor mode", CollectorConfigEnvVar)
+	}
+
+	config, err := loadConfigFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	server, err := supervisorServerFromConfig(config, env)
+	if err != nil {
+		return err
+	}
+
+	supervisorConfig := SupervisorConfig{
+		Server: server,
+		Capabilities: supervisorCapabilities{
+			ReportsEffectiveConfig:     true,
+			ReportsHealth:              true,
+			ReportsRemoteConfig:        true,
+			ReportsAvailableComponents: true,
+			AcceptsRemoteConfig:        true,
+			ReportsOwnMetrics:          false,
+			ReportsHeartbeat:           false,
+		},
+		Storage: supervisorStorage{Directory: paths.StorageDirectory},
+		Agent: supervisorAgent{
+			Executable:         paths.CollectorExecutable,
+			ConfigFiles:        []string{collectorConfigEnvRef},
+			Args:               agentArgs,
+			PassthroughLogs:    true,
+			UseHUPConfigReload: paths.UseHUPConfigReload,
+			ValidateConfig:     true,
+		},
+	}
+	if err := writeYAML(paths.SupervisorConfig, supervisorConfig, 0o600); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// loadConfigFile reads a collector config into a generic map so direct OpAMP
+// settings can be copied into the generated supervisor config when present.
+func loadConfigFile(path string) (map[string]any, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read collector config %q: %w", path, err)
+	}
+	var config map[string]any
+	if err := yaml.Unmarshal(bytes, &config); err != nil {
+		return nil, fmt.Errorf("parse collector config %q: %w", path, err)
+	}
+	if config == nil {
+		config = map[string]any{}
+	}
+	return config, nil
+}
+
+// supervisorServerFromConfig chooses the backend OpAMP endpoint. A direct
+// OpAMP endpoint already present in SPLUNK_CONFIG wins over package fallback
+// values.
+func supervisorServerFromConfig(config map[string]any, env map[string]string) (supervisorServer, error) {
+	if server, ok := configuredOpAMPServer(config); ok {
+		return server, nil
+	}
+
+	endpoint := derivedOpAMPEndpoint(env)
+	if endpoint == "" {
+		return supervisorServer{}, fmt.Errorf("could not derive OpAMP endpoint: neither %s nor %s is set", IngestURLEnvVar, GatewayURLEnvVar)
+	}
+	return supervisorServer{
+		Endpoint: endpoint,
+		Headers: map[string]any{
+			"X-SF-Token": "${SPLUNK_ACCESS_TOKEN}",
+		},
+	}, nil
+}
+
+// configuredOpAMPServer extracts compatible server settings from the direct
+// Splunk OpAMP extension block, if that block exists.
+func configuredOpAMPServer(config map[string]any) (supervisorServer, bool) {
+	extensions, ok := asMap(config["extensions"])
+	if !ok {
+		return supervisorServer{}, false
+	}
+	opamp, ok := asMap(extensions[opampSplunkExtension])
+	if !ok {
+		return supervisorServer{}, false
+	}
+	server, ok := asMap(opamp["server"])
+	if !ok {
+		return supervisorServer{}, false
+	}
+	httpServer, ok := asMap(server["http"])
+	if !ok {
+		return supervisorServer{}, false
+	}
+	endpoint, ok := httpServer["endpoint"].(string)
+	if !ok || strings.TrimSpace(endpoint) == "" {
+		return supervisorServer{}, false
+	}
+
+	out := supervisorServer{Endpoint: endpoint}
+	if headers, ok := asMap(httpServer["headers"]); ok {
+		out.Headers = headers
+	}
+	if tls, ok := httpServer["tls"]; ok {
+		out.TLS = tls
+	}
+	return out, true
+}
+
+// derivedOpAMPEndpoint builds a package-default OpAMP endpoint when direct
+// OpAMP config is not already present.
+func derivedOpAMPEndpoint(env map[string]string) string {
+	if strings.TrimSpace(env[GatewayURLEnvVar]) != "" {
+		return "${" + GatewayURLEnvVar + "}:4320/v1/opamp"
+	}
+	if strings.TrimSpace(env[IngestURLEnvVar]) != "" {
+		return "${" + IngestURLEnvVar + "}/v1/opamp"
+	}
+	return ""
+}
+
+// prepareSupervisorStorageDir creates the supervisor directory before config
+// generation or supervisor persistence files are used.
+func prepareSupervisorStorageDir(paths Paths) error {
+	if err := os.MkdirAll(paths.StorageDirectory, 0o755); err != nil {
+		return fmt.Errorf("create supervisor directory %q: %w", paths.StorageDirectory, err)
+	}
+	if err := os.Chmod(paths.StorageDirectory, 0o755); err != nil {
+		return fmt.Errorf("set supervisor directory permissions %q: %w", paths.StorageDirectory, err)
+	}
+	return nil
+}
+
+// filterSupervisorAgentArgs removes only the direct Splunk OpAMP feature gate
+// and preserves other collector args for the child agent.
+func filterSupervisorAgentArgs(args []string) []string {
+	var out []string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		if arg == "--feature-gates" {
+			if i+1 < len(args) {
+				filtered, keep := filterFeatureGateValue(args[i+1])
+				if keep {
+					out = append(out, arg, filtered)
+				}
+				i++
+			} else {
+				out = append(out, arg)
+			}
+			continue
+		}
+		if strings.HasPrefix(arg, "--feature-gates=") {
+			filtered, keep := filterFeatureGateValue(strings.TrimPrefix(arg, "--feature-gates="))
+			if keep {
+				out = append(out, "--feature-gates="+filtered)
+			}
+			continue
+		}
+
+		out = append(out, arg)
+	}
+	return out
+}
+
+// filterFeatureGateValue drops only the direct Splunk OpAMP feature gate so
+// other collector feature gates continue to flow to the child collector.
+func filterFeatureGateValue(value string) (string, bool) {
+	var kept []string
+	for _, item := range strings.Split(value, ",") {
+		trimmed := strings.TrimSpace(item)
+		if trimmed == "" {
+			continue
+		}
+		gate := strings.TrimLeft(trimmed, "+-")
+		if gate == opampFeatureGate {
+			continue
+		}
+		kept = append(kept, trimmed)
+	}
+	return strings.Join(kept, ","), len(kept) > 0
+}
+
+// writeYAML writes generated config files with their parent directories created
+// for package-managed state paths.
+func writeYAML(path string, value any, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create directory for %q: %w", path, err)
+	}
+	bytes, err := yaml.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("marshal %q: %w", path, err)
+	}
+	if err := os.WriteFile(path, bytes, perm); err != nil {
+		return fmt.Errorf("write %q: %w", path, err)
+	}
+	return nil
+}
+
+// asMap normalizes YAML-decoded map shapes used by different decoders and test
+// inputs.
+func asMap(value any) (map[string]any, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		return typed, true
+	case map[any]any:
+		out := make(map[string]any, len(typed))
+		for key, val := range typed {
+			keyString, ok := key.(string)
+			if !ok {
+				return nil, false
+			}
+			out[keyString] = val
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+// environToMap converts an os.Environ-style slice into lookup form.
+func environToMap(environ []string) map[string]string {
+	out := make(map[string]string, len(environ))
+	for _, entry := range environ {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		out[name] = value
+	}
+	return out
+}

--- a/internal/opampsupervisor/launcher/config.go
+++ b/internal/opampsupervisor/launcher/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -30,19 +31,22 @@ const (
 	CollectorConfigEnvVar = "SPLUNK_CONFIG"
 	GatewayURLEnvVar      = "SPLUNK_GATEWAY_URL"
 	IngestURLEnvVar       = "SPLUNK_INGEST_URL"
+	ListenInterfaceEnvVar = "SPLUNK_LISTEN_INTERFACE"
 
-	opampSplunkExtension  = "opamp/splunk_o11y"
-	opampFeatureGate      = "splunk.opamp.enabled"
-	collectorConfigEnvRef = "${" + CollectorConfigEnvVar + "}"
+	defaultAgentListenInterface = "127.0.0.1"
+	defaultListenInterface      = "0.0.0.0"
+	opampSplunkExtension        = "opamp/splunk_o11y"
 )
 
-// Paths contains package installation paths and supervisor state paths.
+// Paths contains package installation, supervisor config, and state paths.
 type Paths struct {
-	CollectorExecutable  string
-	SupervisorExecutable string
-	SupervisorConfig     string
-	StorageDirectory     string
-	UseHUPConfigReload   bool
+	CollectorExecutable      string
+	SupervisorExecutable     string
+	SupervisorConfig         string
+	GeneratedCollectorConfig string
+	StorageDirectory         string
+	DefaultAgentConfig       string
+	UseHUPConfigReload       bool
 }
 
 // Command is the executable, arguments, and environment the launcher should run.
@@ -117,32 +121,35 @@ func PrepareCommand(args, environ []string, paths Paths) (Command, error) {
 	return Command{
 		Path: paths.SupervisorExecutable,
 		Args: []string{"--config", paths.SupervisorConfig},
-		Env:  environ,
+		Env:  supervisorCommandEnv(environ, env, paths),
 	}, nil
 }
 
-// PrepareSupervisor writes the initial supervisor config only when it does not
-// already exist. Existing supervisor config is user-editable and is preserved
+// PrepareSupervisor refreshes the launcher-managed collector config on every
+// supervisor start and writes the initial supervisor config only when it does
+// not already exist. Existing supervisor config is user-editable and preserved
 // across launcher restarts.
 func PrepareSupervisor(args []string, env map[string]string, paths Paths) error {
-	_, err := os.Stat(paths.SupervisorConfig)
+	collectorConfigPath := strings.TrimSpace(env[CollectorConfigEnvVar])
+	if collectorConfigPath == "" {
+		return fmt.Errorf("%s must be set in supervisor mode", CollectorConfigEnvVar)
+	}
+
+	collectorConfig, err := loadCollectorConfigFile(collectorConfigPath)
+	if err != nil {
+		return err
+	}
+
+	if writeErr := writeYAML(paths.GeneratedCollectorConfig, sanitizedCollectorConfig(collectorConfig)); writeErr != nil {
+		return writeErr
+	}
+
+	_, err = os.Stat(paths.SupervisorConfig)
 	if err == nil {
 		return nil
 	}
 	if !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("stat supervisor config %q: %w", paths.SupervisorConfig, err)
-	}
-
-	agentArgs := filterSupervisorAgentArgs(args)
-
-	configPath := strings.TrimSpace(env[CollectorConfigEnvVar])
-	if configPath == "" {
-		return fmt.Errorf("%s must be set in supervisor mode", CollectorConfigEnvVar)
-	}
-
-	collectorConfig, err := loadCollectorConfigFile(configPath)
-	if err != nil {
-		return err
 	}
 
 	server, err := supervisorServerFromConfig(collectorConfig, env)
@@ -164,18 +171,78 @@ func PrepareSupervisor(args []string, env map[string]string, paths Paths) error 
 		Storage: supervisorStorage{Directory: paths.StorageDirectory},
 		Agent: supervisorAgent{
 			Executable:         paths.CollectorExecutable,
-			ConfigFiles:        []string{collectorConfigEnvRef},
-			Args:               agentArgs,
+			ConfigFiles:        []string{paths.GeneratedCollectorConfig},
+			Args:               args,
 			PassthroughLogs:    true,
 			UseHUPConfigReload: paths.UseHUPConfigReload,
 			ValidateConfig:     true,
 		},
 	}
-	if err := writeYAML(paths.SupervisorConfig, supervisorConfig); err != nil {
-		return err
+	if writeErr := writeYAML(paths.SupervisorConfig, supervisorConfig); writeErr != nil {
+		return writeErr
 	}
 
 	return nil
+}
+
+// supervisorCommandEnv preserves the collector's package default listen
+// interface behavior when supervisor starts the collector from generated config.
+func supervisorCommandEnv(environ []string, env map[string]string, paths Paths) []string {
+	if _, ok := env[ListenInterfaceEnvVar]; ok {
+		return environ
+	}
+	collectorConfigPath := strings.TrimSpace(env[CollectorConfigEnvVar])
+	if collectorConfigPath == "" {
+		return environ
+	}
+	listenInterface := defaultListenInterfaceForConfig(collectorConfigPath, paths.DefaultAgentConfig)
+	return append(environ, ListenInterfaceEnvVar+"="+listenInterface)
+}
+
+func defaultListenInterfaceForConfig(configPath, defaultAgentConfig string) string {
+	if filepath.Clean(configPath) == filepath.Clean(defaultAgentConfig) {
+		return defaultAgentListenInterface
+	}
+	return defaultListenInterface
+}
+
+// sanitizedCollectorConfig returns the collector config used as supervisor's
+// local base config, with only the direct Splunk OpAMP extension removed.
+func sanitizedCollectorConfig(config map[string]any) map[string]any {
+	out := cloneYAMLMap(config)
+	removeSplunkOpAMPFromExtensions(out)
+	removeSplunkOpAMPFromServiceExtensions(out)
+	return out
+}
+
+func removeSplunkOpAMPFromExtensions(config map[string]any) {
+	extensions, ok := asMap(config["extensions"])
+	if !ok {
+		return
+	}
+	delete(extensions, opampSplunkExtension)
+	config["extensions"] = extensions
+}
+
+func removeSplunkOpAMPFromServiceExtensions(config map[string]any) {
+	service, ok := asMap(config["service"])
+	if !ok {
+		return
+	}
+	serviceExtensions, ok := asSlice(service["extensions"])
+	if !ok {
+		return
+	}
+
+	filtered := make([]any, 0, len(serviceExtensions))
+	for _, extension := range serviceExtensions {
+		if name, ok := extension.(string); ok && name == opampSplunkExtension {
+			continue
+		}
+		filtered = append(filtered, extension)
+	}
+	service["extensions"] = filtered
+	config["service"] = service
 }
 
 // loadCollectorConfigFile reads a collector config into a generic map so direct
@@ -262,56 +329,6 @@ func derivedOpAMPEndpoint(env map[string]string) string {
 	return ""
 }
 
-// filterSupervisorAgentArgs removes only the direct Splunk OpAMP feature gate
-// and preserves other collector args for the child agent.
-func filterSupervisorAgentArgs(args []string) []string {
-	var out []string
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-
-		if arg == "--feature-gates" {
-			if i+1 < len(args) {
-				filtered, keep := filterFeatureGateValue(args[i+1])
-				if keep {
-					out = append(out, arg, filtered)
-				}
-				i++
-			} else {
-				out = append(out, arg)
-			}
-			continue
-		}
-		if strings.HasPrefix(arg, "--feature-gates=") {
-			filtered, keep := filterFeatureGateValue(strings.TrimPrefix(arg, "--feature-gates="))
-			if keep {
-				out = append(out, "--feature-gates="+filtered)
-			}
-			continue
-		}
-
-		out = append(out, arg)
-	}
-	return out
-}
-
-// filterFeatureGateValue drops only the direct Splunk OpAMP feature gate so
-// other collector feature gates continue to flow to the child collector.
-func filterFeatureGateValue(value string) (string, bool) {
-	var kept []string
-	for _, item := range strings.Split(value, ",") {
-		trimmed := strings.TrimSpace(item)
-		if trimmed == "" {
-			continue
-		}
-		gate := strings.TrimLeft(trimmed, "+-")
-		if gate == opampFeatureGate {
-			continue
-		}
-		kept = append(kept, trimmed)
-	}
-	return strings.Join(kept, ","), len(kept) > 0
-}
-
 // writeYAML writes generated config files to package-managed config paths.
 func writeYAML(path string, value any) error {
 	bytes, err := yaml.Marshal(value)
@@ -342,6 +359,44 @@ func asMap(value any) (map[string]any, bool) {
 		return out, true
 	default:
 		return nil, false
+	}
+}
+
+func asSlice(value any) ([]any, bool) {
+	switch typed := value.(type) {
+	case []any:
+		return typed, true
+	case []string:
+		out := make([]any, len(typed))
+		for i, value := range typed {
+			out[i] = value
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+func cloneYAMLMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = cloneYAMLValue(value)
+	}
+	return out
+}
+
+func cloneYAMLValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneYAMLMap(typed)
+	case []any:
+		out := make([]any, len(typed))
+		for i, item := range typed {
+			out[i] = cloneYAMLValue(item)
+		}
+		return out
+	default:
+		return value
 	}
 }
 

--- a/internal/opampsupervisor/launcher/config.go
+++ b/internal/opampsupervisor/launcher/config.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -122,14 +121,10 @@ func PrepareCommand(args, environ []string, paths Paths) (Command, error) {
 	}, nil
 }
 
-// PrepareSupervisor creates the supervisor directory and writes the initial
-// supervisor config only when it does not already exist. Existing supervisor
-// config is user-editable and is preserved across launcher restarts.
+// PrepareSupervisor writes the initial supervisor config only when it does not
+// already exist. Existing supervisor config is user-editable and is preserved
+// across launcher restarts.
 func PrepareSupervisor(args []string, env map[string]string, paths Paths) error {
-	if err := prepareSupervisorStorageDir(paths); err != nil {
-		return err
-	}
-
 	_, err := os.Stat(paths.SupervisorConfig)
 	if err == nil {
 		return nil
@@ -145,12 +140,12 @@ func PrepareSupervisor(args []string, env map[string]string, paths Paths) error 
 		return fmt.Errorf("%s must be set in supervisor mode", CollectorConfigEnvVar)
 	}
 
-	config, err := loadConfigFile(configPath)
+	collectorConfig, err := loadCollectorConfigFile(configPath)
 	if err != nil {
 		return err
 	}
 
-	server, err := supervisorServerFromConfig(config, env)
+	server, err := supervisorServerFromConfig(collectorConfig, env)
 	if err != nil {
 		return err
 	}
@@ -176,16 +171,17 @@ func PrepareSupervisor(args []string, env map[string]string, paths Paths) error 
 			ValidateConfig:     true,
 		},
 	}
-	if err := writeYAML(paths.SupervisorConfig, supervisorConfig, 0o600); err != nil {
+	if err := writeYAML(paths.SupervisorConfig, supervisorConfig); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// loadConfigFile reads a collector config into a generic map so direct OpAMP
-// settings can be copied into the generated supervisor config when present.
-func loadConfigFile(path string) (map[string]any, error) {
+// loadCollectorConfigFile reads a collector config into a generic map so direct
+// OpAMP settings can be copied into the generated supervisor config when
+// present.
+func loadCollectorConfigFile(path string) (map[string]any, error) {
 	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read collector config %q: %w", path, err)
@@ -266,18 +262,6 @@ func derivedOpAMPEndpoint(env map[string]string) string {
 	return ""
 }
 
-// prepareSupervisorStorageDir creates the supervisor directory before config
-// generation or supervisor persistence files are used.
-func prepareSupervisorStorageDir(paths Paths) error {
-	if err := os.MkdirAll(paths.StorageDirectory, 0o755); err != nil {
-		return fmt.Errorf("create supervisor directory %q: %w", paths.StorageDirectory, err)
-	}
-	if err := os.Chmod(paths.StorageDirectory, 0o755); err != nil {
-		return fmt.Errorf("set supervisor directory permissions %q: %w", paths.StorageDirectory, err)
-	}
-	return nil
-}
-
 // filterSupervisorAgentArgs removes only the direct Splunk OpAMP feature gate
 // and preserves other collector args for the child agent.
 func filterSupervisorAgentArgs(args []string) []string {
@@ -328,17 +312,13 @@ func filterFeatureGateValue(value string) (string, bool) {
 	return strings.Join(kept, ","), len(kept) > 0
 }
 
-// writeYAML writes generated config files with their parent directories created
-// for package-managed state paths.
-func writeYAML(path string, value any, perm os.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create directory for %q: %w", path, err)
-	}
+// writeYAML writes generated config files to package-managed config paths.
+func writeYAML(path string, value any) error {
 	bytes, err := yaml.Marshal(value)
 	if err != nil {
 		return fmt.Errorf("marshal %q: %w", path, err)
 	}
-	if err := os.WriteFile(path, bytes, perm); err != nil {
+	if err := os.WriteFile(path, bytes, 0o600); err != nil {
 		return fmt.Errorf("write %q: %w", path, err)
 	}
 	return nil

--- a/internal/opampsupervisor/launcher/config_test.go
+++ b/internal/opampsupervisor/launcher/config_test.go
@@ -40,7 +40,7 @@ func TestSupervisorEnabled(t *testing.T) {
 }
 
 func TestPrepareCommandDirectMode(t *testing.T) {
-	paths := testPaths(t.TempDir())
+	paths := testPaths(t, t.TempDir())
 	env := []string{"A=B"}
 	cmd, err := PrepareCommand([]string{"--discovery"}, env, paths)
 	require.NoError(t, err)
@@ -62,7 +62,7 @@ service:
   extensions: [health_check]
 `), 0o600))
 
-	paths := testPaths(dir)
+	paths := testPaths(t, dir)
 	paths.CollectorExecutable = filepath.Join(dir, "test-otelcol")
 
 	env := []string{
@@ -83,7 +83,7 @@ service:
 }
 
 func TestPrepareCommandSupervisorModeErrors(t *testing.T) {
-	_, err := PrepareCommand(nil, []string{SupervisorEnabledEnvVar + "=true"}, testPaths(t.TempDir()))
+	_, err := PrepareCommand(nil, []string{SupervisorEnabledEnvVar + "=true"}, testPaths(t, t.TempDir()))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), CollectorConfigEnvVar)
 }
@@ -107,7 +107,7 @@ service:
   extensions: [health_check, opamp/splunk_o11y]
 `), 0o600))
 
-	paths := testPaths(dir)
+	paths := testPaths(t, dir)
 	err := PrepareSupervisor(
 		[]string{"--feature-gates=+splunk.opamp.enabled,+other.gate"},
 		map[string]string{CollectorConfigEnvVar: configPath, IngestURLEnvVar: "https://ingest.example"},
@@ -130,16 +130,11 @@ service:
 	assert.True(t, supervisorConfig.Agent.PassthroughLogs)
 	assert.True(t, supervisorConfig.Agent.UseHUPConfigReload)
 	assert.True(t, supervisorConfig.Agent.ValidateConfig)
-
-	assertDirExists(t, paths.StorageDirectory)
-	_, err = os.Stat(filepath.Join(paths.StorageDirectory, "collector_config.yaml"))
-	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestPrepareSupervisorPreservesExistingConfig(t *testing.T) {
 	dir := t.TempDir()
-	paths := testPaths(dir)
-	require.NoError(t, os.MkdirAll(paths.StorageDirectory, 0o755))
+	paths := testPaths(t, dir)
 	require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte("user: edited\n"), 0o600))
 
 	err := PrepareSupervisor(
@@ -150,7 +145,6 @@ func TestPrepareSupervisorPreservesExistingConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "user: edited\n", readFile(t, paths.SupervisorConfig))
-	assertDirExists(t, paths.StorageDirectory)
 }
 
 func TestPrepareSupervisorReturnsErrors(t *testing.T) {
@@ -163,13 +157,6 @@ func TestPrepareSupervisorReturnsErrors(t *testing.T) {
 				return map[string]string{IngestURLEnvVar: "https://ingest.example"}
 			},
 			wantErr: CollectorConfigEnvVar,
-		},
-		"Storage directory creation": {
-			setup: func(t *testing.T, _ string, paths Paths) map[string]string {
-				require.NoError(t, os.WriteFile(paths.StorageDirectory, []byte("not a directory"), 0o600))
-				return map[string]string{IngestURLEnvVar: "https://ingest.example"}
-			},
-			wantErr: "create supervisor directory",
 		},
 		"Collector config read": {
 			setup: func(_ *testing.T, dir string, _ Paths) map[string]string {
@@ -204,7 +191,7 @@ func TestPrepareSupervisorReturnsErrors(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			dir := t.TempDir()
-			paths := testPaths(dir)
+			paths := testPaths(t, dir)
 			err := PrepareSupervisor(nil, tt.setup(t, dir, paths), paths)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -212,12 +199,12 @@ func TestPrepareSupervisorReturnsErrors(t *testing.T) {
 	}
 }
 
-func TestLoadConfigFileEmptyConfigReturnsEmptyMap(t *testing.T) {
+func TestLoadCollectorConfigFileEmptyConfigReturnsEmptyMap(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "collector.yaml")
 	require.NoError(t, os.WriteFile(configPath, nil, 0o600))
 
-	config, err := loadConfigFile(configPath)
+	config, err := loadCollectorConfigFile(configPath)
 	require.NoError(t, err)
 	assert.Empty(t, config)
 }
@@ -357,7 +344,13 @@ func TestWriteYAMLErrors(t *testing.T) {
 				require.NoError(t, os.WriteFile(parentPath, []byte("not a directory"), 0o600))
 				return filepath.Join(parentPath, "config.yaml"), map[string]any{}
 			},
-			wantErr: "create directory",
+			wantErr: "write",
+		},
+		"Parent path is missing": {
+			setup: func(_ *testing.T, dir string) (string, any) {
+				return filepath.Join(dir, "missing", "config.yaml"), map[string]any{}
+			},
+			wantErr: "write",
 		},
 		"Marshal failure": {
 			setup: func(_ *testing.T, dir string) (string, any) {
@@ -370,7 +363,7 @@ func TestWriteYAMLErrors(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			path, value := tt.setup(t, t.TempDir())
-			err := writeYAML(path, value, 0o600)
+			err := writeYAML(path, value)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
@@ -406,22 +399,18 @@ func assertMinimalCapabilitiesYAML(t *testing.T, path string) {
 	}, capabilities)
 }
 
-func testPaths(dir string) Paths {
+func testPaths(t *testing.T, dir string) Paths {
+	t.Helper()
+
+	supervisorConfig := filepath.Join(dir, "config", "supervisor_config.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(supervisorConfig), 0o700))
 	return Paths{
 		CollectorExecutable:  "otelcol",
 		SupervisorExecutable: "opampsupervisor",
 		StorageDirectory:     filepath.Join(dir, "supervisor"),
-		SupervisorConfig:     filepath.Join(dir, "supervisor", "supervisor_config.yaml"),
+		SupervisorConfig:     supervisorConfig,
 		UseHUPConfigReload:   true,
 	}
-}
-
-func assertDirExists(t *testing.T, path string) {
-	t.Helper()
-
-	info, err := os.Stat(path)
-	require.NoError(t, err)
-	assert.True(t, info.IsDir())
 }
 
 func readYAML(t *testing.T, path string, out any) {

--- a/internal/opampsupervisor/launcher/config_test.go
+++ b/internal/opampsupervisor/launcher/config_test.go
@@ -79,6 +79,40 @@ service:
 
 	assert.Equal(t, paths.SupervisorExecutable, cmd.Path)
 	assert.Equal(t, []string{"--config", paths.SupervisorConfig}, cmd.Args)
+	assert.Equal(t, append(append([]string{}, env...), ListenInterfaceEnvVar+"="+defaultListenInterface), cmd.Env)
+}
+
+func TestPrepareCommandSupervisorModeDefaultAgentListenInterface(t *testing.T) {
+	dir := t.TempDir()
+	paths := testPaths(t, dir)
+	require.NoError(t, os.WriteFile(paths.DefaultAgentConfig, []byte(`service: {}`), 0o600))
+
+	env := []string{
+		SupervisorEnabledEnvVar + "=true",
+		CollectorConfigEnvVar + "=" + paths.DefaultAgentConfig,
+		IngestURLEnvVar + "=https://ingest.example",
+	}
+	cmd, err := PrepareCommand(nil, env, paths)
+	require.NoError(t, err)
+
+	assert.Equal(t, append(append([]string{}, env...), ListenInterfaceEnvVar+"="+defaultAgentListenInterface), cmd.Env)
+}
+
+func TestPrepareCommandSupervisorModePreservesExplicitListenInterface(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "collector.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
+
+	paths := testPaths(t, dir)
+	env := []string{
+		SupervisorEnabledEnvVar + "=true",
+		CollectorConfigEnvVar + "=" + configPath,
+		IngestURLEnvVar + "=https://ingest.example",
+		ListenInterfaceEnvVar + "=127.0.0.2",
+	}
+	cmd, err := PrepareCommand(nil, env, paths)
+	require.NoError(t, err)
+
 	assert.Equal(t, env, cmd.Env)
 }
 
@@ -94,6 +128,8 @@ func TestPrepareSupervisorUsesConfiguredOpAMPEndpointAndOriginalCollectorConfig(
 	require.NoError(t, os.WriteFile(configPath, []byte(`
 extensions:
   health_check: {}
+  http_forwarder/opamp_splunk_o11y: {}
+  opamp/custom: {}
   opamp/splunk_o11y:
     server:
       http:
@@ -104,12 +140,15 @@ extensions:
         tls:
           insecure_skip_verify: true
 service:
-  extensions: [health_check, opamp/splunk_o11y]
+  extensions: [health_check, opamp/splunk_o11y, http_forwarder/opamp_splunk_o11y, opamp/custom]
 `), 0o600))
 
 	paths := testPaths(t, dir)
 	err := PrepareSupervisor(
-		[]string{"--feature-gates=+splunk.opamp.enabled,+other.gate"},
+		[]string{
+			"--feature-gates=+splunk.opamp.enabled,+other.gate",
+			"--set=processors.batch.timeout=2s",
+		},
 		map[string]string{CollectorConfigEnvVar: configPath, IngestURLEnvVar: "https://ingest.example"},
 		paths,
 	)
@@ -123,28 +162,61 @@ service:
 	assert.Contains(t, readFile(t, paths.SupervisorConfig), "X-SF-Token: ${SPLUNK_ACCESS_TOKEN}")
 	assertMinimalCapabilities(t, supervisorConfig.Capabilities)
 	assertMinimalCapabilitiesYAML(t, paths.SupervisorConfig)
-	assert.Equal(t, []string{collectorConfigEnvRef}, supervisorConfig.Agent.ConfigFiles)
-	assert.Equal(t, []string{"--feature-gates=+other.gate"}, supervisorConfig.Agent.Args)
-	assert.Contains(t, readFile(t, paths.SupervisorConfig), collectorConfigEnvRef)
+	assert.Equal(t, []string{paths.GeneratedCollectorConfig}, supervisorConfig.Agent.ConfigFiles)
+	assert.Equal(t, []string{
+		"--feature-gates=+splunk.opamp.enabled,+other.gate",
+		"--set=processors.batch.timeout=2s",
+	}, supervisorConfig.Agent.Args)
+	assert.Contains(t, readFile(t, paths.SupervisorConfig), paths.GeneratedCollectorConfig)
 	assert.NotContains(t, readFile(t, paths.SupervisorConfig), configPath)
+	assert.Nil(t, supervisorConfig.Agent.Env)
+	assert.NotContains(t, readFile(t, paths.SupervisorConfig), "\nenv:")
 	assert.True(t, supervisorConfig.Agent.PassthroughLogs)
 	assert.True(t, supervisorConfig.Agent.UseHUPConfigReload)
 	assert.True(t, supervisorConfig.Agent.ValidateConfig)
+
+	var generatedConfig map[string]any
+	readYAML(t, paths.GeneratedCollectorConfig, &generatedConfig)
+	extensions := generatedConfig["extensions"].(map[string]any)
+	assert.Contains(t, extensions, "health_check")
+	assert.Contains(t, extensions, "http_forwarder/opamp_splunk_o11y")
+	assert.Contains(t, extensions, "opamp/custom")
+	assert.NotContains(t, extensions, opampSplunkExtension)
+
+	service := generatedConfig["service"].(map[string]any)
+	assert.Equal(t, []any{
+		"health_check",
+		"http_forwarder/opamp_splunk_o11y",
+		"opamp/custom",
+	}, service["extensions"])
 }
 
-func TestPrepareSupervisorPreservesExistingConfig(t *testing.T) {
+func TestPrepareCommandPreservesExistingConfigAndRecomputesEnv(t *testing.T) {
 	dir := t.TempDir()
 	paths := testPaths(t, dir)
 	require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte("user: edited\n"), 0o600))
+	require.NoError(t, os.WriteFile(paths.GeneratedCollectorConfig, []byte("old: generated\n"), 0o600))
 
-	err := PrepareSupervisor(
-		[]string{"--feature-gates=+splunk.opamp.enabled"},
-		map[string]string{IngestURLEnvVar: "https://ingest.example"},
-		paths,
-	)
+	configPath := filepath.Join(dir, "collector.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+extensions:
+  health_check: {}
+  opamp/splunk_o11y: {}
+service:
+  extensions: [opamp/splunk_o11y, health_check]
+`), 0o600))
+
+	env := []string{
+		SupervisorEnabledEnvVar + "=true",
+		CollectorConfigEnvVar + "=" + configPath,
+	}
+	cmd, err := PrepareCommand([]string{"--feature-gates=+splunk.opamp.enabled"}, env, paths)
 	require.NoError(t, err)
 
 	assert.Equal(t, "user: edited\n", readFile(t, paths.SupervisorConfig))
+	assert.NotContains(t, readFile(t, paths.GeneratedCollectorConfig), opampSplunkExtension)
+	assert.Contains(t, readFile(t, paths.GeneratedCollectorConfig), "health_check")
+	assert.Equal(t, append(append([]string{}, env...), ListenInterfaceEnvVar+"="+defaultListenInterface), cmd.Env)
 }
 
 func TestPrepareSupervisorReturnsErrors(t *testing.T) {
@@ -207,6 +279,78 @@ func TestLoadCollectorConfigFileEmptyConfigReturnsEmptyMap(t *testing.T) {
 	config, err := loadCollectorConfigFile(configPath)
 	require.NoError(t, err)
 	assert.Empty(t, config)
+}
+
+func TestSupervisorCommandEnv(t *testing.T) {
+	defaultAgentConfig := "/etc/otel/collector/agent_config.yaml"
+	tests := map[string]struct {
+		configPath string
+		env        []string
+		want       []string
+	}{
+		"linux agent config": {
+			configPath: defaultAgentConfig,
+			want: []string{
+				CollectorConfigEnvVar + "=" + defaultAgentConfig,
+				ListenInterfaceEnvVar + "=" + defaultAgentListenInterface,
+			},
+		},
+		"linux agent config cleaned path": {
+			configPath: "/etc/otel/collector/./agent_config.yaml",
+			want: []string{
+				CollectorConfigEnvVar + "=/etc/otel/collector/./agent_config.yaml",
+				ListenInterfaceEnvVar + "=" + defaultAgentListenInterface,
+			},
+		},
+		"linux gateway config": {
+			configPath: "/etc/otel/collector/gateway_config.yaml",
+			want: []string{
+				CollectorConfigEnvVar + "=/etc/otel/collector/gateway_config.yaml",
+				ListenInterfaceEnvVar + "=" + defaultListenInterface,
+			},
+		},
+		"custom config": {
+			configPath: "/etc/otel/collector/custom.yaml",
+			want: []string{
+				CollectorConfigEnvVar + "=/etc/otel/collector/custom.yaml",
+				ListenInterfaceEnvVar + "=" + defaultListenInterface,
+			},
+		},
+		"existing listen interface": {
+			configPath: defaultAgentConfig,
+			env: []string{
+				CollectorConfigEnvVar + "=" + defaultAgentConfig,
+				ListenInterfaceEnvVar + "=127.0.0.2",
+			},
+			want: []string{
+				CollectorConfigEnvVar + "=" + defaultAgentConfig,
+				ListenInterfaceEnvVar + "=127.0.0.2",
+			},
+		},
+		"existing empty listen interface": {
+			configPath: defaultAgentConfig,
+			env: []string{
+				CollectorConfigEnvVar + "=" + defaultAgentConfig,
+				ListenInterfaceEnvVar + "=",
+			},
+			want: []string{
+				CollectorConfigEnvVar + "=" + defaultAgentConfig,
+				ListenInterfaceEnvVar + "=",
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			environ := tt.env
+			if environ == nil {
+				environ = []string{CollectorConfigEnvVar + "=" + tt.configPath}
+			}
+			assert.Equal(t, tt.want, supervisorCommandEnv(environ, environToMap(environ), Paths{
+				DefaultAgentConfig: defaultAgentConfig,
+			}))
+		})
+	}
 }
 
 func TestSupervisorServerFromConfigDerivesFallbackEndpoint(t *testing.T) {
@@ -281,44 +425,6 @@ func TestConfiguredOpAMPServerErrors(t *testing.T) {
 	}
 }
 
-func TestFilterSupervisorAgentArgs(t *testing.T) {
-	tests := map[string]struct {
-		args []string
-		want []string
-	}{
-		"Remove opamp feature gate with equals": {
-			args: []string{
-				"--feature-gates=+splunk.opamp.enabled,-other.gate,",
-				"--set=processors.batch.timeout=2s",
-			},
-			want: []string{
-				"--feature-gates=-other.gate",
-				"--set=processors.batch.timeout=2s",
-			},
-		},
-		"Remove opamp feature gate with space": {
-			args: []string{
-				"--set=processors.batch.timeout", "2s",
-				"--feature-gates", "+splunk.opamp.enabled,+test.gate",
-			},
-			want: []string{
-				"--set=processors.batch.timeout", "2s",
-				"--feature-gates", "+test.gate",
-			},
-		},
-		"Preserves malformed feature gates arg": {
-			args: []string{"--feature-gates"},
-			want: []string{"--feature-gates"},
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tt.want, filterSupervisorAgentArgs(tt.args))
-		})
-	}
-}
-
 func TestAsMap(t *testing.T) {
 	value, ok := asMap(map[any]any{"key": "value"})
 	require.True(t, ok)
@@ -329,6 +435,16 @@ func TestAsMap(t *testing.T) {
 	assert.Nil(t, value)
 
 	value, ok = asMap("invalid")
+	assert.False(t, ok)
+	assert.Nil(t, value)
+}
+
+func TestAsSlice(t *testing.T) {
+	value, ok := asSlice([]string{"health_check", opampSplunkExtension})
+	require.True(t, ok)
+	assert.Equal(t, []any{"health_check", opampSplunkExtension}, value)
+
+	value, ok = asSlice("invalid")
 	assert.False(t, ok)
 	assert.Nil(t, value)
 }
@@ -405,11 +521,13 @@ func testPaths(t *testing.T, dir string) Paths {
 	supervisorConfig := filepath.Join(dir, "config", "supervisor_config.yaml")
 	require.NoError(t, os.MkdirAll(filepath.Dir(supervisorConfig), 0o700))
 	return Paths{
-		CollectorExecutable:  "otelcol",
-		SupervisorExecutable: "opampsupervisor",
-		StorageDirectory:     filepath.Join(dir, "supervisor"),
-		SupervisorConfig:     supervisorConfig,
-		UseHUPConfigReload:   true,
+		CollectorExecutable:      "otelcol",
+		SupervisorExecutable:     "opampsupervisor",
+		StorageDirectory:         filepath.Join(dir, "supervisor"),
+		SupervisorConfig:         supervisorConfig,
+		GeneratedCollectorConfig: filepath.Join(filepath.Dir(supervisorConfig), "collector_config.yaml"),
+		DefaultAgentConfig:       filepath.Join(dir, "agent_config.yaml"),
+		UseHUPConfigReload:       true,
 	}
 }
 

--- a/internal/opampsupervisor/launcher/config_test.go
+++ b/internal/opampsupervisor/launcher/config_test.go
@@ -1,0 +1,439 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package launcher
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type badYAML struct{}
+
+func (badYAML) MarshalYAML() (any, error) {
+	return nil, errors.New("bad yaml")
+}
+
+func TestSupervisorEnabled(t *testing.T) {
+	assert.False(t, SupervisorEnabled(map[string]string{}))
+	assert.False(t, SupervisorEnabled(map[string]string{SupervisorEnabledEnvVar: "false"}))
+	assert.True(t, SupervisorEnabled(map[string]string{SupervisorEnabledEnvVar: "true"}))
+	assert.True(t, SupervisorEnabled(map[string]string{SupervisorEnabledEnvVar: " TRUE "}))
+	assert.False(t, SupervisorEnabled(map[string]string{SupervisorEnabledEnvVar: "1"}))
+}
+
+func TestPrepareCommandDirectMode(t *testing.T) {
+	paths := testPaths(t.TempDir())
+	env := []string{"A=B"}
+	cmd, err := PrepareCommand([]string{"--discovery"}, env, paths)
+	require.NoError(t, err)
+	assert.Equal(t, "otelcol", cmd.Path)
+	assert.Equal(t, []string{"--discovery"}, cmd.Args)
+	assert.Equal(t, env, cmd.Env)
+
+	_, err = os.Stat(paths.StorageDirectory)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestPrepareCommandSupervisorMode(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "collector.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+extensions:
+  health_check: {}
+service:
+  extensions: [health_check]
+`), 0o600))
+
+	paths := testPaths(dir)
+	paths.CollectorExecutable = filepath.Join(dir, "test-otelcol")
+
+	env := []string{
+		SupervisorEnabledEnvVar + "=true",
+		CollectorConfigEnvVar + "=" + configPath,
+		IngestURLEnvVar + "=https://ingest.example",
+	}
+	cmd, err := PrepareCommand(
+		[]string{"--feature-gates=+splunk.opamp.enabled,+other.gate"},
+		env,
+		paths,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, paths.SupervisorExecutable, cmd.Path)
+	assert.Equal(t, []string{"--config", paths.SupervisorConfig}, cmd.Args)
+	assert.Equal(t, env, cmd.Env)
+}
+
+func TestPrepareCommandSupervisorModeErrors(t *testing.T) {
+	_, err := PrepareCommand(nil, []string{SupervisorEnabledEnvVar + "=true"}, testPaths(t.TempDir()))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), CollectorConfigEnvVar)
+}
+
+func TestPrepareSupervisorUsesConfiguredOpAMPEndpointAndOriginalCollectorConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "collector.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+extensions:
+  health_check: {}
+  opamp/splunk_o11y:
+    server:
+      http:
+        endpoint: "https://custom.example/v1/opamp"
+        polling_interval: 15s
+        headers:
+          X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
+        tls:
+          insecure_skip_verify: true
+service:
+  extensions: [health_check, opamp/splunk_o11y]
+`), 0o600))
+
+	paths := testPaths(dir)
+	err := PrepareSupervisor(
+		[]string{"--feature-gates=+splunk.opamp.enabled,+other.gate"},
+		map[string]string{CollectorConfigEnvVar: configPath, IngestURLEnvVar: "https://ingest.example"},
+		paths,
+	)
+	require.NoError(t, err)
+
+	var supervisorConfig SupervisorConfig
+	readYAML(t, paths.SupervisorConfig, &supervisorConfig)
+	assert.Equal(t, "https://custom.example/v1/opamp", supervisorConfig.Server.Endpoint)
+	assert.Equal(t, map[string]any{"X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"}, supervisorConfig.Server.Headers)
+	assert.Equal(t, map[string]any{"insecure_skip_verify": true}, supervisorConfig.Server.TLS)
+	assert.Contains(t, readFile(t, paths.SupervisorConfig), "X-SF-Token: ${SPLUNK_ACCESS_TOKEN}")
+	assertMinimalCapabilities(t, supervisorConfig.Capabilities)
+	assertMinimalCapabilitiesYAML(t, paths.SupervisorConfig)
+	assert.Equal(t, []string{collectorConfigEnvRef}, supervisorConfig.Agent.ConfigFiles)
+	assert.Equal(t, []string{"--feature-gates=+other.gate"}, supervisorConfig.Agent.Args)
+	assert.Contains(t, readFile(t, paths.SupervisorConfig), collectorConfigEnvRef)
+	assert.NotContains(t, readFile(t, paths.SupervisorConfig), configPath)
+	assert.True(t, supervisorConfig.Agent.PassthroughLogs)
+	assert.True(t, supervisorConfig.Agent.UseHUPConfigReload)
+	assert.True(t, supervisorConfig.Agent.ValidateConfig)
+
+	assertDirExists(t, paths.StorageDirectory)
+	_, err = os.Stat(filepath.Join(paths.StorageDirectory, "collector_config.yaml"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestPrepareSupervisorPreservesExistingConfig(t *testing.T) {
+	dir := t.TempDir()
+	paths := testPaths(dir)
+	require.NoError(t, os.MkdirAll(paths.StorageDirectory, 0o755))
+	require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte("user: edited\n"), 0o600))
+
+	err := PrepareSupervisor(
+		[]string{"--feature-gates=+splunk.opamp.enabled"},
+		map[string]string{IngestURLEnvVar: "https://ingest.example"},
+		paths,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "user: edited\n", readFile(t, paths.SupervisorConfig))
+	assertDirExists(t, paths.StorageDirectory)
+}
+
+func TestPrepareSupervisorReturnsErrors(t *testing.T) {
+	tests := map[string]struct {
+		setup   func(t *testing.T, dir string, paths Paths) map[string]string
+		wantErr string
+	}{
+		"Missing config path": {
+			setup: func(_ *testing.T, _ string, _ Paths) map[string]string {
+				return map[string]string{IngestURLEnvVar: "https://ingest.example"}
+			},
+			wantErr: CollectorConfigEnvVar,
+		},
+		"Storage directory creation": {
+			setup: func(t *testing.T, _ string, paths Paths) map[string]string {
+				require.NoError(t, os.WriteFile(paths.StorageDirectory, []byte("not a directory"), 0o600))
+				return map[string]string{IngestURLEnvVar: "https://ingest.example"}
+			},
+			wantErr: "create supervisor directory",
+		},
+		"Collector config read": {
+			setup: func(_ *testing.T, dir string, _ Paths) map[string]string {
+				return map[string]string{
+					CollectorConfigEnvVar: filepath.Join(dir, "missing.yaml"),
+					IngestURLEnvVar:       "https://ingest.example",
+				}
+			},
+			wantErr: "read collector config",
+		},
+		"Collector config parse": {
+			setup: func(t *testing.T, dir string, _ Paths) map[string]string {
+				configPath := filepath.Join(dir, "collector.yaml")
+				require.NoError(t, os.WriteFile(configPath, []byte("extensions: ["), 0o600))
+				return map[string]string{
+					CollectorConfigEnvVar: configPath,
+					IngestURLEnvVar:       "https://ingest.example",
+				}
+			},
+			wantErr: "parse collector config",
+		},
+		"Missing endpoint inputs": {
+			setup: func(t *testing.T, dir string, _ Paths) map[string]string {
+				configPath := filepath.Join(dir, "collector.yaml")
+				require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
+				return map[string]string{CollectorConfigEnvVar: configPath}
+			},
+			wantErr: "could not derive OpAMP endpoint",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			paths := testPaths(dir)
+			err := PrepareSupervisor(nil, tt.setup(t, dir, paths), paths)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestLoadConfigFileEmptyConfigReturnsEmptyMap(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "collector.yaml")
+	require.NoError(t, os.WriteFile(configPath, nil, 0o600))
+
+	config, err := loadConfigFile(configPath)
+	require.NoError(t, err)
+	assert.Empty(t, config)
+}
+
+func TestSupervisorServerFromConfigDerivesFallbackEndpoint(t *testing.T) {
+	tests := map[string]struct {
+		env          map[string]string
+		wantEndpoint string
+	}{
+		"ingest url": {
+			env:          map[string]string{IngestURLEnvVar: "ingest.example/"},
+			wantEndpoint: "${SPLUNK_INGEST_URL}/v1/opamp",
+		},
+		"gateway url takes precedence": {
+			env: map[string]string{
+				GatewayURLEnvVar: "http://gateway.example",
+				IngestURLEnvVar:  "https://ingest.example",
+			},
+			wantEndpoint: "${SPLUNK_GATEWAY_URL}:4320/v1/opamp",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			server, err := supervisorServerFromConfig(map[string]any{}, tt.env)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantEndpoint, server.Endpoint)
+			assert.Equal(t, map[string]any{"X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"}, server.Headers)
+		})
+	}
+}
+
+func TestConfiguredOpAMPServerErrors(t *testing.T) {
+	tests := map[string]map[string]any{
+		"Missing extensions": {},
+		"Invalid extensions": {"extensions": "invalid"},
+		"Missing splunk opamp": {
+			"extensions": map[string]any{"health_check": map[string]any{}},
+		},
+		"Invalid splunk opamp": {
+			"extensions": map[string]any{opampSplunkExtension: "invalid"},
+		},
+		"Missing server": {
+			"extensions": map[string]any{opampSplunkExtension: map[string]any{}},
+		},
+		"Missing http": {
+			"extensions": map[string]any{
+				opampSplunkExtension: map[string]any{"server": map[string]any{}},
+			},
+		},
+		"Missing endpoint": {
+			"extensions": map[string]any{
+				opampSplunkExtension: map[string]any{
+					"server": map[string]any{"http": map[string]any{}},
+				},
+			},
+		},
+		"Blank endpoint": {
+			"extensions": map[string]any{
+				opampSplunkExtension: map[string]any{
+					"server": map[string]any{"http": map[string]any{"endpoint": "  "}},
+				},
+			},
+		},
+	}
+
+	for name, config := range tests {
+		t.Run(name, func(t *testing.T) {
+			server, ok := configuredOpAMPServer(config)
+			assert.False(t, ok)
+			assert.Empty(t, server)
+		})
+	}
+}
+
+func TestFilterSupervisorAgentArgs(t *testing.T) {
+	tests := map[string]struct {
+		args []string
+		want []string
+	}{
+		"Remove opamp feature gate with equals": {
+			args: []string{
+				"--feature-gates=+splunk.opamp.enabled,-other.gate,",
+				"--set=processors.batch.timeout=2s",
+			},
+			want: []string{
+				"--feature-gates=-other.gate",
+				"--set=processors.batch.timeout=2s",
+			},
+		},
+		"Remove opamp feature gate with space": {
+			args: []string{
+				"--set=processors.batch.timeout", "2s",
+				"--feature-gates", "+splunk.opamp.enabled,+test.gate",
+			},
+			want: []string{
+				"--set=processors.batch.timeout", "2s",
+				"--feature-gates", "+test.gate",
+			},
+		},
+		"Preserves malformed feature gates arg": {
+			args: []string{"--feature-gates"},
+			want: []string{"--feature-gates"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, filterSupervisorAgentArgs(tt.args))
+		})
+	}
+}
+
+func TestAsMap(t *testing.T) {
+	value, ok := asMap(map[any]any{"key": "value"})
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"key": "value"}, value)
+
+	value, ok = asMap(map[any]any{1: "value"})
+	assert.False(t, ok)
+	assert.Nil(t, value)
+
+	value, ok = asMap("invalid")
+	assert.False(t, ok)
+	assert.Nil(t, value)
+}
+
+func TestWriteYAMLErrors(t *testing.T) {
+	tests := map[string]struct {
+		setup   func(t *testing.T, dir string) (string, any)
+		wantErr string
+	}{
+		"Parent path is file": {
+			setup: func(t *testing.T, dir string) (string, any) {
+				parentPath := filepath.Join(dir, "parent")
+				require.NoError(t, os.WriteFile(parentPath, []byte("not a directory"), 0o600))
+				return filepath.Join(parentPath, "config.yaml"), map[string]any{}
+			},
+			wantErr: "create directory",
+		},
+		"Marshal failure": {
+			setup: func(_ *testing.T, dir string) (string, any) {
+				return filepath.Join(dir, "config.yaml"), badYAML{}
+			},
+			wantErr: "marshal",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			path, value := tt.setup(t, t.TempDir())
+			err := writeYAML(path, value, 0o600)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func assertMinimalCapabilities(t *testing.T, capabilities supervisorCapabilities) {
+	t.Helper()
+
+	assert.True(t, capabilities.ReportsEffectiveConfig)
+	assert.False(t, capabilities.ReportsOwnMetrics)
+	assert.True(t, capabilities.ReportsHealth)
+	assert.False(t, capabilities.ReportsHeartbeat)
+	assert.True(t, capabilities.ReportsRemoteConfig)
+	assert.True(t, capabilities.ReportsAvailableComponents)
+	assert.True(t, capabilities.AcceptsRemoteConfig)
+}
+
+func assertMinimalCapabilitiesYAML(t *testing.T, path string) {
+	t.Helper()
+
+	var raw map[string]any
+	readYAML(t, path, &raw)
+	capabilities := raw["capabilities"].(map[string]any)
+	assert.Equal(t, map[string]any{
+		"reports_effective_config":     true,
+		"reports_health":               true,
+		"reports_available_components": true,
+		"accepts_remote_config":        true,
+		"reports_remote_config":        true,
+		"reports_own_metrics":          false,
+		"reports_heartbeat":            false,
+	}, capabilities)
+}
+
+func testPaths(dir string) Paths {
+	return Paths{
+		CollectorExecutable:  "otelcol",
+		SupervisorExecutable: "opampsupervisor",
+		StorageDirectory:     filepath.Join(dir, "supervisor"),
+		SupervisorConfig:     filepath.Join(dir, "supervisor", "supervisor_config.yaml"),
+		UseHUPConfigReload:   true,
+	}
+}
+
+func assertDirExists(t *testing.T, path string) {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func readYAML(t *testing.T, path string, out any) {
+	t.Helper()
+	bytes := []byte(readFile(t, path))
+	require.NoError(t, yaml.Unmarshal(bytes, out))
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+
+	bytes, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(bytes)
+}

--- a/internal/opampsupervisor/launcher/paths_others.go
+++ b/internal/opampsupervisor/launcher/paths_others.go
@@ -22,8 +22,8 @@ func DefaultPaths() Paths {
 	return Paths{
 		CollectorExecutable:  "/usr/bin/otelcol",
 		SupervisorExecutable: "/usr/bin/opampsupervisor",
-		SupervisorConfig:     "/etc/otel/collector/supervisor/supervisor_config.yaml",
-		StorageDirectory:     "/etc/otel/collector/supervisor",
+		SupervisorConfig:     "/etc/otel/collector/supervisor_config.yaml",
+		StorageDirectory:     "/var/lib/otelcol/supervisor",
 		UseHUPConfigReload:   true,
 	}
 }

--- a/internal/opampsupervisor/launcher/paths_others.go
+++ b/internal/opampsupervisor/launcher/paths_others.go
@@ -1,0 +1,29 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package launcher
+
+// DefaultPaths returns the installed collector, supervisor, and state
+// locations used by the package-managed service on Linux packages.
+func DefaultPaths() Paths {
+	return Paths{
+		CollectorExecutable:  "/usr/bin/otelcol",
+		SupervisorExecutable: "/usr/bin/opampsupervisor",
+		SupervisorConfig:     "/etc/otel/collector/supervisor/supervisor_config.yaml",
+		StorageDirectory:     "/etc/otel/collector/supervisor",
+		UseHUPConfigReload:   true,
+	}
+}

--- a/internal/opampsupervisor/launcher/paths_others.go
+++ b/internal/opampsupervisor/launcher/paths_others.go
@@ -20,10 +20,12 @@ package launcher
 // locations used by the package-managed service on Linux packages.
 func DefaultPaths() Paths {
 	return Paths{
-		CollectorExecutable:  "/usr/bin/otelcol",
-		SupervisorExecutable: "/usr/bin/opampsupervisor",
-		SupervisorConfig:     "/etc/otel/collector/supervisor_config.yaml",
-		StorageDirectory:     "/var/lib/otelcol/supervisor",
-		UseHUPConfigReload:   true,
+		CollectorExecutable:      "/usr/bin/otelcol",
+		SupervisorExecutable:     "/usr/bin/opampsupervisor",
+		SupervisorConfig:         "/etc/otel/collector/supervisor/supervisor_config.yaml",
+		GeneratedCollectorConfig: "/etc/otel/collector/supervisor/collector_config.yaml",
+		StorageDirectory:         "/var/lib/otelcol/supervisor",
+		DefaultAgentConfig:       "/etc/otel/collector/agent_config.yaml",
+		UseHUPConfigReload:       true,
 	}
 }

--- a/internal/opampsupervisor/launcher/paths_windows.go
+++ b/internal/opampsupervisor/launcher/paths_windows.go
@@ -34,11 +34,14 @@ func DefaultPaths() Paths {
 	}
 	installDir := filepath.Join(programFiles, "Splunk", "OpenTelemetry Collector")
 	stateDir := filepath.Join(programData, "Splunk", "OpenTelemetry Collector", "supervisor")
+	defaultAgentConfig := filepath.Join(programData, "Splunk", "OpenTelemetry Collector", "agent_config.yaml")
 	return Paths{
-		CollectorExecutable:  filepath.Join(installDir, "otelcol.exe"),
-		SupervisorExecutable: filepath.Join(installDir, "opampsupervisor.exe"),
-		SupervisorConfig:     filepath.Join(stateDir, "supervisor_config.yaml"),
-		StorageDirectory:     stateDir,
-		UseHUPConfigReload:   false,
+		CollectorExecutable:      filepath.Join(installDir, "otelcol.exe"),
+		SupervisorExecutable:     filepath.Join(installDir, "opampsupervisor.exe"),
+		SupervisorConfig:         filepath.Join(stateDir, "supervisor_config.yaml"),
+		GeneratedCollectorConfig: filepath.Join(stateDir, "collector_config.yaml"),
+		StorageDirectory:         stateDir,
+		DefaultAgentConfig:       defaultAgentConfig,
+		UseHUPConfigReload:       false,
 	}
 }

--- a/internal/opampsupervisor/launcher/paths_windows.go
+++ b/internal/opampsupervisor/launcher/paths_windows.go
@@ -1,0 +1,44 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package launcher
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// DefaultPaths returns the installed collector, supervisor, and state
+// locations used by the package-managed service on Windows packages.
+func DefaultPaths() Paths {
+	programFiles := os.Getenv("ProgramFiles")
+	if programFiles == "" {
+		programFiles = `\Program Files`
+	}
+	programData := os.Getenv("ProgramData")
+	if programData == "" {
+		programData = `\ProgramData`
+	}
+	installDir := filepath.Join(programFiles, "Splunk", "OpenTelemetry Collector")
+	stateDir := filepath.Join(programData, "Splunk", "OpenTelemetry Collector", "supervisor")
+	return Paths{
+		CollectorExecutable:  filepath.Join(installDir, "otelcol.exe"),
+		SupervisorExecutable: filepath.Join(installDir, "opampsupervisor.exe"),
+		SupervisorConfig:     filepath.Join(stateDir, "supervisor_config.yaml"),
+		StorageDirectory:     stateDir,
+		UseHUPConfigReload:   false,
+	}
+}

--- a/internal/opampsupervisor/launcher/paths_windows_test.go
+++ b/internal/opampsupervisor/launcher/paths_windows_test.go
@@ -35,6 +35,19 @@ func TestDefaultPathsWindowsFallbacksAlignWithInstaller(t *testing.T) {
 	assert.Equal(t, filepath.Join(installDir, "otelcol.exe"), paths.CollectorExecutable)
 	assert.Equal(t, filepath.Join(installDir, "opampsupervisor.exe"), paths.SupervisorExecutable)
 	assert.Equal(t, filepath.Join(stateDir, "supervisor_config.yaml"), paths.SupervisorConfig)
+	assert.Equal(t, filepath.Join(stateDir, "collector_config.yaml"), paths.GeneratedCollectorConfig)
 	assert.Equal(t, stateDir, paths.StorageDirectory)
+	assert.Equal(t, filepath.Join(`\ProgramData`, "Splunk", "OpenTelemetry Collector", "agent_config.yaml"), paths.DefaultAgentConfig)
 	assert.False(t, paths.UseHUPConfigReload)
+}
+
+func TestDefaultListenInterfaceForWindowsAgentConfig(t *testing.T) {
+	t.Setenv("ProgramData", "")
+
+	programData := `\ProgramData`
+	agentConfig := filepath.Join(programData, "Splunk", "OpenTelemetry Collector", "agent_config.yaml")
+	gatewayConfig := filepath.Join(programData, "Splunk", "OpenTelemetry Collector", "gateway_config.yaml")
+
+	assert.Equal(t, defaultAgentListenInterface, defaultListenInterfaceForConfig(agentConfig, agentConfig))
+	assert.Equal(t, defaultListenInterface, defaultListenInterfaceForConfig(gatewayConfig, agentConfig))
 }

--- a/internal/opampsupervisor/launcher/paths_windows_test.go
+++ b/internal/opampsupervisor/launcher/paths_windows_test.go
@@ -1,0 +1,40 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package launcher
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultPathsWindowsFallbacksAlignWithInstaller(t *testing.T) {
+	t.Setenv("ProgramFiles", "")
+	t.Setenv("ProgramData", "")
+
+	paths := DefaultPaths()
+
+	installDir := filepath.Join(`\Program Files`, "Splunk", "OpenTelemetry Collector")
+	stateDir := filepath.Join(`\ProgramData`, "Splunk", "OpenTelemetry Collector", "supervisor")
+
+	assert.Equal(t, filepath.Join(installDir, "otelcol.exe"), paths.CollectorExecutable)
+	assert.Equal(t, filepath.Join(installDir, "opampsupervisor.exe"), paths.SupervisorExecutable)
+	assert.Equal(t, filepath.Join(stateDir, "supervisor_config.yaml"), paths.SupervisorConfig)
+	assert.Equal(t, stateDir, paths.StorageDirectory)
+	assert.False(t, paths.UseHUPConfigReload)
+}


### PR DESCRIPTION
**Description:** 
This PR breaks out the launcher core from the larger OpAMP Supervisor POC (https://github.com/signalfx/splunk-otel-collector/pull/7578) so it can be reviewed independently. It adds a new `splunk-otel-collector-launcher` entrypoint and internal OpAMP Supervisor launcher config package. 

The launcher keeps direct mode as the default (keeping existing collector runtime behavior), using `SPLUNK_OPAMP_SUPERVISOR_ENABLED=true` to switch into supervisor mode. In supervisor mode it:
-  generates the initial supervisor config, preserving existing generated supervisor config on later starts
- derives or preserves OpAMP endpoint settings and enables the same capabilities supported by opamp extension plus remote config support 
- starts the collector with any args (if set) and a sanitized collector config with the splunk opamp extension disabled (as supervisor adds its own)
- ensures existing default behavior for the listen interface (agent_config.yaml => 127.0.01, gateway_config.yaml => 0.0.0.0)

This slice intentionally does not include packaging/install changes, full Windows service behavior, or config converter changes. Windows currently gets a compile-only launcher stub, followup PR will add service behavior separately.