### PR TITLE
[chore] wait for repo metadata to be updated

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1285,6 +1285,13 @@ verify-signed-metadata:
     - release-debs
     - release-rpms
   retry: 2
+  parallel:
+    matrix:
+      - TARGET: deb
+      - TARGET: rpm
+        ARCH: x86_64
+      - TARGET: rpm
+        ARCH: aarch64
   variables:
     SPLUNK_RPM_GPG_KEY_URL: "https://splunk.jfrog.io/splunk/otel-collector-rpm/splunk-B3CD4420.pub"
     SPLUNK_DEB_GPG_KEY_URL: "https://splunk.jfrog.io/splunk/otel-collector-deb/splunk-B3CD4420.gpg"
@@ -1304,29 +1311,46 @@ verify-signed-metadata:
       gpg --list-keys "${SPLUNK_GPG_FINGERPRINT}" >/dev/null \
         || { echo "Expected signing key ${SPLUNK_GPG_FINGERPRINT} not found at the published key URL(s)!"; exit 1; }
 
-      verify_detached() {
-        local data_url="$1" sig_url="$2" name="$3" local_sig="${4:-}"
-        echo "Verifying live signature for ${name} ..."
-        curl -fsSL "$data_url" -o "metadata.${name}"
-        curl -fsSL "$sig_url" -o "metadata.${name}.asc"
-        # The published signature must validate against the live metadata
-        # Artifactory is serving (catches the async-regeneration race)
-        gpg --status-fd=1 --verify "metadata.${name}.asc" "metadata.${name}" \
-          | grep -Eq "^\[GNUPG:\] VALIDSIG ${SPLUNK_GPG_FINGERPRINT}( |\$)" \
-          || { echo "Signature for ${name} did not validate against pinned key ${SPLUNK_GPG_FINGERPRINT}!"; exit 1; }
-        # The published signature is the one this pipeline uploaded (catches a failed upload or a stale/cached .asc)
-        if [ -n "$local_sig" ]; then
-          diff "metadata.${name}.asc" "$local_sig"
-        fi
-      }
+      # Resolve this matrix target's live metadata URL, its detached signature
+      # URL, and the signature this pipeline produced (from the release job
+      # artifacts).
+      case "$TARGET" in
+        deb)
+          base="https://splunk.jfrog.io/artifactory/otel-collector-deb/dists/${STAGE}"
+          data_url="${base}/Release"
+          sig_url="${base}/Release.gpg"
+          name="deb-Release"
+          local_sig="signed/Release.asc"
+          ;;
+        rpm)
+          base="https://splunk.jfrog.io/artifactory/otel-collector-rpm/${STAGE}/${ARCH}/repodata"
+          data_url="${base}/repomd.xml"
+          sig_url="${base}/repomd.xml.asc"
+          name="rpm-${ARCH}-repomd.xml"
+          local_sig="signed/${ARCH}/repomd.xml.asc"
+          ;;
+        *)
+          echo "Unknown TARGET '${TARGET}'"; exit 1
+          ;;
+      esac
 
-      deb_base="https://splunk.jfrog.io/artifactory/otel-collector-deb/dists/${STAGE}"
-      verify_detached "${deb_base}/Release" "${deb_base}/Release.gpg" "deb-Release" "signed/Release.asc"
+      echo "Verifying live signature for ${name} ..."
+      curl -fsSL "$data_url" -o "metadata.${name}"
+      curl -fsSL "$sig_url" -o "metadata.${name}.asc"
 
-      for arch in x86_64 aarch64; do
-        rpm_base="https://splunk.jfrog.io/artifactory/otel-collector-rpm/${STAGE}/${arch}/repodata"
-        verify_detached "${rpm_base}/repomd.xml" "${rpm_base}/repomd.xml.asc" "rpm-${arch}-repomd.xml" "signed/${arch}/repomd.xml.asc"
-      done
+      # The published signature must validate against the live metadata
+      # Artifactory is serving (catches the async-regeneration race).
+      gpg --status-fd=1 --verify "metadata.${name}.asc" "metadata.${name}" \
+        | grep -Eq "^\[GNUPG:\] VALIDSIG ${SPLUNK_GPG_FINGERPRINT}( |\$)" \
+        || { echo "Signature for ${name} did not validate against pinned key ${SPLUNK_GPG_FINGERPRINT}!"; exit 1; }
+
+      # The published signature is the one this pipeline uploaded (catches a
+      # failed upload or a stale/cached .asc).
+      if [ -n "$local_sig" ]; then
+        diff "metadata.${name}.asc" "$local_sig"
+      fi
+
+      echo "Signature OK for ${name}"
 
 # only upload the msi to S3 for stable release tags
 release-msi:
@@ -1654,6 +1678,8 @@ github-release:
       artifacts: true
     - job: release-rpms
       artifacts: true
+    - job: verify-signed-metadata
+      artifacts: false
     - job: sign-msi
       artifacts: true
     - job: sign-tar

--- a/packaging/release/helpers/constants.py
+++ b/packaging/release/helpers/constants.py
@@ -25,7 +25,7 @@ DEFAULT_ARTIFACTORY_USERNAME = "otel-collector"
 DEFAULT_TIMEOUT = 1200
 # After the repo metadata first changes following our upload, require it to stay
 # unchanged for this many seconds before treating it as settled.
-METADATA_SETTLE_DELAY = 30
+METADATA_SETTLE_DELAY = 90
 
 # Package/Release
 REPO_DIR = Path(__file__).parent.parent.parent.parent.resolve()

--- a/packaging/release/helpers/constants.py
+++ b/packaging/release/helpers/constants.py
@@ -23,6 +23,9 @@ ARTIFACTORY_RPM_REPO = "otel-collector-rpm"
 ARTIFACTORY_RPM_REPO_URL = f"{ARTIFACTORY_URL}/{ARTIFACTORY_RPM_REPO}"
 DEFAULT_ARTIFACTORY_USERNAME = "otel-collector"
 DEFAULT_TIMEOUT = 1200
+# After the repo metadata first changes following our upload, require it to stay
+# unchanged for this many seconds before treating it as settled.
+METADATA_SETTLE_DELAY = 30
 
 # Package/Release
 REPO_DIR = Path(__file__).parent.parent.parent.parent.resolve()

--- a/packaging/release/helpers/constants.py
+++ b/packaging/release/helpers/constants.py
@@ -25,7 +25,7 @@ DEFAULT_ARTIFACTORY_USERNAME = "otel-collector"
 DEFAULT_TIMEOUT = 1200
 # After the repo metadata first changes following our upload, require it to stay
 # unchanged for this many seconds before treating it as settled.
-METADATA_SETTLE_DELAY = 90
+METADATA_SETTLE_DELAY = 60
 
 # Package/Release
 REPO_DIR = Path(__file__).parent.parent.parent.parent.resolve()

--- a/packaging/release/helpers/release_args.py
+++ b/packaging/release/helpers/release_args.py
@@ -136,7 +136,7 @@ def get_args_and_asset():
     )
     parser.add_argument(
         "--sync-calculate-metadata",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=os.environ.get("ARTIFACTORY_SYNC_CALCULATE", "").lower() in ("1", "true", "yes"),
         required=False,
         help="""

--- a/packaging/release/helpers/release_args.py
+++ b/packaging/release/helpers/release_args.py
@@ -134,6 +134,18 @@ def get_args_and_asset():
         required=False,
         help="Never prompt when overwriting existing files.",
     )
+    parser.add_argument(
+        "--sync-calculate-metadata",
+        action="store_true",
+        default=os.environ.get("ARTIFACTORY_SYNC_CALCULATE", "").lower() in ("1", "true", "yes"),
+        required=False,
+        help="""
+            For deb/rpm uploads, explicitly trigger Artifactory's metadata
+            calculation synchronously (async=0) after upload and before signing,
+            instead of relying only on the asynchronous auto-calculation.
+            Defaults to the ARTIFACTORY_SYNC_CALCULATE env var if truthy.
+        """,
+    )
 
     add_artifactory_args(parser)
 

--- a/packaging/release/helpers/util.py
+++ b/packaging/release/helpers/util.py
@@ -185,7 +185,7 @@ def wait_for_artifactory_metadata(
     # during the window, adopt the new value and keep waiting.
     while True:
         elapsed = int(time.time() - start_time)
-        assert elapsed < timeout, (
+        assert elapsed + settle_delay <= timeout, (
             f"Timed out after {elapsed}s waiting for {url} to settle "
             f"(last seen MD5: {last_md5})"
         )
@@ -194,7 +194,7 @@ def wait_for_artifactory_metadata(
         new_md5 = get_md5_from_artifactory(url, user, token)
         if new_md5 and str(new_md5).lower() == str(last_md5).lower():
             print(
-                f"Metadata settled after {elapsed}s "
+                f"Metadata settled after {int(time.time() - start_time)}s "
                 f"(unchanged for {settle_delay}s, MD5: {new_md5})"
             )
             return

--- a/packaging/release/helpers/util.py
+++ b/packaging/release/helpers/util.py
@@ -166,8 +166,8 @@ def wait_for_artifactory_metadata(
         if new_md5 and str(orig_md5).lower() != str(new_md5).lower():
             last_md5 = new_md5
             print(
-                f"Metadata updated after {elapsed}s (new MD5: {new_md5}); "
-                f"reconfirming it has settled ..."
+                f"Metadata updated after {int(time.time() - start_time)}s "
+                f"(new MD5: {new_md5}); reconfirming it has settled ..."
             )
             break
 
@@ -190,6 +190,7 @@ def wait_for_artifactory_metadata(
             f"(last seen MD5: {last_md5})"
         )
 
+        print(f"Waiting {settle_delay}s to confirm the metadata has settled ...")
         time.sleep(settle_delay)
         new_md5 = get_md5_from_artifactory(url, user, token)
         if new_md5 and str(new_md5).lower() == str(last_md5).lower():

--- a/packaging/release/helpers/util.py
+++ b/packaging/release/helpers/util.py
@@ -33,6 +33,7 @@ from .constants import (
     DEFAULT_TIMEOUT,
     EXTENSIONS,
     INSTALLER_SCRIPTS,
+    METADATA_SETTLE_DELAY,
     PACKAGE_NAME,
     REPO_DIR,
     S3_BUCKET,
@@ -135,10 +136,24 @@ def get_md5_from_artifactory(url, user, token):
     return md5
 
 
-def wait_for_artifactory_metadata(url, orig_md5, user, token, timeout=DEFAULT_TIMEOUT):
+def trigger_metadata_calculation(calculate_url, user, token, timeout=DEFAULT_TIMEOUT):
+    # Explicitly ask Artifactory to (re)calculate the repo metadata and block
+    # until it finishes (async=0).
+    print(f"Triggering synchronous metadata calculation: {calculate_url}")
+    resp = requests.post(calculate_url, auth=(user, token), timeout=timeout)
+    print(f"Calculation response: {resp.status_code} {resp.text.strip()}")
+    resp.raise_for_status()
+
+
+def wait_for_artifactory_metadata(
+    url, orig_md5, user, token, timeout=DEFAULT_TIMEOUT, settle_delay=METADATA_SETTLE_DELAY
+):
     print(f"Waiting for {url} to be updated (original MD5: {orig_md5}) ...")
 
     start_time = time.time()
+
+    # wait for the metadata to change from the pre-upload snapshot.
+    last_md5 = orig_md5
     while True:
         elapsed = int(time.time() - start_time)
         assert elapsed < timeout, (
@@ -149,13 +164,46 @@ def wait_for_artifactory_metadata(url, orig_md5, user, token, timeout=DEFAULT_TI
         new_md5 = get_md5_from_artifactory(url, user, token)
 
         if new_md5 and str(orig_md5).lower() != str(new_md5).lower():
-            print(f"Metadata updated after {elapsed}s (new MD5: {new_md5})")
+            last_md5 = new_md5
+            print(
+                f"Metadata updated after {elapsed}s (new MD5: {new_md5}); "
+                f"reconfirming it has settled ..."
+            )
             break
 
         if elapsed > 0 and elapsed % 60 == 0:
             print(f"  Still waiting after {elapsed}s (MD5 unchanged: {new_md5}) ...")
 
         time.sleep(5)
+
+    # Require the metadata to stay unchanged across a settle window
+    # before treating it as final. Artifactory recalculates metadata
+    # asynchronously and may run more than one calculation pass for a batch, so
+    # returning on the first change can capture an intermediate snapshot that a
+    # later pass overwrites whose detached signature would no longer match the
+    # published metadata and break repo_gpgcheck for clients. If it changes again
+    # during the window, adopt the new value and keep waiting.
+    while True:
+        elapsed = int(time.time() - start_time)
+        assert elapsed < timeout, (
+            f"Timed out after {elapsed}s waiting for {url} to settle "
+            f"(last seen MD5: {last_md5})"
+        )
+
+        time.sleep(settle_delay)
+        new_md5 = get_md5_from_artifactory(url, user, token)
+        if new_md5 and str(new_md5).lower() == str(last_md5).lower():
+            print(
+                f"Metadata settled after {elapsed}s "
+                f"(unchanged for {settle_delay}s, MD5: {new_md5})"
+            )
+            return
+        print(
+            f"Metadata changed again during settle window "
+            f"(MD5 {last_md5} -> {new_md5}); reconfirming ..."
+        )
+        last_md5 = new_md5
+
 
 def upload_package_to_artifactory(
     path,
@@ -166,6 +214,7 @@ def upload_package_to_artifactory(
     metadata_url,
     sign_metadata=True,
     timeout=DEFAULT_TIMEOUT,
+    calculate_url=None,
 ):
     local_md5 = get_checksum(path, hashlib.md5())
     clean_url = dest_url.split(";")[0]
@@ -193,6 +242,8 @@ def upload_package_to_artifactory(
 
     if sign_metadata:
         if content_changed:
+            if calculate_url:
+                trigger_metadata_calculation(calculate_url, user, token, timeout=timeout)
             wait_for_artifactory_metadata(metadata_api_url, orig_md5, user, token, timeout=timeout)
         else:
             print(
@@ -223,6 +274,10 @@ def release_deb_to_artifactory(asset, args):
         if resp.lower() not in ("y", "yes"):
             sys.exit(1)
 
+    calculate_url = None
+    if getattr(args, "sync_calculate_metadata", False):
+        calculate_url = f"{ARTIFACTORY_API_URL}/deb/reindex/{ARTIFACTORY_DEB_REPO}?async=0"
+
     upload_package_to_artifactory(
         asset.path,
         dest_url,
@@ -232,6 +287,7 @@ def release_deb_to_artifactory(asset, args):
         metadata_url,
         sign_metadata=True,
         timeout=args.timeout,
+        calculate_url=calculate_url,
     )
 
 
@@ -253,6 +309,10 @@ def release_rpm_to_artifactory(asset, args):
         if resp.lower() not in ("y", "yes"):
             sys.exit(1)
 
+    calculate_url = None
+    if getattr(args, "sync_calculate_metadata", False):
+        calculate_url = f"{ARTIFACTORY_API_URL}/yum/{ARTIFACTORY_RPM_REPO}/{args.stage}/{arch}?async=0"
+
     upload_package_to_artifactory(
         asset.path,
         dest_url,
@@ -262,6 +322,7 @@ def release_rpm_to_artifactory(asset, args):
         metadata_url,
         sign_metadata=True,
         timeout=args.timeout,
+        calculate_url=calculate_url,
     )
 
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
- Settle before signing(`release.py`/`util.py`): after upload, wait for the metadata to change and then stay unchanged for a settle window (`METADATA_SETTLE_DELAY=60s`) before downloading + signing, so we don't sign an intermediate snapshot that a subsequent pass overwrites.
- `verify-signed-metadata` → parallel matrix (`deb`, `rpm/x86_64`, `rpm/aarch64`):  each target verifies independently instead of existing job bailing on the first failure and hiding the rest.
-  `github-release` now `needs: verify-signed-metadata`, so a signature that doesn't validate against the live metadata blocks the git tag / GitHub release from being created.
- Opt-in synchronous calculation (`--sync-calculate-metadata` / `ARTIFACTORY_SYNC_CALCULATE`, default off): explicitly POST Artifactory's metadata-calculation API with `async=0` before signing. Per JFrog docs this is only truly synchronous when Auto-Calculate is disabled on the repo, so it's shipped off-by-default for evaluation in the `test`/`beta` stages once we update the repo settings.

