### PR TITLE
[chore] Fix Tanzu Tile workflow

### DIFF
--- a/.github/workflows/tanzu-tile.yml
+++ b/.github/workflows/tanzu-tile.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Install BOSH CLI
         shell: bash
         run: |
+          brew trust cloudfoundry/tap
           brew install cloudfoundry/tap/bosh-cli
           bosh -v
       - name: Install PCF CLI

--- a/.github/workflows/tanzu-tile.yml
+++ b/.github/workflows/tanzu-tile.yml
@@ -10,6 +10,7 @@ on:
       - main
   pull_request:
     paths:
+      - '.github/workflows/tanzu-tile.yml'
       - 'deployments/cloudfoundry/bosh/**'
       - 'deployments/cloudfoundry/tile/**'
 

--- a/.github/workflows/tanzu-tile.yml
+++ b/.github/workflows/tanzu-tile.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Install BOSH CLI
         shell: bash
         run: |
+          export HOMEBREW_NO_SANDBOX_LINUX=1
           brew install bubblewrap
           brew trust cloudfoundry/tap
           brew install cloudfoundry/tap/bosh-cli

--- a/.github/workflows/tanzu-tile.yml
+++ b/.github/workflows/tanzu-tile.yml
@@ -67,7 +67,12 @@ jobs:
       - name: Install BOSH CLI
         shell: bash
         run: |
-          export HOMEBREW_NO_SANDBOX_LINUX=1
+          brew install bubblewrap
+          # Required for bubblewrap to function properly
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
+          sudo sysctl -w user.max_user_namespaces=28633
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+
           brew trust cloudfoundry/tap
           brew install cloudfoundry/tap/bosh-cli
           bosh -v

--- a/.github/workflows/tanzu-tile.yml
+++ b/.github/workflows/tanzu-tile.yml
@@ -68,7 +68,6 @@ jobs:
         shell: bash
         run: |
           export HOMEBREW_NO_SANDBOX_LINUX=1
-          brew install bubblewrap
           brew trust cloudfoundry/tap
           brew install cloudfoundry/tap/bosh-cli
           bosh -v

--- a/.github/workflows/tanzu-tile.yml
+++ b/.github/workflows/tanzu-tile.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Install BOSH CLI
         shell: bash
         run: |
+          brew install bubblewrap
           brew trust cloudfoundry/tap
           brew install cloudfoundry/tap/bosh-cli
           bosh -v


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The workflow's been failing 100% of the time for the last week or so ([example](https://github.com/signalfx/splunk-otel-collector/actions/runs/27431314121/job/81082114316)).

Failure logs:
```
Warning: Skipping cloudfoundry/tap because it is not trusted. Run `brew trust cloudfoundry/tap` to trust it.
...
==> Installing bosh-cli from cloudfoundry/tap
Error: Bubblewrap is required to use the Linux sandbox but was not found.

Install Bubblewrap and ensure a rootless `bwrap` executable is available on `PATH`.

As a final workaround, disable the Linux sandbox:
  export HOMEBREW_NO_SANDBOX_LINUX=1

Error: Process completed with exit code 1.
```
Linux sandbox is not required for this workflow's functionality to successfully complete, so it works to just disable. Something must have been updated on GitHub runners that made this start to fail, I don't see anything related in our repo.