### PR TITLE
[chore] run win-package-test on packaging/installer changes

### DIFF
--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -14,6 +14,7 @@ on:
       - 'internal/**'
       - 'Makefile'
       - 'Makefile.Common'
+      - 'packaging/installer/*.ps1'
       - 'packaging/msi/**'
       - 'tests/zeroconfig/windows/**'
       - 'tests/msi/**'


### PR DESCRIPTION
The `win-package-test` workflow's pull_request trigger did not include `packaging/installer/**`, so PRs that only modified the Windows install script (install.ps1) skipped the `windows-script-upgrade-test` that covers it. The regression from #7700 therefore only surfaced after merge, on the unconditional push-to-main trigger. Add `packaging/installer/**` to the path filter so installer script changes are validated on the PR.
