### PR TITLE
installer: add config path to svc args

### DIFF
--- a/.chloggen/fix-win-msi-splunk-config-svc-args.yaml
+++ b/.chloggen/fix-win-msi-splunk-config-svc-args.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: installer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the Windows MSI so the collector service starts when `SPLUNK_CONFIG` is provided as an install property.
+
+# One or more tracking issues related to the change
+issues: [7701]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Since v0.154.0, tooling that passes `SPLUNK_CONFIG` as an MSI property (e.g. the Puppet and Ansible
+  modules) produced a service with no config, so it failed to start. The MSI now routes a supplied
+  `SPLUNK_CONFIG` into `COLLECTOR_SVC_ARGS` as a `--config "<path>"` argument.

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/custom_vars/windows-verify.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/custom_vars/windows-verify.yml
@@ -5,7 +5,6 @@
   become: no
   vars:
     collector_reg_values:
-      SPLUNK_CONFIG: '{{ ansible_env.ProgramData }}\Splunk\OpenTelemetry Collector\custom_config.yml'
       SPLUNK_INGEST_URL: https://fake-splunk-ingest.com
       SPLUNK_API_URL: https://fake-splunk-api.com
       SPLUNK_HEC_URL: https://fake-splunk-hec.com
@@ -71,7 +70,8 @@
         name: ImagePath
       register: collector_imagepath
 
-    - name: Assert service ImagePath ends with the splunk_otel_collector_command_line_args value used in the playbook
+    - name: Assert service ImagePath contains the custom command line args and the SPLUNK_CONFIG --config value
       ansible.builtin.assert:
         that:
-          - collector_imagepath.value.endswith("--discovery --set=processors.batch.timeout=10s")
+          - "'--discovery --set=processors.batch.timeout=10s' in collector_imagepath.value"
+          - "'custom_config.yml' in collector_imagepath.value"

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/default/windows-verify.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/default/windows-verify.yml
@@ -5,7 +5,6 @@
   become: no
   vars:
     collector_reg_values:
-      SPLUNK_CONFIG: '{{ ansible_env.ProgramData }}\Splunk\OpenTelemetry Collector\agent_config.yaml'
       SPLUNK_ACCESS_TOKEN: fake-token
       SPLUNK_REALM: fake-realm
       SPLUNK_API_URL: https://api.fake-realm.observability.splunkcloud.com
@@ -30,3 +29,15 @@
       ansible.builtin.assert:
         that: (item.key + '=' + (item.value | string)) in collector_env.value
       loop: "{{ collector_reg_values | dict2items }}"
+
+    - name: Get splunk-otel-collector service ImagePath
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Services\splunk-otel-collector
+        name: ImagePath
+      register: collector_imagepath
+
+    - name: Assert the default config is passed to the collector service via --config
+      ansible.builtin.assert:
+        that:
+          - "'--config' in collector_imagepath.value"
+          - "'agent_config.yaml' in collector_imagepath.value"

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/default_install_remote_version/windows-verify.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/default_install_remote_version/windows-verify.yml
@@ -5,7 +5,6 @@
   become: no
   vars:
     collector_reg_values:
-      SPLUNK_CONFIG: '{{ ansible_env.ProgramData }}\Splunk\OpenTelemetry Collector\agent_config.yaml'
       SPLUNK_ACCESS_TOKEN: fake-token
       SPLUNK_REALM: fake-realm
       SPLUNK_API_URL: https://api.fake-realm.observability.splunkcloud.com
@@ -54,3 +53,15 @@
       ansible.builtin.assert:
         that: (item.key + '=' + (item.value | string)) in collector_env.value
       loop: "{{ collector_reg_values | dict2items }}"
+
+    - name: Get splunk-otel-collector service ImagePath
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Services\splunk-otel-collector
+        name: ImagePath
+      register: collector_imagepath
+
+    - name: Assert the default config is passed to the collector service via --config
+      ansible.builtin.assert:
+        that:
+          - "'--config' in collector_imagepath.value"
+          - "'agent_config.yaml' in collector_imagepath.value"

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/with_instrumentation/windows-verify.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/molecule/with_instrumentation/windows-verify.yml
@@ -5,7 +5,6 @@
   become: no
   vars:
     collector_reg_values:
-      SPLUNK_CONFIG: '{{ ansible_env.ProgramData }}\Splunk\OpenTelemetry Collector\agent_config.yaml'
       SPLUNK_ACCESS_TOKEN: fake-token
       SPLUNK_REALM: fake-realm
       SPLUNK_API_URL: https://api.fake-realm.observability.splunkcloud.com
@@ -56,3 +55,15 @@
         item_name: "{{ item.key }}"
         exists: false
       loop: "{{ iis_reg_values | dict2items }}"
+
+    - name: Get splunk-otel-collector service ImagePath
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Services\splunk-otel-collector
+        name: ImagePath
+      register: collector_imagepath
+
+    - name: Assert the default config is passed to the collector service via --config
+      ansible.builtin.assert:
+        that:
+          - "'--config' in collector_imagepath.value"
+          - "'agent_config.yaml' in collector_imagepath.value"

--- a/packaging/msi/splunk-otel-collector.wxs
+++ b/packaging/msi/splunk-otel-collector.wxs
@@ -56,6 +56,8 @@
       <CustomAction Id="SetLogsConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="--config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\splunk_logs_config_windows.yaml&quot;" />
       <CustomAction Id="AppendLogsConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="[COLLECTOR_SVC_ARGS] --config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\splunk_logs_config_windows.yaml&quot;" />
       <CustomAction Id="AppendMergeOptionTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="[COLLECTOR_SVC_ARGS] --feature-gates=confmap.enableMergeAppendOption" />
+      <CustomAction Id="SetSplunkConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="--config &quot;[SPLUNK_CONFIG]&quot;" />
+      <CustomAction Id="AppendSplunkConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="[COLLECTOR_SVC_ARGS] --config &quot;[SPLUNK_CONFIG]&quot;" />
       <CustomAction Id="Set_SPLUNK_API_URL" Property="SPLUNK_API_URL" Value="https://api.[SPLUNK_REALM].observability.splunkcloud.com" />
       <CustomAction Id="Set_SPLUNK_INGEST_URL" Property="SPLUNK_INGEST_URL" Value="https://ingest.[SPLUNK_REALM].observability.splunkcloud.com" />
       <CustomAction Id="Set_SPLUNK_HEC_URL" Property="SPLUNK_HEC_URL" Value="[SPLUNK_INGEST_URL]/v1/log" />
@@ -69,6 +71,8 @@
          <Custom Action="SetLogsConfigTo_COLLECTOR_SVC_ARGS" After="AppendLogsConfigTo_COLLECTOR_SVC_ARGS" Condition="SPLUNK_PLATFORM_URL AND NOT SPLUNK_CONFIG AND NOT COLLECTOR_SVC_ARGS" />
          <!-- TODO Change below after metrics are added -->
          <Custom Action="AppendMergeOptionTo_COLLECTOR_SVC_ARGS" After="SetLogsConfigTo_COLLECTOR_SVC_ARGS" Condition="SPLUNK_ACCESS_TOKEN AND SPLUNK_PLATFORM_URL AND NOT SPLUNK_CONFIG AND COLLECTOR_SVC_ARGS" />
+         <Custom Action="AppendSplunkConfigTo_COLLECTOR_SVC_ARGS" After="AppendMergeOptionTo_COLLECTOR_SVC_ARGS" Condition="SPLUNK_CONFIG AND COLLECTOR_SVC_ARGS" />
+         <Custom Action="SetSplunkConfigTo_COLLECTOR_SVC_ARGS" After="AppendSplunkConfigTo_COLLECTOR_SVC_ARGS" Condition="SPLUNK_CONFIG AND NOT COLLECTOR_SVC_ARGS" />
          <Custom Action="Set_SPLUNK_API_URL" After="LaunchConditions" Condition="NOT SPLUNK_API_URL" />
          <Custom Action="Set_SPLUNK_INGEST_URL" After="LaunchConditions" Condition="NOT SPLUNK_INGEST_URL" />
          <!-- The properties below depend on another properties and should be run only after all other properties are set -->

--- a/tests/msi/msi_test.go
+++ b/tests/msi/msi_test.go
@@ -100,6 +100,15 @@ func TestMSI(t *testing.T) {
 				"SPLUNK_SETUP_COLLECTOR_MODE": "agent",
 			},
 		},
+		{
+			// Mirrors how the Puppet/Ansible modules install the MSI: SPLUNK_CONFIG is
+			// passed as a property. The service must still start with the given config.
+			name: "splunk-config",
+			collectorMSIProperties: map[string]string{
+				"SPLUNK_ACCESS_TOKEN": "fakeToken",
+				"SPLUNK_CONFIG":       `C:\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml`,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -217,6 +226,25 @@ func TestExpectedCollectorServiceArgs(t *testing.T) {
 				"SPLUNK_PLATFORM_TOKEN": "platformToken",
 			},
 			expectedArgs: strings.Join([]string{defaultConfigArg, logsConfigArg, mergeAppendFeatureGateArg}, " "),
+		},
+		{
+			// SPLUNK_CONFIG (set by the Puppet/Ansible modules) must be
+			// honored and take precedence over the default config.
+			name: "splunk-config-overrides-default",
+			msiProperties: map[string]string{
+				"SPLUNK_ACCESS_TOKEN": "fakeToken",
+				"SPLUNK_CONFIG":       `C:\custom\config.yaml`,
+			},
+			expectedArgs: `--config "C:\custom\config.yaml"`,
+		},
+		{
+			name: "splunk-config-with-user-svc-args",
+			msiProperties: map[string]string{
+				"SPLUNK_ACCESS_TOKEN": "fakeToken",
+				"COLLECTOR_SVC_ARGS":  "--feature-gates=foo",
+				"SPLUNK_CONFIG":       `C:\custom\config.yaml`,
+			},
+			expectedArgs: `--feature-gates=foo --config "C:\custom\config.yaml"`,
 		},
 	}
 
@@ -497,8 +525,8 @@ func expectedCollectorServiceArgs(t *testing.T, msiProperties map[string]string)
 	collectorServiceArgs = strings.Trim(collectorServiceArgs, "\"")
 	collectorServiceArgs = strings.ReplaceAll(collectorServiceArgs, "\"\"", "\"")
 
-	if _, ok := msiProperties["SPLUNK_CONFIG"]; ok {
-		return collectorServiceArgs
+	if splunkConfig, ok := msiProperties["SPLUNK_CONFIG"]; ok {
+		return appendServiceArg(collectorServiceArgs, `--config "`+splunkConfig+`"`)
 	}
 
 	if msiProperties["SPLUNK_ACCESS_TOKEN"] != "" {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Fixes a regression introduced in v0.154.0 (#7592) where the Windows collector service fails to start after the MSI is installed with `SPLUNK_CONFIG` set as a property.

#7592 moved config selection from the `SPLUNK_CONFIG` service env var to the `COLLECTOR_SVC_ARGS`, but only populates those args when `SPLUNK_CONFIG` is unset, and it also stopped writing `SPLUNK_CONFIG` to the service env. Tooling that passes `SPLUNK_CONFIG` as an MSI property therefore ended up with a service that had neither a `--config` argument nor the env var, so the collector started with no config and the service timed out ("did not respond to the start or control request in a timely fashion" seen in [tests](https://github.com/signalfx/splunk-otel-collector/actions/runs/27855740450/job/82443576781)).

The MSI now routes a supplied `SPLUNK_CONFIG` into `COLLECTOR_SVC_ARGS` as `--config "<path>"`, restoring backwards compatibility while keeping config selection on the service arguments. The Ansible Windows molecule verifications are updated to check the config is passed via the service ImagePath instead of asserting the removed SPLUNK_CONFIG env var (the legacy 0.97.0 scenario is unchanged).
