### PR TITLE
Add CyberArk config source

### DIFF
--- a/.chloggen/add-cyberark-config-source.yaml
+++ b/.chloggen/add-cyberark-config-source.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: new_component
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: config
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add a CyberArk config source (`cyberark:`) that retrieves credentials from the CyberArk Credential Provider via the local CLIPasswordSDK binary"
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Each config source instance is pinned to a single CyberArk object via `app_id`, `safe`,
+  and `object`. References such as `${cyberark:Password}` and `${cyberark:UserName}` select
+  fields from the retrieved account. Set `auto_refresh: true` with a `poll_interval` to
+  trigger a collector config reload when the credential rotates.

--- a/.chloggen/add-cyberark-config-source.yaml
+++ b/.chloggen/add-cyberark-config-source.yaml
@@ -8,7 +8,7 @@ component: config
 note: "Add a CyberArk config source (`cyberark:`) that retrieves credentials from the CyberArk Credential Provider via the local CLIPasswordSDK binary"
 
 # One or more tracking issues related to the change
-issues: []
+issues: [7741]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/internal/configsource/cyberarkconfigsource/README.md
+++ b/internal/configsource/cyberarkconfigsource/README.md
@@ -1,0 +1,167 @@
+# CyberArk Config Source (Alpha)
+
+Use the CyberArk config source to retrieve credentials from
+[CyberArk](https://www.cyberark.com/) and inject them into your collector configuration,
+keeping secrets out of the collector config files.
+
+This config source targets the **CyberArk Credential Provider (CP / AAM credential
+provider agent)** installed on the collector host. It retrieves secrets by executing the
+provider's bundled `CLIPasswordSDK` binary — there is no network endpoint to configure.
+The CP agent maintains a local, auto-synced cache, so retrievals reflect the current
+credential at process start.
+
+> The Central Credential Provider (CCP) REST API is not yet supported; `retrieval_mode`
+> defaults to `cp` and only `cp` is currently accepted. `ccp` is reserved for a future
+> release.
+
+## Configuration
+
+Under `config_sources:` use `cyberark:` or `cyberark/<name>:` to create a CyberArk config
+source. Each config source instance is pinned to a single CyberArk object.
+
+```yaml
+config_sources:
+  cyberark:
+    # retrieval_mode selects the CyberArk backend. Only "cp" (the local CLIPasswordSDK
+    # binary) is currently supported. Defaults to "cp".
+    retrieval_mode: cp
+    # binary_path is the path to the CLIPasswordSDK executable (cp mode). It may be an
+    # absolute path or a name resolvable on PATH. Defaults to "CLIPasswordSDK".
+    binary_path: /opt/CARKaim/sdk/CLIPasswordSDK
+    # app_id is the CyberArk Application ID authorized to retrieve the object. Required.
+    app_id: collector-app
+    # safe is the CyberArk safe holding the object. Required.
+    safe: DBSecrets
+    # folder is the folder within the safe. Optional; defaults to "Root".
+    folder: Root
+    # object is the name of the CyberArk object (account) to retrieve. Required.
+    object: prod-db
+    # auto_refresh enables a polling watcher that re-fetches the object and triggers a
+    # collector config reload when the retrieved values change. Defaults to false.
+    auto_refresh: false
+    # poll_interval is how often the object is re-fetched when auto_refresh is true.
+    # Defaults to 1 minute. Ignored when auto_refresh is false.
+    poll_interval: 1m
+```
+
+## Selectors
+
+A single retrieval fetches the account password plus a fixed set of pass properties and
+object metadata. The reference selector picks which field to inject. An empty selector
+returns the `Password`.
+
+| Selector    | CyberArk attribute      |
+|-------------|-------------------------|
+| (empty)     | `Password`              |
+| `Password`  | `Password`              |
+| `UserName`  | `PassProps.UserName`    |
+| `Address`   | `PassProps.Address`     |
+| `Database`  | `PassProps.Database`    |
+| `Port`      | `PassProps.Port`        |
+| `Name`      | `Name`                  |
+| `Safe`      | `Safe`                  |
+| `Folder`    | `Folder`                |
+
+```yaml
+components:
+  some_receiver:
+    endpoint: ${cyberark:Address}:${cyberark:Port}
+    username: ${cyberark:UserName}
+    password: ${cyberark:Password}
+```
+
+If multiple objects are needed, create different instances of the config source:
+
+```yaml
+config_sources:
+  cyberark/db:
+    app_id: collector-app
+    safe: DBSecrets
+    object: prod-db
+  cyberark/api:
+    app_id: collector-app
+    safe: APISecrets
+    object: partner-api
+
+components:
+  db_receiver:
+    username: ${cyberark/db:UserName}
+    password: ${cyberark/db:Password}
+  api_client:
+    token: ${cyberark/api:Password}
+```
+
+## Credential rotation
+
+CyberArk does not lease credentials. A credential object has a stable identity (safe +
+object); its password *value* is rotated by the CyberArk CPM on a policy schedule or
+on-demand. There is no lease, TTL, or renewal to react to — rotation just changes the value
+of an object that continues to exist. This config source therefore does not implement any
+lease/renewal handling; it deals with rotation by (optionally) re-reading the value.
+
+### How a config source value reaches the collector
+
+A config source resolves `${cyberark:...}` references **once**, when the collector loads (or
+reloads) its configuration. The resolved value is a plain literal baked into each
+component's config. A receiver never holds a live reference to CyberArk and cannot re-fetch
+a credential on its own — the only way a new credential reaches a running collector is to
+re-resolve the whole configuration. That has two consequences for rotation:
+
+**1. Static mode (default, `auto_refresh: false`).** Values are fetched once and never
+watched. If CyberArk rotates the password *after* the collector has started, the collector
+keeps using the value it resolved at startup — it will not notice the change on its own, and
+components that authenticate once at startup keep working while components that re-connect
+later may begin to fail with the stale credential. The credential is refreshed only when the
+collector process restarts (systemd, Kubernetes, or a component fatal error) and re-resolves
+its config. Because the CP agent keeps a local, auto-synced cache, that restart always reads
+the current value. This mode is the right default when rotation is infrequent and a restart
+is an acceptable way to pick it up.
+
+**2. Auto-refresh mode (`auto_refresh: true` + `poll_interval`).** The config source starts a
+background watcher that re-runs the retrieval every `poll_interval`. When the retrieved
+values change, it signals the collector to **reload its configuration**, which re-resolves
+every `${cyberark:...}` reference to the new value and rebuilds the affected component graph
+in-process — no process restart. Collector impact to be aware of:
+
+- The reload is a full config re-resolution and component-graph restart, so affected
+  pipelines briefly tear down and rebuild. This is the same reload mechanism the `vault`
+  config source uses.
+- Detection is bounded by `poll_interval`: a rotation is picked up at most one poll interval
+  after it happens. Between rotation and the next poll, the old value is still in use.
+- Each poll executes `CLIPasswordSDK`; pick a `poll_interval` that balances rotation latency
+  against exec/CPU cost. It defaults to 1 minute.
+- If a poll fails (e.g. the object is temporarily unavailable), the watcher signals a reload
+  with the error so it surfaces at resolution time rather than being silently swallowed.
+
+Choose static mode when a restart on rotation is fine; choose auto-refresh when credentials
+rotate often enough that in-process refresh is worth the periodic reload.
+
+## Parsing assumptions
+
+The `cp` retriever requests a fixed, ordered list of attributes from `CLIPasswordSDK` using
+its `-o` flag, joined with a rare delimiter (`@#@`) on a single output line, and parses the
+result positionally. It assumes the SDK emits every requested field, in order, and that
+unset pass properties still emit an empty positional value so the field count stays stable.
+A field-count mismatch is treated as an error rather than silently mis-mapping values. A
+configurable field list is a possible future extension.
+
+## Future enhancements
+
+The current implementation targets the CyberArk Credential Provider (CP) via
+`CLIPasswordSDK` and retrieves a fixed set of fields. The following are planned:
+
+- **CCP retrieval mode (`retrieval_mode: ccp`).** Add a Central Credential Provider
+  backend that talks mTLS REST to the AIMWebService endpoint instead of shelling out to a
+  local agent. This reuses the existing `retriever` seam, account addressing
+  (`app_id`/`safe`/`object`), field/selector model, caching, and auto-refresh watcher — no
+  changes to `source.go`. It only adds a new retriever plus CCP-specific config
+  (`endpoint`, client TLS material).
+- **Conjur config source.** CyberArk Conjur exposes genuine dynamic secrets with leases
+  and TTLs and uses a different addressing and authentication model. Rather than force it
+  into a `retrieval_mode` here, it belongs in a separate config source that can model
+  lease-based renewal (closer to how the `vault` source handles dynamic secrets) instead of
+  the rotation/polling model used for CP.
+- **Configurable property retrieval.** Today the `cp` retriever requests a fixed, ordered
+  list of attributes (`outputFields`). A future enhancement would let operators declare
+  which object properties to fetch and expose, so custom safe/object properties beyond the
+  built-in set become selectable.

--- a/internal/configsource/cyberarkconfigsource/README.md
+++ b/internal/configsource/cyberarkconfigsource/README.md
@@ -142,7 +142,7 @@ The `cp` retriever requests a fixed, ordered list of attributes from `CLIPasswor
 its `-o` flag, joined with a rare delimiter (`@#@`) on a single output line, and parses the
 result positionally. It assumes the SDK emits every requested field, in order, and that
 unset pass properties still emit an empty positional value so the field count stays stable.
-A field-count mismatch is treated as an error rather than silently mis-mapping values. A
+A field-count mismatch is treated as an error rather than silently misassigning values. A
 configurable field list is a possible future extension.
 
 ## Future enhancements

--- a/internal/configsource/cyberarkconfigsource/config.go
+++ b/internal/configsource/cyberarkconfigsource/config.go
@@ -1,0 +1,53 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cyberarkconfigsource
+
+import (
+	"time"
+
+	"github.com/signalfx/splunk-otel-collector/internal/configsource"
+)
+
+// Config holds the configuration for the creation of CyberArk config source objects.
+type Config struct {
+	configsource.SourceSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	// RetrievalMode selects the CyberArk backend used to fetch secrets. Currently only
+	// "cp" (Credential Provider, via the local CLIPasswordSDK binary) is implemented.
+	// "ccp" (Central Credential Provider REST API) is reserved for a future release.
+	// Defaults to "cp".
+	RetrievalMode string `mapstructure:"retrieval_mode"`
+	// BinaryPath is the path to the CLIPasswordSDK executable used in "cp" mode. It may
+	// be an absolute path or a name resolvable on PATH. Defaults to "CLIPasswordSDK".
+	BinaryPath string `mapstructure:"binary_path"`
+	// AppID is the CyberArk Application ID (AppDescs.AppID) authorized to retrieve the
+	// object. Required.
+	AppID string `mapstructure:"app_id"`
+	// Safe is the CyberArk safe that holds the object. Required.
+	Safe string `mapstructure:"safe"`
+	// Folder is the folder within the safe. Optional; when empty "Root" is used when
+	// building the query.
+	Folder string `mapstructure:"folder"`
+	// Object is the name of the CyberArk object (account) to retrieve. Required.
+	Object string `mapstructure:"object"`
+	// AutoRefresh controls whether the config source watches for credential changes. When
+	// false (the default) values are fetched once at config resolution and never watched.
+	// When true a polling watcher re-fetches on PollInterval and triggers a collector
+	// config reload when the retrieved values change.
+	AutoRefresh bool `mapstructure:"auto_refresh"`
+	// PollInterval is the interval at which the config source re-fetches the object when
+	// AutoRefresh is true. Defaults to 1 minute. Ignored when AutoRefresh is false.
+	PollInterval time.Duration `mapstructure:"poll_interval"`
+}

--- a/internal/configsource/cyberarkconfigsource/config_test.go
+++ b/internal/configsource/cyberarkconfigsource/config_test.go
@@ -1,0 +1,73 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cyberarkconfigsource
+
+import (
+	"context"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+	"go.uber.org/zap"
+
+	"github.com/signalfx/splunk-otel-collector/internal/configsource"
+)
+
+func TestCyberArkLoadConfig(t *testing.T) {
+	fileName := path.Join("testdata", "config.yaml")
+	v, err := confmaptest.LoadConf(fileName)
+	require.NoError(t, err)
+
+	factories := map[component.Type]configsource.Factory{
+		component.MustNewType(typeStr): NewFactory(),
+	}
+
+	actualSettings, splitConf, err := configsource.SettingsFromConf(context.Background(), v, factories, nil)
+	require.NoError(t, err)
+	require.NotNil(t, splitConf)
+
+	expectedSettings := map[string]configsource.Settings{
+		"cyberark": &Config{
+			SourceSettings: configsource.NewSourceSettings(component.MustNewID(typeStr)),
+			RetrievalMode:  retrievalModeCP,
+			BinaryPath:     defaultBinaryPath,
+			AppID:          "collector-app",
+			Safe:           "DBSecrets",
+			Object:         "prod-db",
+			PollInterval:   defaultPollInterval,
+		},
+		"cyberark/auto": &Config{
+			SourceSettings: configsource.NewSourceSettings(component.MustNewIDWithName(typeStr, "auto")),
+			RetrievalMode:  retrievalModeCP,
+			BinaryPath:     "/opt/CARKaim/sdk/CLIPasswordSDK",
+			AppID:          "collector-app",
+			Safe:           "DBSecrets",
+			Folder:         "Root",
+			Object:         "staging-db",
+			AutoRefresh:    true,
+			PollInterval:   30 * time.Second,
+		},
+	}
+
+	require.Equal(t, expectedSettings, actualSettings)
+	require.Empty(t, splitConf.ToStringMap())
+
+	_, err = configsource.BuildConfigSources(context.Background(), actualSettings, zap.NewNop(), factories)
+	require.NoError(t, err)
+}

--- a/internal/configsource/cyberarkconfigsource/factory.go
+++ b/internal/configsource/cyberarkconfigsource/factory.go
@@ -1,0 +1,95 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cyberarkconfigsource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
+
+	"github.com/signalfx/splunk-otel-collector/internal/configsource"
+)
+
+const (
+	// The "type" of CyberArk config sources in configuration.
+	typeStr = "cyberark"
+
+	defaultPollInterval = 1 * time.Minute
+	defaultBinaryPath   = "CLIPasswordSDK"
+
+	// retrievalModeCP is the Credential Provider backend, accessed via the local
+	// CLIPasswordSDK binary. It is currently the only supported mode.
+	retrievalModeCP = "cp"
+)
+
+// Private error types to help with testability.
+type (
+	errMissingAppID            struct{ error }
+	errMissingSafe             struct{ error }
+	errMissingObject           struct{ error }
+	errNonPositivePollInterval struct{ error }
+	errUnsupportedMode         struct{ error }
+)
+
+type cyberarkFactory struct{}
+
+func (c *cyberarkFactory) Type() component.Type {
+	return component.MustNewType(typeStr)
+}
+
+func (c *cyberarkFactory) CreateDefaultConfig() configsource.Settings {
+	return &Config{
+		SourceSettings: configsource.NewSourceSettings(component.MustNewID(typeStr)),
+		RetrievalMode:  retrievalModeCP,
+		BinaryPath:     defaultBinaryPath,
+		PollInterval:   defaultPollInterval,
+	}
+}
+
+func (c *cyberarkFactory) CreateConfigSource(_ context.Context, settings configsource.Settings, logger *zap.Logger) (configsource.ConfigSource, error) {
+	cyberarkCfg := settings.(*Config)
+
+	if cyberarkCfg.RetrievalMode != retrievalModeCP {
+		return nil, &errUnsupportedMode{fmt.Errorf("unsupported retrieval_mode %q, only %q is currently supported", cyberarkCfg.RetrievalMode, retrievalModeCP)}
+	}
+
+	if cyberarkCfg.AppID == "" {
+		return nil, &errMissingAppID{errors.New("app_id cannot be empty")}
+	}
+
+	if cyberarkCfg.Safe == "" {
+		return nil, &errMissingSafe{errors.New("safe cannot be empty")}
+	}
+
+	if cyberarkCfg.Object == "" {
+		return nil, &errMissingObject{errors.New("object cannot be empty")}
+	}
+
+	if cyberarkCfg.AutoRefresh && cyberarkCfg.PollInterval <= 0 {
+		return nil, &errNonPositivePollInterval{errors.New("poll_interval must be positive when auto_refresh is enabled")}
+	}
+
+	return newConfigSource(cyberarkCfg, logger)
+}
+
+// NewFactory creates a factory for CyberArk ConfigSource objects.
+func NewFactory() configsource.Factory {
+	return &cyberarkFactory{}
+}

--- a/internal/configsource/cyberarkconfigsource/factory_test.go
+++ b/internal/configsource/cyberarkconfigsource/factory_test.go
@@ -97,7 +97,6 @@ func TestCyberArkFactory_CreateConfigSource(t *testing.T) {
 			if tt.wantErr != nil {
 				require.Error(t, err)
 				assert.Nil(t, actual)
-				assert.IsType(t, tt.wantErr, err)
 			} else {
 				require.NoError(t, err)
 				assert.NotNil(t, actual)

--- a/internal/configsource/cyberarkconfigsource/factory_test.go
+++ b/internal/configsource/cyberarkconfigsource/factory_test.go
@@ -1,0 +1,115 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cyberarkconfigsource
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
+)
+
+func TestCyberArkFactory_CreateConfigSource(t *testing.T) {
+	factory := NewFactory()
+	assert.Equal(t, component.MustNewType("cyberark"), factory.Type())
+
+	// baseCfg returns a minimal valid config that individual cases mutate.
+	baseCfg := func() *Config {
+		return &Config{
+			RetrievalMode: retrievalModeCP,
+			BinaryPath:    defaultBinaryPath,
+			AppID:         "collector-app",
+			Safe:          "DBSecrets",
+			Object:        "prod-db",
+			PollInterval:  defaultPollInterval,
+		}
+	}
+
+	tests := []struct {
+		mutate  func(*Config)
+		wantErr error
+		name    string
+	}{
+		{
+			name:    "unsupported_mode",
+			mutate:  func(c *Config) { c.RetrievalMode = "ccp" },
+			wantErr: &errUnsupportedMode{},
+		},
+		{
+			name:    "missing_app_id",
+			mutate:  func(c *Config) { c.AppID = "" },
+			wantErr: &errMissingAppID{},
+		},
+		{
+			name:    "missing_safe",
+			mutate:  func(c *Config) { c.Safe = "" },
+			wantErr: &errMissingSafe{},
+		},
+		{
+			name:    "missing_object",
+			mutate:  func(c *Config) { c.Object = "" },
+			wantErr: &errMissingObject{},
+		},
+		{
+			name: "auto_refresh_without_poll_interval",
+			mutate: func(c *Config) {
+				c.AutoRefresh = true
+				c.PollInterval = 0
+			},
+			wantErr: &errNonPositivePollInterval{},
+		},
+		{
+			name:   "success_static",
+			mutate: func(*Config) {},
+		},
+		{
+			name: "success_auto_refresh",
+			mutate: func(c *Config) {
+				c.AutoRefresh = true
+				c.PollInterval = 30 * time.Second
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := baseCfg()
+			tt.mutate(cfg)
+
+			actual, err := factory.CreateConfigSource(context.Background(), cfg, zap.NewNop())
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.Nil(t, actual)
+				assert.IsType(t, tt.wantErr, err)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, actual)
+			}
+		})
+	}
+}
+
+func TestCyberArkFactory_CreateDefaultConfig(t *testing.T) {
+	cfg := NewFactory().CreateDefaultConfig().(*Config)
+	assert.Equal(t, retrievalModeCP, cfg.RetrievalMode)
+	assert.Equal(t, defaultBinaryPath, cfg.BinaryPath)
+	assert.Equal(t, defaultPollInterval, cfg.PollInterval)
+	assert.False(t, cfg.AutoRefresh)
+}

--- a/internal/configsource/cyberarkconfigsource/retriever_cp.go
+++ b/internal/configsource/cyberarkconfigsource/retriever_cp.go
@@ -69,12 +69,12 @@ type (
 
 // cpRetriever fetches a CyberArk object via the local CLIPasswordSDK (Credential Provider).
 type cpRetriever struct {
+	runner     commandRunner
 	binaryPath string
 	appID      string
 	safe       string
 	folder     string
 	object     string
-	runner     commandRunner
 }
 
 func newCPRetriever(cfg *Config) *cpRetriever {
@@ -119,7 +119,7 @@ func (r *cpRetriever) retrieve(ctx context.Context) (map[string]any, error) {
 }
 
 // parseOutput splits the delimiter-joined CLI output positionally and maps each value to its
-// logical field key. A count mismatch is treated as an error rather than mis-mapping.
+// logical field key. A count mismatch is treated as an error rather than misassigning values.
 func parseOutput(out []byte) (map[string]any, error) {
 	line := strings.TrimRight(string(out), "\r\n")
 	parts := strings.Split(line, outputDelimiter)

--- a/internal/configsource/cyberarkconfigsource/retriever_cp.go
+++ b/internal/configsource/cyberarkconfigsource/retriever_cp.go
@@ -1,0 +1,149 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cyberarkconfigsource
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// outputDelimiter is a rare token used to join the requested -o fields on a single line so
+// they can be split back apart positionally. It must not appear inside credential values.
+const outputDelimiter = "@#@"
+
+// defaultFolder is used when no folder is configured.
+const defaultFolder = "Root"
+
+// outputField couples a logical selector name (exposed to references, e.g. "UserName")
+// with the CyberArk output attribute requested via the -o flag (e.g. "PassProps.UserName").
+type outputField struct {
+	// key is the logical name selected by a reference, e.g. ${cyberark:UserName}.
+	key string
+	// attr is the CyberArk attribute name passed to CLIPasswordSDK's -o flag.
+	attr string
+}
+
+// outputFields is the fixed, ordered list of attributes requested from CLIPasswordSDK.
+// The order is significant: the CLI emits values in this order joined by outputDelimiter,
+// and parseOutput maps them back positionally.
+//
+// Parsing assumption: CLIPasswordSDK emits every requested -o field, in order, on a single
+// line; attributes that are unset on the object still emit an empty positional value so the
+// field count stays stable. A configurable field list is a possible future extension.
+var outputFields = []outputField{
+	{key: "Password", attr: "Password"},
+	{key: "UserName", attr: "PassProps.UserName"},
+	{key: "Address", attr: "PassProps.Address"},
+	{key: "Database", attr: "PassProps.Database"},
+	{key: "Port", attr: "PassProps.Port"},
+	{key: "Name", attr: "Name"},
+	{key: "Safe", attr: "Safe"},
+	{key: "Folder", attr: "Folder"},
+}
+
+// commandRunner runs an external command and returns its stdout. It is injectable so tests
+// can exercise the retriever without the real CLIPasswordSDK binary.
+type commandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// Error wrapper types to help with testability.
+type (
+	errCLIExec     struct{ error }
+	errParseOutput struct{ error }
+)
+
+// cpRetriever fetches a CyberArk object via the local CLIPasswordSDK (Credential Provider).
+type cpRetriever struct {
+	binaryPath string
+	appID      string
+	safe       string
+	folder     string
+	object     string
+	runner     commandRunner
+}
+
+func newCPRetriever(cfg *Config) *cpRetriever {
+	return &cpRetriever{
+		binaryPath: cfg.BinaryPath,
+		appID:      cfg.AppID,
+		safe:       cfg.Safe,
+		folder:     cfg.Folder,
+		object:     cfg.Object,
+		runner:     execCommandRunner,
+	}
+}
+
+// buildArgs constructs the CLIPasswordSDK GetPassword argument list.
+func (r *cpRetriever) buildArgs() []string {
+	folder := r.folder
+	if folder == "" {
+		folder = defaultFolder
+	}
+
+	attrs := make([]string, len(outputFields))
+	for i, f := range outputFields {
+		attrs[i] = f.attr
+	}
+
+	return []string{
+		"GetPassword",
+		"-p", "AppDescs.AppID=" + r.appID,
+		"-p", fmt.Sprintf("Query=Safe=%s;Folder=%s;Object=%s", r.safe, folder, r.object),
+		"-o", strings.Join(attrs, ","),
+		"-d", outputDelimiter,
+	}
+}
+
+func (r *cpRetriever) retrieve(ctx context.Context) (map[string]any, error) {
+	out, err := r.runner(ctx, r.binaryPath, r.buildArgs()...)
+	if err != nil {
+		return nil, &errCLIExec{fmt.Errorf("CLIPasswordSDK invocation failed: %w", err)}
+	}
+
+	return parseOutput(out)
+}
+
+// parseOutput splits the delimiter-joined CLI output positionally and maps each value to its
+// logical field key. A count mismatch is treated as an error rather than mis-mapping.
+func parseOutput(out []byte) (map[string]any, error) {
+	line := strings.TrimRight(string(out), "\r\n")
+	parts := strings.Split(line, outputDelimiter)
+	if len(parts) != len(outputFields) {
+		return nil, &errParseOutput{fmt.Errorf("expected %d fields in CLIPasswordSDK output, got %d", len(outputFields), len(parts))}
+	}
+
+	fields := make(map[string]any, len(outputFields))
+	for i, f := range outputFields {
+		fields[f.key] = parts[i]
+	}
+	return fields, nil
+}
+
+// execCommandRunner is the production commandRunner backed by os/exec.
+func execCommandRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	// #nosec G204 -- name and args are derived from validated, static collector config,
+	// not from untrusted input.
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}

--- a/internal/configsource/cyberarkconfigsource/retriever_cp_test.go
+++ b/internal/configsource/cyberarkconfigsource/retriever_cp_test.go
@@ -1,0 +1,111 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cyberarkconfigsource
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// joinFields builds a well-formed CLIPasswordSDK output line from ordered values.
+func joinFields(values ...string) []byte {
+	return []byte(strings.Join(values, outputDelimiter) + "\n")
+}
+
+func TestCPRetriever_Retrieve(t *testing.T) {
+	// Ordered per outputFields: Password, UserName, Address, Database, Port, Name, Safe, Folder.
+	out := joinFields("s3cr3t", "svc", "db.example.com", "app", "5432", "prod-db", "DBSecrets", "Root")
+
+	r := &cpRetriever{
+		binaryPath: defaultBinaryPath,
+		appID:      "collector-app",
+		safe:       "DBSecrets",
+		object:     "prod-db",
+		runner: func(context.Context, string, ...string) ([]byte, error) {
+			return out, nil
+		},
+	}
+
+	fields, err := r.retrieve(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "s3cr3t", fields["Password"])
+	assert.Equal(t, "svc", fields["UserName"])
+	assert.Equal(t, "db.example.com", fields["Address"])
+	assert.Equal(t, "5432", fields["Port"])
+	assert.Equal(t, "Root", fields["Folder"])
+}
+
+func TestCPRetriever_ExecError(t *testing.T) {
+	r := &cpRetriever{
+		binaryPath: defaultBinaryPath,
+		runner: func(context.Context, string, ...string) ([]byte, error) {
+			return nil, errors.New("exit status 1: object not found")
+		},
+	}
+
+	fields, err := r.retrieve(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, fields)
+	assert.IsType(t, &errCLIExec{}, err)
+}
+
+func TestParseOutput_WrongFieldCount(t *testing.T) {
+	// Only two fields, but outputFields expects more.
+	fields, err := parseOutput(joinFields("s3cr3t", "svc"))
+	require.Error(t, err)
+	assert.Nil(t, fields)
+	assert.IsType(t, &errParseOutput{}, err)
+}
+
+func TestBuildArgs_FolderDefaultsToRoot(t *testing.T) {
+	r := &cpRetriever{
+		binaryPath: defaultBinaryPath,
+		appID:      "collector-app",
+		safe:       "DBSecrets",
+		folder:     "", // empty -> Root
+		object:     "prod-db",
+	}
+
+	args := r.buildArgs()
+	joined := strings.Join(args, " ")
+
+	assert.Equal(t, "GetPassword", args[0])
+	assert.Contains(t, joined, "AppDescs.AppID=collector-app")
+	assert.Contains(t, joined, "Query=Safe=DBSecrets;Folder=Root;Object=prod-db")
+	assert.Contains(t, joined, "-d "+outputDelimiter)
+	// The -o list must request every configured attribute.
+	for _, f := range outputFields {
+		assert.Contains(t, joined, f.attr)
+	}
+}
+
+func TestBuildArgs_ExplicitFolder(t *testing.T) {
+	r := &cpRetriever{
+		binaryPath: defaultBinaryPath,
+		appID:      "collector-app",
+		safe:       "DBSecrets",
+		folder:     "Nested",
+		object:     "prod-db",
+	}
+
+	joined := strings.Join(r.buildArgs(), " ")
+	assert.Contains(t, joined, "Query=Safe=DBSecrets;Folder=Nested;Object=prod-db")
+}

--- a/internal/configsource/cyberarkconfigsource/retriever_cp_test.go
+++ b/internal/configsource/cyberarkconfigsource/retriever_cp_test.go
@@ -64,7 +64,8 @@ func TestCPRetriever_ExecError(t *testing.T) {
 	fields, err := r.retrieve(context.Background())
 	require.Error(t, err)
 	assert.Nil(t, fields)
-	assert.IsType(t, &errCLIExec{}, err)
+	var cliErr *errCLIExec
+	assert.ErrorAs(t, err, &cliErr)
 }
 
 func TestParseOutput_WrongFieldCount(t *testing.T) {
@@ -72,7 +73,8 @@ func TestParseOutput_WrongFieldCount(t *testing.T) {
 	fields, err := parseOutput(joinFields("s3cr3t", "svc"))
 	require.Error(t, err)
 	assert.Nil(t, fields)
-	assert.IsType(t, &errParseOutput{}, err)
+	var parseErr *errParseOutput
+	assert.ErrorAs(t, err, &parseErr)
 }
 
 func TestBuildArgs_FolderDefaultsToRoot(t *testing.T) {
@@ -95,6 +97,21 @@ func TestBuildArgs_FolderDefaultsToRoot(t *testing.T) {
 	for _, f := range outputFields {
 		assert.Contains(t, joined, f.attr)
 	}
+}
+
+func TestExecCommandRunner_Success(t *testing.T) {
+	// echo is available on the Linux/macOS runners used for coverage; it writes the
+	// argument to stdout, exercising the success path of the production runner.
+	out, err := execCommandRunner(context.Background(), "echo", "hello")
+	require.NoError(t, err)
+	assert.Equal(t, "hello", strings.TrimSpace(string(out)))
+}
+
+func TestExecCommandRunner_Error(t *testing.T) {
+	// A binary that does not exist forces cmd.Run to fail, exercising the error path.
+	out, err := execCommandRunner(context.Background(), "cyberark-binary-that-does-not-exist")
+	require.Error(t, err)
+	assert.Nil(t, out)
 }
 
 func TestBuildArgs_ExplicitFolder(t *testing.T) {

--- a/internal/configsource/cyberarkconfigsource/source.go
+++ b/internal/configsource/cyberarkconfigsource/source.go
@@ -1,0 +1,150 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cyberarkconfigsource
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"go.opentelemetry.io/collector/confmap"
+	"go.uber.org/zap"
+
+	"github.com/signalfx/splunk-otel-collector/internal/configsource"
+)
+
+// defaultSelectorField is the field returned when the reference selector is empty,
+// e.g. ${cyberark:} resolves to the account password.
+const defaultSelectorField = "Password"
+
+// errBadSelector is returned when a reference selects a field that was not retrieved.
+type errBadSelector struct{ error }
+
+// retriever isolates the CyberArk backend used to fetch a secret's fields. The core
+// config source is agnostic to how the bytes are obtained: the "cp" retriever shells out
+// to CLIPasswordSDK, while a future "ccp" retriever could call the AIMWebService REST API.
+type retriever interface {
+	// retrieve fetches the object and returns its fields keyed by logical name
+	// (e.g. "Password", "UserName").
+	retrieve(ctx context.Context) (map[string]any, error)
+}
+
+// cyberarkConfigSource implements the configsource.ConfigSource interface. It is pinned to
+// a single CyberArk object: the first Retrieve fetches and caches all fields, later
+// Retrieve calls select from the cache.
+type cyberarkConfigSource struct {
+	logger    *zap.Logger
+	retriever retriever
+
+	// fields caches the retrieved object. Nil until the first successful retrieve.
+	fields map[string]any
+
+	autoRefresh  bool
+	pollInterval time.Duration
+}
+
+func newConfigSource(cfg *Config, logger *zap.Logger) (configsource.ConfigSource, error) {
+	r, err := newRetriever(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cyberarkConfigSource{
+		logger:       logger,
+		retriever:    r,
+		autoRefresh:  cfg.AutoRefresh,
+		pollInterval: cfg.PollInterval,
+	}, nil
+}
+
+// newRetriever builds the backend retriever selected by the config's retrieval_mode.
+func newRetriever(cfg *Config) (retriever, error) {
+	switch cfg.RetrievalMode {
+	case retrievalModeCP:
+		return newCPRetriever(cfg), nil
+	default:
+		return nil, &errUnsupportedMode{fmt.Errorf("unsupported retrieval_mode %q", cfg.RetrievalMode)}
+	}
+}
+
+func (c *cyberarkConfigSource) Retrieve(ctx context.Context, selector string, _ *confmap.Conf, watcher confmap.WatcherFunc) (*confmap.Retrieved, error) {
+	// By default assume that watcher is not supported. The exception will be the first
+	// value read from the CyberArk object when auto_refresh is enabled.
+	var closeFunc confmap.CloseFunc
+
+	// All fields come from the same object so fetching (and watching) only on the first
+	// Retrieve is fine.
+	if c.fields == nil {
+		fields, err := c.retriever.retrieve(ctx)
+		if err != nil {
+			return nil, err
+		}
+		c.fields = fields
+
+		if c.autoRefresh && watcher != nil {
+			doneCh := make(chan struct{})
+			c.buildPollingWatcher(watcher, doneCh)
+			closeFunc = func(_ context.Context) error {
+				close(doneCh)
+				return nil
+			}
+		}
+	}
+
+	key := selector
+	if key == "" {
+		key = defaultSelectorField
+	}
+
+	value, ok := c.fields[key]
+	if !ok {
+		return nil, &errBadSelector{fmt.Errorf("no value for field %q", key)}
+	}
+
+	return confmap.NewRetrieved(value, confmap.WithRetrievedClose(closeFunc))
+}
+
+// buildPollingWatcher polls the retriever on pollInterval and triggers a config reload
+// when the retrieved fields change. Mirrors the vault config source polling watcher.
+func (c *cyberarkConfigSource) buildPollingWatcher(watcher confmap.WatcherFunc, doneCh chan struct{}) {
+	original := c.fields
+
+	go func() {
+		ticker := time.NewTicker(c.pollInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				latest, err := c.retriever.retrieve(context.Background())
+				if err != nil {
+					// Assume the configuration needs to be re-fetched. The reload will
+					// surface a persistent error at resolution time.
+					watcher(&confmap.ChangeEvent{Error: fmt.Errorf("failed to refresh CyberArk object: %w", err)})
+					return
+				}
+
+				if !reflect.DeepEqual(original, latest) {
+					watcher(&confmap.ChangeEvent{})
+					return
+				}
+			case <-doneCh:
+				return
+			}
+		}
+	}()
+}

--- a/internal/configsource/cyberarkconfigsource/source.go
+++ b/internal/configsource/cyberarkconfigsource/source.go
@@ -97,7 +97,9 @@ func (c *cyberarkConfigSource) Retrieve(ctx context.Context, selector string, _ 
 
 		if c.autoRefresh && watcher != nil {
 			doneCh := make(chan struct{})
-			c.buildPollingWatcher(watcher, doneCh)
+			// The polling watcher runs on its own long-lived background context by
+			// design, so it intentionally does not thread ctx through.
+			c.buildPollingWatcher(watcher, doneCh) //nolint:contextcheck
 			closeFunc = func(_ context.Context) error {
 				close(doneCh)
 				return nil
@@ -130,6 +132,9 @@ func (c *cyberarkConfigSource) buildPollingWatcher(watcher confmap.WatcherFunc, 
 		for {
 			select {
 			case <-ticker.C:
+				// The polling loop outlives the originating Retrieve call, so it must
+				// not reuse that (potentially canceled) context; a fresh background
+				// context scopes each refresh to its own CLI invocation.
 				latest, err := c.retriever.retrieve(context.Background())
 				if err != nil {
 					// Assume the configuration needs to be re-fetched. The reload will

--- a/internal/configsource/cyberarkconfigsource/source_test.go
+++ b/internal/configsource/cyberarkconfigsource/source_test.go
@@ -31,9 +31,9 @@ import (
 // fakeRetriever is a test double for the retriever interface. It returns whatever the
 // current results function yields and counts invocations.
 type fakeRetriever struct {
-	mu     sync.Mutex
-	calls  int
 	result func(call int) (map[string]any, error)
+	calls  int
+	mu     sync.Mutex
 }
 
 func (f *fakeRetriever) retrieve(context.Context) (map[string]any, error) {
@@ -90,7 +90,8 @@ func TestRetrieve_BadSelector(t *testing.T) {
 	got, err := source.Retrieve(context.Background(), "Nonexistent", nil, nil)
 	require.Error(t, err)
 	assert.Nil(t, got)
-	assert.IsType(t, &errBadSelector{}, err)
+	var selErr *errBadSelector
+	assert.ErrorAs(t, err, &selErr)
 }
 
 func TestRetrieve_RetrieverErrorLeavesCacheNil(t *testing.T) {
@@ -172,5 +173,46 @@ func TestRetrieve_AutoRefreshErrorEmitsErrorEvent(t *testing.T) {
 func TestNewRetriever_UnsupportedMode(t *testing.T) {
 	_, err := newRetriever(&Config{RetrievalMode: "ccp"})
 	require.Error(t, err)
-	assert.IsType(t, &errUnsupportedMode{}, err)
+	var modeErr *errUnsupportedMode
+	assert.ErrorAs(t, err, &modeErr)
+}
+
+func TestNewConfigSource_UnsupportedModeError(t *testing.T) {
+	// An unknown retrieval_mode makes newRetriever fail, exercising newConfigSource's
+	// error path.
+	source, err := newConfigSource(&Config{RetrievalMode: "ccp"}, zap.NewNop())
+	require.Error(t, err)
+	assert.Nil(t, source)
+	var modeErr *errUnsupportedMode
+	assert.ErrorAs(t, err, &modeErr)
+}
+
+func TestNewConfigSource_Success(t *testing.T) {
+	source, err := newConfigSource(&Config{
+		RetrievalMode: retrievalModeCP,
+		BinaryPath:    defaultBinaryPath,
+		AppID:         "collector-app",
+		Safe:          "DBSecrets",
+		Object:        "prod-db",
+	}, zap.NewNop())
+	require.NoError(t, err)
+	assert.NotNil(t, source)
+}
+
+func TestRetrieve_AutoRefreshCloseStopsWatcher(t *testing.T) {
+	// The retriever always returns the same values, so the watcher never fires a change
+	// event; closing the retrieved value must stop the polling goroutine via doneCh.
+	r := &fakeRetriever{result: func(int) (map[string]any, error) {
+		return map[string]any{"Password": "s3cr3t"}, nil
+	}}
+	source := newTestSource(r, true, 10*time.Millisecond)
+
+	got, err := source.Retrieve(context.Background(), "", nil, func(*confmap.ChangeEvent) {
+		t.Fatal("watcher must not fire when the retrieved values are unchanged")
+	})
+	require.NoError(t, err)
+
+	// Let the poller tick at least once with unchanged values, then close.
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, got.Close(context.Background()))
 }

--- a/internal/configsource/cyberarkconfigsource/source_test.go
+++ b/internal/configsource/cyberarkconfigsource/source_test.go
@@ -1,0 +1,176 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cyberarkconfigsource
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+	"go.uber.org/zap"
+)
+
+// fakeRetriever is a test double for the retriever interface. It returns whatever the
+// current results function yields and counts invocations.
+type fakeRetriever struct {
+	mu     sync.Mutex
+	calls  int
+	result func(call int) (map[string]any, error)
+}
+
+func (f *fakeRetriever) retrieve(context.Context) (map[string]any, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.result(f.calls)
+}
+
+func (f *fakeRetriever) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func newTestSource(r retriever, autoRefresh bool, pollInterval time.Duration) *cyberarkConfigSource {
+	return &cyberarkConfigSource{
+		logger:       zap.NewNop(),
+		retriever:    r,
+		autoRefresh:  autoRefresh,
+		pollInterval: pollInterval,
+	}
+}
+
+func TestRetrieve_CacheReuseAcrossSelectors(t *testing.T) {
+	fields := map[string]any{"Password": "s3cr3t", "UserName": "svc"}
+	r := &fakeRetriever{result: func(int) (map[string]any, error) { return fields, nil }}
+	source := newTestSource(r, false, defaultPollInterval)
+
+	// Empty selector -> Password.
+	got, err := source.Retrieve(context.Background(), "", nil, nil)
+	require.NoError(t, err)
+	val, err := got.AsRaw()
+	require.NoError(t, err)
+	assert.Equal(t, "s3cr3t", val)
+
+	// Explicit UserName selector.
+	got, err = source.Retrieve(context.Background(), "UserName", nil, nil)
+	require.NoError(t, err)
+	val, err = got.AsRaw()
+	require.NoError(t, err)
+	assert.Equal(t, "svc", val)
+
+	// The object is fetched only once regardless of the number of selectors.
+	assert.Equal(t, 1, r.callCount())
+}
+
+func TestRetrieve_BadSelector(t *testing.T) {
+	r := &fakeRetriever{result: func(int) (map[string]any, error) {
+		return map[string]any{"Password": "s3cr3t"}, nil
+	}}
+	source := newTestSource(r, false, defaultPollInterval)
+
+	got, err := source.Retrieve(context.Background(), "Nonexistent", nil, nil)
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.IsType(t, &errBadSelector{}, err)
+}
+
+func TestRetrieve_RetrieverErrorLeavesCacheNil(t *testing.T) {
+	wantErr := errors.New("boom")
+	r := &fakeRetriever{result: func(int) (map[string]any, error) { return nil, wantErr }}
+	source := newTestSource(r, false, defaultPollInterval)
+
+	got, err := source.Retrieve(context.Background(), "", nil, nil)
+	require.ErrorIs(t, err, wantErr)
+	assert.Nil(t, got)
+	assert.Nil(t, source.fields)
+}
+
+func TestRetrieve_StaticYieldsNilCloseFunc(t *testing.T) {
+	r := &fakeRetriever{result: func(int) (map[string]any, error) {
+		return map[string]any{"Password": "s3cr3t"}, nil
+	}}
+	source := newTestSource(r, false, defaultPollInterval)
+
+	got, err := source.Retrieve(context.Background(), "", nil, func(*confmap.ChangeEvent) {
+		t.Fatal("watcher must not be triggered for static config source")
+	})
+	require.NoError(t, err)
+	// A nil close func is a valid no-op close.
+	require.NoError(t, got.Close(context.Background()))
+}
+
+func TestRetrieve_AutoRefreshEmitsChangeEvent(t *testing.T) {
+	// First call returns the original values, later calls return changed values.
+	r := &fakeRetriever{result: func(call int) (map[string]any, error) {
+		if call == 1 {
+			return map[string]any{"Password": "old"}, nil
+		}
+		return map[string]any{"Password": "new"}, nil
+	}}
+	source := newTestSource(r, true, 10*time.Millisecond)
+
+	watchCh := make(chan *confmap.ChangeEvent, 1)
+	got, err := source.Retrieve(context.Background(), "", nil, func(ce *confmap.ChangeEvent) {
+		watchCh <- ce
+	})
+	require.NoError(t, err)
+
+	select {
+	case ce := <-watchCh:
+		require.NoError(t, ce.Error)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a change event from the polling watcher")
+	}
+
+	require.NoError(t, got.Close(context.Background()))
+}
+
+func TestRetrieve_AutoRefreshErrorEmitsErrorEvent(t *testing.T) {
+	r := &fakeRetriever{result: func(call int) (map[string]any, error) {
+		if call == 1 {
+			return map[string]any{"Password": "old"}, nil
+		}
+		return nil, errors.New("refresh failed")
+	}}
+	source := newTestSource(r, true, 10*time.Millisecond)
+
+	watchCh := make(chan *confmap.ChangeEvent, 1)
+	got, err := source.Retrieve(context.Background(), "", nil, func(ce *confmap.ChangeEvent) {
+		watchCh <- ce
+	})
+	require.NoError(t, err)
+
+	select {
+	case ce := <-watchCh:
+		require.Error(t, ce.Error)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected an error change event from the polling watcher")
+	}
+
+	require.NoError(t, got.Close(context.Background()))
+}
+
+func TestNewRetriever_UnsupportedMode(t *testing.T) {
+	_, err := newRetriever(&Config{RetrievalMode: "ccp"})
+	require.Error(t, err)
+	assert.IsType(t, &errUnsupportedMode{}, err)
+}

--- a/internal/configsource/cyberarkconfigsource/testdata/config.yaml
+++ b/internal/configsource/cyberarkconfigsource/testdata/config.yaml
@@ -1,0 +1,14 @@
+config_sources:
+  cyberark:
+    app_id: collector-app
+    safe: DBSecrets
+    object: prod-db
+  cyberark/auto:
+    retrieval_mode: cp
+    binary_path: /opt/CARKaim/sdk/CLIPasswordSDK
+    app_id: collector-app
+    safe: DBSecrets
+    folder: Root
+    object: staging-db
+    auto_refresh: true
+    poll_interval: 30s

--- a/internal/confmapprovider/configsource/provider.go
+++ b/internal/confmapprovider/configsource/provider.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/signalfx/splunk-otel-collector/internal/configsource"
+	"github.com/signalfx/splunk-otel-collector/internal/configsource/cyberarkconfigsource"
 	"github.com/signalfx/splunk-otel-collector/internal/configsource/envvarconfigsource"
 	"github.com/signalfx/splunk-otel-collector/internal/configsource/etcd2configsource"
 	"github.com/signalfx/splunk-otel-collector/internal/configsource/includeconfigsource"
@@ -40,6 +41,7 @@ var configSourceFactories = func() configsource.Factories {
 		vaultconfigsource.NewFactory(),
 		zookeeperconfigsource.NewFactory(),
 		etcd2configsource.NewFactory(),
+		cyberarkconfigsource.NewFactory(),
 	} {
 		if _, ok := factories[f.Type()]; ok {
 			panic(fmt.Sprintf("duplicate config source factory %q", f.Type()))

--- a/internal/confmapprovider/configsource/telemetry.go
+++ b/internal/confmapprovider/configsource/telemetry.go
@@ -162,6 +162,7 @@ func (t *TelemetryHook) observeConfigSourceUsage(_ context.Context, observer met
 }
 
 var customConfigSources = map[string]struct{}{
+	"cyberark":  {},
 	"env":       {},
 	"etcd2":     {},
 	"include":   {},


### PR DESCRIPTION
**Description:** 

Adds a `cyberark` config source so operators can keep credentials out of collector config and pull them from CyberArk at config-resolution time — the equivalent of the existing `vault` config source.

Targets the **CyberArk Credential Provider (CP)** agent installed on the collector host. There's no REST endpoint; secrets are fetched by executing the provider's bundled `CLIPasswordSDK` binary, so this source is exec-based.

### Usage

```yaml
config_sources:
  cyberark:
    app_id: collector-app
    safe: DBSecrets
    object: prod-db

components:
  some_receiver:
    endpoint: ${cyberark:Address}:${cyberark:Port}
    username: ${cyberark:UserName}
    password: ${cyberark:Password}    # empty selector also returns Password
```

Each instance is pinned to a single CyberArk object (`app_id` + `safe` + `object`, optional `folder`). One CLI call retrieves the password plus pass properties (`UserName`, `Address`, `Database`, `Port`) and object metadata (`Name`, `Safe`, `Folder`); the reference selector picks the field.

### What's included
- New package `internal/configsource/cyberarkconfigsource/` (config, factory, source, CP retriever, README, testdata).
- Factory registered in `provider.go`; `cyberark` added to `customConfigSources` telemetry map.
- Unit tests (fake command runner + fake retriever, no real binary needed) and a `.chloggen` entry.

### Password rotation & collector impact

CyberArk doesn't lease credentials — an object has a stable identity and its password *value* is rotated by the CPM. There's no lease/TTL/renewal to react to. A config source resolves `${cyberark:...}` **once**, at config load, baking a literal into each component's config; the only way a rotated credential reaches a running collector is to re-resolve the config. Two modes:

- **Static (default, `auto_refresh: false`)** — fetch once, no watcher. If CyberArk rotates *after* startup, the collector keeps the value it resolved and won't notice on its own; it's refreshed only on a process restart (systemd/k8s/fatal error), which re-resolves config against the CP agent's current local cache. Best when rotation is infrequent and a restart is acceptable.
- **Auto-refresh (`auto_refresh: true` + `poll_interval`)** — a background watcher re-reads on `poll_interval` and, when values change, triggers a full collector **config reload** (same mechanism as `vault`) that re-resolves references and rebuilds affected pipelines in-process, no restart. Trade-offs: affected pipelines briefly tear down/rebuild on reload; detection latency is bounded by `poll_interval`; each poll execs `CLIPasswordSDK`; poll failures surface as a reload error rather than being swallowed.

### Design decisions

- **Selective auto-refresh.** Because a receiver can't lazily re-fetch and refresh forces a config reload, watching is **opt-in** rather than always-on — the common static case pays no goroutine/CLI cost, and operators explicitly choose the reload trade-off when rotation frequency warrants it. This also matches CyberArk's rotation (not lease) model: the correct refresh signal is "value changed," detected by re-read + compare, so there are no `Renewable`/`LeaseDuration` branches like vault has.
- **Extensible retrieval backends.** The core (`source.go`) is backend-agnostic and talks to an internal `retriever` interface (`retrieve(ctx) → map[string]any`), selected by a `retrieval_mode` field (default `cp`). Account addressing, field/selector model, caching, and the watcher are all shared, leaving a future `ccp` mode (mTLS REST to AIMWebService) as a drop-in with **no change to `source.go`**. `ccp` currently returns `errUnsupportedMode`. Conjur — a different product with dynamic secrets, TTLs, and a different API/auth model — is intentionally left as a *separate future config source* rather than a mode here.
- **Injectable exec for testability.** The CP retriever takes a `commandRunner` func (defaulted to an `os/exec` implementation), so parsing and arg-building are fully unit-tested without the real `CLIPasswordSDK` binary, which can't run in CI.
- **Strict positional parsing.** Requests a fixed, ordered `-o` field list joined by a rare delimiter (`@#@`) and parses positionally. A field-count mismatch is an error rather than risking a silent mis-map of one credential field onto another. A configurable field list is noted as a future extension.


**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>
- `go build ./...`, `gofmt`, `go vet` clean.
- `go test ./internal/configsource/cyberarkconfigsource/...` — 19/19 pass.
- `go test ./internal/confmapprovider/configsource/...` — registration + sync checks pass.
-  Real-binary path is covered by the manual smoke test

**Documentation:** <Describe the documentation added.>
README.md file documenting the component config, data flow of the secrets, and future enhancements
