### PR TITLE
Warn if deprecated otlp_config_linux.yaml is used

### DIFF
--- a/.chloggen/deprecate-otlp-config-linux.yaml
+++ b/.chloggen/deprecate-otlp-config-linux.yaml
@@ -1,0 +1,5 @@
+change_type: deprecation
+component: configuration
+note: Deprecate `/etc/otel/collector/otlp_config_linux.yaml` and warn users to migrate to `/etc/otel/collector/agent_config.yaml`.
+issues: [7729]
+subtext: Set `SPLUNK_LISTEN_INTERFACE=0.0.0.0` when migrating if receivers need to listen outside the container.

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -85,6 +85,8 @@ var DefaultAgentConfigWindows = func() string {
 	return filepath.Clean(path)
 }()
 
+var statConfigFile = os.Stat
+
 var defaultFeatureGates = []string{}
 
 type Settings struct {
@@ -578,7 +580,7 @@ func checkInputConfigs(settings *Settings) error {
 			}
 			filePath = location
 		}
-		if _, err := os.Stat(filePath); err != nil {
+		if _, err := statConfigFile(filePath); err != nil {
 			return fmt.Errorf("unable to find the configuration file %s, ensure flag '--config' is set properly: %w", filePath, err)
 		}
 		configFilePaths = append(configFilePaths, filePath)
@@ -614,7 +616,7 @@ func checkConfigPathEnvVar(settings *Settings) error {
 	configPath := os.Getenv(ConfigEnvVar)
 	configYaml := os.Getenv(ConfigYamlEnvVar)
 
-	if _, err := os.Stat(configPath); err != nil {
+	if _, err := statConfigFile(configPath); err != nil {
 		return fmt.Errorf("unable to find the configuration file (%s), ensure %s environment variable is set properly: %w", configPath, ConfigEnvVar, err)
 	}
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -588,6 +588,8 @@ func checkInputConfigs(settings *Settings) error {
 		return nil
 	}
 
+	warnIfDeprecatedOTLPLinuxConfigUsed(configFilePaths)
+
 	if configPathVar != "" {
 		differingVals := true
 		for _, p := range configFilePaths {
@@ -624,7 +626,31 @@ func checkConfigPathEnvVar(settings *Settings) error {
 		_ = settings.configPaths.Set(configPath)
 	}
 
+	warnIfDeprecatedOTLPLinuxConfigUsed(settings.configPaths.value)
+
 	return confirmRequiredEnvVarsForDefaultConfigs(settings.configPaths.value)
+}
+
+func warnIfDeprecatedOTLPLinuxConfigUsed(paths []string) {
+	for _, path := range paths {
+		if isDeprecatedOTLPLinuxConfig(path) {
+			logWarn(
+				"Configuration file %s is deprecated and will be removed in a future release. "+
+					"Use --config=%s instead. If you need receivers to listen outside the container, set %s=0.0.0.0 when migrating.",
+				path, DefaultAgentConfigLinux, ListenInterfaceEnvVar)
+			return
+		}
+	}
+}
+
+func isDeprecatedOTLPLinuxConfig(path string) bool {
+	scheme, location, isURI := parseURI(path)
+	if isURI && scheme == fileProviderScheme {
+		path = location
+	}
+
+	cleaned := filepath.Clean(path)
+	return path == DefaultOTLPLinuxConfig || cleaned == filepath.Clean(DefaultOTLPLinuxConfig)
 }
 
 func confirmRequiredEnvVarsForDefaultConfigs(paths []string) error {

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -422,6 +422,44 @@ func TestUseConfigPathsFromEnvVar(t *testing.T) {
 	require.Equal(t, []string{localGatewayConfig}, settings.ResolverURIs())
 }
 
+func TestDeprecatedOTLPLinuxConfigWarning(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "config path",
+			path: DefaultOTLPLinuxConfig,
+		},
+		{
+			name: "config file URI",
+			path: "file:" + DefaultOTLPLinuxConfig,
+		},
+		{
+			name: "cleaned config path",
+			path: "/etc/otel/collector/../collector/otlp_config_linux.yaml",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			oldWriter := log.Default().Writer()
+			logs := new(bytes.Buffer)
+			log.Default().SetOutput(logs)
+			t.Cleanup(func() {
+				log.Default().SetOutput(oldWriter)
+			})
+
+			warnIfDeprecatedOTLPLinuxConfigUsed([]string{test.path})
+
+			actualLogs := logs.String()
+			require.Contains(t, actualLogs, "otlp_config_linux.yaml is deprecated and will be removed in a future release")
+			require.Contains(t, actualLogs, "Use --config=/etc/otel/collector/agent_config.yaml instead")
+			require.Contains(t, actualLogs, "set SPLUNK_LISTEN_INTERFACE=0.0.0.0 when migrating")
+		})
+	}
+}
+
 func TestConfigPrecedence(t *testing.T) {
 	validConfig := `receivers:
   host_metrics:

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -460,6 +460,75 @@ func TestDeprecatedOTLPLinuxConfigWarning(t *testing.T) {
 	}
 }
 
+func TestDeprecatedOTLPLinuxConfigWarningFromSelectedConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		args             []string
+		env              map[string]string
+		expectedResolver []string
+	}{
+		{
+			name:             "config flag",
+			args:             []string{"--config", DefaultOTLPLinuxConfig},
+			expectedResolver: []string{DefaultOTLPLinuxConfig},
+		},
+		{
+			name:             "config flag file URI",
+			args:             []string{"--config", "file:" + DefaultOTLPLinuxConfig},
+			expectedResolver: []string{"file:" + DefaultOTLPLinuxConfig},
+		},
+		{
+			name: "config env var",
+			env: map[string]string{
+				ConfigEnvVar: DefaultOTLPLinuxConfig,
+			},
+			expectedResolver: []string{DefaultOTLPLinuxConfig},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Cleanup(clearEnv(t))
+			setStatConfigFileForDefaultOTLPLinuxConfig(t)
+			t.Setenv(RealmEnvVar, "us0")
+			t.Setenv(TokenEnvVar, "access_token")
+
+			oldWriter := log.Default().Writer()
+			logs := new(bytes.Buffer)
+			log.Default().SetOutput(logs)
+			t.Cleanup(func() {
+				log.Default().SetOutput(oldWriter)
+			})
+
+			for key, value := range test.env {
+				t.Setenv(key, value)
+			}
+
+			settings, err := New(test.args)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedResolver, settings.ResolverURIs())
+
+			actualLogs := logs.String()
+			require.Contains(t, actualLogs, "Configuration file /etc/otel/collector/otlp_config_linux.yaml is deprecated")
+			require.Contains(t, actualLogs, "Use --config=/etc/otel/collector/agent_config.yaml instead")
+			require.Contains(t, actualLogs, "set SPLUNK_LISTEN_INTERFACE=0.0.0.0 when migrating")
+		})
+	}
+}
+
+func setStatConfigFileForDefaultOTLPLinuxConfig(t *testing.T) {
+	oldStatConfigFile := statConfigFile
+	statConfigFile = func(name string) (os.FileInfo, error) {
+		if name == DefaultOTLPLinuxConfig || filepath.Clean(name) == filepath.Clean(DefaultOTLPLinuxConfig) {
+			return os.Stat(localOTLPLinuxConfig)
+		}
+		return os.Stat(name)
+	}
+	t.Cleanup(func() {
+		statConfigFile = oldStatConfigFile
+	})
+}
+
 func TestConfigPrecedence(t *testing.T) {
 	validConfig := `receivers:
   host_metrics:


### PR DESCRIPTION
**Description:**
Use of the otlp_config_linux.yaml bundled with Docker images is now deprecated and the file is planned to be removed from future images. To prepare for removal, when deprecated otlp_config_linux.yaml is set as the config path, emit a warning.
