### PR TITLE
[chore] Allow having closed-source private Go dependency

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,9 +1,26 @@
 name: 'setup environment'
 description: 'setup go environment'
 
+inputs:
+  private-modules-token:
+    description: 'GitHub token with read access to private Go module repositories'
+    required: true
+
 runs:
   using: "composite"
   steps:
+    - name: Configure private Go module access
+      shell: bash
+      env:
+        PRIVATE_MODULES_TOKEN: ${{ inputs.private-modules-token }}
+      run: |
+        if [ -z "$PRIVATE_MODULES_TOKEN" ]; then
+          echo "private-modules-token is required to fetch private Go modules" >&2
+          exit 1
+        fi
+        git config --global url."https://x-access-token:${PRIVATE_MODULES_TOKEN}@github.com/".insteadOf "https://github.com/"
+        echo "GOPRIVATE=github.com/signalfx/splunk-otel-collector-components" >> "$GITHUB_ENV"
+
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
       with:

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -2,20 +2,25 @@ name: 'setup environment'
 description: 'setup go environment'
 
 inputs:
+  private-modules:
+    description: 'Enable private Go module access'
+    required: false
+    default: 'false'
   private-modules-token:
-    description: 'GitHub token with read access to private Go module repositories'
-    required: true
+    description: 'GitHub token with read access to private Go module repositories. Required when private-modules is true.'
+    required: false
 
 runs:
   using: "composite"
   steps:
     - name: Configure private Go module access
+      if: inputs.private-modules == 'true'
       shell: bash
       env:
         PRIVATE_MODULES_TOKEN: ${{ inputs.private-modules-token }}
       run: |
         if [ -z "$PRIVATE_MODULES_TOKEN" ]; then
-          echo "private-modules-token is required to fetch private Go modules" >&2
+          echo "private-modules-token is required when private-modules is enabled" >&2
           exit 1
         fi
         git config --global url."https://x-access-token:${PRIVATE_MODULES_TOKEN}@github.com/".insteadOf "https://github.com/"

--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -33,6 +33,7 @@ jobs:
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
+    secrets: inherit
 
   build-package:
     runs-on: ${{ matrix.ARCH == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: tidy
         run: |
@@ -36,6 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: gofmt
         run: |
@@ -51,6 +55,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: generate-metrics
         run: |
@@ -81,6 +87,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - run: echo "GOLANGCI_LINT_CACHE=${HOME}/.cache/golangci-lint" >> "$GITHUB_ENV"
 
@@ -128,6 +136,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Free up disk space for next step
         run: .github/workflows/scripts/free-disk-space.sh
@@ -152,6 +162,7 @@ jobs:
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
+    secrets: inherit
 
   latest-dockerd-test:
     # Run this as a separate test to avoid affecting other tests with the dockerd upgrade.
@@ -159,6 +170,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: dockerd test
         working-directory: ./internal/signalfx-agent/pkg/monitors/docker

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
+          private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: tidy
@@ -39,6 +40,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
+          private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: gofmt
@@ -56,6 +58,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
+          private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: generate-metrics
@@ -88,6 +91,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
+          private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - run: echo "GOLANGCI_LINT_CACHE=${HOME}/.cache/golangci-lint" >> "$GITHUB_ENV"
@@ -137,6 +141,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
+          private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Free up disk space for next step
@@ -171,6 +176,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
+          private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: dockerd test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,6 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup-environment
         with:
+          private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
       - run: make binaries-linux_${{ matrix.ARCH }} COVER_TESTING=true
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -22,10 +22,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+      - uses: ./.github/actions/setup-environment
         with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
       - run: make binaries-linux_${{ matrix.ARCH }} COVER_TESTING=true
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
+          private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Lint

--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Lint
         run: |

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
+    secrets: inherit
 
   build-package:
     needs: [cross-compile]

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-environment
         with:
+          private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build Docker image from local changes

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Set up environment
         uses: ./.github/actions/setup-environment
+        with:
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build Docker image from local changes
         run: |

--- a/.github/workflows/otelcol-fips.yml
+++ b/.github/workflows/otelcol-fips.yml
@@ -56,6 +56,7 @@ jobs:
         env:
           GOOS: ${{ matrix.GOOS }}
           GOARCH: ${{ matrix.GOARCH }}
+          OTELCOL_PRIVATE_MODULES_TOKEN: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: otelcol-fips-${{ matrix.GOOS }}-${{ matrix.GOARCH }}

--- a/.github/workflows/reusable-compile.yml
+++ b/.github/workflows/reusable-compile.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build Collector
         run: |

--- a/.github/workflows/reusable-compile.yml
+++ b/.github/workflows/reusable-compile.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
+          private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build Collector

--- a/.github/workflows/reusable-unit-test.yml
+++ b/.github/workflows/reusable-unit-test.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
+          private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Set CGO_ENABLED

--- a/.github/workflows/reusable-unit-test.yml
+++ b/.github/workflows/reusable-unit-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Set CGO_ENABLED
         # Currently, CGO enabled is required for:

--- a/.github/workflows/ta-v2.yaml
+++ b/.github/workflows/ta-v2.yaml
@@ -37,6 +37,7 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:
+          private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build collector binaries (linux & windows)

--- a/.github/workflows/ta-v2.yaml
+++ b/.github/workflows/ta-v2.yaml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
+        with:
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build collector binaries (linux & windows)
         run: |

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-environment
         with:
+          private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
       - run: |
           make docker-otelcol ARCH=${{ matrix.ARCH }} FIPS="${{ matrix.FIPS }}"
@@ -238,6 +239,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
+          private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Echo `govulncheck` version

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -51,6 +51,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up environment
         uses: ./.github/actions/setup-environment
+        with:
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
       - run: |
           make docker-otelcol ARCH=${{ matrix.ARCH }} FIPS="${{ matrix.FIPS }}"
         env:
@@ -69,6 +71,7 @@ jobs:
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
+    secrets: inherit
 
   anchore-image-scan:
     if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'Run vulnerabilities scan') }}
@@ -234,6 +237,8 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Echo `govulncheck` version
         continue-on-error: true

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -36,6 +36,7 @@ jobs:
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
+    secrets: inherit
 
   msi-custom-actions:
     uses: ./.github/workflows/reusable-msi-custom-actions.yml

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -29,6 +29,17 @@ jobs:
           $ErrorActionPreference = 'Continue'
           & ${{ github.workspace }}\.github\workflows\scripts\win-required-ports.ps1
 
+      - name: Configure private Go module access
+        env:
+          PRIVATE_MODULES_TOKEN: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not $env:PRIVATE_MODULES_TOKEN) {
+            throw "OTELCOL_PRIVATE_MODULES_TOKEN is required to fetch private Go modules"
+          }
+          git config --global url."https://x-access-token:$($env:PRIVATE_MODULES_TOKEN)@github.com/".insteadOf "https://github.com/"
+          "GOPRIVATE=github.com/signalfx/splunk-otel-collector-components" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -222,11 +222,22 @@ sast-scan:
         fi
       fi
 
+# Configure git and GOPRIVATE so `go build`/`go mod` can fetch private modules
+# under github.com/signalfx/*. Requires OTELCOL_PRIVATE_MODULES_TOKEN.
+.private-modules-setup: &private-modules-setup |
+  if [ -z "${OTELCOL_PRIVATE_MODULES_TOKEN:-}" ]; then
+    echo "OTELCOL_PRIVATE_MODULES_TOKEN is required to fetch private Go modules" >&2
+    exit 1
+  fi
+  git config --global "url.https://x-access-token:${OTELCOL_PRIVATE_MODULES_TOKEN}@github.com/.insteadOf" "https://github.com/"
+
 .go-cache:
   image: '${DOCKER_HUB_REPO}/golang:${GO_VERSION}'
   variables:
     GOPATH: "$CI_PROJECT_DIR/.go"
+    GOPRIVATE: "github.com/signalfx/splunk-otel-collector-components"
   before_script:
+    - *private-modules-setup
     - mkdir -p $GOPATH
     - make install-tools
     - export PATH=$GOPATH/bin:$PATH
@@ -403,6 +414,7 @@ otelcol-fips:
       aud: $CICD_VAULT_ADDR
   script:
     - *docker-reader-role
+    - *private-modules-setup
     - |
       VERSION_TAG="${RELEASE_VERSION:-${CI_COMMIT_TAG:-}}"
       make otelcol-fips VERSION=${VERSION_TAG} DOCKER_REPO=${DOCKER_HUB_REPO}

--- a/Makefile
+++ b/Makefile
@@ -355,6 +355,7 @@ endif
 	docker buildx build --pull \
 		--tag otelcol-fips-builder-$(GOOS)-$(GOARCH) \
 		--platform linux/$(GOARCH) \
+		--secret id=private_modules_token,env=OTELCOL_PRIVATE_MODULES_TOKEN \
 		--build-arg DOCKER_REPO=$(DOCKER_REPO) \
 		--build-arg BUILD_INFO='$(BUILD_INFO)' \
 		--file cmd/otelcol/fips/build/Dockerfile.$(GOOS) ./

--- a/cmd/otelcol/fips/build/Dockerfile.linux
+++ b/cmd/otelcol/fips/build/Dockerfile.linux
@@ -17,6 +17,10 @@ ENV GOOS=linux
 ENV GOARCH=${TARGETARCH}
 ENV GOFLAGS="-tags=requirefips"
 ENV GOMODCACHE=/go/pkg/mod
+ENV GOPRIVATE=github.com/signalfx/splunk-otel-collector-components
 
 WORKDIR /src
-RUN --mount=type=cache,target=${GOMODCACHE} make otelcol BUILD_INFO="${BUILD_INFO}"
+RUN --mount=type=cache,target=${GOMODCACHE} \
+    --mount=type=secret,id=private_modules_token,required=true \
+    git config --global "url.https://x-access-token:$(cat /run/secrets/private_modules_token)@github.com/.insteadOf" "https://github.com/" && \
+    make otelcol BUILD_INFO="${BUILD_INFO}"

--- a/cmd/otelcol/fips/build/Dockerfile.windows
+++ b/cmd/otelcol/fips/build/Dockerfile.windows
@@ -19,6 +19,10 @@ ENV GOMODCACHE=/go/pkg/mod
 ENV GOFLAGS="-tags=requirefips"
 ENV GOEXPERIMENT=systemcrypto
 ENV EXTENSION=.exe
+ENV GOPRIVATE=github.com/signalfx/splunk-otel-collector-components
 
 WORKDIR /src
-RUN --mount=type=cache,target=${GOMODCACHE} make otelcol BUILD_INFO="${BUILD_INFO}"
+RUN --mount=type=cache,target=${GOMODCACHE} \
+    --mount=type=secret,id=private_modules_token,required=true \
+    git config --global "url.https://x-access-token:$(cat /run/secrets/private_modules_token)@github.com/.insteadOf" "https://github.com/" && \
+    make otelcol BUILD_INFO="${BUILD_INFO}"


### PR DESCRIPTION
Allows consuming closed-source Go packages from a private GitHub repository `github.com/signalfx/splunk-otel-collector-components`

For now we don't pull anything from the closed sourced repo. It will only be used behing a go build flag ensuring that the open-source part is the default in can be built with no extra credentials