### PR TITLE
[installer] Deprecate HEC URL parameter

### DIFF
--- a/.chloggen/deprecate_hec_url_param.yaml
+++ b/.chloggen/deprecate_hec_url_param.yaml
@@ -2,13 +2,13 @@
 change_type: deprecation
 
 # The name of the component, or a single word describing the area of concern, (e.g. crosslink)
-component: installer scripts
+component: installer
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Deprecate the HEC URL parameter
 
 # One or more tracking issues related to the change
-issues: []
+issues: [7611]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/deprecate_hec_url_param.yaml
+++ b/.chloggen/deprecate_hec_url_param.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: installer scripts
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the HEC URL parameter
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `--hec-url` and `-hec_url` parameters (for BASH and PowerShell, respectively) have been
+  deprecated and will be removed in September 2026.

--- a/README.md
+++ b/README.md
@@ -227,12 +227,12 @@ Default endpoint URLs have changed from *.signalfx.com to *.observability.splunk
   `install.sh` (add these flags):
   
     --api-url https://api.<realm>.signalfx.com \
-    --ingest-url https://ingest.<realm>.signalfx.com \
+    --ingest-url https://ingest.<realm>.signalfx.com
   
   `install.ps1` (add these flags):
   
     -api_url https://api.<realm>.signalfx.com `
-    -ingest_url https://ingest.<realm>.signalfx.com `
+    -ingest_url https://ingest.<realm>.signalfx.com
   
   Chocolatey (add these params):
   

--- a/README.md
+++ b/README.md
@@ -228,13 +228,11 @@ Default endpoint URLs have changed from *.signalfx.com to *.observability.splunk
   
     --api-url https://api.<realm>.signalfx.com \
     --ingest-url https://ingest.<realm>.signalfx.com \
-    --hec-url https://ingest.<realm>.signalfx.com/v1/log
   
   `install.ps1` (add these flags):
   
     -api_url https://api.<realm>.signalfx.com `
     -ingest_url https://ingest.<realm>.signalfx.com `
-    -hec_url https://ingest.<realm>.signalfx.com/v1/log
   
   Chocolatey (add these params):
   

--- a/packaging/installer/install.ps1
+++ b/packaging/installer/install.ps1
@@ -53,7 +53,7 @@
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -api_url "https://api.us1.observability.splunkcloud.com"
 .PARAMETER hec_url
-    (OPTIONAL) Set the HEC endpoint URL explicitly instead of the endpoint inferred from the specified realm (default: https://ingest.REALM.observability.splunkcloud.com/v1/log).
+    (DEPRECATED) Set the HEC endpoint URL explicitly instead of the endpoint inferred from the specified realm (default: https://ingest.REALM.observability.splunkcloud.com/v1/log).
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -hec_url "https://ingest.us1.observability.splunkcloud.com/v1/log"
 .PARAMETER hec_token
@@ -537,6 +537,9 @@ if ($api_url -eq "") {
 
 if ($hec_url -eq "") {
     $hec_url = "$ingest_url/v1/log"
+}
+else {
+    Write-Warning "[DEPRECATED] The parameter '-hec_url' is deprecated and will be removed in September 2026."
 }
 
 if ($hec_token -eq "") {

--- a/packaging/installer/install.sh
+++ b/packaging/installer/install.sh
@@ -1451,7 +1451,7 @@ parse_args_and_install() {
         ;;
       --hec-url)
         hec_url="$2"
-        echo "[DEPRECATED]: The parameter '--hec-url' is deprecated and will be removed in September 2026."
+        echo "[DEPRECATED]: The parameter '--hec-url' is deprecated and will be removed in September 2026." >&2
         shift 1
         ;;
       --splunk-platform-token)

--- a/packaging/installer/install.sh
+++ b/packaging/installer/install.sh
@@ -1090,7 +1090,7 @@ Collector:
                                         (default: "$default_collector_version")
   --discovery                           Enable discovery mode on collector startup (disabled by default).
   --hec-token <token>                   Set the HEC token if different than the specified access_token.
-  --hec-url <url>                       Set the HEC endpoint URL explicitly instead of the endpoint inferred from the
+  --hec-url <url>                       [DEPRECATED] Set the HEC endpoint URL explicitly instead of the endpoint inferred from the
                                         specified realm.
                                         (default: https://ingest.REALM.observability.splunkcloud.com/v1/log)
   --godebug <value>                     Set values for the GODEBUG environment variable.
@@ -1451,6 +1451,7 @@ parse_args_and_install() {
         ;;
       --hec-url)
         hec_url="$2"
+        echo "[DEPRECATED]: The parameter '--hec-url' is deprecated and will be removed in September 2026."
         shift 1
         ;;
       --splunk-platform-token)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Deprecates the `--hec-url` and `-hec_url` parameters of the BASH and PowerShell installation scripts (respectively).