### PR TITLE
[chore] Reduce Ansible test flakiness on Windows

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -238,6 +238,7 @@ jobs:
       - name: Install vagrant and virtualbox
         run: |
           sudo apt update && sudo apt install -y virtualbox
+          sudo modprobe vboxdrv
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
           sudo apt update && sudo apt install -y vagrant


### PR DESCRIPTION
Fix suggested by Copilot, reasoning:

Workaround for https://github.com/actions/runner-images/issues/13202 — explicitly load the vboxdrv kernel module after installing VirtualBox so Vagrant can start VMs successfully.