### PR TITLE
[config] Remove signalfx exporter from all trace pipelines

### DIFF
--- a/.chloggen/remove_signalfx_traces.yaml
+++ b/.chloggen/remove_signalfx_traces.yaml
@@ -8,7 +8,7 @@ component: config
 note: Remove `signalfx` exporter from trace pipelines in all default configs
 
 # One or more tracking issues related to the change
-issues: []
+issues: [7594]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/remove_signalfx_traces.yaml
+++ b/.chloggen/remove_signalfx_traces.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: config
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `signalfx` exporter from trace pipelines in all default configs
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Trace correlation can now be done without including the `signalfx` exporter in trace pipelines.

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Default endpoint URLs have changed from *.signalfx.com to *.observability.splunk
     service:
       pipelines:
         traces:
-          exporters: [otlphttp, signalfx]
+          exporters: [otlphttp]
     ```
 
 

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -224,9 +224,9 @@ service:
       - batch
       - resourcedetection
       #- resource/add_environment
-      exporters: [otlp_http, signalfx]
+      exporters: [otlp_http]
       # Use instead when sending to gateway
-      #exporters: [otlp_grpc/gateway, signalfx]
+      #exporters: [otlp_grpc/gateway]
     metrics:
       receivers: [host_metrics, otlp]
       processors: [memory_limiter, batch, resourcedetection]

--- a/cmd/otelcol/config/collector/ecs_ec2_config.yaml
+++ b/cmd/otelcol/config/collector/ecs_ec2_config.yaml
@@ -173,7 +173,7 @@ service:
         - batch
         - resourcedetection
         #- resource/add_environment
-      exporters: [otlp_http, signalfx]
+      exporters: [otlp_http]
     metrics:
       receivers: [host_metrics, otlp, awsecscontainermetrics]
       processors: [memory_limiter, batch, filter, resourcedetection]

--- a/cmd/otelcol/config/collector/fargate_config.yaml
+++ b/cmd/otelcol/config/collector/fargate_config.yaml
@@ -144,7 +144,7 @@ service:
         - batch
         - resourcedetection
         #- resource/add_environment
-      exporters: [otlp_http, signalfx]
+      exporters: [otlp_http]
     metrics:
       receivers: [otlp, awsecscontainermetrics, prometheus/internal]
       processors: [memory_limiter, batch, resourcedetection]

--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -763,7 +763,7 @@ service:
       - memory_limiter
       - batch
       #- resource/add_environment
-      exporters: [otlp_http, signalfx]
+      exporters: [otlp_http]
     metrics:
       receivers: [otlp]
       processors: [memory_limiter, batch]

--- a/cmd/otelcol/config/collector/otlp_config_linux.yaml
+++ b/cmd/otelcol/config/collector/otlp_config_linux.yaml
@@ -141,7 +141,7 @@ service:
       - memory_limiter
       - batch
       #- resource/add_environment
-      exporters: [otlp_http, signalfx]
+      exporters: [otlp_http]
     metrics:
       receivers: [otlp]
       processors: [memory_limiter, batch]

--- a/cmd/otelcol/config/collector/upstream_agent_config.yaml
+++ b/cmd/otelcol/config/collector/upstream_agent_config.yaml
@@ -205,9 +205,9 @@ service:
       - batch
       - resourcedetection
       #- resource/add_environment
-      exporters: [otlp_http, signalfx]
+      exporters: [otlp_http]
       # Use instead when sending to gateway
-      #exporters: [otlp_grpc/gateway, signalfx]
+      #exporters: [otlp_grpc/gateway]
     # Required for Splunk Infrastructure Monitoring
     metrics:
       receivers: [host_metrics, otlp]

--- a/cmd/otelcol/fips/config/agent_config.yaml
+++ b/cmd/otelcol/fips/config/agent_config.yaml
@@ -218,9 +218,9 @@ service:
       - batch
       - resourcedetection
       #- resource/add_environment
-      exporters: [otlp_http, signalfx]
+      exporters: [otlp_http]
       # Use instead when sending to gateway
-      #exporters: [otlp_grpc, signalfx]
+      #exporters: [otlp_grpc]
     metrics:
       receivers: [host_metrics, otlp]
       processors: [memory_limiter, batch, resourcedetection]

--- a/cmd/otelcol/fips/config/ecs_ec2_config.yaml
+++ b/cmd/otelcol/fips/config/ecs_ec2_config.yaml
@@ -178,7 +178,7 @@ service:
         - batch
         - resourcedetection
         #- resource/add_environment
-      exporters: [otlp_http, signalfx]
+      exporters: [otlp_http]
     metrics:
       receivers: [host_metrics, otlp]
       processors: [memory_limiter, batch, filter, resourcedetection]

--- a/cmd/otelcol/fips/config/fargate_config.yaml
+++ b/cmd/otelcol/fips/config/fargate_config.yaml
@@ -144,7 +144,7 @@ service:
         - batch
         - resourcedetection
         #- resource/add_environment
-      exporters: [otlp_http, signalfx]
+      exporters: [otlp_http]
     metrics:
       receivers: [otlp, prometheus/internal]
       processors: [memory_limiter, batch, resourcedetection]

--- a/cmd/otelcol/fips/config/otlp_config_linux.yaml
+++ b/cmd/otelcol/fips/config/otlp_config_linux.yaml
@@ -141,7 +141,7 @@ service:
       - memory_limiter
       - batch
       #- resource/add_environment
-      exporters: [otlp_http, signalfx]
+      exporters: [otlp_http]
     metrics:
       receivers: [otlp]
       processors: [memory_limiter, batch]

--- a/deployments/nomad/otel-agent.nomad
+++ b/deployments/nomad/otel-agent.nomad
@@ -229,7 +229,6 @@ service:
       exporters:
       - debug
       - otlp_http
-      - signalfx
       processors:
       - memory_limiter
       - batch

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histograms_disabled.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histograms_disabled.yaml
@@ -22,11 +22,6 @@ service:
       exporters:
         - otlp_grpc
         - signalfx
-    traces/signalfx:
-      receivers:
-        - otlp
-      exporters:
-        - signalfx
   telemetry:
     resource:
       resattr1: val1

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histograms_disabled_expected.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histograms_disabled_expected.yaml
@@ -22,11 +22,6 @@ service:
       exporters:
         - otlp_grpc
         - signalfx
-    traces/signalfx:
-      receivers:
-        - otlp
-      exporters:
-        - signalfx
   telemetry:
     resource:
       resattr1: val1

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histograms_disabled_no_exp.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histograms_disabled_no_exp.yaml
@@ -28,12 +28,6 @@ service:
       exporters:
         - otlp_grpc
         - signalfx
-    traces/signalfx:
-      receivers:
-        - otlp
-      exporters:
-        - signalfx
-  telemetry:
     resource:
       resattr1: val1
       resattr2: val2

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histograms_disabled_no_exp.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histograms_disabled_no_exp.yaml
@@ -28,6 +28,7 @@ service:
       exporters:
         - otlp_grpc
         - signalfx
+  telemetry:
     resource:
       resattr1: val1
       resattr2: val2

--- a/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histograms_disabled_no_exp_expected.yaml
+++ b/internal/configconverter/testdata/otlp_histograms_attr/send_otlp_histograms_disabled_no_exp_expected.yaml
@@ -28,11 +28,6 @@ service:
       exporters:
         - otlp_grpc
         - signalfx
-    traces/signalfx:
-      receivers:
-        - otlp
-      exporters:
-        - signalfx
   telemetry:
     resource:
       resattr1: val1

--- a/tests/general/default_config_test.go
+++ b/tests/general/default_config_test.go
@@ -536,7 +536,7 @@ func TestDefaultAgentConfig(t *testing.T) {
 							"receivers":  []any{"prometheus/internal"},
 						},
 						"traces": map[string]any{
-							"exporters":  []any{"otlp_http", "signalfx"},
+							"exporters":  []any{"otlp_http"},
 							"processors": []any{"memory_limiter", "batch", "resourcedetection"},
 							"receivers":  []any{"jaeger", "otlp", "zipkin"},
 						},


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Correlation is handled by backend now, trace correlation can be done using OTLP exporters on their own now.