### PR TITLE
feat: add logs config for Windows

### DIFF
--- a/.chloggen/support-logs-to-splunk-platform-on-windows.yaml
+++ b/.chloggen/support-logs-to-splunk-platform-on-windows.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: installer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add Splunk Platform log collection support to the Windows installer script.
+
+# One or more tracking issues related to the change
+issues: [7592]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  New MSI install parameters: SPLUNK_PLATFORM_URL, SPLUNK_PLATFORM_TOKEN, SPLUNK_PLATFORM_LOGS_INDEX
+  enable forwarding host logs to Splunk Platform via HEC. A new `splunk_logs_config_windows.yaml`
+  config file is installed with filelog & windows_event_log receivers.

--- a/.github/workflows/scripts/win-test-services.ps1
+++ b/.github/workflows/scripts/win-test-services.ps1
@@ -6,7 +6,10 @@ param (
     [string]$with_msi_uninstall_comments = "",
     [string]$api_url = "https://api.${realm}.observability.splunkcloud.com",
     [string]$ingest_url = "https://ingest.${realm}.observability.splunkcloud.com",
-    [string]$with_svc_args = ""
+    [string]$with_svc_args = "",
+    [string]$splunk_platform_url = "",
+    [string]$splunk_platform_token = "",
+    [string]$splunk_platform_logs_index = ""
 )
 
 $ErrorActionPreference = 'Stop'
@@ -14,15 +17,20 @@ Set-PSDebug -Trace 1
 
 function check_collector_svc_environment([hashtable]$expected_env_vars) {
     $actual_env_vars = @{}
+    $env_array = @()
     try {
         $env_array = Get-ItemPropertyValue -Path "HKLM:\SYSTEM\CurrentControlSet\Services\splunk-otel-collector" -Name "Environment"
-        foreach ($entry in $env_array) {
-            $key, $value = $entry.Split("=", 2)
-            $actual_env_vars.Add($key, $value)
-        }
     } catch {
         Write-Host "Assuming an old version of the collector with environment variables at the machine scope"
         $actual_env_vars = [Environment]::GetEnvironmentVariables("Machine")<#Do this if a terminating exception happens#>
+    }
+
+    foreach ($entry in $env_array) {
+        $key, $value = $entry.Split("=", 2)
+        if ($actual_env_vars.ContainsKey($key)) {
+            throw "Environment variable $key is duplicated in the splunk-otel-collector service Environment registry entry."
+        }
+        $actual_env_vars.Add($key, $value)
     }
 
     foreach ($key in $expected_env_vars.Keys) {
@@ -32,14 +40,27 @@ function check_collector_svc_environment([hashtable]$expected_env_vars) {
             throw "Environment variable $key is not properly set. Found: '$actual_value', Expected '$expected_value'"
         }
     }
+
+    return $actual_env_vars
 }
 
 function service_running([string]$name) {
     return ((Get-CimInstance -ClassName win32_service -Filter "Name = '$name'" | Select Name, State).State -Eq "Running")
 }
 
+function append_svc_arg([string]$svc_args, [string]$arg) {
+    if ([string]::IsNullOrWhitespace($svc_args)) {
+        return $arg
+    }
+    return "$svc_args $arg"
+}
+
+$program_data_collector_dir = "${env:PROGRAMDATA}\Splunk\OpenTelemetry Collector"
+$program_files_collector_dir = "${Env:ProgramFiles}\Splunk\OpenTelemetry Collector"
+$default_config_path = "${program_data_collector_dir}\${mode}_config.yaml"
+$logs_config_path = "${program_data_collector_dir}\splunk_logs_config_windows.yaml"
+
 $expected_svc_env_vars = @{
-  "SPLUNK_CONFIG"           = "${env:PROGRAMDATA}\Splunk\OpenTelemetry Collector\${mode}_config.yaml";
   "SPLUNK_ACCESS_TOKEN"     = "$access_token";
   "SPLUNK_REALM"            = "$realm";
   "SPLUNK_API_URL"          = "$api_url";
@@ -52,7 +73,25 @@ if (![string]::IsNullOrWhitespace($memory)) {
     $expected_svc_env_vars["SPLUNK_MEMORY_TOTAL_MIB"] = "$memory"
 }
 
-check_collector_svc_environment $expected_svc_env_vars
+if (![string]::IsNullOrWhitespace($splunk_platform_url)) {
+    $expected_svc_env_vars["SPLUNK_PLATFORM_URL"] = "$splunk_platform_url"
+}
+if (![string]::IsNullOrWhitespace($splunk_platform_token)) {
+    $expected_svc_env_vars["SPLUNK_PLATFORM_TOKEN"] = "$splunk_platform_token"
+}
+if (![string]::IsNullOrWhitespace($splunk_platform_logs_index)) {
+    $expected_svc_env_vars["SPLUNK_PLATFORM_LOGS_INDEX"] = "$splunk_platform_logs_index"
+}
+
+$actual_svc_env_vars = check_collector_svc_environment $expected_svc_env_vars
+$actual_config_path = ""
+if ($actual_svc_env_vars.ContainsKey("SPLUNK_CONFIG")) {
+    $actual_config_path = $actual_svc_env_vars["SPLUNK_CONFIG"]
+}
+$config_set_by_env = ![string]::IsNullOrWhitespace($actual_config_path)
+if ($config_set_by_env -and ($actual_config_path -ne $default_config_path)) {
+    throw "Environment variable SPLUNK_CONFIG is not properly set. Found: '$actual_config_path', Expected '$default_config_path'"
+}
 
 if ((service_running -name "splunk-otel-collector")) {
     write-host "splunk-otel-collector service is running."
@@ -73,13 +112,17 @@ if ($with_msi_uninstall_comments -ne "") {
 
 $installed_version = [Version]$uninstallProperties.DisplayVersion
 if ($installed_version -gt [Version]"0.97.0.0") {
-    if (Test-Path -Path "${Env:ProgramFiles}\Splunk\OpenTelemetry Collector\*_config.yaml") {
-        throw "Found config files in '${Env:ProgramFiles}\Splunk\OpenTelemetry Collector' these files should not be present"
+    if (Test-Path -Path "${program_files_collector_dir}\*_config.yaml") {
+        throw "Found config files in '${program_files_collector_dir}' these files should not be present"
     }
 }
 
-If (!(Test-Path -Path "${Env:ProgramData}\Splunk\OpenTelemetry Collector\*_config.yaml")) {
-    throw "No config files found in ${Env:ProgramData}\Splunk\OpenTelemetry Collector these files are expected after the install"
+If (!(Test-Path -Path "$default_config_path")) {
+    throw "Config file '$default_config_path' was not found after the install"
+}
+
+if (![string]::IsNullOrWhitespace($splunk_platform_url) -and !(Test-Path -Path "$logs_config_path")) {
+    throw "Config file '$logs_config_path' was not found after the install"
 }
 
 $svc_commandline = ""
@@ -89,9 +132,20 @@ try {
     throw "Failed to retrieve the service command line from the registry."
 }
 
-if ($with_svc_args -ne "") {
-    if (-not $svc_commandline.EndsWith($with_svc_args)) {
-        throw "Service command line does not match the expected arguments. Found: '$svc_commandline', Expected to end with: '$with_svc_args'"
+$expected_svc_args = $with_svc_args.Trim('"').Replace('""', '"')
+if (!$config_set_by_env -and ![string]::IsNullOrWhitespace($access_token)) {
+    $expected_svc_args = append_svc_arg $expected_svc_args "--config `"${default_config_path}`""
+}
+if (![string]::IsNullOrWhitespace($splunk_platform_url)) {
+    $expected_svc_args = append_svc_arg $expected_svc_args "--config `"${logs_config_path}`""
+}
+if (!$config_set_by_env -and ![string]::IsNullOrWhitespace($access_token) -and ![string]::IsNullOrWhitespace($splunk_platform_url)) {
+    $expected_svc_args = append_svc_arg $expected_svc_args "--feature-gates=confmap.enableMergeAppendOption"
+}
+
+if ($expected_svc_args -ne "") {
+    if (-not $svc_commandline.EndsWith($expected_svc_args)) {
+        throw "Service command line does not match the expected arguments. Found: '$svc_commandline', Expected to end with: '$expected_svc_args'"
     } else {
         Write-Host "Service command line matches the expected arguments."
     }

--- a/cmd/otelcol/config/collector/splunk_logs_config_windows.yaml
+++ b/cmd/otelcol/config/collector/splunk_logs_config_windows.yaml
@@ -9,6 +9,7 @@ receivers:
     # Remove entries below if you want to collect those events despite the error.
     exclude_providers:
       - "XENAGENT"
+      - "Tenable Nessus Agent"
 
   windows_event_log/security:
     channel: Security
@@ -147,19 +148,19 @@ receivers:
   #   Workaround: use a scheduled task to periodically copy dns.log to a
   #   staging path, then monitor that path with filelog.
 
-  filelog/dns_debug:
-    include:
-      - '${env:SystemDrive}\dns_log_copy\dns.log'
-    start_at: beginning
-    include_file_path: true
-    operators:
-      - type: move
-        from: attributes["log.file.path"]
-        to: resource["com.splunk.source"]
-      - type: add
-        field: resource["com.splunk.sourcetype"]
-        value: MSAD:NT6:DNS
-    storage: file_storage/filelogs
+  #  filelog/dns_debug:
+  #    include:
+  #      - '${env:SystemDrive}\dns_log_copy\dns.log'
+  #    start_at: beginning
+  #    include_file_path: true
+  #    operators:
+  #      - type: move
+  #        from: attributes["log.file.path"]
+  #        to: resource["com.splunk.source"]
+  #      - type: add
+  #        field: resource["com.splunk.sourcetype"]
+  #        value: MSAD:NT6:DNS
+  #    storage: file_storage/filelogs
 
 processors:
   batch:
@@ -243,10 +244,9 @@ processors:
 
 exporters:
   splunk_hec/logs:
-    endpoint: "${SPLUNK_HEC_URL}"
-    token: "${SPLUNK_HEC_TOKEN}"
+    endpoint: "${SPLUNK_PLATFORM_URL}"
+    token: "${SPLUNK_PLATFORM_TOKEN}"
     source: "otel"
-    sourcetype: "otel"
     index: "${SPLUNK_PLATFORM_LOGS_INDEX}"
 
 extensions:
@@ -318,9 +318,5 @@ service:
       exporters: [splunk_hec/logs]
     logs/firewall:
       receivers: [filelog/firewall]
-      processors: [batch, resourcedetection]
-      exporters: [splunk_hec/logs]
-    logs/dns_debug:
-      receivers: [filelog/dns_debug]
       processors: [batch, resourcedetection]
       exporters: [splunk_hec/logs]

--- a/cmd/otelcol/config/collector/splunk_logs_windows_config.yaml
+++ b/cmd/otelcol/config/collector/splunk_logs_windows_config.yaml
@@ -1,0 +1,326 @@
+receivers:
+  windows_event_log:
+    channel: Application
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+    # Excludes events from providers whose metadata DLL is not accessible
+    # to the collector process.
+    # Remove entries below if you want to collect those events despite the error.
+    exclude_providers:
+      - "XENAGENT"
+
+  windows_event_log/security:
+    channel: Security
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+    # NOTE: Splunk blacklists the following with a message-body regex condition:
+    #   EventCode 4662 where Object Type != groupPolicyContainer
+    #   EventCode 566  where Object Type != groupPolicyContainer
+    # The exclude_events filter below drops ALL 4662/566 events — it cannot
+    # replicate the groupPolicyContainer exception. Use a filterprocessor
+    # with OTTL if you need conditional filtering.
+    #
+    # exclude_events:
+    #   - event_ids: [4662, 566]
+
+  windows_event_log/system:
+    channel: System
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  windows_event_log/printservice:
+    channel: Microsoft-Windows-PrintService/Operational
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  # --- Disabled in inputs.conf -------------------------------------------
+
+  # ForwardedEvents exists but is disabled — enable on WEF collectors only
+  windows_event_log/forwardedevents:
+    channel: ForwardedEvents
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  # DC-only channels — will silently no-op on non-DC machines due to ignore_channel_errors
+  windows_event_log/dfs_replication:
+    channel: DFS Replication
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  windows_event_log/directory_service:
+    channel: Directory Service
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  windows_event_log/file_replication:
+    channel: File Replication Service
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  windows_event_log/dns_server:
+    channel: DNS Server
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  windows_event_log/key_management:
+    channel: Key Management Service
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  windows_event_log/defender:
+    channel: Microsoft-Windows-Windows Defender/Operational
+    start_at: beginning
+    raw: true
+    ignore_channel_errors: true
+
+  filelog/dhcp:
+    include:
+      - '${env:SystemRoot}\System32\DHCP\DhcpSrvLog*'
+    start_at: beginning
+    include_file_path: true
+    operators:
+      - type: move
+        from: attributes["log.file.path"]
+        to: resource["com.splunk.source"]
+      - type: add
+        field: resource["com.splunk.sourcetype"]
+        value: DhcpSrvLog
+    storage: file_storage/filelogs
+
+  filelog/windowsupdate_legacy:
+    # For Windows 8 / Server 2008R2 / Server 2012 / Server 2012R2
+    include:
+      - '${env:SystemRoot}\WindowsUpdate.log'
+    start_at: beginning
+    include_file_path: true
+    operators:
+      - type: move
+        from: attributes["log.file.path"]
+        to: resource["com.splunk.source"]
+      - type: add
+        field: resource["com.splunk.sourcetype"]
+        value: WindowsUpdateLog
+    storage: file_storage/filelogs
+
+  filelog/netlogon:
+    include:
+      - '${env:SystemRoot}\debug\netlogon.log'
+    start_at: beginning
+    include_file_path: true
+    operators:
+      - type: move
+        from: attributes["log.file.path"]
+        to: resource["com.splunk.source"]
+      - type: add
+        field: resource["com.splunk.sourcetype"]
+        value: MSAD:NT6:Netlogon
+    storage: file_storage/filelogs
+
+  filelog/firewall:
+    include:
+      - '${env:SystemRoot}\System32\LogFiles\Firewall\*'
+    start_at: beginning
+    include_file_path: true
+    operators:
+      - type: move
+        from: attributes["log.file.path"]
+        to: resource["com.splunk.source"]
+      - type: add
+        field: resource["com.splunk.sourcetype"]
+        value: WindowsFirewallLog
+    storage: file_storage/filelogs
+
+  #   --- GAP: dns.log (MonitorNoHandle) ------------------------------------
+  #   [MonitorNoHandle://$WINDIR\System32\Dns\dns.log]
+  #   The live DNS debug log is held open with an exclusive lock by the DNS
+  #   service. filelogreceiver cannot reliably read exclusively locked files.
+  #   Workaround: use a scheduled task to periodically copy dns.log to a
+  #   staging path, then monitor that path with filelog.
+
+  filelog/dns_debug:
+    include:
+      - '${env:SystemDrive}\dns_log_copy\dns.log'
+    start_at: beginning
+    include_file_path: true
+    operators:
+      - type: move
+        from: attributes["log.file.path"]
+        to: resource["com.splunk.source"]
+      - type: add
+        field: resource["com.splunk.sourcetype"]
+        value: MSAD:NT6:DNS
+    storage: file_storage/filelogs
+
+processors:
+  batch:
+  resourcedetection:
+    detectors: [ system, env ]
+    system:
+      hostname_sources: [ "os" ]
+  # WinEventLog://Application -> sourcetype=XmlWinEventLog  source=WinEventLog:Application
+  transform/application:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:Application")
+  # WinEventLog://Security -> sourcetype=XmlWinEventLog  source=WinEventLog:Security
+  transform/security:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:Security")
+  # WinEventLog://System -> sourcetype=XmlWinEventLog  source=WinEventLog:System
+  transform/system:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:System")
+  # WinEventLog://Microsoft-Windows-PrintService/Operational
+  # No renderXml in inputs.conf -> sourcetype=WinEventLog
+  transform/printservice:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "WinEventLog")
+          - set(attributes["com.splunk.source"], "WinEventLog:Microsoft-Windows-PrintService/Operational")
+  # transform/forwardedevents — uncomment if enabling ForwardedEvents receiver
+  transform/forwardedevents:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:ForwardedEvents")
+  transform/dfs_replication:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:DFS Replication")
+  transform/directory_service:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:Directory Service")
+  transform/file_replication:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:File Replication Service")
+  transform/dns_server:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:DNS Server")
+  transform/key_management:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:Key Management Service")
+  transform/defender:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["com.splunk.sourcetype"], "XmlWinEventLog")
+          - set(attributes["com.splunk.source"], "XmlWinEventLog:Microsoft-Windows-Windows Defender/Operational")
+
+
+exporters:
+  splunk_hec/logs:
+    endpoint: "${SPLUNK_HEC_URL}"
+    token: "${SPLUNK_HEC_TOKEN}"
+    source: "otel"
+    sourcetype: "otel"
+    index: "${SPLUNK_PLATFORM_LOGS_INDEX}"
+
+extensions:
+  file_storage/filelogs:
+    directory: "${ProgramData}/Splunk/OpenTelemetry Collector/FileStorage"
+    compaction:
+      on_start: true
+      directory: ${env:TEMP}
+    create_directory: true
+
+service:
+  extensions: [file_storage/filelogs]
+  pipelines:
+    logs/application:
+      receivers: [windows_event_log]
+      processors: [transform/application, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/security:
+      receivers: [windows_event_log/security]
+      processors: [transform/security, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/system:
+      receivers: [windows_event_log/system]
+      processors: [transform/system, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/printservice:
+      receivers: [windows_event_log/printservice]
+      processors: [transform/printservice, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/forwardedevents:
+      receivers: [windows_event_log/forwardedevents]
+      processors: [transform/forwardedevents, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/dfs_replication:
+      receivers: [windows_event_log/dfs_replication]
+      processors: [transform/dfs_replication, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/directory_service:
+      receivers: [windows_event_log/directory_service]
+      processors: [transform/directory_service, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/file_replication:
+      receivers: [windows_event_log/file_replication]
+      processors: [transform/file_replication, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/dns_server:
+      receivers: [windows_event_log/dns_server]
+      processors: [transform/dns_server, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/key_management:
+      receivers: [windows_event_log/key_management]
+      processors: [transform/key_management, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/defender:
+      receivers: [windows_event_log/defender]
+      processors: [transform/defender, batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/dhcp:
+      receivers: [filelog/dhcp]
+      processors: [batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/windowsupdate:
+      receivers: [filelog/windowsupdate_legacy]
+      processors: [batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/netlogon:
+      receivers: [filelog/netlogon]
+      processors: [batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/firewall:
+      receivers: [filelog/firewall]
+      processors: [batch, resourcedetection]
+      exporters: [splunk_hec/logs]
+    logs/dns_debug:
+      receivers: [filelog/dns_debug]
+      processors: [batch, resourcedetection]
+      exporters: [splunk_hec/logs]

--- a/cmd/otelcol/main_test.go
+++ b/cmd/otelcol/main_test.go
@@ -41,17 +41,18 @@ func TestRunFromCmdLine(t *testing.T) {
 
 	configFiles, err = filepath.Glob(filepath.Join("config", "collector", "*.yaml"))
 	require.NoError(t, err)
-	require.Len(t, configFiles, 9, "A new test case must be added to TestRunFromCmdLine to validate default configurations")
+	require.Len(t, configFiles, 10, "A new test case must be added to TestRunFromCmdLine to validate default configurations")
 
 	tests := []struct {
-		extraEnvVars map[string]string
-		name         string
-		panicMsg     string
-		skipMsg      string
-		args         []string
-		timeout      time.Duration
-		skipWindows  bool
-		validateOnly bool
+		extraEnvVars   map[string]string
+		name           string
+		panicMsg       string
+		skipMsg        string
+		args           []string
+		timeout        time.Duration
+		skipNonWindows bool
+		skipWindows    bool
+		validateOnly   bool
 	}{
 		{
 			name:    "agent",
@@ -164,6 +165,35 @@ func TestRunFromCmdLine(t *testing.T) {
 			panicMsg: "unexpected call to os.Exit(0) during test", // os.Exit(0) in the normal execution is expected for '--dry-run'.
 			skipMsg:  "Skipping this test by default because --dry-run uses os.Exit(0) to end the execution",
 		},
+		{
+			name: "splunk_logs_windows",
+			args: []string{"otelcol", "--config=config/collector/splunk_logs_config_windows.yaml"},
+			extraEnvVars: map[string]string{
+				"SPLUNK_PLATFORM_URL":        "https://localhost:8088/services/collector",
+				"SPLUNK_PLATFORM_TOKEN":      "test-token",
+				"SPLUNK_PLATFORM_LOGS_INDEX": "main",
+			},
+			timeout:        15 * time.Second,
+			skipNonWindows: true,
+			validateOnly:   true,
+		},
+		{
+			name: "agent_plus_splunk_logs_windows",
+			args: []string{
+				"otelcol",
+				"--config=config/collector/agent_config.yaml",
+				"--config=config/collector/splunk_logs_config_windows.yaml",
+				"--feature-gates=confmap.enableMergeAppendOption",
+			},
+			extraEnvVars: map[string]string{
+				"SPLUNK_PLATFORM_URL":        "https://localhost:8088/services/collector",
+				"SPLUNK_PLATFORM_TOKEN":      "test-token",
+				"SPLUNK_PLATFORM_LOGS_INDEX": "main",
+			},
+			timeout:        15 * time.Second,
+			skipNonWindows: true,
+			validateOnly:   true,
+		},
 	}
 
 	// Set execution environment
@@ -182,6 +212,9 @@ func TestRunFromCmdLine(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.skipWindows && runtime.GOOS == "windows" {
 				t.Skip("skipping test on windows")
+			}
+			if tt.skipNonWindows && runtime.GOOS != "windows" {
+				t.Skip("skipping test on non-windows")
 			}
 
 			if tt.skipMsg != "" {

--- a/packaging/msi/msi-builder/build.sh
+++ b/packaging/msi/msi-builder/build.sh
@@ -24,7 +24,7 @@ PROJECT_DIR=${PROJECT_DIR:-"${REPO_DIR}"}
 MSI_SRC_DIR=${MSI_SRC_DIR:-"${REPO_DIR}/packaging/msi"}
 WXS_PATH="${MSI_SRC_DIR}/splunk-otel-collector.wxs"
 AGENT_CONFIG="${REPO_DIR}/cmd/otelcol/config/collector/agent_config.yaml"
-SPLUNK_LOGS_CONFIG="${REPO_DIR}/cmd/otelcol/config/collector/splunk_logs_windows_config.yaml"
+SPLUNK_LOGS_CONFIG="${REPO_DIR}/cmd/otelcol/config/collector/splunk_logs_config_windows.yaml"
 GATEWAY_CONFIG="${REPO_DIR}/cmd/otelcol/config/collector/gateway_config.yaml"
 SUPPORT_BUNDLE_SCRIPT=${SUPPORT_BUNDLE_SCRIPT:-"${MSI_SRC_DIR}/splunk-support-bundle.ps1"}
 SPLUNK_ICON="${MSI_SRC_DIR}/splunk.ico"
@@ -161,7 +161,7 @@ parse_args_and_build() {
     mkdir -p "${files_dir}"
     cp "$support_bundle" "${files_dir}/splunk-support-bundle.ps1"
     cp "$agent_config" "${files_dir}/agent_config.yaml"
-    cp "$splunk_logs_config" "${files_dir}/splunk_logs_windows_config.yaml"
+    cp "$splunk_logs_config" "${files_dir}/splunk_logs_config_windows.yaml"
     cp "$gateway_config" "${files_dir}/gateway_config.yaml"
 
     jmx_metrics_jar="${build_dir}/opentelemetry-java-contrib-jmx-metrics.jar"

--- a/packaging/msi/msi-builder/build.sh
+++ b/packaging/msi/msi-builder/build.sh
@@ -24,6 +24,7 @@ PROJECT_DIR=${PROJECT_DIR:-"${REPO_DIR}"}
 MSI_SRC_DIR=${MSI_SRC_DIR:-"${REPO_DIR}/packaging/msi"}
 WXS_PATH="${MSI_SRC_DIR}/splunk-otel-collector.wxs"
 AGENT_CONFIG="${REPO_DIR}/cmd/otelcol/config/collector/agent_config.yaml"
+SPLUNK_LOGS_CONFIG="${REPO_DIR}/cmd/otelcol/config/collector/splunk_logs_windows_config.yaml"
 GATEWAY_CONFIG="${REPO_DIR}/cmd/otelcol/config/collector/gateway_config.yaml"
 SUPPORT_BUNDLE_SCRIPT=${SUPPORT_BUNDLE_SCRIPT:-"${MSI_SRC_DIR}/splunk-support-bundle.ps1"}
 SPLUNK_ICON="${MSI_SRC_DIR}/splunk.ico"
@@ -62,6 +63,7 @@ parse_args_and_build() {
     local otelcol=""
     local agent_config="$AGENT_CONFIG"
     local gateway_config="$GATEWAY_CONFIG"
+    local splunk_logs_config="$SPLUNK_LOGS_CONFIG"
     local support_bundle="$SUPPORT_BUNDLE_SCRIPT"
     local jmx_metric_gatherer_release="$JMX_METRIC_GATHERER_RELEASE"
     local splunk_icon="$SPLUNK_ICON"
@@ -159,6 +161,7 @@ parse_args_and_build() {
     mkdir -p "${files_dir}"
     cp "$support_bundle" "${files_dir}/splunk-support-bundle.ps1"
     cp "$agent_config" "${files_dir}/agent_config.yaml"
+    cp "$splunk_logs_config" "${files_dir}/splunk_logs_windows_config.yaml"
     cp "$gateway_config" "${files_dir}/gateway_config.yaml"
 
     jmx_metrics_jar="${build_dir}/opentelemetry-java-contrib-jmx-metrics.jar"

--- a/packaging/msi/splunk-otel-collector.wxs
+++ b/packaging/msi/splunk-otel-collector.wxs
@@ -21,7 +21,7 @@
       <!-- Load the Splunk custom actions -->
       <Binary Id="SplunkCustomActionsDll" SourceFile="$(sys.SOURCEFILEDIR)/SplunkCustomActions/bin/Release/SplunkCustomActions.CA.dll" />
       <CustomAction Id="CheckLaunchConditions" DllEntry="CheckLaunchConditions" Execute="immediate" BinaryRef="SplunkCustomActionsDll" />
-      <CustomAction Id="AddOptionalConfigurationsCustomActionData" Property="AddOptionalConfigurations" Value="GODEBUG=[GODEBUG];GOMEMLIMIT=[GOMEMLIMIT];SPLUNK_GATEWAY_URL=[SPLUNK_GATEWAY_URL];SPLUNK_LISTEN_INTERFACE=[SPLUNK_LISTEN_INTERFACE];SPLUNK_MEMORY_LIMIT_MIB=[SPLUNK_MEMORY_LIMIT_MIB];SPLUNK_MEMORY_TOTAL_MIB=[SPLUNK_MEMORY_TOTAL_MIB]" />
+      <CustomAction Id="AddOptionalConfigurationsCustomActionData" Property="AddOptionalConfigurations" Value="GODEBUG=[GODEBUG];GOMEMLIMIT=[GOMEMLIMIT];SPLUNK_GATEWAY_URL=[SPLUNK_GATEWAY_URL];SPLUNK_LISTEN_INTERFACE=[SPLUNK_LISTEN_INTERFACE];SPLUNK_MEMORY_LIMIT_MIB=[SPLUNK_MEMORY_LIMIT_MIB];SPLUNK_MEMORY_TOTAL_MIB=[SPLUNK_MEMORY_TOTAL_MIB];SPLUNK_PLATFORM_URL=[SPLUNK_PLATFORM_URL];SPLUNK_PLATFORM_TOKEN=[SPLUNK_PLATFORM_TOKEN];SPLUNK_PLATFORM_LOGS_INDEX=[SPLUNK_PLATFORM_LOGS_INDEX]" />
       <CustomAction Id="AddOptionalConfigurations" DllEntry="AddOptionalConfigurations" Execute="deferred" Impersonate="no" BinaryRef="SplunkCustomActionsDll" />
 
       <!-- Following name convention for this property to match upstream -->
@@ -40,13 +40,22 @@
       <!-- SPLUNK_*_URL properties required to start the collector -->
       <Property Id="SPLUNK_REALM" Value="us0" Secure="yes" />
 
+      <Property Id="SPLUNK_CONFIG" Secure="yes" />
       <Property Id="SPLUNK_API_URL" Secure="yes" />
       <Property Id="SPLUNK_INGEST_URL" Secure="yes" />
       <Property Id="SPLUNK_HEC_URL" Secure="yes" />
+      <Property Id="SPLUNK_PLATFORM_URL" Secure="yes" />
+      <Property Id="SPLUNK_PLATFORM_TOKEN" Secure="yes" />
       <Property Id="SPLUNK_PLATFORM_LOGS_INDEX" Secure="yes" />
 
+      <Launch Condition="NOT SPLUNK_PLATFORM_URL OR SPLUNK_PLATFORM_TOKEN" Message="SPLUNK_PLATFORM_TOKEN is required when SPLUNK_PLATFORM_URL is set." />
+      <Launch Condition="NOT SPLUNK_PLATFORM_TOKEN OR SPLUNK_PLATFORM_URL" Message="SPLUNK_PLATFORM_URL is required when SPLUNK_PLATFORM_TOKEN is set." />
+
+      <CustomAction Id="SetDefaultConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="--config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\[SPLUNK_SETUP_COLLECTOR_MODE]_config.yaml&quot;" />
       <CustomAction Id="AppendDefaultConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="[COLLECTOR_SVC_ARGS] --config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\[SPLUNK_SETUP_COLLECTOR_MODE]_config.yaml&quot;" />
-      <CustomAction Id="AppendLogsConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="[COLLECTOR_SVC_ARGS] --config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\splunk_logs_windows_config.yaml&quot;" />
+      <CustomAction Id="SetLogsConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="--config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\splunk_logs_config_windows.yaml&quot;" />
+      <CustomAction Id="AppendLogsConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="[COLLECTOR_SVC_ARGS] --config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\splunk_logs_config_windows.yaml&quot;" />
+      <CustomAction Id="AppendMergeOptionTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="[COLLECTOR_SVC_ARGS] --feature-gates=confmap.enableMergeAppendOption" />
       <CustomAction Id="Set_SPLUNK_API_URL" Property="SPLUNK_API_URL" Value="https://api.[SPLUNK_REALM].observability.splunkcloud.com" />
       <CustomAction Id="Set_SPLUNK_INGEST_URL" Property="SPLUNK_INGEST_URL" Value="https://ingest.[SPLUNK_REALM].observability.splunkcloud.com" />
       <CustomAction Id="Set_SPLUNK_HEC_URL" Property="SPLUNK_HEC_URL" Value="[SPLUNK_INGEST_URL]/v1/log" />
@@ -54,8 +63,12 @@
       <InstallExecuteSequence>
          <Custom Action="CheckLaunchConditions" After="LaunchConditions" />
          <Custom Action="Set_SPLUNK_HEC_TOKEN" After="LaunchConditions" Condition="NOT SPLUNK_HEC_TOKEN" />
-         <Custom Action="AppendDefaultConfigTo_COLLECTOR_SVC_ARGS" After="CheckLaunchConditions" Condition="SPLUNK_ACCESS_TOKEN" />
-         <Custom Action="AppendLogsConfigTo_COLLECTOR_SVC_ARGS" After="AppendDefaultConfigTo_COLLECTOR_SVC_ARGS" Condition="SPLUNK_PLATFORM_LOGS_INDEX" />
+         <Custom Action="AppendDefaultConfigTo_COLLECTOR_SVC_ARGS" After="CheckLaunchConditions" Condition="SPLUNK_ACCESS_TOKEN AND NOT SPLUNK_CONFIG AND COLLECTOR_SVC_ARGS" />
+         <Custom Action="SetDefaultConfigTo_COLLECTOR_SVC_ARGS" After="AppendDefaultConfigTo_COLLECTOR_SVC_ARGS" Condition="SPLUNK_ACCESS_TOKEN AND NOT SPLUNK_CONFIG AND NOT COLLECTOR_SVC_ARGS" />
+         <Custom Action="AppendLogsConfigTo_COLLECTOR_SVC_ARGS" After="SetDefaultConfigTo_COLLECTOR_SVC_ARGS" Condition="SPLUNK_PLATFORM_URL AND NOT SPLUNK_CONFIG AND COLLECTOR_SVC_ARGS" />
+         <Custom Action="SetLogsConfigTo_COLLECTOR_SVC_ARGS" After="AppendLogsConfigTo_COLLECTOR_SVC_ARGS" Condition="SPLUNK_PLATFORM_URL AND NOT SPLUNK_CONFIG AND NOT COLLECTOR_SVC_ARGS" />
+         <!-- TODO Change below after metrics are added -->
+         <Custom Action="AppendMergeOptionTo_COLLECTOR_SVC_ARGS" After="SetLogsConfigTo_COLLECTOR_SVC_ARGS" Condition="SPLUNK_ACCESS_TOKEN AND SPLUNK_PLATFORM_URL AND NOT SPLUNK_CONFIG AND COLLECTOR_SVC_ARGS" />
          <Custom Action="Set_SPLUNK_API_URL" After="LaunchConditions" Condition="NOT SPLUNK_API_URL" />
          <Custom Action="Set_SPLUNK_INGEST_URL" After="LaunchConditions" Condition="NOT SPLUNK_INGEST_URL" />
          <!-- The properties below depend on another properties and should be run only after all other properties are set -->
@@ -81,14 +94,13 @@
                <MultiStringValue Value="SPLUNK_HEC_URL=[SPLUNK_HEC_URL]" />
                <MultiStringValue Value="SPLUNK_INGEST_URL=[SPLUNK_INGEST_URL]" />
                <MultiStringValue Value="SPLUNK_REALM=[SPLUNK_REALM]" />
-               <MultiStringValue Value="SPLUNK_PLATFORM_LOGS_INDEX=[SPLUNK_PLATFORM_LOGS_INDEX]" />
             </RegistryValue>
          </RegistryKey>
       </Component>
 
       <Feature Id="SplunkOtelCollector" Level="1">
-         <ComponentRef Id="ApplicationComponent" />
          <Feature Id="SplunkCollectorConfiguration" Level="1">
+            <ComponentRef Id="ApplicationComponent" />
             <ComponentRef Id="RegistryComponent" />
          </Feature>
          <ComponentRef Id="JmxMetricsJarComponent" />
@@ -107,8 +119,8 @@
       </Property>
 
       <!-- Copy the default agent config file to ProgramData if it does not already exist -->
-      <CustomAction Id="CopyConfig" ExeCommand="xcopy /y &quot;[INSTALLDIR]*_config.yaml&quot; &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\&quot;" Directory="INSTALLDIR" Impersonate="no" Execute="deferred" Return="check" />
-      <CustomAction Id="DeleteProgramFilesConfig" ExeCommand="cmd /c del /q &quot;[INSTALLDIR]*config.yaml&quot;" Directory="INSTALLDIR" Impersonate="no" Execute="deferred" Return="ignore" />
+      <CustomAction Id="CopyConfig" ExeCommand="xcopy /y &quot;[INSTALLDIR]*_config*.yaml&quot; &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\&quot;" Directory="INSTALLDIR" Impersonate="no" Execute="deferred" Return="check" />
+      <CustomAction Id="DeleteProgramFilesConfig" ExeCommand="cmd /c del /q &quot;[INSTALLDIR]*config*.yaml&quot;" Directory="INSTALLDIR" Impersonate="no" Execute="deferred" Return="ignore" />
 
       <ComponentGroup Id="AssortedFiles">
          <Files Directory="INSTALLDIR" Include="$(var.FilesDir)\**" />

--- a/packaging/msi/splunk-otel-collector.wxs
+++ b/packaging/msi/splunk-otel-collector.wxs
@@ -40,11 +40,13 @@
       <!-- SPLUNK_*_URL properties required to start the collector -->
       <Property Id="SPLUNK_REALM" Value="us0" Secure="yes" />
 
-      <Property Id="SPLUNK_CONFIG" Secure="yes" />
       <Property Id="SPLUNK_API_URL" Secure="yes" />
       <Property Id="SPLUNK_INGEST_URL" Secure="yes" />
       <Property Id="SPLUNK_HEC_URL" Secure="yes" />
-      <CustomAction Id="Set_SPLUNK_CONFIG" Property="SPLUNK_CONFIG" Value="[CommonAppDataFolder]Splunk\OpenTelemetry Collector\[SPLUNK_SETUP_COLLECTOR_MODE]_config.yaml" />
+      <Property Id="SPLUNK_PLATFORM_LOGS_INDEX" Secure="yes" />
+
+      <CustomAction Id="AppendDefaultConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="[COLLECTOR_SVC_ARGS] --config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\[SPLUNK_SETUP_COLLECTOR_MODE]_config.yaml&quot;" />
+      <CustomAction Id="AppendLogsConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="[COLLECTOR_SVC_ARGS] --config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\splunk_logs_windows_config.yaml&quot;" />
       <CustomAction Id="Set_SPLUNK_API_URL" Property="SPLUNK_API_URL" Value="https://api.[SPLUNK_REALM].observability.splunkcloud.com" />
       <CustomAction Id="Set_SPLUNK_INGEST_URL" Property="SPLUNK_INGEST_URL" Value="https://ingest.[SPLUNK_REALM].observability.splunkcloud.com" />
       <CustomAction Id="Set_SPLUNK_HEC_URL" Property="SPLUNK_HEC_URL" Value="[SPLUNK_INGEST_URL]/v1/log" />
@@ -52,7 +54,8 @@
       <InstallExecuteSequence>
          <Custom Action="CheckLaunchConditions" After="LaunchConditions" />
          <Custom Action="Set_SPLUNK_HEC_TOKEN" After="LaunchConditions" Condition="NOT SPLUNK_HEC_TOKEN" />
-         <Custom Action="Set_SPLUNK_CONFIG" After="LaunchConditions" Condition="NOT SPLUNK_CONFIG" />
+         <Custom Action="AppendDefaultConfigTo_COLLECTOR_SVC_ARGS" After="CheckLaunchConditions" Condition="SPLUNK_ACCESS_TOKEN" />
+         <Custom Action="AppendLogsConfigTo_COLLECTOR_SVC_ARGS" After="AppendDefaultConfigTo_COLLECTOR_SVC_ARGS" Condition="SPLUNK_PLATFORM_LOGS_INDEX" />
          <Custom Action="Set_SPLUNK_API_URL" After="LaunchConditions" Condition="NOT SPLUNK_API_URL" />
          <Custom Action="Set_SPLUNK_INGEST_URL" After="LaunchConditions" Condition="NOT SPLUNK_INGEST_URL" />
          <!-- The properties below depend on another properties and should be run only after all other properties are set -->
@@ -74,11 +77,11 @@
             <RegistryValue Type="multiString" Name="Environment">
                <MultiStringValue Value="SPLUNK_ACCESS_TOKEN=[SPLUNK_ACCESS_TOKEN]" />
                <MultiStringValue Value="SPLUNK_API_URL=[SPLUNK_API_URL]" />
-               <MultiStringValue Value="SPLUNK_CONFIG=[SPLUNK_CONFIG]" />
                <MultiStringValue Value="SPLUNK_HEC_TOKEN=[SPLUNK_HEC_TOKEN]" />
                <MultiStringValue Value="SPLUNK_HEC_URL=[SPLUNK_HEC_URL]" />
                <MultiStringValue Value="SPLUNK_INGEST_URL=[SPLUNK_INGEST_URL]" />
                <MultiStringValue Value="SPLUNK_REALM=[SPLUNK_REALM]" />
+               <MultiStringValue Value="SPLUNK_PLATFORM_LOGS_INDEX=[SPLUNK_PLATFORM_LOGS_INDEX]" />
             </RegistryValue>
          </RegistryKey>
       </Component>

--- a/tests/msi/msi_test.go
+++ b/tests/msi/msi_test.go
@@ -90,6 +90,16 @@ func TestMSI(t *testing.T) {
 				"SPLUNK_ACCESS_TOKEN":     "fakeToken",
 			},
 		},
+		{
+			name: "platform-logs",
+			collectorMSIProperties: map[string]string{
+				"SPLUNK_ACCESS_TOKEN":         "fakeToken",
+				"SPLUNK_PLATFORM_URL":         "http://localhost:8088/services/collector",
+				"SPLUNK_PLATFORM_TOKEN":       "platformToken",
+				"SPLUNK_PLATFORM_LOGS_INDEX":  "otel_logs",
+				"SPLUNK_SETUP_COLLECTOR_MODE": "agent",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -122,7 +132,6 @@ func TestCollectorReconfiguration(t *testing.T) {
 				"SPLUNK_MEMORY_TOTAL_MIB":     "256",
 				"GODEBUG":                     "fips140=on",
 			},
-			skipSvcStart: true,
 			genericMSIProperties: map[string]string{
 				"REINSTALL": "SplunkCollectorConfiguration", // MSI property to reinstall the configuration
 			},
@@ -132,6 +141,95 @@ func TestCollectorReconfiguration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			runMsiTest(t, tt, msiInstallerPath)
+		})
+	}
+}
+
+func TestMSILaunchConditions(t *testing.T) {
+	msiInstallerPath := getInstallerPath(t)
+
+	tests := []struct {
+		name                   string
+		collectorMSIProperties map[string]string
+		expectedLogMessage     string
+	}{
+		{
+			name: "platform-url-requires-platform-token",
+			collectorMSIProperties: map[string]string{
+				"SPLUNK_ACCESS_TOKEN": "fakeToken",
+				"SPLUNK_PLATFORM_URL": "http://localhost:8088/services/collector",
+			},
+			expectedLogMessage: "SPLUNK_PLATFORM_TOKEN is required when SPLUNK_PLATFORM_URL is set.",
+		},
+		{
+			name: "platform-token-requires-platform-url",
+			collectorMSIProperties: map[string]string{
+				"SPLUNK_ACCESS_TOKEN":   "fakeToken",
+				"SPLUNK_PLATFORM_TOKEN": "platformToken",
+			},
+			expectedLogMessage: "SPLUNK_PLATFORM_URL is required when SPLUNK_PLATFORM_TOKEN is set.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runMsiInstallFailureTest(t, msiTest{
+				name:                   tt.name,
+				collectorMSIProperties: tt.collectorMSIProperties,
+			}, msiInstallerPath, tt.expectedLogMessage)
+		})
+	}
+}
+
+func TestExpectedCollectorServiceArgs(t *testing.T) {
+	t.Setenv("PROGRAMDATA", `C:\ProgramData`)
+
+	collectorConfigDir := filepath.Join(os.Getenv("PROGRAMDATA"), "Splunk", "OpenTelemetry Collector")
+	defaultConfigArg := "--config " + quotedIfRequired(filepath.Join(collectorConfigDir, "agent_config.yaml"))
+	logsConfigArg := "--config " + quotedIfRequired(filepath.Join(collectorConfigDir, "splunk_logs_config_windows.yaml"))
+	mergeAppendFeatureGateArg := "--feature-gates=confmap.enableMergeAppendOption"
+
+	tests := []struct {
+		name          string
+		msiProperties map[string]string
+		expectedArgs  string
+	}{
+		{
+			name: "default-config-only",
+			msiProperties: map[string]string{
+				"SPLUNK_ACCESS_TOKEN": "fakeToken",
+			},
+			expectedArgs: defaultConfigArg,
+		},
+		{
+			name: "logs-config-only",
+			msiProperties: map[string]string{
+				"SPLUNK_PLATFORM_URL":   "http://localhost:8088/services/collector",
+				"SPLUNK_PLATFORM_TOKEN": "platformToken",
+			},
+			expectedArgs: logsConfigArg,
+		},
+		{
+			name: "default-and-logs-configs",
+			msiProperties: map[string]string{
+				"SPLUNK_ACCESS_TOKEN":   "fakeToken",
+				"SPLUNK_PLATFORM_URL":   "http://localhost:8088/services/collector",
+				"SPLUNK_PLATFORM_TOKEN": "platformToken",
+			},
+			expectedArgs: strings.Join([]string{defaultConfigArg, logsConfigArg, mergeAppendFeatureGateArg}, " "),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualArgs := expectedCollectorServiceArgs(t, tt.msiProperties)
+			assert.Equal(t, tt.expectedArgs, actualArgs)
+			assert.Equal(
+				t,
+				strings.Count(actualArgs, "--config") == 2,
+				strings.Contains(actualArgs, mergeAppendFeatureGateArg),
+				"merge append feature gate must be present only when two --config entries are present",
+			)
 		})
 	}
 }
@@ -207,8 +305,7 @@ func runMsiTest(t *testing.T, test msiTest, msiInstallerPath string) {
 	defer service.Close()
 
 	if !test.skipSvcStart {
-		err = service.Start()
-		require.NoError(t, err)
+		startServiceIfStopped(t, service)
 	}
 	if !test.skipSvcStop {
 		defer func() {
@@ -236,6 +333,48 @@ func runMsiTest(t *testing.T, test msiTest, msiInstallerPath string) {
 	assertServiceConfiguration(t, test.collectorMSIProperties, svcConfig)
 }
 
+func startServiceIfStopped(t *testing.T, service *mgr.Service) {
+	status, err := service.Query()
+	require.NoError(t, err)
+	if status.State == svc.Running {
+		return
+	}
+
+	err = service.Start()
+	require.NoError(t, err)
+}
+
+func runMsiInstallFailureTest(t *testing.T, test msiTest, msiInstallerPath, expectedLogMessage string) {
+	allMSIProperties := make(map[string]string)
+	for key, value := range test.genericMSIProperties {
+		allMSIProperties[key] = value
+	}
+	for key, value := range test.collectorMSIProperties {
+		allMSIProperties[key] = value
+	}
+
+	installLogFile := filepath.Join(os.TempDir(), "install.log")
+	args := []string{"/i", msiInstallerPath, "/qn", "/l*v", installLogFile}
+	for key, value := range allMSIProperties {
+		if strings.Contains(value, "\"") || strings.Contains(value, " ") {
+			value = strings.ReplaceAll(value, "\"", "\"\"")
+			value = "\"" + value + "\""
+		}
+		args = append(args, key+"="+value)
+	}
+
+	installCmd := exec.Command("msiexec")
+	cmdLine := strings.Join(args, " ")
+	installCmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: "msiexec " + cmdLine}
+	t.Logf("Install command: %s", installCmd.SysProcAttr.CmdLine)
+
+	err := installCmd.Run()
+	require.Error(t, err, "MSI installation should fail")
+
+	installLog := readInstallLog(t, installLogFile)
+	assert.Contains(t, installLog, expectedLogMessage)
+}
+
 func assertServiceConfiguration(t *testing.T, msiProperties map[string]string, svcConfig mgr.Config) {
 	programDataDir := os.Getenv("PROGRAMDATA")
 	require.NotEmpty(t, programDataDir, "PROGRAMDATA environment variable is not set")
@@ -253,9 +392,13 @@ func assertServiceConfiguration(t *testing.T, msiProperties map[string]string, s
 	configFileFullName := filepath.Join(programDataDir, "Splunk", "OpenTelemetry Collector", configFileName)
 	assert.FileExists(t, configFileFullName)
 	assert.NoFileExists(t, filepath.Join(programFilesDir, "Splunk", "OpenTelemetry Collector", configFileName))
+	if msiProperties["SPLUNK_PLATFORM_URL"] != "" {
+		logsConfigFileName := "splunk_logs_config_windows.yaml"
+		assert.FileExists(t, filepath.Join(programDataDir, "Splunk", "OpenTelemetry Collector", logsConfigFileName))
+		assert.NoFileExists(t, filepath.Join(programFilesDir, "Splunk", "OpenTelemetry Collector", logsConfigFileName))
+	}
 
 	expectedEnvVars := map[string]string{
-		"SPLUNK_CONFIG":       configFileFullName,
 		"SPLUNK_ACCESS_TOKEN": msiProperties["SPLUNK_ACCESS_TOKEN"], // Required install property for a successful start of the service
 		"SPLUNK_REALM":        installRealm,
 		"SPLUNK_API_URL":      optionalInstallPropertyOrDefault(msiProperties, "SPLUNK_API_URL", "https://api."+installRealm+".observability.splunkcloud.com"),
@@ -269,14 +412,25 @@ func assertServiceConfiguration(t *testing.T, msiProperties map[string]string, s
 	if goDebug, ok := msiProperties["GODEBUG"]; ok {
 		expectedEnvVars["GODEBUG"] = goDebug
 	}
+	for _, key := range []string{
+		"GOMEMLIMIT",
+		"SPLUNK_GATEWAY_URL",
+		"SPLUNK_LISTEN_INTERFACE",
+		"SPLUNK_MEMORY_LIMIT_MIB",
+		"SPLUNK_PLATFORM_URL",
+		"SPLUNK_PLATFORM_TOKEN",
+		"SPLUNK_PLATFORM_LOGS_INDEX",
+	} {
+		if value, ok := msiProperties[key]; ok {
+			expectedEnvVars[key] = value
+		}
+	}
 
 	// Verify the environment variables set for the service
 	svcEnvVars := getServiceEnvVars(t, "splunk-otel-collector")
 	assert.Equal(t, expectedEnvVars, svcEnvVars)
 
-	if svcArgs, ok := msiProperties["COLLECTOR_SVC_ARGS"]; ok {
-		assert.Equal(t, expectedServiceCommand(t, svcArgs), svcConfig.BinaryPathName)
-	}
+	assert.Equal(t, expectedServiceCommand(t, expectedCollectorServiceArgs(t, msiProperties)), svcConfig.BinaryPathName)
 }
 
 func optionalInstallPropertyOrDefault(msiProperties map[string]string, key, defaultValue string) string {
@@ -300,10 +454,28 @@ func getServiceEnvVars(t *testing.T, serviceName string) map[string]string {
 	for _, envVar := range svcEnv {
 		parts := strings.SplitN(envVar, "=", 2)
 		require.Len(t, parts, 2)
+		assert.NotContains(t, envVars, parts[0], "Duplicate service environment variable %q", parts[0])
 		envVars[parts[0]] = parts[1]
 	}
 
 	return envVars
+}
+
+func readInstallLog(t *testing.T, installLogFile string) string {
+	logFile, err := os.Open(installLogFile)
+	require.NoError(t, err, "Failed to open install log file")
+	defer logFile.Close()
+
+	var logLines []string
+	scanner := bufio.NewScanner(transform.NewReader(
+		logFile,
+		unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewDecoder()))
+	for scanner.Scan() {
+		logLines = append(logLines, scanner.Text())
+	}
+	require.NoError(t, scanner.Err(), "Error reading install log file")
+
+	return strings.Join(logLines, "\n")
 }
 
 func getInstallerPath(t *testing.T) string {
@@ -317,6 +489,43 @@ func getInstallerPath(t *testing.T) string {
 	return msiInstallerPath
 }
 
+func expectedCollectorServiceArgs(t *testing.T, msiProperties map[string]string) string {
+	programDataDir := os.Getenv("PROGRAMDATA")
+	require.NotEmpty(t, programDataDir, "PROGRAMDATA environment variable is not set")
+
+	collectorServiceArgs := optionalInstallPropertyOrDefault(msiProperties, "COLLECTOR_SVC_ARGS", "")
+	collectorServiceArgs = strings.Trim(collectorServiceArgs, "\"")
+	collectorServiceArgs = strings.ReplaceAll(collectorServiceArgs, "\"\"", "\"")
+
+	if _, ok := msiProperties["SPLUNK_CONFIG"]; ok {
+		return collectorServiceArgs
+	}
+
+	if msiProperties["SPLUNK_ACCESS_TOKEN"] != "" {
+		installMode := optionalInstallPropertyOrDefault(msiProperties, "SPLUNK_SETUP_COLLECTOR_MODE", "agent")
+		configFileFullName := filepath.Join(programDataDir, "Splunk", "OpenTelemetry Collector", installMode+"_config.yaml")
+		collectorServiceArgs = appendServiceArg(collectorServiceArgs, "--config "+quotedIfRequired(configFileFullName))
+	}
+
+	if msiProperties["SPLUNK_PLATFORM_URL"] != "" {
+		logsConfigFileFullName := filepath.Join(programDataDir, "Splunk", "OpenTelemetry Collector", "splunk_logs_config_windows.yaml")
+		collectorServiceArgs = appendServiceArg(collectorServiceArgs, "--config "+quotedIfRequired(logsConfigFileFullName))
+	}
+
+	if msiProperties["SPLUNK_ACCESS_TOKEN"] != "" && msiProperties["SPLUNK_PLATFORM_URL"] != "" {
+		collectorServiceArgs = appendServiceArg(collectorServiceArgs, "--feature-gates=confmap.enableMergeAppendOption")
+	}
+
+	return collectorServiceArgs
+}
+
+func appendServiceArg(collectorServiceArgs, arg string) string {
+	if collectorServiceArgs == "" {
+		return arg
+	}
+	return collectorServiceArgs + " " + arg
+}
+
 func expectedServiceCommand(t *testing.T, collectorServiceArgs string) string {
 	programFilesDir := os.Getenv("PROGRAMFILES")
 	require.NotEmpty(t, programFilesDir, "PROGRAMFILES environment variable is not set")
@@ -327,10 +536,6 @@ func expectedServiceCommand(t *testing.T, collectorServiceArgs string) string {
 	if collectorServiceArgs == "" {
 		return quotedIfRequired(collectorExe)
 	}
-
-	// Remove any quotation added for the msiexec command line
-	collectorServiceArgs = strings.Trim(collectorServiceArgs, "\"")
-	collectorServiceArgs = strings.ReplaceAll(collectorServiceArgs, "\"\"", "\"")
 
 	return quotedIfRequired(collectorExe) + " " + collectorServiceArgs
 }


### PR DESCRIPTION
Adds new logs_windows_config.yaml to MSI distribution

OTEL is run with following files depending on presence of specified parameter:
agent_config.yaml -> SPLUNK_ACCESS_TOKEN
logs_windows_config.yaml -> SPLUNK_PLATFORM_URL
