### PR TITLE
[config] Generate agent configs

### DIFF
--- a/.chloggen/generate_default_configs.yaml
+++ b/.chloggen/generate_default_configs.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: agent
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Generate agent configurations from a single source
+
+# One or more tracking issues related to the change
+issues: [7709]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The collector now includes default agent configs for deployments with a gateway
+  (`agent_to_gateway_config.yaml`) and without (`agent_config.yaml`).

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,6 +45,21 @@ jobs:
             exit 1
           fi
 
+  generate-configs:
+    name: generate-configs
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup-environment
+
+      - name: generate-configs
+        run: |
+          make generate-configs
+          if ! git diff --exit-code; then
+            echo "Generated configs are out of date. Run 'make generate-configs' and push the changes."
+            exit 1
+          fi
+
   generate-metrics:
     name: generate-metrics
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,10 @@ install-tools:
 	cd ./internal/tools && go install go.opentelemetry.io/build-tools/chloggen
 	cd ./internal/tools && go install mvdan.cc/gofumpt
 
+.PHONY: generate-configs
+generate-configs:
+	cd $(SRC_ROOT)/cmd/default-config-generator && $(GOCMD) run .
+
 .PHONY: generate-metrics
 generate-metrics:
 	go generate -tags mdatagen ./...

--- a/cmd/default-config-generator/agent_config_source.yaml
+++ b/cmd/default-config-generator/agent_config_source.yaml
@@ -1,3 +1,24 @@
+# <-- generated comment -->
+# This file is being used to generate two config files:
+#   1. agent_config.yaml: An agent config used without a gateway
+#   2. agent_to_gateway_config.yaml: An agent config used with a gateway
+#
+# How it works:
+# Specialized blocks are used to determine which comments can be dropped, or which
+# functionality is only valid for the agent to gateway or agent without gateway scenarios.
+#
+# Specialized block format:
+# <-- gateway enabled -->
+# <-- gateway disabled -->
+# <-- generated comment -->
+
+# Note: Nesting blocks is not supported
+# Run `make generate-configs` to ensure both configurations have been generated
+
+# <---->
+# <---->
+# <---->
+# <---->
 # Default configuration file for the Linux (deb/rpm) and Windows MSI collector packages
 
 # If the collector is installed without the Linux/Windows installer script, the following
@@ -22,7 +43,12 @@ extensions:
     ingress:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:6060"
     egress:
+      # <-- gateway disabled -->
       endpoint: "${SPLUNK_API_URL}"
+      # <---->
+      # <-- gateway enabled -->
+      endpoint: "${SPLUNK_GATEWAY_URL}"
+      # <---->
 
   http_forwarder/opamp_splunk_o11y:
     ingress:

--- a/cmd/default-config-generator/config_templates/agent_config_source.yaml.tmpl
+++ b/cmd/default-config-generator/config_templates/agent_config_source.yaml.tmpl
@@ -1,0 +1,281 @@
+# <-- generated comment -->
+# This file is being used to generate two config files:
+#   1. agent_config.yaml: An agent config used without a gateway
+#   2. agent_to_gateway_config.yaml: An agent config used with a gateway
+#
+# How it works:
+# Specialized blocks are used to determine which comments can be dropped, or which
+# functionality is only valid for the agent to gateway or agent without gateway scenarios.
+#
+# Specialized block format:
+# <-- gateway enabled -->
+# this line should only be rendered in the agent to gateway config file
+# <-- gateway enabled end -->
+# <-- gateway disabled -->
+# this line should only be rendered in the agent to backend config file
+# <-- gateway disabled end -->
+
+# Note: Nesting blocks is not supported
+# Run `make generate-configs` to ensure both configurations have been generated
+
+# <-- generated comment end -->
+# Default configuration file for the Linux (deb/rpm) and Windows MSI collector packages
+
+# If the collector is installed without the Linux/Windows installer script, the following
+# environment variables are required to be manually defined or configured below:
+# - SPLUNK_ACCESS_TOKEN: The Splunk access token to authenticate requests
+# - SPLUNK_API_URL: The Splunk API URL, e.g. https://api.us0.observability.splunkcloud.com
+# - SPLUNK_HEC_TOKEN: The Splunk HEC authentication token
+# - SPLUNK_HEC_URL: The Splunk HEC endpoint URL, e.g. https://http-inputs-acme.splunkcloud.com/services/collector
+# - SPLUNK_INGEST_URL: The Splunk ingest URL, e.g. https://ingest.us0.observability.splunkcloud.com
+# - SPLUNK_LISTEN_INTERFACE: The network interface the agent receivers listen on.
+
+extensions:
+  headers_setter:
+    headers:
+      - action: upsert
+        key: X-SF-TOKEN
+        from_context: X-SF-TOKEN
+        default_value: "${SPLUNK_ACCESS_TOKEN}"
+  health_check:
+    endpoint: "${SPLUNK_LISTEN_INTERFACE}:13133"
+  http_forwarder:
+    ingress:
+      endpoint: "${SPLUNK_LISTEN_INTERFACE}:6060"
+    egress:
+      # <-- gateway disabled -->
+      endpoint: "${SPLUNK_API_URL}"
+      # <-- gateway disabled end -->
+      # <-- gateway enabled -->
+      endpoint: "${SPLUNK_GATEWAY_URL}"
+      # <-- gateway enabled end -->
+
+  http_forwarder/opamp_splunk_o11y:
+    ingress:
+      endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
+    egress:
+      endpoint: "${SPLUNK_INGEST_URL}"
+      # Use instead when sending to gateway
+      #endpoint: "${SPLUNK_GATEWAY_URL}:4320"
+  # opamp/splunk_o11y is included in the default config, but startup removes it
+  # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
+  opamp/splunk_o11y:
+    agent_description:
+      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
+      include_resource_attributes: true
+    server:
+      http:
+        endpoint: "${SPLUNK_INGEST_URL}/v1/opamp"
+        # Use instead when sending to gateway (assuming the gateway is running http_forwarder/signalfx on port 4320)
+        #endpoint: "${SPLUNK_GATEWAY_URL}:4320/v1/opamp"
+        polling_interval: 30s
+        headers:
+          X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
+  zpages:
+    #endpoint: "${SPLUNK_LISTEN_INTERFACE}:55679"
+    expvar:
+      enabled: true
+
+receivers:
+  fluent_forward:
+    endpoint: "${SPLUNK_LISTEN_INTERFACE}:8006"
+  host_metrics:
+    collection_interval: 10s
+    scrapers:
+      cpu:
+      disk:
+      filesystem:
+      memory:
+      network:
+      # System load average metrics https://en.wikipedia.org/wiki/Load_(computing)
+      load:
+      # Paging/Swap space utilization and I/O metrics
+      paging:
+      # Aggregated system process count metrics
+      processes:
+      # System processes metrics, disabled by default
+      # process:
+  jaeger:
+    protocols:
+      grpc:
+        endpoint: "${SPLUNK_LISTEN_INTERFACE}:14250"
+      thrift_binary:
+        endpoint: "${SPLUNK_LISTEN_INTERFACE}:6832"
+      thrift_compact:
+        endpoint: "${SPLUNK_LISTEN_INTERFACE}:6831"
+      thrift_http:
+        endpoint: "${SPLUNK_LISTEN_INTERFACE}:14268"
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "${SPLUNK_LISTEN_INTERFACE}:4317"
+        # Uncomment below config to preserve incoming access token and use it instead of the token value set in exporter config
+        # include_metadata: true
+      http:
+        endpoint: "${SPLUNK_LISTEN_INTERFACE}:4318"
+        # Uncomment below config to preserve incoming access token and use it instead of the token value set in exporter config
+        # include_metadata: true
+  # This section is used to collect the OpenTelemetry Collector metrics
+  # Even if just a Splunk APM customer, these metrics are included
+  prometheus/internal:
+    config:
+      scrape_configs:
+        - job_name: 'otel-collector'
+          scrape_interval: 10s
+          static_configs:
+            - targets: ["0.0.0.0:8888"]
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'promhttp_metric_handler_errors.*'
+              action: drop
+            - source_labels: [ __name__ ]
+              regex: 'otelcol_processor_batch_.*'
+              action: drop
+  smartagent/processlist:
+    type: processlist
+  zipkin:
+    endpoint: "${SPLUNK_LISTEN_INTERFACE}:9411"
+  nop:
+
+processors:
+  batch:
+    metadata_keys:
+      - X-SF-Token
+  # Enabling the memory_limiter is strongly recommended for every pipeline.
+  # Configuration is based on the amount of memory allocated to the collector.
+  # For more information about memory limiter, see
+  # https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiter/README.md
+  memory_limiter:
+    check_interval: 2s
+    limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+
+  # Detect if the collector is running on a cloud system, which is important for creating unique cloud provider dimensions.
+  # Detector order is important: the `system` detector goes last so it can't preclude cloud detectors from setting host/os info.
+  # Resource detection processor is configured to override all host and cloud attributes because instrumentation
+  # libraries can send wrong values from container environments.
+  # https://docs.splunk.com/Observability/gdi/opentelemetry/components/resourcedetection-processor.html#ordering-considerations
+  resourcedetection:
+    detectors: [gcp, ecs, ec2, azure, system]
+    override: true
+
+      # Optional: The following processor can be used to add a default "deployment.environment" attribute to the logs and
+      # traces when it's not populated by instrumentation libraries.
+      # If enabled, make sure to enable this processor in a pipeline.
+      # For more information, see https://docs.splunk.com/Observability/gdi/opentelemetry/components/resource-processor.html
+      #resource/add_environment:
+      #attributes:
+      #- action: insert
+      #value: staging/production/...
+    #key: deployment.environment
+
+exporters:
+  # Traces
+  otlp_http:
+    traces_endpoint: "${SPLUNK_INGEST_URL}/v2/trace/otlp"
+    headers:
+      "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"
+    auth:
+      authenticator: headers_setter
+  # Metrics + Events
+  signalfx:
+    access_token: "${SPLUNK_ACCESS_TOKEN}"
+    api_url: "${SPLUNK_API_URL}"
+    ingest_url: "${SPLUNK_INGEST_URL}"
+    # Use instead when sending to gateway
+    #api_url: http://${SPLUNK_GATEWAY_URL}:6060
+    #ingest_url: http://${SPLUNK_GATEWAY_URL}:9943
+    sync_host_metadata: true
+    correlation:
+  # Entities (applicable only if discovery mode is enabled)
+  otlp_http/entities:
+    logs_endpoint: "${SPLUNK_INGEST_URL}/v3/event"
+    headers:
+      "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"
+    auth:
+      authenticator: headers_setter
+  # Logs
+  splunk_hec:
+    token: "${SPLUNK_HEC_TOKEN}"
+    endpoint: "${SPLUNK_HEC_URL}"
+    source: "otel"
+    sourcetype: "otel"
+    profiling_data_enabled: false
+  # Profiling
+  splunk_hec/profiling:
+    token: "${SPLUNK_ACCESS_TOKEN}"
+    endpoint: "${SPLUNK_INGEST_URL}/v1/log"
+    log_data_enabled: false
+  # Send to gateway
+  otlp_grpc/gateway:
+    endpoint: "${SPLUNK_GATEWAY_URL}:4317"
+    tls:
+      insecure: true
+    auth:
+      authenticator: headers_setter
+  # Debug
+  debug:
+    verbosity: detailed
+
+service:
+  telemetry:
+    logs:
+      level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+    # Resource attributes attached to the Collector's internal telemetry. These
+    # are also exposed via OpAMP when the opamp/splunk_o11y extension is enabled
+    # with agent_description.include_resource_attributes set to true.
+    resource:
+      attributes:
+        - name: otelcol.service.mode
+          value: agent
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '127.0.0.1'
+                port: 8888
+  extensions: [headers_setter, health_check, http_forwarder, http_forwarder/opamp_splunk_o11y, opamp/splunk_o11y, zpages]
+  pipelines:
+    traces:
+      receivers: [jaeger, otlp, zipkin]
+      processors:
+        - memory_limiter
+        - batch
+        - resourcedetection
+      #- resource/add_environment
+      exporters: [otlp_http]
+      # Use instead when sending to gateway
+      #exporters: [otlp_grpc/gateway]
+    metrics:
+      receivers: [host_metrics, otlp]
+      processors: [memory_limiter, batch, resourcedetection]
+      exporters: [signalfx]
+      # Use instead when sending to gateway
+      #exporters: [otlp_grpc/gateway]
+    metrics/internal:
+      receivers: [prometheus/internal]
+      processors: [memory_limiter, batch, resourcedetection]
+      # When sending to gateway, at least one metrics pipeline needs
+      # to use signalfx exporter so host metadata gets emitted
+      exporters: [signalfx]
+    logs/signalfx:
+      receivers: [smartagent/processlist]
+      processors: [memory_limiter, batch, resourcedetection]
+      exporters: [signalfx]
+    logs/entities:
+      # Receivers are dynamically added if discovery mode is enabled
+      receivers: [nop]
+      processors: [memory_limiter, batch, resourcedetection]
+      exporters: [otlp_http/entities]
+      # Use instead when sending to gateway
+      #exporters: [otlp_grpc/gateway]
+    logs:
+      receivers: [fluent_forward, otlp]
+      processors:
+        - memory_limiter
+        - batch
+        - resourcedetection
+      #- resource/add_environment
+      exporters: [splunk_hec, splunk_hec/profiling]
+      # Use instead when sending to gateway
+      #exporters: [otlp_grpc/gateway]

--- a/cmd/default-config-generator/config_templates/agent_config_source.yaml.tmpl
+++ b/cmd/default-config-generator/config_templates/agent_config_source.yaml.tmpl
@@ -2,24 +2,14 @@
 # This file is being used to generate two config files:
 #   1. agent_config.yaml: An agent config used without a gateway
 #   2. agent_to_gateway_config.yaml: An agent config used with a gateway
-#
-# How it works:
-# Specialized blocks are used to determine which comments can be dropped, or which
-# functionality is only valid for the agent to gateway or agent without gateway scenarios.
-#
-# Specialized block format:
-# <-- gateway enabled -->
-# this line should only be rendered in the agent to gateway config file
-# <-- gateway enabled end -->
-# <-- gateway disabled -->
-# this line should only be rendered in the agent to backend config file
-# <-- gateway disabled end -->
-
-# Note: Nesting blocks is not supported
-# Run `make generate-configs` to ensure both configurations have been generated
-
 # <-- generated comment end -->
 # Default configuration file for the Linux (deb/rpm) and Windows MSI collector packages
+# <-- gateway disabled -->
+# This agent configuration file is meant to be used without a gateway.
+# <-- gateway disabled end -->
+# <-- gateway enabled -->
+# This agent configuration file is meant to be used when sending telemetry to a gateway.
+# <-- gateway enabled end -->
 
 # If the collector is installed without the Linux/Windows installer script, the following
 # environment variables are required to be manually defined or configured below:

--- a/cmd/default-config-generator/main.go
+++ b/cmd/default-config-generator/main.go
@@ -1,3 +1,17 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/default-config-generator/main.go
+++ b/cmd/default-config-generator/main.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const agentConfigGatewayDisabledPath = "../otelcol/config/collector/agent_config.yaml"
+const agentConfigGatewayEnabledPath = "../otelcol/config/collector/agent_to_gateway_config.yaml"
+const agentConfigSourcePath = "./agent_config_source.yaml"
+const blockEndMarker = "# <---->"
+const gatewayDisabledMarker = "# <-- gateway disabled -->"
+const gatewayEnabledMarker = "# <-- gateway enabled -->"
+const generatedCommentMarker = "# <-- generated comment -->"
+const leadingLineBreakCharacters = "\r\n"
+const lineBreak = "\n"
+
+type configGenerator struct {
+	configSourcePath     string
+	sourceConfigContents string
+}
+
+func newConfigGenerator(configSourcePath string) *configGenerator {
+	return &configGenerator{
+		configSourcePath: configSourcePath,
+	}
+}
+
+func (generator *configGenerator) loadSourceConfigFile() error {
+	source, err := os.ReadFile(generator.configSourcePath)
+	if err != nil {
+		return err
+	}
+	generator.sourceConfigContents = string(source)
+	return nil
+}
+
+func (generator *configGenerator) writeGeneratedConfigFile(generatedConfig []byte, filePath string) error {
+	return os.WriteFile(filePath, generatedConfig, 0644)
+}
+
+func (generator *configGenerator) convertSourceConfig(gatewayEnabled bool) ([]byte, error) {
+	var configFileContents strings.Builder
+	insideGatewayDisabledOnlyBlock := false
+	insideGatewayOnlyBlock := false
+	insideCommentBlock := false
+
+	for _, line := range strings.Split(generator.sourceConfigContents, lineBreak) {
+		// Need to keep track of whether the current line is in a specialized block
+		if strings.Contains(line, blockEndMarker) {
+			// Nesting specialized blocks is not allowed, any ending marker means all special sections are over.
+			insideGatewayDisabledOnlyBlock = false
+			insideGatewayOnlyBlock = false
+			insideCommentBlock = false
+			continue
+		}
+		if strings.Contains(line, gatewayDisabledMarker) {
+			insideGatewayDisabledOnlyBlock = true
+			continue
+		}
+		if strings.Contains(line, gatewayEnabledMarker) {
+			insideGatewayOnlyBlock = true
+			continue
+		}
+		if strings.Contains(line, generatedCommentMarker) {
+			insideCommentBlock = true
+			continue
+		}
+
+		// Cases where we can skip the current line
+		if insideCommentBlock {
+			continue
+		}
+		if gatewayEnabled && insideGatewayDisabledOnlyBlock {
+			continue
+		}
+		if !gatewayEnabled && insideGatewayOnlyBlock {
+			continue
+		}
+
+		configFileContents.WriteString(line + lineBreak)
+	}
+
+	return []byte(configFileContents.String()), nil
+}
+
+func (generator *configGenerator) validateMatchingConfigMarkers() error {
+	if generator.sourceConfigContents == "" {
+		return fmt.Errorf("no config source defined")
+	}
+	markupEndCount := 0
+	markupStartCount := 0
+	for _, line := range strings.Split(generator.sourceConfigContents, lineBreak) {
+		if strings.Contains(line, blockEndMarker) {
+			markupEndCount++
+		} else if strings.Contains(line, gatewayDisabledMarker) ||
+			strings.Contains(line, gatewayEnabledMarker) ||
+			strings.Contains(line, generatedCommentMarker) {
+			markupStartCount++
+		}
+	}
+	if markupStartCount != markupEndCount {
+		return fmt.Errorf("Mismatch count of marker start blocks and marker end blocks: %d != %d", markupStartCount, markupEndCount)
+	}
+	return nil
+}
+
+func (generator *configGenerator) validateSourceConfigFile() error {
+	return generator.validateMatchingConfigMarkers()
+}
+
+func main() {
+	generator := newConfigGenerator(agentConfigSourcePath)
+	err := generator.loadSourceConfigFile()
+	if err != nil {
+		fmt.Printf("Error loading source config file: %v\n", err)
+		os.Exit(1)
+	}
+	err = generator.validateSourceConfigFile()
+	if err != nil {
+		fmt.Printf("Error validating source config file: %v\n", err)
+		os.Exit(1)
+	}
+
+	agentWithoutGateway, err := generator.convertSourceConfig(false)
+	if err != nil {
+		fmt.Printf("Error generating agent without gateway config file: %v\n", err)
+		os.Exit(1)
+	}
+	generator.writeGeneratedConfigFile(agentWithoutGateway, agentConfigGatewayDisabledPath)
+
+	agentToGateway, err := generator.convertSourceConfig(true)
+	if err != nil {
+		fmt.Printf("Error generating agent to gateway config file: %v\n", err)
+		os.Exit(1)
+	}
+	generator.writeGeneratedConfigFile(agentToGateway, agentConfigGatewayEnabledPath)
+}

--- a/cmd/default-config-generator/main.go
+++ b/cmd/default-config-generator/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,7 +47,7 @@ func (cfg *configToGenerate) AppendGeneratedConfigContents(line string) {
 }
 
 func (cfg *configToGenerate) writeGeneratedConfigFile() error {
-	return os.WriteFile(cfg.destinationPath, cfg.generatedConfigContents.Bytes(), 0o644)
+	return os.WriteFile(cfg.destinationPath, cfg.generatedConfigContents.Bytes(), 0o444)
 }
 
 type sourceTemplate struct {
@@ -160,7 +161,7 @@ func (generator *sourceTemplate) writeAllGeneratedConfigFiles() error {
 
 func (generator *sourceTemplate) validateSourceConfigFile() error {
 	if generator.sourceTemplatePath == "" {
-		return fmt.Errorf("source template is empty")
+		return errors.New("source template is empty")
 	}
 
 	return nil

--- a/cmd/default-config-generator/main.go
+++ b/cmd/default-config-generator/main.go
@@ -23,23 +23,18 @@ import (
 	"strings"
 )
 
-const generatedCommentMarker = "# <-- generated comment -->"
-const generatedCommentEndMarker = "# <-- generated comment end -->"
-
-const gatewayDisabledMarker = "# <-- gateway disabled -->"
-const gatewayDisabledEndMarker = "# <-- gateway disabled end -->"
-
-const gatewayEnabledMarker = "# <-- gateway enabled -->"
-const gatewayEnabledEndMarker = "# <-- gateway enabled end -->"
-
-const lineBreak = "\n"
+const (
+	generatedCommentMarker    = "# <-- generated comment -->"
+	generatedCommentEndMarker = "# <-- generated comment end -->"
+	lineBreak                 = "\n"
+)
 
 type configToGenerate struct {
 	destinationPath         string
-	generatedConfigContents *bytes.Buffer
 	startMarker             string
 	endMarker               string
 	insideMarker            bool
+	generatedConfigContents *bytes.Buffer
 }
 
 func (cfg *configToGenerate) AppendGeneratedConfigContents(line string) {
@@ -61,14 +56,14 @@ func getAgentSourceTemplate() sourceTemplate {
 		generateConfigs: []*configToGenerate{
 			{
 				destinationPath:         filepath.Join("..", "otelcol", "config", "collector", "agent_config.yaml"),
-				endMarker:               gatewayDisabledEndMarker,
-				startMarker:             gatewayDisabledMarker,
+				startMarker:             "# <-- gateway disabled -->",
+				endMarker:               "# <-- gateway disabled end -->",
 				generatedConfigContents: bytes.NewBuffer(make([]byte, 0)),
 			},
 			{
 				destinationPath:         filepath.Join("..", "otelcol", "config", "collector", "agent_to_gateway_config.yaml"),
-				endMarker:               gatewayEnabledEndMarker,
-				startMarker:             gatewayEnabledMarker,
+				startMarker:             "# <-- gateway enabled -->",
+				endMarker:               "# <-- gateway enabled end -->",
 				generatedConfigContents: bytes.NewBuffer(make([]byte, 0)),
 			},
 		},

--- a/cmd/default-config-generator/main.go
+++ b/cmd/default-config-generator/main.go
@@ -33,7 +33,7 @@ const gatewayEnabledEndMarker = "# <-- gateway enabled end -->"
 
 const lineBreak = "\n"
 
-type generateConfig struct {
+type configToGenerate struct {
 	destinationPath         string
 	generatedConfigContents *bytes.Buffer
 	startMarker             string
@@ -41,23 +41,23 @@ type generateConfig struct {
 	insideMarker            bool
 }
 
-func (cfg *generateConfig) AppendGeneratedConfigContents(line string) {
+func (cfg *configToGenerate) AppendGeneratedConfigContents(line string) {
 	cfg.generatedConfigContents.WriteString(line + lineBreak)
 }
 
-func (cfg *generateConfig) writeGeneratedConfigFile() error {
+func (cfg *configToGenerate) writeGeneratedConfigFile() error {
 	return os.WriteFile(cfg.destinationPath, cfg.generatedConfigContents.Bytes(), 0o644)
 }
 
 type sourceTemplate struct {
-	generateConfigs      []*generateConfig
-	sourceTemplatePath   string
-	sourceConfigContents string
+	generateConfigs        []*configToGenerate
+	sourceTemplatePath     string
+	sourceTemplateContents string
 }
 
 func getAgentSourceTemplate() sourceTemplate {
 	return sourceTemplate{
-		generateConfigs: []*generateConfig{
+		generateConfigs: []*configToGenerate{
 			{
 				destinationPath:         filepath.Join("..", "otelcol", "config", "collector", "agent_config.yaml"),
 				endMarker:               gatewayDisabledEndMarker,
@@ -80,13 +80,13 @@ func (generator *sourceTemplate) loadSourceConfigFile() error {
 	if err != nil {
 		return err
 	}
-	generator.sourceConfigContents = string(source)
+	generator.sourceTemplateContents = string(source)
 	return nil
 }
 
 func (generator *sourceTemplate) convertTemplate() {
 	insideCommentBlock := false
-	for _, line := range strings.Split(generator.sourceConfigContents, lineBreak) {
+	for _, line := range strings.Split(generator.sourceTemplateContents, lineBreak) {
 		if strings.Contains(line, generatedCommentEndMarker) {
 			// Everything inside of comments is disregarded, can safely reset all status markers
 			// when comment is finished
@@ -136,8 +136,7 @@ func (generator *sourceTemplate) convertTemplate() {
 			if config.insideMarker {
 				inSpecializedBlock = true
 				config.AppendGeneratedConfigContents(line)
-				// Enforce only being in one special block at a time
-				break
+				break // Enforce only being in one special block at a time
 			}
 		}
 		if inSpecializedBlock {
@@ -159,12 +158,12 @@ func (generator *sourceTemplate) writeAllGeneratedConfigFiles() error {
 	return nil
 }
 
-func (generator *sourceTemplate) validateMatchingConfigMarkers() error {
-	return nil
-}
-
 func (generator *sourceTemplate) validateSourceConfigFile() error {
-	return generator.validateMatchingConfigMarkers()
+	if generator.sourceTemplatePath == "" {
+		return fmt.Errorf("source template is empty")
+	}
+
+	return nil
 }
 
 func main() {

--- a/cmd/default-config-generator/main.go
+++ b/cmd/default-config-generator/main.go
@@ -1,34 +1,68 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
-const agentConfigGatewayDisabledPath = "../otelcol/config/collector/agent_config.yaml"
-const agentConfigGatewayEnabledPath = "../otelcol/config/collector/agent_to_gateway_config.yaml"
-const agentConfigSourcePath = "./agent_config_source.yaml"
-const blockEndMarker = "# <---->"
-const gatewayDisabledMarker = "# <-- gateway disabled -->"
-const gatewayEnabledMarker = "# <-- gateway enabled -->"
 const generatedCommentMarker = "# <-- generated comment -->"
-const leadingLineBreakCharacters = "\r\n"
+const generatedCommentEndMarker = "# <-- generated comment end -->"
+
+const gatewayDisabledMarker = "# <-- gateway disabled -->"
+const gatewayDisabledEndMarker = "# <-- gateway disabled end -->"
+
+const gatewayEnabledMarker = "# <-- gateway enabled -->"
+const gatewayEnabledEndMarker = "# <-- gateway enabled end -->"
+
 const lineBreak = "\n"
 
-type configGenerator struct {
-	configSourcePath     string
+type generateConfig struct {
+	destinationPath         string
+	generatedConfigContents *bytes.Buffer
+	startMarker             string
+	endMarker               string
+	insideMarker            bool
+}
+
+func (cfg *generateConfig) AppendGeneratedConfigContents(line string) {
+	cfg.generatedConfigContents.WriteString(line + lineBreak)
+}
+
+func (cfg *generateConfig) writeGeneratedConfigFile() error {
+	return os.WriteFile(cfg.destinationPath, cfg.generatedConfigContents.Bytes(), 0o644)
+}
+
+type sourceTemplate struct {
+	generateConfigs      []*generateConfig
+	sourceTemplatePath   string
 	sourceConfigContents string
 }
 
-func newConfigGenerator(configSourcePath string) *configGenerator {
-	return &configGenerator{
-		configSourcePath: configSourcePath,
+func getAgentSourceTemplate() sourceTemplate {
+	return sourceTemplate{
+		generateConfigs: []*generateConfig{
+			{
+				destinationPath:         filepath.Join("..", "otelcol", "config", "collector", "agent_config.yaml"),
+				endMarker:               gatewayDisabledEndMarker,
+				startMarker:             gatewayDisabledMarker,
+				generatedConfigContents: bytes.NewBuffer(make([]byte, 0)),
+			},
+			{
+				destinationPath:         filepath.Join("..", "otelcol", "config", "collector", "agent_to_gateway_config.yaml"),
+				endMarker:               gatewayEnabledEndMarker,
+				startMarker:             gatewayEnabledMarker,
+				generatedConfigContents: bytes.NewBuffer(make([]byte, 0)),
+			},
+		},
+		sourceTemplatePath: filepath.Join("config_templates", "agent_config_source.yaml.tmpl"),
 	}
 }
 
-func (generator *configGenerator) loadSourceConfigFile() error {
-	source, err := os.ReadFile(generator.configSourcePath)
+func (generator *sourceTemplate) loadSourceConfigFile() error {
+	source, err := os.ReadFile(generator.sourceTemplatePath)
 	if err != nil {
 		return err
 	}
@@ -36,104 +70,107 @@ func (generator *configGenerator) loadSourceConfigFile() error {
 	return nil
 }
 
-func (generator *configGenerator) writeGeneratedConfigFile(generatedConfig []byte, filePath string) error {
-	return os.WriteFile(filePath, generatedConfig, 0644)
-}
-
-func (generator *configGenerator) convertSourceConfig(gatewayEnabled bool) ([]byte, error) {
-	var configFileContents strings.Builder
-	insideGatewayDisabledOnlyBlock := false
-	insideGatewayOnlyBlock := false
+func (generator *sourceTemplate) convertTemplate() {
 	insideCommentBlock := false
-
 	for _, line := range strings.Split(generator.sourceConfigContents, lineBreak) {
-		// Need to keep track of whether the current line is in a specialized block
-		if strings.Contains(line, blockEndMarker) {
-			// Nesting specialized blocks is not allowed, any ending marker means all special sections are over.
-			insideGatewayDisabledOnlyBlock = false
-			insideGatewayOnlyBlock = false
+		if strings.Contains(line, generatedCommentEndMarker) {
+			// Everything inside of comments is disregarded, can safely reset all status markers
+			// when comment is finished
+			for _, config := range generator.generateConfigs {
+				config.insideMarker = false
+			}
 			insideCommentBlock = false
 			continue
 		}
-		if strings.Contains(line, gatewayDisabledMarker) {
-			insideGatewayDisabledOnlyBlock = true
+		if insideCommentBlock {
 			continue
 		}
-		if strings.Contains(line, gatewayEnabledMarker) {
-			insideGatewayOnlyBlock = true
-			continue
-		}
+
+		// Track start of special blocks
 		if strings.Contains(line, generatedCommentMarker) {
 			insideCommentBlock = true
 			continue
 		}
 
-		// Cases where we can skip the current line
-		if insideCommentBlock {
-			continue
+		lineContainsStartMarker := false
+		for _, config := range generator.generateConfigs {
+			if strings.Contains(line, config.startMarker) {
+				config.insideMarker = true
+				lineContainsStartMarker = true
+				break
+			}
 		}
-		if gatewayEnabled && insideGatewayDisabledOnlyBlock {
-			continue
-		}
-		if !gatewayEnabled && insideGatewayOnlyBlock {
+		if lineContainsStartMarker {
 			continue
 		}
 
-		configFileContents.WriteString(line + lineBreak)
+		// Track end of special blocks
+		lineContainsEndMarker := false
+		for _, config := range generator.generateConfigs {
+			if strings.Contains(line, config.endMarker) {
+				config.insideMarker = false
+				lineContainsEndMarker = true
+				break
+			}
+		}
+		if lineContainsEndMarker {
+			continue
+		}
+
+		inSpecializedBlock := false
+		for _, config := range generator.generateConfigs {
+			if config.insideMarker {
+				inSpecializedBlock = true
+				config.AppendGeneratedConfigContents(line)
+				// Enforce only being in one special block at a time
+				break
+			}
+		}
+		if inSpecializedBlock {
+			continue
+		}
+
+		for _, config := range generator.generateConfigs {
+			config.AppendGeneratedConfigContents(line)
+		}
 	}
-
-	return []byte(configFileContents.String()), nil
 }
 
-func (generator *configGenerator) validateMatchingConfigMarkers() error {
-	if generator.sourceConfigContents == "" {
-		return fmt.Errorf("no config source defined")
-	}
-	markupEndCount := 0
-	markupStartCount := 0
-	for _, line := range strings.Split(generator.sourceConfigContents, lineBreak) {
-		if strings.Contains(line, blockEndMarker) {
-			markupEndCount++
-		} else if strings.Contains(line, gatewayDisabledMarker) ||
-			strings.Contains(line, gatewayEnabledMarker) ||
-			strings.Contains(line, generatedCommentMarker) {
-			markupStartCount++
+func (generator *sourceTemplate) writeAllGeneratedConfigFiles() error {
+	for _, config := range generator.generateConfigs {
+		if err := config.writeGeneratedConfigFile(); err != nil {
+			return err
 		}
-	}
-	if markupStartCount != markupEndCount {
-		return fmt.Errorf("Mismatch count of marker start blocks and marker end blocks: %d != %d", markupStartCount, markupEndCount)
 	}
 	return nil
 }
 
-func (generator *configGenerator) validateSourceConfigFile() error {
+func (generator *sourceTemplate) validateMatchingConfigMarkers() error {
+	return nil
+}
+
+func (generator *sourceTemplate) validateSourceConfigFile() error {
 	return generator.validateMatchingConfigMarkers()
 }
 
 func main() {
-	generator := newConfigGenerator(agentConfigSourcePath)
-	err := generator.loadSourceConfigFile()
+	agentTemplate := getAgentSourceTemplate()
+
+	err := agentTemplate.loadSourceConfigFile()
 	if err != nil {
 		fmt.Printf("Error loading source config file: %v\n", err)
 		os.Exit(1)
 	}
-	err = generator.validateSourceConfigFile()
+	err = agentTemplate.validateSourceConfigFile()
 	if err != nil {
 		fmt.Printf("Error validating source config file: %v\n", err)
 		os.Exit(1)
 	}
 
-	agentWithoutGateway, err := generator.convertSourceConfig(false)
+	agentTemplate.convertTemplate()
+	err = agentTemplate.writeAllGeneratedConfigFiles()
 	if err != nil {
-		fmt.Printf("Error generating agent without gateway config file: %v\n", err)
+		fmt.Printf("Error writing all generated config files: %v\n", err)
 		os.Exit(1)
 	}
-	generator.writeGeneratedConfigFile(agentWithoutGateway, agentConfigGatewayDisabledPath)
-
-	agentToGateway, err := generator.convertSourceConfig(true)
-	if err != nil {
-		fmt.Printf("Error generating agent to gateway config file: %v\n", err)
-		os.Exit(1)
-	}
-	generator.writeGeneratedConfigFile(agentToGateway, agentConfigGatewayEnabledPath)
 }

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -1,4 +1,5 @@
 # Default configuration file for the Linux (deb/rpm) and Windows MSI collector packages
+# This agent configuration file is meant to be used without a gateway.
 
 # If the collector is installed without the Linux/Windows installer script, the following
 # environment variables are required to be manually defined or configured below:

--- a/cmd/otelcol/config/collector/agent_to_gateway_config.yaml
+++ b/cmd/otelcol/config/collector/agent_to_gateway_config.yaml
@@ -1,24 +1,3 @@
-# <-- generated comment -->
-# This file is being used to generate two config files:
-#   1. agent_config.yaml: An agent config used without a gateway
-#   2. agent_to_gateway_config.yaml: An agent config used with a gateway
-#
-# How it works:
-# Specialized blocks are used to determine which comments can be dropped, or which
-# functionality is only valid for the agent to gateway or agent without gateway scenarios.
-#
-# Specialized block format:
-# <-- gateway enabled -->
-# <-- gateway disabled -->
-# <-- generated comment -->
-
-# Note: Nesting blocks is not supported
-# Run `make generate-configs` to ensure both configurations have been generated
-
-# <---->
-# <---->
-# <---->
-# <---->
 # Default configuration file for the Linux (deb/rpm) and Windows MSI collector packages
 
 # If the collector is installed without the Linux/Windows installer script, the following
@@ -43,12 +22,7 @@ extensions:
     ingress:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:6060"
     egress:
-      # <-- gateway disabled -->
-      endpoint: "${SPLUNK_API_URL}"
-      # <---->
-      # <-- gateway enabled -->
       endpoint: "${SPLUNK_GATEWAY_URL}"
-      # <---->
 
   http_forwarder/opamp_splunk_o11y:
     ingress:

--- a/cmd/otelcol/config/collector/agent_to_gateway_config.yaml
+++ b/cmd/otelcol/config/collector/agent_to_gateway_config.yaml
@@ -1,4 +1,5 @@
 # Default configuration file for the Linux (deb/rpm) and Windows MSI collector packages
+# This agent configuration file is meant to be used when sending telemetry to a gateway.
 
 # If the collector is installed without the Linux/Windows installer script, the following
 # environment variables are required to be manually defined or configured below:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Having one default agent config with comments specifying what should be included when the agent is sending data to just the backend vs. gateway is confusing. This change moves to have a source config file that is then used to generate both agent configs: one that is deployed with a gateway, one without.

NOTE: Still need validation and testing, this still in a POC stage