### PR TITLE
[chore] enable semgrep high failures, fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,6 +116,9 @@ sast-scan:
   stage: test
   extends: .sast_scan
   needs: []
+  variables:
+    alert_mode: "policy"
+  allow_failure: false
 
 .docker-reader-role: &docker-reader-role |
   creds-helper init

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -6,4 +6,5 @@ EXPOSE 7099
 ENV KAFKA_BIN="/opt/bitnami/kafka/bin"
 
 ADD scripts/* scripts/
+USER 1001
 CMD ["bash", "scripts/run.sh"]

--- a/docker/mongodb/Dockerfile
+++ b/docker/mongodb/Dockerfile
@@ -9,6 +9,8 @@ COPY mongod.conf /home/mongodb
 
 WORKDIR /home/mongodb
 
-RUN chmod +x /home/mongodb/scripts/*.sh
+RUN chmod +x /home/mongodb/scripts/*.sh && \
+    chown -R mongodb:mongodb /home/mongodb /data/db /data/configdb
 
+USER mongodb
 CMD ["/bin/bash", "/home/mongodb/scripts/run.sh"]

--- a/docker/mongodb/scripts/run.sh
+++ b/docker/mongodb/scripts/run.sh
@@ -7,15 +7,13 @@ if [ $major -gt 5 ]; then
 fi
 
 run_mongo_commandline () {
-    nohup gosu mongodb $MONGO admin --eval "help" > /dev/null 2>&1
+    nohup $MONGO admin --eval "help" > /dev/null 2>&1
 
 }
 
 sleep 5
 
-chown -R mongodb:mongodb /home/mongodb
-
-nohup gosu mongodb mongod --dbpath=/data/db &
+nohup mongod --dbpath=/data/db &
 
 run_mongo_commandline
 
@@ -30,4 +28,4 @@ done
 
 bash /home/mongodb/scripts/setup_user.sh
 
-gosu mongodb mongod --dbpath=/data/db --config mongod.conf
+mongod --dbpath=/data/db --config mongod.conf

--- a/docker/mongodb/scripts/setup_user.sh
+++ b/docker/mongodb/scripts/setup_user.sh
@@ -32,18 +32,17 @@ while [ $SECONDS -lt $end ]; do
 done
 
 # create root user
-nohup gosu mongodb $MONGO DBNAME --eval "db.createUser({user: 'admin1', pwd: 'pass1', roles:[{ role: 'root', db: 'admin' }, { role: 'read', db: 'local' }]});"
+nohup $MONGO DBNAME --eval "db.createUser({user: 'admin1', pwd: 'pass1', roles:[{ role: 'root', db: 'admin' }, { role: 'read', db: 'local' }]});"
 
 # create app user/database
-nohup gosu mongodb $MONGO DBNAME --eval "db.createUser({ user: 'NEWUSER', pwd: 'PASSWORD', roles: [{ role: 'readWrite', db: 'admin' }, { role: 'read', db: 'local' }]});"
+nohup $MONGO DBNAME --eval "db.createUser({ user: 'NEWUSER', pwd: 'PASSWORD', roles: [{ role: 'readWrite', db: 'admin' }, { role: 'read', db: 'local' }]});"
 
 
-nohup gosu mongodb $MONGO DBNAME --eval "db.createUser({ user: 'testUser', pwd: 'testPass', roles: [{ role: 'clusterMonitor', db: 'admin' }, { role: 'read', db: 'local' }]});"
+nohup $MONGO DBNAME --eval "db.createUser({ user: 'testUser', pwd: 'testPass', roles: [{ role: 'clusterMonitor', db: 'admin' }, { role: 'read', db: 'local' }]});"
 
 
 echo "************************************************************"
 echo "Shutting down"
 echo "************************************************************"
-nohup gosu mongodb $MONGO admin --eval "db.shutdownServer();"
-
+nohup $MONGO admin --eval "db.shutdownServer();"
 

--- a/docker/oracle/Dockerfile
+++ b/docker/oracle/Dockerfile
@@ -4,4 +4,6 @@ ENV ORACLE_PASSWORD=mysecurepassword
 
 COPY initOracleDB.sql /container-entrypoint-initdb.d/startup.sql
 
+USER oracle
+
 HEALTHCHECK CMD "$ORACLE_BASE/healthcheck.sh"

--- a/docker/redis_client/Dockerfile
+++ b/docker/redis_client/Dockerfile
@@ -2,4 +2,6 @@ FROM redis:8.6
 
 COPY init.sh /usr/local/bin/init.sh
 
+USER redis
+
 CMD ["init.sh"]

--- a/docker/redis_server/Dockerfile
+++ b/docker/redis_server/Dockerfile
@@ -2,4 +2,6 @@ FROM redis:8.6
 
 COPY redis.conf /usr/local/etc/redis/redis.conf
 
+USER redis
+
 CMD [ "redis-server", "/usr/local/etc/redis/redis.conf" ]

--- a/examples/collectd/collectd/Dockerfile
+++ b/examples/collectd/collectd/Dockerfile
@@ -2,4 +2,6 @@ FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y collectd && apt-get clean
 
+USER nobody:nogroup
+
 CMD ["/usr/sbin/collectd", "-f"]

--- a/examples/prometheus-federation/prom-counter/Dockerfile
+++ b/examples/prometheus-federation/prom-counter/Dockerfile
@@ -9,4 +9,6 @@ RUN go get
 
 RUN go build
 
+USER 65532:65532
+
 CMD /go/src/app/prom-counter

--- a/examples/prometheusexec-migration/Dockerfile
+++ b/examples/prometheusexec-migration/Dockerfile
@@ -1,3 +1,4 @@
 FROM quay.io/signalfx/splunk-otel-collector:latest
 COPY --from=quay.io/prometheus/node-exporter:v1.6.1 --chown=999 /bin/node_exporter /usr/bin/node_exporter
+USER 999
 CMD ["otelcol"]

--- a/examples/splunk-hec-traces/tracing/Dockerfile
+++ b/examples/splunk-hec-traces/tracing/Dockerfile
@@ -9,4 +9,6 @@ RUN go get
 
 RUN go build
 
+USER 65532:65532
+
 CMD /go/src/app/tracing

--- a/examples/splunk-hec/logging/Dockerfile
+++ b/examples/splunk-hec/logging/Dockerfile
@@ -9,4 +9,6 @@ RUN go get
 
 RUN go build
 
+USER 65532:65532
+
 CMD /go/src/app/logging

--- a/internal/signalfx-agent/pkg/monitors/traefik/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/traefik/metadata.yaml
@@ -31,7 +31,7 @@ monitors:
     `docker run -d -p 8080:8080 -p 80:80 -v $PWD/traefik.toml:/etc/traefik/traefik.toml`
 
     If the Traefik configuration file is not available use the sample configuration file
-    <a target="_blank" href="https://raw.githubusercontent.com/containous/traefik/master/traefik.sample.toml">here</a>
+    <a target="_blank" href="https://raw.githubusercontent.com/traefik/traefik/v3.0/traefik.sample.toml">here</a>
     to get started.
 
     See <a target="_blank" href="https://docs.traefik.io/">here</a> for complete Traefik docs.

--- a/k8s/envoy/envoy.yaml
+++ b/k8s/envoy/envoy.yaml
@@ -18,9 +18,20 @@ spec:
         - image: envoyproxy/envoy:v1.38-latest
           name: envoy-test
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 10000
               name: envoy
             - containerPort: 9901
               name: admin
-
+          volumeMounts:
+            - name: envoy-tmp
+              mountPath: /tmp
+      volumes:
+        - name: envoy-tmp
+          emptyDir: {}

--- a/k8s/envoy/envoy.yaml
+++ b/k8s/envoy/envoy.yaml
@@ -14,13 +14,23 @@ spec:
         app: envoy-test
     spec:
       automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 101
       containers:
         - image: envoyproxy/envoy:v1.38-latest
           name: envoy-test
           imagePullPolicy: IfNotPresent
+          command:
+            - envoy
+          args:
+            - -c
+            - /etc/envoy/envoy.yaml
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 101
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Enable high-severity findings to fail CI sast job. Also cleans up several non-customer-facing Medium findings by running test/example Docker images as non-root, hardening the Envoy test manifest, and pinning a Traefik sample config link.