### PR TITLE
[chore] Fix TA v2 publication script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1531,8 +1531,8 @@ ta-v2-splunkbase-release:
         declare -A log_files pids
         for entry in \
             "7125:${TA_DIR}/Splunk_TA_otel.tgz" \
-            "8968:${TA_DIR}/Splunk_TA_otel_linux_x86_64.tgz" \
-            "8969:${TA_DIR}/Splunk_TA_otel_windows_x86_64.tgz"
+            "8698:${TA_DIR}/Splunk_TA_otel_linux_x86_64.tgz" \
+            "8699:${TA_DIR}/Splunk_TA_otel_windows_x86_64.tgz"
         do
           app_id="${entry%%:*}"
           package="${entry#*:}"
@@ -1548,8 +1548,7 @@ ta-v2-splunkbase-release:
 
         overall_status=0
         for app_id in "${!pids[@]}"; do
-          wait "${pids[$app_id]}"
-          publish_status=$?
+          wait "${pids[$app_id]}" && publish_status=0 || publish_status=$?
           if [[ "$publish_status" -ne 0 ]]; then
             overall_status=1
           fi

--- a/.gitlab/publish-ta-v2-to-splunkbase.sh
+++ b/.gitlab/publish-ta-v2-to-splunkbase.sh
@@ -121,9 +121,20 @@ fi
 echo "Step 3: Updating release notes for release_file ${release_file}..."
 curl -u "${AUTH}" \
     --request PUT "https://splunkbase.splunk.com/api/v2/apps/${APP_ID}/releases/${release_file}/" \
-    --json "{\"release_notes\": \"Add-On with Splunk OpenTelemetry Collector ${VERSION_TAG}\\n\\n[Release Notes](https://github.com/signalfx/splunk-otel-collector/releases/tag/${VERSION_TAG})\"}" \
+    --json "{\"public\":true,\"release_notes\": \"Add-On with Splunk OpenTelemetry Collector ${VERSION_TAG}\\n\\n[Release Notes](https://github.com/signalfx/splunk-otel-collector/releases/tag/${VERSION_TAG})\"}" \
     -fSs \
     || { echo "Failed to update release notes for ${file_name}"; exit 1; }
 echo ""
 echo "Updated release notes for ${file_name} (release_file: ${release_file})"
+
+# Step 4: Make the latest release the default version for the app
+echo "Step 4: Setting release_file ${release_file} as default version for app ${APP_ID}..."
+curl -u "${AUTH}" \
+    --request PATCH "https://splunkbase.splunk.com/api/v2/apps/${APP_ID}/" \
+    --json "{\"latest_release\": ${release_file}}" \
+    -fSs \
+    || { echo "Failed to set default version for ${file_name}"; exit 1; }
+echo ""
+echo "Set ${release_file} as default version for app ${APP_ID}"
+
 echo "--- Done with ${file_name} ---"


### PR DESCRIPTION
Fix 3 issues:

1. Script was bailing out on first failure, now it will loop through all publication scripts that were forked
2. The IDs of the per platform TAs had a typo
3. Make the latest release the default, it requires first to make it public