### PR TITLE
[chore] Fix GitLab puppet-release job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1722,6 +1722,7 @@ puppet-release:
     - if: $CI_COMMIT_TAG =~ /^puppet-v[0-9]+\.[0-9]+\.[0-9]+.*/
   needs: []
   before_script:
+    - gem update --system 3.2.3
     - gem install bundler -v 2.4.22
     - cd deployments/puppet
     - bundle install

--- a/deployments/puppet/Gemfile.lock
+++ b/deployments/puppet/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.9.0)
-      public_suffix (>= 2.0.2, < 5.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ansi (1.5.0)
     ast (2.4.2)
     awesome_print (1.9.2)
@@ -79,7 +79,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    public_suffix (4.0.6)
+    public_suffix (5.1.1)
     puppet (7.12.1)
       concurrent-ruby (~> 1.0)
       deep_merge (~> 1.0)
@@ -139,9 +139,9 @@ GEM
       pathspec (>= 0.2.1, < 2.0.0)
     puppet-resource_api (1.8.14)
       hocon (>= 1.0)
-    puppet-strings (2.7.0)
+    puppet-strings (2.9.0)
       rgen
-      yard (>= 0.9.36)
+      yard (~> 0.9.5)
     puppet-syntax (3.1.0)
       puppet (>= 5)
       rake
@@ -168,7 +168,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.4.2)
-    rgen (0.8.2)
+    rgen (0.10.2)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -251,10 +251,10 @@ GEM
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     unicode_utils (1.4.0)
-    yard (0.9.26)
+    yard (0.9.44)
 
 PLATFORMS
-  ruby
+  aarch64-linux
 
 DEPENDENCIES
   fast_gettext
@@ -266,4 +266,4 @@ DEPENDENCIES
   rspec_junit_formatter
 
 BUNDLED WITH
-   2.2.33
+   2.4.22


### PR DESCRIPTION
Update version and Gemfile.lock to correctly publish a Puppet release
