### PR TITLE
[chore] Improve RPM release metadata verification

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ variables:
     description: "Set to 'true' to do a dry-run of most jobs, publishing dev images and test packages when appropriate."
   RUN_RPM_METADATA_REPAIR:
     value: "false"
-    description: "Set to 'true' on a manual main pipeline to re-sign the current release RPM repo metadata."
+    description: "Set to 'true' on a manual main web pipeline to re-sign the current release RPM repo metadata."
   GO_VERSION: 1.26.4
   WIN_2019_BASE_IMAGE: mcr.microsoft.com/windows/servercore:ltsc2019
   WIN_2022_BASE_IMAGE: mcr.microsoft.com/windows/servercore:ltsc2022
@@ -102,6 +102,8 @@ manual_release_trigger:
 
       echo "Manual release triggered for version $RELEASE_VERSION"
   rules:
+    - if: '$RUN_RPM_METADATA_REPAIR == "true"'
+      when: never
     - if: '$CI_PIPELINE_SOURCE == "web" && $RELEASE_VERSION && $CI_COMMIT_BRANCH == "main"'
       when: on_success
   allow_failure: false
@@ -1313,7 +1315,7 @@ sign-release-rpm-metadata:
     matrix:
       - ARCH: ['x86_64', 'aarch64']
   rules:
-    - if: '$RUN_RPM_METADATA_REPAIR == "true" && $CI_COMMIT_BRANCH == "main"'
+    - if: '$RUN_RPM_METADATA_REPAIR == "true" && $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_BRANCH == "main"'
   before_script:
     - apt update && apt install -y curl
     - |
@@ -1342,7 +1344,7 @@ publish-release-rpm-metadata-signature:
     - job: sign-release-rpm-metadata
       artifacts: true
   rules:
-    - if: '$RUN_RPM_METADATA_REPAIR == "true" && $CI_COMMIT_BRANCH == "main"'
+    - if: '$RUN_RPM_METADATA_REPAIR == "true" && $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_BRANCH == "main"'
   variables:
     SPLUNK_RPM_GPG_KEY_URL: "https://splunk.jfrog.io/splunk/otel-collector-rpm/splunk-B3CD4420.pub"
     SPLUNK_GPG_FINGERPRINT: "58C33310B7A354C1279DB6695EFA01EDB3CD4420"
@@ -1380,7 +1382,7 @@ verify-release-rpm-metadata-signature:
   needs:
     - publish-release-rpm-metadata-signature
   rules:
-    - if: '$RUN_RPM_METADATA_REPAIR == "true" && $CI_COMMIT_BRANCH == "main"'
+    - if: '$RUN_RPM_METADATA_REPAIR == "true" && $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_BRANCH == "main"'
   variables:
     SPLUNK_RPM_GPG_KEY_URL: "https://splunk.jfrog.io/splunk/otel-collector-rpm/splunk-B3CD4420.pub"
     SPLUNK_GPG_FINGERPRINT: "58C33310B7A354C1279DB6695EFA01EDB3CD4420"
@@ -1473,6 +1475,26 @@ verify-deb-metadata:
   variables:
     TARGET: deb
 
+verify-deb-install:
+  extends: .trigger-filter
+  image: ubuntu:22.04
+  needs:
+    - job: release-debs
+      artifacts: true
+    - job: verify-deb-metadata
+      artifacts: false
+  variables:
+    ARCH: amd64
+    DEBIAN_FRONTEND: noninteractive
+  script:
+    - *get-artifactory-stage
+    - |
+      set -euxo pipefail
+      shopt -s nullglob
+      deb_paths=(dist/signed/*_"${ARCH}".deb)
+      shopt -u nullglob
+      packaging/release/verify-deb-install.sh "${deb_paths[@]}"
+
 # verify the rpm repo metadata signatures per-arch; only needs the rpm release artifacts.
 verify-rpm-metadata:
   extends: .verify-metadata
@@ -1497,52 +1519,10 @@ verify-rpm-install:
     - *get-artifactory-stage
     - |
       set -euxo pipefail
-
       shopt -s nullglob
       rpm_paths=(dist/signed/*"${ARCH}".rpm)
       shopt -u nullglob
-      if [ "${#rpm_paths[@]}" -lt 2 ]; then
-        echo "Expected collector and instrumentation RPMs for ${ARCH}, found ${#rpm_paths[@]}"
-        exit 1
-      fi
-
-      collector_nevra=""
-      instrumentation_nevra=""
-      instrumentation_rpm=""
-      for path in "${rpm_paths[@]}"; do
-        nevra="$(rpm -qp --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}' "$path")"
-        case "$nevra" in
-          splunk-otel-collector-*) collector_nevra="$nevra" ;;
-          splunk-otel-auto-instrumentation-*)
-            instrumentation_nevra="$nevra"
-            instrumentation_rpm="$(basename "$path")"
-            ;;
-        esac
-      done
-      test -n "$collector_nevra"
-      test -n "$instrumentation_nevra"
-      test -n "$instrumentation_rpm"
-
-      printf '%s\n' \
-        '[splunk-otel-collector]' \
-        'name=Splunk OpenTelemetry Collector Repository' \
-        "baseurl=https://splunk.jfrog.io/splunk/otel-collector-rpm/${STAGE}/\$basearch" \
-        'gpgcheck=1' \
-        'repo_gpgcheck=1' \
-        'gpgkey=https://splunk.jfrog.io/splunk/otel-collector-rpm/splunk-B3CD4420.pub' \
-        'enabled=1' \
-        > /etc/yum.repos.d/splunk-otel-collector.repo
-
-      dnf clean all
-      dnf -y --disablerepo='*' --enablerepo=splunk-otel-collector makecache
-      dnf -y install "$collector_nevra" "$instrumentation_nevra"
-      rpm -q "$collector_nevra" "$instrumentation_nevra"
-
-      # Direct rpm URL installs bypass repo_gpgcheck, but some users install this way.
-      instrumentation_url="https://splunk.jfrog.io/splunk/otel-collector-rpm/${STAGE}/${ARCH}/${instrumentation_rpm}"
-      rpm -e splunk-otel-auto-instrumentation
-      rpm -ivh "$instrumentation_url"
-      rpm -q "$instrumentation_nevra"
+      packaging/release/verify-rpm-install.sh "${rpm_paths[@]}"
 
 # only upload the msi to S3 for stable release tags
 release-msi:
@@ -1873,6 +1853,8 @@ github-release:
     - job: release-rpms
       artifacts: true
     - job: verify-deb-metadata
+      artifacts: false
+    - job: verify-deb-install
       artifacts: false
     - job: verify-rpm-metadata
       artifacts: false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1246,9 +1246,10 @@ release-debs:
   after_script:
     - *get-artifactory-stage
     - |
-      set -ex
+      set +x
+      set -euo pipefail
       if [[ "$CI_JOB_STATUS" = "success" ]] && [[ -f signed/Release.asc ]]; then
-        curl -fu ${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN} -X PUT "https://splunk.jfrog.io/artifactory/otel-collector-deb/dists/${STAGE}/Release.gpg" -T signed/Release.asc
+        curl -fu "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}" -X PUT "https://splunk.jfrog.io/artifactory/otel-collector-deb/dists/${STAGE}/Release.gpg" -T signed/Release.asc
       fi
   artifacts:
     paths:
@@ -1266,31 +1267,40 @@ release-rpms:
   needs:
     - job: sign-rpms
       artifacts: true
-  retry: 2
+  timeout: 2h
   before_script:
     - *get-artifactory-stage
     - pip3 install -r packaging/release/requirements.txt
     - apt update && apt install -y curl
     - |
       set -ex
-      for path in dist/signed/*${ARCH}.rpm; do
+      shopt -s nullglob
+      rpm_paths=(dist/signed/*"${ARCH}".rpm)
+      shopt -u nullglob
+      if [ "${#rpm_paths[@]}" -lt 2 ]; then
+        echo "Expected collector and instrumentation RPMs for ${ARCH}, found ${#rpm_paths[@]}"
+        exit 1
+      fi
+      for path in "${rpm_paths[@]}"; do
         if [ ! -f "$path" ]; then
           echo "$path not found!"
           exit 1
         fi
-        python3 packaging/release/release.py --force --stage=${STAGE} --path=$path
       done
+      python3 packaging/release/release.py --force --stage="${STAGE}" --timeout="${ARTIFACTORY_RELEASE_TIMEOUT}" --paths "${rpm_paths[@]}"
     - test -f repomd.xml
   variables:
     ARTIFACT: repomd.xml
     SIGN_TYPE: GPG
     DOWNLOAD_DIR: signed/${ARCH}
+    ARTIFACTORY_RELEASE_TIMEOUT: "6000"
   after_script:
     - *get-artifactory-stage
     - |
-      set -ex
+      set +x
+      set -euo pipefail
       if [[ "$CI_JOB_STATUS" = "success" ]] && [[ -f signed/${ARCH}/repomd.xml.asc ]]; then
-        curl -fu ${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN} -X PUT "https://splunk.jfrog.io/artifactory/otel-collector-rpm/${STAGE}/${ARCH}/repodata/repomd.xml.asc" -T signed/${ARCH}/repomd.xml.asc
+        curl -fu "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}" -X PUT "https://splunk.jfrog.io/artifactory/otel-collector-rpm/${STAGE}/${ARCH}/repodata/repomd.xml.asc" -T "signed/${ARCH}/repomd.xml.asc"
       fi
   artifacts:
     paths:
@@ -1394,19 +1404,8 @@ verify-release-rpm-metadata-signature:
         || { echo "Published RPM metadata signature did not validate."; exit 1; }
 
 # since "after_script" failures or missing artifacts will not fail the job, use this job to verify that the signatures were uploaded successfully
-verify-signed-metadata:
+.verify-metadata:
   extends: .trigger-filter
-  needs:
-    - release-debs
-    - release-rpms
-  retry: 2
-  parallel:
-    matrix:
-      - TARGET: deb
-      - TARGET: rpm
-        ARCH: x86_64
-      - TARGET: rpm
-        ARCH: aarch64
   variables:
     SPLUNK_RPM_GPG_KEY_URL: "https://splunk.jfrog.io/splunk/otel-collector-rpm/splunk-B3CD4420.pub"
     SPLUNK_DEB_GPG_KEY_URL: "https://splunk.jfrog.io/splunk/otel-collector-deb/splunk-B3CD4420.gpg"
@@ -1426,9 +1425,8 @@ verify-signed-metadata:
       gpg --list-keys "${SPLUNK_GPG_FINGERPRINT}" >/dev/null \
         || { echo "Expected signing key ${SPLUNK_GPG_FINGERPRINT} not found at the published key URL(s)!"; exit 1; }
 
-      # Resolve this matrix target's live metadata URL, its detached signature
-      # URL, and the signature this pipeline produced (from the release job
-      # artifacts).
+      # Resolve this target's live metadata URL, its detached signature URL, and
+      # the signature this pipeline produced (from the release job artifacts).
       case "$TARGET" in
         deb)
           base="https://splunk.jfrog.io/artifactory/otel-collector-deb/dists/${STAGE}"
@@ -1466,6 +1464,85 @@ verify-signed-metadata:
       fi
 
       echo "Signature OK for ${name}"
+
+# verify the deb repo metadata signature; only needs the deb release artifacts.
+verify-deb-metadata:
+  extends: .verify-metadata
+  needs:
+    - release-debs
+  variables:
+    TARGET: deb
+
+# verify the rpm repo metadata signatures per-arch; only needs the rpm release artifacts.
+verify-rpm-metadata:
+  extends: .verify-metadata
+  needs:
+    - release-rpms
+  parallel:
+    matrix:
+      - TARGET: rpm
+        ARCH: [x86_64, aarch64]
+
+verify-rpm-install:
+  extends: .trigger-filter
+  image: quay.io/rockylinux/rockylinux:9
+  needs:
+    - job: release-rpms
+      artifacts: true
+    - job: verify-rpm-metadata
+      artifacts: false
+  variables:
+    ARCH: x86_64
+  script:
+    - *get-artifactory-stage
+    - |
+      set -euxo pipefail
+
+      shopt -s nullglob
+      rpm_paths=(dist/signed/*"${ARCH}".rpm)
+      shopt -u nullglob
+      if [ "${#rpm_paths[@]}" -lt 2 ]; then
+        echo "Expected collector and instrumentation RPMs for ${ARCH}, found ${#rpm_paths[@]}"
+        exit 1
+      fi
+
+      collector_nevra=""
+      instrumentation_nevra=""
+      instrumentation_rpm=""
+      for path in "${rpm_paths[@]}"; do
+        nevra="$(rpm -qp --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}' "$path")"
+        case "$nevra" in
+          splunk-otel-collector-*) collector_nevra="$nevra" ;;
+          splunk-otel-auto-instrumentation-*)
+            instrumentation_nevra="$nevra"
+            instrumentation_rpm="$(basename "$path")"
+            ;;
+        esac
+      done
+      test -n "$collector_nevra"
+      test -n "$instrumentation_nevra"
+      test -n "$instrumentation_rpm"
+
+      printf '%s\n' \
+        '[splunk-otel-collector]' \
+        'name=Splunk OpenTelemetry Collector Repository' \
+        "baseurl=https://splunk.jfrog.io/splunk/otel-collector-rpm/${STAGE}/\$basearch" \
+        'gpgcheck=1' \
+        'repo_gpgcheck=1' \
+        'gpgkey=https://splunk.jfrog.io/splunk/otel-collector-rpm/splunk-B3CD4420.pub' \
+        'enabled=1' \
+        > /etc/yum.repos.d/splunk-otel-collector.repo
+
+      dnf clean all
+      dnf -y --disablerepo='*' --enablerepo=splunk-otel-collector makecache
+      dnf -y install "$collector_nevra" "$instrumentation_nevra"
+      rpm -q "$collector_nevra" "$instrumentation_nevra"
+
+      # Direct rpm URL installs bypass repo_gpgcheck, but some users install this way.
+      instrumentation_url="https://splunk.jfrog.io/splunk/otel-collector-rpm/${STAGE}/${ARCH}/${instrumentation_rpm}"
+      rpm -e splunk-otel-auto-instrumentation
+      rpm -ivh "$instrumentation_url"
+      rpm -q "$instrumentation_nevra"
 
 # only upload the msi to S3 for stable release tags
 release-msi:
@@ -1795,7 +1872,11 @@ github-release:
       artifacts: true
     - job: release-rpms
       artifacts: true
-    - job: verify-signed-metadata
+    - job: verify-deb-metadata
+      artifacts: false
+    - job: verify-rpm-metadata
+      artifacts: false
+    - job: verify-rpm-install
       artifacts: false
     - job: sign-msi
       artifacts: true

--- a/packaging/release/helpers/constants.py
+++ b/packaging/release/helpers/constants.py
@@ -22,7 +22,7 @@ ARTIFACTORY_DEB_REPO_URL = f"{ARTIFACTORY_URL}/{ARTIFACTORY_DEB_REPO}"
 ARTIFACTORY_RPM_REPO = "otel-collector-rpm"
 ARTIFACTORY_RPM_REPO_URL = f"{ARTIFACTORY_URL}/{ARTIFACTORY_RPM_REPO}"
 DEFAULT_ARTIFACTORY_USERNAME = "otel-collector"
-DEFAULT_TIMEOUT = 1200
+DEFAULT_TIMEOUT = 2700
 # After the repo metadata first changes following our upload, require it to stay
 # unchanged for this many seconds before treating it as settled.
 METADATA_SETTLE_DELAY = 60

--- a/packaging/release/helpers/release_args.py
+++ b/packaging/release/helpers/release_args.py
@@ -95,7 +95,19 @@ def get_args_and_asset():
         help=f"""
             Sign/release a local file.
             Only files with {EXTENSIONS} extensions or is named 'otelcol_darwin_*' are supported.
-            Required if the --installers option is not specified.
+            Required if neither --paths nor --installers is specified.
+        """,
+    )
+    parser.add_argument(
+        "--paths",
+        type=str,
+        nargs="+",
+        default=None,
+        metavar="PATH",
+        required=False,
+        help="""
+            Sign/release multiple local files as one batch.
+            Currently only RPM batches are supported.
         """,
     )
     parser.add_argument(
@@ -105,7 +117,7 @@ def get_args_and_asset():
         required=False,
         help="""
             Release the installer scripts to S3.
-            Required if the --path option is not specified.
+            Required if neither --path nor --paths is specified.
         """,
     )
     parser.add_argument(
@@ -137,13 +149,14 @@ def get_args_and_asset():
     parser.add_argument(
         "--sync-calculate-metadata",
         action=argparse.BooleanOptionalAction,
-        default=os.environ.get("ARTIFACTORY_SYNC_CALCULATE", "").lower() in ("1", "true", "yes"),
+        default=os.environ.get("ARTIFACTORY_SYNC_CALCULATE", "").lower()
+        in ("1", "true", "yes"),
         required=False,
         help="""
-            For deb/rpm uploads, explicitly trigger Artifactory's metadata
-            calculation synchronously (async=0) after upload and before signing,
-            instead of relying only on the asynchronous auto-calculation.
-            Defaults to the ARTIFACTORY_SYNC_CALCULATE env var if truthy.
+            For deb uploads, explicitly trigger Artifactory's metadata calculation
+            synchronously after upload and before signing. RPM uploads always
+            trigger synchronous YUM metadata calculation before signing.
+            Defaults to the ARTIFACTORY_SYNC_CALCULATE env var if truthy for debs.
         """,
     )
 
@@ -151,13 +164,23 @@ def get_args_and_asset():
 
     args = parser.parse_args()
 
-    assert args.path or args.installers, "Either --path or --installers must be specified"
+    assert (
+        args.path or args.paths or args.installers
+    ), "Either --path, --paths, or --installers must be specified"
+    assert not (
+        args.path and args.paths
+    ), "Only one of --path or --paths may be specified"
 
     asset = None
     if args.path:
         asset = get_asset(args.path)
+    elif args.paths:
+        asset = [get_asset(path) for path in args.paths]
+        assert all(a.component == "rpm" for a in asset), "Only RPM batches are supported"
 
-    if asset and asset.component in ("deb", "rpm"):
+    if isinstance(asset, list):
+        check_artifactory_args(args)
+    elif asset and asset.component in ("deb", "rpm"):
         check_artifactory_args(args)
 
     return args, asset

--- a/packaging/release/helpers/util.py
+++ b/packaging/release/helpers/util.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gzip
 import hashlib
 import os
 import re
 import sys
 import tempfile
 import time
+import xml.etree.ElementTree as ET
 
 import boto3
 import requests
@@ -136,11 +138,17 @@ def get_md5_from_artifactory(url, user, token):
     return md5
 
 
-def trigger_metadata_calculation(calculate_url, user, token, timeout=DEFAULT_TIMEOUT):
-    # Explicitly ask Artifactory to (re)calculate the repo metadata and block
-    # until it finishes (async=0).
-    print(f"Triggering synchronous metadata calculation: {calculate_url}")
-    resp = requests.post(calculate_url, auth=(user, token), timeout=timeout)
+def trigger_metadata_calculation(
+    calculate_url, user, token, sync=False, timeout=DEFAULT_TIMEOUT, params=None
+):
+    params = dict(params or {})
+    if "async" not in params and "async=" not in calculate_url:
+        params["async"] = "0" if sync else "1"
+    params_msg = f" params={params}" if params else ""
+    print(f"Triggering metadata calculation: {calculate_url}{params_msg}")
+    resp = requests.post(
+        calculate_url, auth=(user, token), params=params or None, timeout=timeout
+    )
     print(f"Calculation response: {resp.status_code} {resp.text.strip()}")
     resp.raise_for_status()
 
@@ -176,13 +184,7 @@ def wait_for_artifactory_metadata(
 
         time.sleep(5)
 
-    # Require the metadata to stay unchanged across a settle window
-    # before treating it as final. Artifactory recalculates metadata
-    # asynchronously and may run more than one calculation pass for a batch, so
-    # returning on the first change can capture an intermediate snapshot that a
-    # later pass overwrites whose detached signature would no longer match the
-    # published metadata and break repo_gpgcheck for clients. If it changes again
-    # during the window, adopt the new value and keep waiting.
+    # Treat the first metadata change as provisional until it stays stable.
     while True:
         elapsed = int(time.time() - start_time)
         assert elapsed + settle_delay <= timeout, (
@@ -206,6 +208,114 @@ def wait_for_artifactory_metadata(
         last_md5 = new_md5
 
 
+def wait_for_package_in_metadata(package_present_check, package_name, timeout=DEFAULT_TIMEOUT):
+    print(f"Waiting for {package_name} to appear in live repo metadata ...")
+    start_time = time.time()
+
+    while True:
+        present = package_present_check()
+        if present is True:
+            print(f"{package_name} is present in live repo metadata.")
+            return
+
+        elapsed = int(time.time() - start_time)
+        assert elapsed < timeout, (
+            f"Timed out after {elapsed}s waiting for {package_name} to appear "
+            f"in live repo metadata (last result: {present})"
+        )
+
+        if elapsed > 0 and elapsed % 60 == 0:
+            print(
+                f"  Still waiting after {elapsed}s for {package_name} "
+                f"to appear in live repo metadata (last result: {present}) ..."
+            )
+
+        time.sleep(5)
+
+
+def rpm_package_in_metadata(stage, arch, package_name, user, token):
+    # Return True/False if package_name (the rpm filename) is listed in the live
+    # repodata primary.xml, or None if it can't be determined.
+    repomd_url = f"{ARTIFACTORY_RPM_REPO_URL}/{stage}/{arch}/repodata/repomd.xml"
+    resp = requests.get(repomd_url, auth=(user, token))
+    if resp.status_code != 200:
+        print(f"Could not fetch {repomd_url}: {resp.status_code}")
+        return None
+
+    try:
+        repomd = ET.fromstring(resp.content)
+    except ET.ParseError as err:
+        print(f"Could not parse {repomd_url}: {err}")
+        return None
+
+    primary_href = None
+    for data in repomd.findall(".//{*}data"):
+        if data.attrib.get("type") == "primary":
+            location = data.find("{*}location")
+            if location is not None:
+                primary_href = location.attrib.get("href")
+            break
+
+    if not primary_href:
+        print(f"Could not find primary metadata href in {repomd_url}")
+        return None
+
+    if primary_href.startswith("http://") or primary_href.startswith("https://"):
+        primary_url = primary_href
+    else:
+        primary_url = f"{ARTIFACTORY_RPM_REPO_URL}/{stage}/{arch}/{primary_href}"
+
+    resp = requests.get(primary_url, auth=(user, token))
+    if resp.status_code != 200:
+        print(f"Could not fetch {primary_url}: {resp.status_code}")
+        return None
+
+    primary_content = resp.content
+    if primary_href.endswith(".gz"):
+        try:
+            primary_content = gzip.decompress(primary_content)
+        except OSError as err:
+            print(f"Could not decompress {primary_url}: {err}")
+            return None
+
+    try:
+        primary = ET.fromstring(primary_content)
+    except ET.ParseError as err:
+        print(f"Could not parse {primary_url}: {err}")
+        return None
+
+    for location in primary.findall(".//{*}location"):
+        href = location.attrib.get("href", "")
+        if os.path.basename(href) == package_name:
+            return True
+    return False
+
+
+def deb_package_in_metadata(stage, arch, package_name, user, token):
+    # Return True/False if package_name (the .deb filename) is listed in the live
+    # Packages index for this distribution/arch, or None if it can't be
+    # determined.
+    base = f"{ARTIFACTORY_DEB_REPO_URL}/dists/{stage}/main/binary-{arch}"
+    text = None
+    resp = requests.get(f"{base}/Packages.gz", auth=(user, token))
+    if resp.status_code == 200:
+        try:
+            text = gzip.decompress(resp.content).decode("utf-8", "replace")
+        except OSError:
+            text = None
+    if text is None:
+        resp = requests.get(f"{base}/Packages", auth=(user, token))
+        if resp.status_code == 200:
+            text = resp.text
+    if text is None:
+        return None
+    # Packages lists each entry as "Filename: pool/<stage>/<arch>/<file>.deb"
+    return any(
+        line.startswith("Filename:") and line.strip().endswith(package_name)
+        for line in text.splitlines()
+    )
+
+
 def upload_package_to_artifactory(
     path,
     dest_url,
@@ -216,6 +326,9 @@ def upload_package_to_artifactory(
     sign_metadata=True,
     timeout=DEFAULT_TIMEOUT,
     calculate_url=None,
+    calculate_params=None,
+    package_present_check=None,
+    sync_calculate=False,
 ):
     local_md5 = get_checksum(path, hashlib.md5())
     clean_url = dest_url.split(";")[0]
@@ -242,14 +355,56 @@ def upload_package_to_artifactory(
     upload_file_to_artifactory(path, dest_url, user, token)
 
     if sign_metadata:
-        if content_changed:
+        do_wait = content_changed
+        if not content_changed:
+            # Existing bytes do not prove live metadata references the package.
+            present = package_present_check() if package_present_check else None
+            if present is False:
+                print(
+                    "Upload content is identical to the existing file, but the "
+                    "package is NOT present in the live repo metadata; the index "
+                    "is stale. Forcing metadata regeneration before signing."
+                )
+                do_wait = True
+            elif present is True:
+                print(
+                    "Upload content is identical and the package is already present "
+                    "in the live repo metadata."
+                )
+                do_wait = False
+            else:
+                print(
+                    "Upload content is identical to existing file and metadata "
+                    "presence could not be confirmed."
+                )
+                do_wait = True
+        if do_wait:
             if calculate_url:
-                trigger_metadata_calculation(calculate_url, user, token, timeout=timeout)
-            wait_for_artifactory_metadata(metadata_api_url, orig_md5, user, token, timeout=timeout)
-        else:
-            print(
-                "Upload content is identical to existing file. "
-                "Repo metadata will not be regenerated — skipping metadata wait."
+                trigger_metadata_calculation(
+                    calculate_url,
+                    user,
+                    token,
+                    sync=sync_calculate,
+                    timeout=timeout,
+                    params=calculate_params,
+                )
+                current_md5 = get_md5_from_artifactory(metadata_api_url, user, token)
+                if current_md5 and str(orig_md5).lower() != str(current_md5).lower():
+                    wait_for_artifactory_metadata(
+                        metadata_api_url, orig_md5, user, token, timeout=timeout
+                    )
+                else:
+                    print(
+                        "Metadata MD5 did not change after calculation; "
+                        "checking package presence before signing."
+                    )
+            else:
+                wait_for_artifactory_metadata(
+                    metadata_api_url, orig_md5, user, token, timeout=timeout
+                )
+        if package_present_check:
+            wait_for_package_in_metadata(
+                package_present_check, os.path.basename(path), timeout=timeout
             )
         dest = os.path.join(REPO_DIR, os.path.basename(metadata_url))
         download_file(metadata_url, dest, user, token)
@@ -275,9 +430,7 @@ def release_deb_to_artifactory(asset, args):
         if resp.lower() not in ("y", "yes"):
             sys.exit(1)
 
-    calculate_url = None
-    if getattr(args, "sync_calculate_metadata", False):
-        calculate_url = f"{ARTIFACTORY_API_URL}/deb/reindex/{ARTIFACTORY_DEB_REPO}?async=0"
+    calculate_url = f"{ARTIFACTORY_API_URL}/deb/reindex/{ARTIFACTORY_DEB_REPO}"
 
     upload_package_to_artifactory(
         asset.path,
@@ -289,42 +442,101 @@ def release_deb_to_artifactory(asset, args):
         sign_metadata=True,
         timeout=args.timeout,
         calculate_url=calculate_url,
+        package_present_check=lambda: deb_package_in_metadata(
+            args.stage, arch, asset.name, user, token
+        ),
+        sync_calculate=getattr(args, "sync_calculate_metadata", False),
     )
 
+
+def get_rpm_arch(asset):
+    match = re.match(r".*\.(x86_64|aarch64)\.rpm$", asset.name)
+    assert match, f"Failed to get arch from {asset.path}!"
+    return match.groups()[0]
 
 
 def release_rpm_to_artifactory(asset, args):
+    release_rpms_to_artifactory([asset], args)
+
+
+def release_rpms_to_artifactory(assets, args):
+    assert assets, "No RPM assets specified"
+
     user = args.artifactory_user
     token = args.artifactory_token
 
-    match = re.match(r".*\.(x86_64|aarch64)\.rpm$", asset.name)
-    assert match, f"Failed to get arch from {asset.path}!"
-    arch = match.groups()[0]
+    arch = get_rpm_arch(assets[0])
+    for asset in assets:
+        assert get_rpm_arch(asset) == arch, "RPM batch must use a single arch"
 
     metadata_api_url = f"{ARTIFACTORY_API_URL}/storage/{ARTIFACTORY_RPM_REPO}/{args.stage}/{arch}/repodata/repomd.xml"
     metadata_url = f"{ARTIFACTORY_RPM_REPO_URL}/{args.stage}/{arch}/repodata/repomd.xml"
-    dest_url = f"{ARTIFACTORY_RPM_REPO_URL}/{args.stage}/{arch}/{asset.name}"
 
-    if not args.force and artifactory_file_exists(dest_url, user, token):
-        resp = input(f"{dest_url} already exists.\nOverwrite? [y/N]: ")
-        if resp.lower() not in ("y", "yes"):
-            sys.exit(1)
-
-    calculate_url = None
-    if getattr(args, "sync_calculate_metadata", False):
-        calculate_url = f"{ARTIFACTORY_API_URL}/yum/{ARTIFACTORY_RPM_REPO}/{args.stage}/{arch}?async=0"
-
-    upload_package_to_artifactory(
-        asset.path,
-        dest_url,
-        user,
-        token,
-        metadata_api_url,
-        metadata_url,
-        sign_metadata=True,
-        timeout=args.timeout,
-        calculate_url=calculate_url,
+    # Auto Calculate RPM Metadata is disabled for this repo, so the release
+    # pipeline recalculates once after all RPMs are uploaded.
+    calculate_url = (
+        f"{ARTIFACTORY_API_URL}/yum/{ARTIFACTORY_RPM_REPO}/"
+        f"{args.stage}/{arch}?async=0"
     )
+
+    orig_md5 = get_md5_from_artifactory(metadata_api_url, user, token)
+    print(f"Pre-upload metadata MD5:       {orig_md5}")
+
+    for asset in assets:
+        dest_url = f"{ARTIFACTORY_RPM_REPO_URL}/{args.stage}/{arch}/{asset.name}"
+
+        if not args.force and artifactory_file_exists(dest_url, user, token):
+            resp = input(f"{dest_url} already exists.\nOverwrite? [y/N]: ")
+            if resp.lower() not in ("y", "yes"):
+                sys.exit(1)
+
+        upload_package_to_artifactory(
+            asset.path,
+            dest_url,
+            user,
+            token,
+            metadata_api_url,
+            metadata_url,
+            sign_metadata=False,
+            timeout=args.timeout,
+        )
+
+    try:
+        trigger_metadata_calculation(
+            calculate_url,
+            user,
+            token,
+            sync=True,
+            timeout=args.timeout,
+        )
+    except requests.exceptions.ReadTimeout:
+        print(
+            "Timed out waiting for the synchronous metadata calculation response; "
+            "polling live metadata before signing."
+        )
+
+    current_md5 = get_md5_from_artifactory(metadata_api_url, user, token)
+    if current_md5 and str(orig_md5).lower() != str(current_md5).lower():
+        wait_for_artifactory_metadata(
+            metadata_api_url, orig_md5, user, token, timeout=args.timeout
+        )
+    else:
+        print(
+            "Metadata MD5 did not change after calculation; "
+            "checking package presence before signing."
+        )
+
+    for asset in assets:
+        wait_for_package_in_metadata(
+            lambda asset=asset: rpm_package_in_metadata(
+                args.stage, arch, asset.name, user, token
+            ),
+            asset.name,
+            timeout=args.timeout,
+        )
+
+    dest = os.path.join(REPO_DIR, os.path.basename(metadata_url))
+    download_file(metadata_url, dest, user, token)
 
 
 def s3_file_exists(s3_client, path):

--- a/packaging/release/helpers/util.py
+++ b/packaging/release/helpers/util.py
@@ -430,7 +430,9 @@ def release_deb_to_artifactory(asset, args):
         if resp.lower() not in ("y", "yes"):
             sys.exit(1)
 
-    calculate_url = f"{ARTIFACTORY_API_URL}/deb/reindex/{ARTIFACTORY_DEB_REPO}"
+    calculate_url = None
+    if getattr(args, "sync_calculate_metadata", False):
+        calculate_url = f"{ARTIFACTORY_API_URL}/deb/reindex/{ARTIFACTORY_DEB_REPO}?async=0"
 
     upload_package_to_artifactory(
         asset.path,

--- a/packaging/release/release.py
+++ b/packaging/release/release.py
@@ -21,6 +21,7 @@ from helpers.util import (
     release_deb_to_artifactory,
     release_installers_to_s3,
     release_msi_to_s3,
+    release_rpms_to_artifactory,
     release_rpm_to_artifactory,
 )
 
@@ -30,14 +31,20 @@ def main():
 
     if asset:
         print(f"Releasing the following asset to the '{args.stage}' stage:")
-        print(asset.path)
+        if isinstance(asset, list):
+            for item in asset:
+                print(item.path)
+        else:
+            print(asset.path)
 
         if not args.force:
             resp = input("Continue? [y/N]: ")
             if resp.lower() not in ("y", "yes"):
                 sys.exit(1)
 
-        if asset.component == "deb":
+        if isinstance(asset, list):
+            release_rpms_to_artifactory(asset, args)
+        elif asset.component == "deb":
             # Release deb to artifactory
             release_deb_to_artifactory(asset, args)
         elif asset.component == "rpm":

--- a/packaging/release/verify-deb-install.sh
+++ b/packaging/release/verify-deb-install.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export DEBIAN_FRONTEND="${DEBIAN_FRONTEND:-noninteractive}"
+
+ARCH="${ARCH:-}"
+STAGE="${STAGE:-test}"
+DEB_REPO_BASE="${DEB_REPO_BASE:-https://splunk.jfrog.io/splunk/otel-collector-deb}"
+DEB_REPO_FILE="${DEB_REPO_FILE:-/etc/apt/sources.list.d/splunk-otel-collector.list}"
+DEB_KEYRING="${DEB_KEYRING:-/usr/share/keyrings/splunk-otel-collector.gpg}"
+
+if [[ "$#" -gt 0 ]]; then
+    deb_paths=("$@")
+else
+    ARCH="${ARCH:-amd64}"
+    shopt -s nullglob
+    deb_paths=(dist/signed/*_"${ARCH}".deb)
+    shopt -u nullglob
+fi
+
+if [[ "${#deb_paths[@]}" -lt 2 ]]; then
+    echo "Expected collector and instrumentation DEBs for ${ARCH}, found ${#deb_paths[@]}" >&2
+    exit 1
+fi
+
+collector_version=""
+instrumentation_version=""
+instrumentation_deb=""
+for path in "${deb_paths[@]}"; do
+    if [[ ! -f "$path" ]]; then
+        echo "$path not found!" >&2
+        exit 1
+    fi
+
+    package="$(dpkg-deb -f "$path" Package)"
+    version="$(dpkg-deb -f "$path" Version)"
+    deb_arch="$(dpkg-deb -f "$path" Architecture)"
+
+    if [[ -z "$ARCH" ]]; then
+        ARCH="$deb_arch"
+    elif [[ "$deb_arch" != "$ARCH" ]]; then
+        echo "DEB arch mismatch: expected ${ARCH}, got ${deb_arch} for ${path}" >&2
+        exit 1
+    fi
+
+    case "$package" in
+        splunk-otel-collector)
+            collector_version="$version"
+            ;;
+        splunk-otel-auto-instrumentation)
+            instrumentation_version="$version"
+            instrumentation_deb="$(basename "$path")"
+            ;;
+    esac
+done
+
+test -n "$collector_version"
+test -n "$instrumentation_version"
+test -n "$instrumentation_deb"
+
+apt-get -y update
+apt-get -y install apt-transport-https ca-certificates curl gnupg
+
+install -d -m 0755 "$(dirname "$DEB_REPO_FILE")" "$(dirname "$DEB_KEYRING")"
+curl -fsSL "${DEB_REPO_BASE}/splunk-B3CD4420.gpg" -o "$DEB_KEYRING"
+chmod 0644 "$DEB_KEYRING"
+
+cat > "$DEB_REPO_FILE" <<EOF
+deb [arch=${ARCH} signed-by=${DEB_KEYRING}] ${DEB_REPO_BASE} ${STAGE} main
+EOF
+
+apt-get -y update
+apt-get -y install \
+    "splunk-otel-collector=${collector_version}" \
+    "splunk-otel-auto-instrumentation=${instrumentation_version}"
+
+dpkg-query -W -f='${Package} ${Version} ${Architecture}\n' \
+    splunk-otel-collector splunk-otel-auto-instrumentation
+
+test "$(dpkg-query -W -f='${Version}' splunk-otel-collector)" = "$collector_version"
+test "$(dpkg-query -W -f='${Version}' splunk-otel-auto-instrumentation)" = "$instrumentation_version"
+test "$(dpkg-query -W -f='${Architecture}' splunk-otel-collector)" = "$ARCH"
+test "$(dpkg-query -W -f='${Architecture}' splunk-otel-auto-instrumentation)" = "$ARCH"
+
+# Direct .deb URL installs bypass repo metadata signature checks, but some users install this way.
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+instrumentation_url="${DEB_REPO_BASE}/pool/${STAGE}/${ARCH}/${instrumentation_deb}"
+apt-get -y remove splunk-otel-auto-instrumentation
+curl -fsSL "$instrumentation_url" -o "${tmpdir}/${instrumentation_deb}"
+apt-get -y install "${tmpdir}/${instrumentation_deb}"
+
+dpkg-query -W -f='${Package} ${Version} ${Architecture}\n' splunk-otel-auto-instrumentation
+test "$(dpkg-query -W -f='${Version}' splunk-otel-auto-instrumentation)" = "$instrumentation_version"
+test "$(dpkg-query -W -f='${Architecture}' splunk-otel-auto-instrumentation)" = "$ARCH"

--- a/packaging/release/verify-rpm-install.sh
+++ b/packaging/release/verify-rpm-install.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ARCH="${ARCH:-}"
+STAGE="${STAGE:-test}"
+RPM_REPO_FILE="${RPM_REPO_FILE:-/etc/yum.repos.d/splunk-otel-collector.repo}"
+
+if [[ "$#" -gt 0 ]]; then
+    rpm_paths=("$@")
+else
+    ARCH="${ARCH:-x86_64}"
+    shopt -s nullglob
+    rpm_paths=(dist/signed/*"${ARCH}".rpm)
+    shopt -u nullglob
+fi
+
+if [[ "${#rpm_paths[@]}" -lt 2 ]]; then
+    echo "Expected collector and instrumentation RPMs for ${ARCH}, found ${#rpm_paths[@]}" >&2
+    exit 1
+fi
+
+collector_nevra=""
+instrumentation_nevra=""
+instrumentation_rpm=""
+for path in "${rpm_paths[@]}"; do
+    if [[ ! -f "$path" ]]; then
+        echo "$path not found!" >&2
+        exit 1
+    fi
+
+    rpm_arch="$(rpm -qp --queryformat '%{ARCH}' "$path")"
+    if [[ -z "$ARCH" ]]; then
+        ARCH="$rpm_arch"
+    elif [[ "$rpm_arch" != "$ARCH" ]]; then
+        echo "RPM arch mismatch: expected ${ARCH}, got ${rpm_arch} for ${path}" >&2
+        exit 1
+    fi
+
+    nevra="$(rpm -qp --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}' "$path")"
+    case "$nevra" in
+        splunk-otel-collector-*) collector_nevra="$nevra" ;;
+        splunk-otel-auto-instrumentation-*)
+            instrumentation_nevra="$nevra"
+            instrumentation_rpm="$(basename "$path")"
+            ;;
+    esac
+done
+
+test -n "$collector_nevra"
+test -n "$instrumentation_nevra"
+test -n "$instrumentation_rpm"
+
+cat > "$RPM_REPO_FILE" <<EOF
+[splunk-otel-collector]
+name=Splunk OpenTelemetry Collector Repository
+baseurl=https://splunk.jfrog.io/splunk/otel-collector-rpm/${STAGE}/\$basearch
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://splunk.jfrog.io/splunk/otel-collector-rpm/splunk-B3CD4420.pub
+enabled=1
+EOF
+
+dnf clean all
+dnf -y --disablerepo='*' --enablerepo=splunk-otel-collector makecache
+dnf -y install "$collector_nevra" "$instrumentation_nevra"
+rpm -q "$collector_nevra" "$instrumentation_nevra"
+
+# Direct rpm URL installs bypass repo_gpgcheck, but some users install this way.
+instrumentation_url="https://splunk.jfrog.io/splunk/otel-collector-rpm/${STAGE}/${ARCH}/${instrumentation_rpm}"
+rpm -e splunk-otel-auto-instrumentation
+rpm -ivh "$instrumentation_url"
+rpm -q "$instrumentation_nevra"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Updates the RPM release flow to avoid signing stale Artifactory yum metadata. release-rpms now uploads the collector and auto-instrumentation RPMs for an arch as one batch, triggers synchronous yum metadata recalculation for that stage/arch, waits for both RPMs to appear in live metadata, then downloads repomd.xml for signing and uploads the returned repomd.xml.asc.

Adds stronger publish verification: metadata verification checks live repomd.xml against the published .asc using the pinned Splunk GPG fingerprint, and a new RPM install smoke job configures the public repo with repo_gpgcheck=1, runs dnf makecache, installs both RPM packages, and checks direct URL install for the auto-instrumentation RPM.

Also removes retry from the RPM release/metadata verify path to avoid replaying a partially published state, keeps the longer release timeout, and tightens quoting on the signature upload command.