### PR TITLE
[chore] add sast-scan

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,13 +25,11 @@ variables:
   CREDS_HELPER_ALLOW_LEGACY: "true"
 
 include:
-  - project: 'prodsec/scp-scanning/gitlab-checkmarx'
-    ref: latest
-    file: '/templates/.sast_scan.yml'
   - project: 'ci-cd/templates'
     ref: main
     file:
       - '/prodsec/.oss-scan.yml'
+      - '/prodsec/.sast-scan.yml'
       - '/prodsec/.binary-scan.yml'
       - '/prodsec/.container-scan.yml'
   - project: 'core-ee/signing/api-integration'
@@ -113,6 +111,11 @@ fossa:
   variables:
     jira_automation: "true"
   # allow_failure: false
+
+sast-scan:
+  stage: test
+  extends: .sast_scan
+  needs: []
 
 .docker-reader-role: &docker-reader-role |
   creds-helper init


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Onboard to prodsec managed sast scans in splunk-otel-collector-releaser gitlab repo. The old templates are not maintained and we were not actually using them in the pipeline. Adding the test stage for now, I'll update this with more appropriate rules in a follow up after checking the pipeline.