### PR TITLE
[chore] verify-signed-metadata checks against artifactory repomod

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1301,7 +1301,6 @@ verify-signed-metadata:
       gpg --import <(curl -fsSL "${SPLUNK_RPM_GPG_KEY_URL}")
       gpg --import <(curl -fsSL "${SPLUNK_DEB_GPG_KEY_URL}")
 
-      # Confirm the key served at the published URL is the one we expect.
       gpg --list-keys "${SPLUNK_GPG_FINGERPRINT}" >/dev/null \
         || { echo "Expected signing key ${SPLUNK_GPG_FINGERPRINT} not found at the published key URL(s)!"; exit 1; }
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1288,6 +1288,7 @@ verify-signed-metadata:
   variables:
     SPLUNK_RPM_GPG_KEY_URL: "https://splunk.jfrog.io/splunk/otel-collector-rpm/splunk-B3CD4420.pub"
     SPLUNK_DEB_GPG_KEY_URL: "https://splunk.jfrog.io/splunk/otel-collector-deb/splunk-B3CD4420.gpg"
+    SPLUNK_GPG_FINGERPRINT: "58C33310B7A354C1279DB6695EFA01EDB3CD4420"
   before_script:
     - apt update && apt install -y curl gnupg
   script:
@@ -1296,17 +1297,24 @@ verify-signed-metadata:
       set -exo pipefail
 
       export GNUPGHOME="$(mktemp -d)"
+      trap 'rm -rf "$GNUPGHOME"' EXIT
       gpg --import <(curl -fsSL "${SPLUNK_RPM_GPG_KEY_URL}")
       gpg --import <(curl -fsSL "${SPLUNK_DEB_GPG_KEY_URL}")
+
+      # Confirm the key served at the published URL is the one we expect.
+      gpg --list-keys "${SPLUNK_GPG_FINGERPRINT}" >/dev/null \
+        || { echo "Expected signing key ${SPLUNK_GPG_FINGERPRINT} not found at the published key URL(s)!"; exit 1; }
 
       verify_detached() {
         local data_url="$1" sig_url="$2" name="$3" local_sig="${4:-}"
         echo "Verifying live signature for ${name} ..."
         curl -fsSL "$data_url" -o "metadata.${name}"
         curl -fsSL "$sig_url" -o "metadata.${name}.asc"
-        # The published signature must validate against the live
-        # metadata Artifactory is serving (catches the async-regeneration race).
-        gpg --verify "metadata.${name}.asc" "metadata.${name}"
+        # The published signature must validate against the live metadata
+        # Artifactory is serving (catches the async-regeneration race)
+        gpg --status-fd=1 --verify "metadata.${name}.asc" "metadata.${name}" \
+          | grep -Eq "^\[GNUPG:\] VALIDSIG ${SPLUNK_GPG_FINGERPRINT}( |\$)" \
+          || { echo "Signature for ${name} did not validate against pinned key ${SPLUNK_GPG_FINGERPRINT}!"; exit 1; }
         # The published signature is the one this pipeline uploaded (catches a failed upload or a stale/cached .asc)
         if [ -n "$local_sig" ]; then
           diff "metadata.${name}.asc" "$local_sig"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1285,15 +1285,41 @@ verify-signed-metadata:
     - release-debs
     - release-rpms
   retry: 2
+  variables:
+    SPLUNK_RPM_GPG_KEY_URL: "https://splunk.jfrog.io/splunk/otel-collector-rpm/splunk-B3CD4420.pub"
+    SPLUNK_DEB_GPG_KEY_URL: "https://splunk.jfrog.io/splunk/otel-collector-deb/splunk-B3CD4420.gpg"
   before_script:
-    - apt update && apt install -y curl
+    - apt update && apt install -y curl gnupg
   script:
     - *get-artifactory-stage
     - |
       set -exo pipefail
-      curl -fq https://splunk.jfrog.io/artifactory/otel-collector-deb/dists/${STAGE}/Release.gpg | diff - signed/Release.asc
-      curl -fq https://splunk.jfrog.io/artifactory/otel-collector-rpm/${STAGE}/x86_64/repodata/repomd.xml.asc | diff - signed/x86_64/repomd.xml.asc
-      curl -fq https://splunk.jfrog.io/artifactory/otel-collector-rpm/${STAGE}/aarch64/repodata/repomd.xml.asc | diff - signed/aarch64/repomd.xml.asc
+
+      export GNUPGHOME="$(mktemp -d)"
+      gpg --import <(curl -fsSL "${SPLUNK_RPM_GPG_KEY_URL}")
+      gpg --import <(curl -fsSL "${SPLUNK_DEB_GPG_KEY_URL}")
+
+      verify_detached() {
+        local data_url="$1" sig_url="$2" name="$3" local_sig="${4:-}"
+        echo "Verifying live signature for ${name} ..."
+        curl -fsSL "$data_url" -o "metadata.${name}"
+        curl -fsSL "$sig_url" -o "metadata.${name}.asc"
+        # The published signature must validate against the live
+        # metadata Artifactory is serving (catches the async-regeneration race).
+        gpg --verify "metadata.${name}.asc" "metadata.${name}"
+        # The published signature is the one this pipeline uploaded (catches a failed upload or a stale/cached .asc)
+        if [ -n "$local_sig" ]; then
+          diff "metadata.${name}.asc" "$local_sig"
+        fi
+      }
+
+      deb_base="https://splunk.jfrog.io/artifactory/otel-collector-deb/dists/${STAGE}"
+      verify_detached "${deb_base}/Release" "${deb_base}/Release.gpg" "deb-Release" "signed/Release.asc"
+
+      for arch in x86_64 aarch64; do
+        rpm_base="https://splunk.jfrog.io/artifactory/otel-collector-rpm/${STAGE}/${arch}/repodata"
+        verify_detached "${rpm_base}/repomd.xml" "${rpm_base}/repomd.xml.asc" "rpm-${arch}-repomd.xml" "signed/${arch}/repomd.xml.asc"
+      done
 
 # only upload the msi to S3 for stable release tags
 release-msi:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The verify-signed-metadata job was meant to confirm our repo metadata signatures are valid, but it currently only compares the published `.asc` to the local `.asc` we generated. It never checks the signature against the `repomd.xml/Release` that Artifactory is serving, so if the published metadata doesn't match its signature, this check still passes.

Artifactory regenerates RPM/Debian metadata asynchronously: our release script never calls Artifactory's metadata-calculation API, it uploads the package and then polls for repomd.xml to change on its own ([ref](https://github.com/signalfx/splunk-otel-collector/blob/a0c2651b6642e46612ec73ef0efa6335f8920980/packaging/release/helpers/util.py#L192-L203)), i.e. it relies on Artifactory's "Auto Calculate RPM Metadata," which is [asynchronous by default](https://jfrog.com/help/r/how-rpm-repository-indexing-works-in-artifactory/how-rpm-repository-indexing-works-in-artifactory). A calculation pass can rewrite repomd.xml (new <revision>) after we've signed the snapshot we fetched. The uploaded .asc is then stale relative to the live repomd.xml, and clients with `repo_gpgcheck=1` fail with `repomd.xml GPG signature verification error: Bad GPG signature`.

This change imports Splunk's public signing key and runs `gpg --verify` of the live repomd.xml (both arches) and Release against their detached signatures. The existing diff is kept, so the job now asserts both: the published signature validates against the live metadata (catches the regeneration race), and it's same as the signature this pipeline produced (catches a failed upload or a stale/cached .asc).