### PR TITLE
[chore] Improve release metadata polling

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1236,13 +1236,14 @@ release-debs:
   script:
     - |
       set -ex
-      for path in dist/signed/*.deb; do
-        if [ ! -f "$path" ]; then
-          echo "$path not found!"
-          exit 1
-        fi
-        python3 packaging/release/release.py --force --stage=${STAGE} --timeout=5400 --path="$path"
-      done
+      shopt -s nullglob
+      paths=(dist/signed/*.deb)
+      shopt -u nullglob
+      if [ "${#paths[@]}" -eq 0 ]; then
+        echo "No signed debs found!"
+        exit 1
+      fi
+      python3 packaging/release/release.py --force --stage=${STAGE} --timeout=5400 --paths "${paths[@]}"
   artifacts:
     paths:
       - dist/signed/*.deb
@@ -1272,13 +1273,14 @@ release-rpms:
   script:
     - |
       set -ex
-      for path in dist/signed/*${ARCH}.rpm; do
-        if [ ! -f "$path" ]; then
-          echo "$path not found!"
-          exit 1
-        fi
-        python3 packaging/release/release.py --force --stage=${STAGE} --timeout=5400 --path="$path"
-      done
+      shopt -s nullglob
+      paths=(dist/signed/*${ARCH}.rpm)
+      shopt -u nullglob
+      if [ "${#paths[@]}" -eq 0 ]; then
+        echo "No signed rpms found for ${ARCH}!"
+        exit 1
+      fi
+      python3 packaging/release/release.py --force --stage=${STAGE} --timeout=5400 --paths "${paths[@]}"
   artifacts:
     paths:
       - dist/signed/*${ARCH}.rpm

--- a/packaging/release/helpers/constants.py
+++ b/packaging/release/helpers/constants.py
@@ -23,9 +23,6 @@ ARTIFACTORY_RPM_REPO = "otel-collector-rpm"
 ARTIFACTORY_RPM_REPO_URL = f"{ARTIFACTORY_URL}/{ARTIFACTORY_RPM_REPO}"
 DEFAULT_ARTIFACTORY_USERNAME = "otel-collector"
 DEFAULT_TIMEOUT = 1200
-# After the repo metadata first changes following our upload, require it to stay
-# unchanged for this many seconds before treating it as settled.
-METADATA_SETTLE_DELAY = 60
 
 # Package/Release
 REPO_DIR = Path(__file__).parent.parent.parent.parent.resolve()

--- a/packaging/release/helpers/release_args.py
+++ b/packaging/release/helpers/release_args.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import argparse
-import os
 
 from .constants import (
     ARTIFACTORY_URL,
@@ -99,6 +98,17 @@ def get_args_and_asset():
         """,
     )
     parser.add_argument(
+        "--paths",
+        type=str,
+        nargs="+",
+        default=None,
+        metavar="PATH",
+        required=False,
+        help="""
+            Release a batch of local files. Only supported for deb/rpm packages.
+        """,
+    )
+    parser.add_argument(
         "--installers",
         action="store_true",
         default=False,
@@ -125,7 +135,7 @@ def get_args_and_asset():
         default=DEFAULT_TIMEOUT,
         metavar="TIMEOUT",
         required=False,
-        help=f"Signing request timeout in seconds. Defaults to {DEFAULT_TIMEOUT}.",
+        help=f"Artifactory metadata wait timeout in seconds. Defaults to {DEFAULT_TIMEOUT}.",
     )
     parser.add_argument(
         "--force",
@@ -134,30 +144,28 @@ def get_args_and_asset():
         required=False,
         help="Never prompt when overwriting existing files.",
     )
-    parser.add_argument(
-        "--sync-calculate-metadata",
-        action=argparse.BooleanOptionalAction,
-        default=os.environ.get("ARTIFACTORY_SYNC_CALCULATE", "").lower() in ("1", "true", "yes"),
-        required=False,
-        help="""
-            For deb/rpm uploads, explicitly trigger Artifactory's metadata
-            calculation synchronously (async=0) after upload and before signing,
-            instead of relying only on the asynchronous auto-calculation.
-            Defaults to the ARTIFACTORY_SYNC_CALCULATE env var if truthy.
-        """,
-    )
-
     add_artifactory_args(parser)
 
     args = parser.parse_args()
 
-    assert args.path or args.installers, "Either --path or --installers must be specified"
+    assert args.path or args.paths or args.installers, "Either --path, --paths, or --installers must be specified"
+    assert not (args.path and args.paths), "Only one of --path or --paths may be specified"
 
     asset = None
+    args.assets = []
     if args.path:
         asset = get_asset(args.path)
+        args.assets = [asset]
+    elif args.paths:
+        args.assets = [get_asset(path) for path in args.paths]
+        components = {asset.component for asset in args.assets}
+        assert len(components) == 1, f"All --paths assets must have the same component: {components}"
+        component = next(iter(components))
+        assert component in ("deb", "rpm"), "--paths is only supported for deb/rpm packages"
+        if len(args.assets) == 1:
+            asset = args.assets[0]
 
-    if asset and asset.component in ("deb", "rpm"):
+    if any(asset.component in ("deb", "rpm") for asset in args.assets):
         check_artifactory_args(args)
 
     return args, asset

--- a/packaging/release/helpers/release_args.py
+++ b/packaging/release/helpers/release_args.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import os
 
 from .constants import (
     ARTIFACTORY_URL,

--- a/packaging/release/helpers/util.py
+++ b/packaging/release/helpers/util.py
@@ -38,6 +38,13 @@ from .constants import (
 )
 
 
+METADATA_POLL_INTERVAL = 60
+
+
+class MetadataNotReady(Exception):
+    pass
+
+
 class Asset(object):
     def __init__(self, url=None, path=None):
         assert url or path, "Either url= or path= is required!"
@@ -112,7 +119,12 @@ def download_file(url, dest, user=None, token=None):
 
 def get_url_bytes(url, user=None, token=None):
     auth = (user, token) if user and token else None
-    resp = requests.get(url, auth=auth, timeout=60)
+    try:
+        resp = requests.get(url, auth=auth, timeout=60)
+    except requests.RequestException as err:
+        raise MetadataNotReady(f"download failed: {err}") from err
+    if resp.status_code == 404 or resp.status_code >= 500:
+        raise MetadataNotReady(f"download failed:\n{resp.reason}\n{resp.text}")
     assert resp.status_code == 200, f"download failed:\n{resp.reason}\n{resp.text}"
     return resp.content
 
@@ -130,9 +142,7 @@ def verify_bytes_checksum(data, checksum_type, expected_checksum, expected_size=
         assert len(data) == int(expected_size), (
             f"size mismatch: expected {expected_size}, got {len(data)}"
         )
-    hash_name = checksum_type.replace("-", "")
-    if hash_name == "sha":
-        hash_name = "sha1"
+    hash_name = normalize_checksum_type(checksum_type)
     digest = hashlib.new(hash_name)
     digest.update(data)
     actual_checksum = digest.hexdigest().lower()
@@ -141,10 +151,27 @@ def verify_bytes_checksum(data, checksum_type, expected_checksum, expected_size=
     )
 
 
+def normalize_checksum_type(checksum_type):
+    if not checksum_type:
+        return ""
+    hash_name = checksum_type.replace("-", "").lower()
+    if hash_name == "sha":
+        return "sha1"
+    return hash_name
+
+
+def package_checksum_matches(package, expected):
+    checksum_type = normalize_checksum_type(package.get("checksum_type", ""))
+    expected_checksum = expected.get(checksum_type, "")
+    return bool(expected_checksum) and (package.get("checksum") or "").lower() == expected_checksum.lower()
+
+
 def get_deb_package_info(asset):
     match = re.match(r"(?P<name>.+)_(?P<version>[^_]+)_(?P<arch>amd64|arm64)\.deb$", asset.name)
     assert match, f"Failed to get deb package info from {asset.path}!"
-    return match.groupdict()
+    package_info = match.groupdict()
+    package_info["sha256"] = get_checksum(asset.path, hashlib.sha256())
+    return package_info
 
 
 def get_rpm_package_info(asset):
@@ -153,7 +180,10 @@ def get_rpm_package_info(asset):
         asset.name,
     )
     assert match, f"Failed to get rpm package info from {asset.path}!"
-    return match.groupdict()
+    package_info = match.groupdict()
+    package_info["sha1"] = get_checksum(asset.path, hashlib.sha1())
+    package_info["sha256"] = get_checksum(asset.path, hashlib.sha256())
+    return package_info
 
 
 def parse_deb_release_sha256(release_text):
@@ -203,12 +233,15 @@ def get_deb_packages_from_metadata(stage, arch, user, token):
         packages_url = f"{ARTIFACTORY_DEB_REPO_URL}/dists/{stage}/{packages_path}"
         packages_bytes = get_url_bytes(packages_url, user, token)
         checksum, size = checksums[packages_path]
-        verify_bytes_checksum(packages_bytes, "sha256", checksum, size)
+        try:
+            verify_bytes_checksum(packages_bytes, "sha256", checksum, size)
+        except AssertionError as err:
+            raise MetadataNotReady(f"{packages_path} checksum is not stable: {err}") from err
         if packages_path.endswith(".gz"):
             packages_bytes = gzip.decompress(packages_bytes)
         return parse_deb_packages(packages_bytes.decode("utf-8"))
 
-    raise AssertionError(f"No Packages metadata found in Release for {stage}/{arch}")
+    raise MetadataNotReady(f"No Packages metadata found in Release for {stage}/{arch}")
 
 
 def get_rpm_packages_from_metadata(stage, arch, user, token):
@@ -226,16 +259,21 @@ def get_rpm_packages_from_metadata(stage, arch, user, token):
         if data.attrib.get("type") == "primary":
             primary = data
             break
-    assert primary is not None, f"primary metadata not found in {repomd_url}"
+    if primary is None:
+        raise MetadataNotReady(f"primary metadata not found in {repomd_url}")
 
     checksum = primary.find(f"{repo_ns}checksum")
     location = primary.find(f"{repo_ns}location")
-    assert checksum is not None and location is not None, f"primary checksum/location missing in {repomd_url}"
+    if checksum is None or location is None:
+        raise MetadataNotReady(f"primary checksum/location missing in {repomd_url}")
 
     repo_root_url = repomd_url.rsplit("/repodata/repomd.xml", 1)[0] + "/"
     primary_url = urllib.parse.urljoin(repo_root_url, location.attrib["href"])
     primary_bytes = get_url_bytes(primary_url, user, token)
-    verify_bytes_checksum(primary_bytes, checksum.attrib["type"], checksum.text)
+    try:
+        verify_bytes_checksum(primary_bytes, checksum.attrib["type"], checksum.text)
+    except AssertionError as err:
+        raise MetadataNotReady(f"primary metadata checksum is not stable: {err}") from err
     if primary_url.endswith(".gz"):
         primary_bytes = gzip.decompress(primary_bytes)
 
@@ -243,12 +281,15 @@ def get_rpm_packages_from_metadata(stage, arch, user, token):
     packages = []
     for package in primary_xml.findall(f"{common_ns}package"):
         version = package.find(f"{common_ns}version")
+        checksum = package.find(f"{common_ns}checksum")
         packages.append(
             {
                 "name": package.findtext(f"{common_ns}name"),
                 "arch": package.findtext(f"{common_ns}arch"),
                 "version": version.attrib.get("ver") if version is not None else None,
                 "release": version.attrib.get("rel") if version is not None else None,
+                "checksum": checksum.text if checksum is not None else None,
+                "checksum_type": checksum.attrib.get("type") if checksum is not None else None,
             }
         )
     return packages
@@ -257,10 +298,11 @@ def get_rpm_packages_from_metadata(stage, arch, user, token):
 def wait_for_packages_in_metadata(package_type, expected_packages, stage, user, token, timeout=DEFAULT_TIMEOUT):
     print(
         f"Waiting for {len(expected_packages)} {package_type} package(s) "
-        f"to appear in {stage} repo metadata ..."
+        f"to appear in {stage} repo metadata "
+        f"(polling every {METADATA_POLL_INTERVAL}s) ..."
     )
     start_time = time.time()
-    last_log = -60
+    last_log = -METADATA_POLL_INTERVAL
 
     while True:
         elapsed = int(time.time() - start_time)
@@ -271,17 +313,17 @@ def wait_for_packages_in_metadata(package_type, expected_packages, stage, user, 
 
         try:
             missing = get_missing_packages_from_metadata(package_type, expected_packages, stage, user, token)
-        except Exception as err:
+        except MetadataNotReady as err:
             missing = [f"metadata not ready: {err}"]
 
         if not missing:
             print(f"All expected {package_type} package(s) are present in repo metadata.")
             return
 
-        if elapsed - last_log >= 60:
+        if elapsed - last_log >= METADATA_POLL_INTERVAL:
             print(f"  Still waiting after {elapsed}s. Missing: {missing}")
             last_log = elapsed
-        time.sleep(10)
+        time.sleep(min(METADATA_POLL_INTERVAL, max(1, timeout - elapsed)))
 
 
 def get_missing_packages_from_metadata(package_type, expected_packages, stage, user, token):
@@ -295,6 +337,7 @@ def get_missing_packages_from_metadata(package_type, expected_packages, stage, u
                     package.get("Package") == expected["name"]
                     and package.get("Version") == expected["version"]
                     and package.get("Architecture") == expected["arch"]
+                    and package.get("SHA256", "").lower() == expected["sha256"]
                     for package in live_packages
                 ):
                     missing.append(expected)
@@ -306,6 +349,7 @@ def get_missing_packages_from_metadata(package_type, expected_packages, stage, u
                     and package.get("version") == expected["version"]
                     and package.get("release") == expected["release"]
                     and package.get("arch") == expected["arch"]
+                    and package_checksum_matches(package, expected)
                     for package in live_packages
                 ):
                     missing.append(expected)

--- a/packaging/release/helpers/util.py
+++ b/packaging/release/helpers/util.py
@@ -13,29 +13,28 @@
 # limitations under the License.
 
 import hashlib
+import gzip
 import os
 import re
 import sys
 import tempfile
 import time
+import urllib.parse
+import xml.etree.ElementTree as ET
 
 import boto3
 import requests
 
 from .constants import (
     ARTIFACTORY_API_URL,
-    ARTIFACTORY_DEB_REPO,
     ARTIFACTORY_DEB_REPO_URL,
-    ARTIFACTORY_RPM_REPO,
     ARTIFACTORY_RPM_REPO_URL,
     ARTIFACTORY_URL,
     CLOUDFRONT_DISTRIBUTION_ID,
     DEFAULT_TIMEOUT,
     EXTENSIONS,
     INSTALLER_SCRIPTS,
-    METADATA_SETTLE_DELAY,
     PACKAGE_NAME,
-    REPO_DIR,
     S3_BUCKET,
     S3_MSI_BASE_DIR,
 )
@@ -113,6 +112,13 @@ def download_file(url, dest, user=None, token=None):
         fd.write(resp.content)
 
 
+def get_url_bytes(url, user=None, token=None):
+    auth = (user, token) if user and token else None
+    resp = requests.get(url, auth=auth, timeout=60)
+    assert resp.status_code == 200, f"download failed:\n{resp.reason}\n{resp.text}"
+    return resp.content
+
+
 def delete_artifactory_file(url, user, token):
     print(f"deleting {url} ...")
 
@@ -136,74 +142,187 @@ def get_md5_from_artifactory(url, user, token):
     return md5
 
 
-def trigger_metadata_calculation(calculate_url, user, token, timeout=DEFAULT_TIMEOUT):
-    # Explicitly ask Artifactory to (re)calculate the repo metadata and block
-    # until it finishes (async=0).
-    print(f"Triggering synchronous metadata calculation: {calculate_url}")
-    resp = requests.post(calculate_url, auth=(user, token), timeout=timeout)
-    print(f"Calculation response: {resp.status_code} {resp.text.strip()}")
-    resp.raise_for_status()
+def verify_bytes_checksum(data, checksum_type, expected_checksum, expected_size=None):
+    if expected_size is not None:
+        assert len(data) == int(expected_size), (
+            f"size mismatch: expected {expected_size}, got {len(data)}"
+        )
+    hash_name = checksum_type.replace("-", "")
+    if hash_name == "sha":
+        hash_name = "sha1"
+    digest = hashlib.new(hash_name)
+    digest.update(data)
+    actual_checksum = digest.hexdigest().lower()
+    assert actual_checksum == expected_checksum.lower(), (
+        f"{checksum_type} mismatch: expected {expected_checksum}, got {actual_checksum}"
+    )
 
 
-def wait_for_artifactory_metadata(
-    url, orig_md5, user, token, timeout=DEFAULT_TIMEOUT, settle_delay=METADATA_SETTLE_DELAY
-):
-    print(f"Waiting for {url} to be updated (original MD5: {orig_md5}) ...")
+def get_deb_package_info(asset):
+    match = re.match(r"(?P<name>.+)_(?P<version>[^_]+)_(?P<arch>amd64|arm64)\.deb$", asset.name)
+    assert match, f"Failed to get deb package info from {asset.path}!"
+    return match.groupdict()
 
+
+def get_rpm_package_info(asset):
+    match = re.match(
+        r"(?P<name>.+)-(?P<version>[0-9][^-]*)-(?P<release>[^-]+)\.(?P<arch>x86_64|aarch64)\.rpm$",
+        asset.name,
+    )
+    assert match, f"Failed to get rpm package info from {asset.path}!"
+    return match.groupdict()
+
+
+def parse_deb_release_sha256(release_text):
+    entries = {}
+    in_sha256 = False
+    for line in release_text.splitlines():
+        if line == "SHA256:":
+            in_sha256 = True
+            continue
+        if re.match(r"^[A-Za-z0-9-]+:", line):
+            in_sha256 = False
+        if in_sha256 and line.startswith(" "):
+            checksum, size, path = line.split()
+            entries[path] = (checksum, int(size))
+    return entries
+
+
+def parse_deb_packages(packages_text):
+    packages = []
+    current = {}
+    for line in packages_text.splitlines():
+        if not line:
+            if current:
+                packages.append(current)
+                current = {}
+            continue
+        if line[0].isspace() or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        current[key] = value.strip()
+    if current:
+        packages.append(current)
+    return packages
+
+
+def get_deb_packages_from_metadata(stage, arch, user, token):
+    release_url = f"{ARTIFACTORY_DEB_REPO_URL}/dists/{stage}/Release"
+    release_text = get_url_bytes(release_url, user, token).decode("utf-8")
+    checksums = parse_deb_release_sha256(release_text)
+
+    for packages_path in (f"main/binary-{arch}/Packages", f"main/binary-{arch}/Packages.gz"):
+        if packages_path not in checksums:
+            continue
+        packages_url = f"{ARTIFACTORY_DEB_REPO_URL}/dists/{stage}/{packages_path}"
+        packages_bytes = get_url_bytes(packages_url, user, token)
+        checksum, size = checksums[packages_path]
+        verify_bytes_checksum(packages_bytes, "sha256", checksum, size)
+        if packages_path.endswith(".gz"):
+            packages_bytes = gzip.decompress(packages_bytes)
+        return parse_deb_packages(packages_bytes.decode("utf-8"))
+
+    raise AssertionError(f"No Packages metadata found in Release for {stage}/{arch}")
+
+
+def get_rpm_packages_from_metadata(stage, arch, user, token):
+    repomd_url = f"{ARTIFACTORY_RPM_REPO_URL}/{stage}/{arch}/repodata/repomd.xml"
+    repomd_bytes = get_url_bytes(repomd_url, user, token)
+    repo_ns = "{http://linux.duke.edu/metadata/repo}"
+    common_ns = "{http://linux.duke.edu/metadata/common}"
+
+    repomd = ET.fromstring(repomd_bytes)
+    primary = None
+    for data in repomd.findall(f"{repo_ns}data"):
+        if data.attrib.get("type") == "primary":
+            primary = data
+            break
+    assert primary is not None, f"primary metadata not found in {repomd_url}"
+
+    checksum = primary.find(f"{repo_ns}checksum")
+    location = primary.find(f"{repo_ns}location")
+    assert checksum is not None and location is not None, f"primary checksum/location missing in {repomd_url}"
+
+    repo_root_url = repomd_url.rsplit("/repodata/repomd.xml", 1)[0] + "/"
+    primary_url = urllib.parse.urljoin(repo_root_url, location.attrib["href"])
+    primary_bytes = get_url_bytes(primary_url, user, token)
+    verify_bytes_checksum(primary_bytes, checksum.attrib["type"], checksum.text)
+    if primary_url.endswith(".gz"):
+        primary_bytes = gzip.decompress(primary_bytes)
+
+    primary_xml = ET.fromstring(primary_bytes)
+    packages = []
+    for package in primary_xml.findall(f"{common_ns}package"):
+        version = package.find(f"{common_ns}version")
+        packages.append(
+            {
+                "name": package.findtext(f"{common_ns}name"),
+                "arch": package.findtext(f"{common_ns}arch"),
+                "version": version.attrib.get("ver") if version is not None else None,
+                "release": version.attrib.get("rel") if version is not None else None,
+            }
+        )
+    return packages
+
+
+def wait_for_packages_in_metadata(package_type, expected_packages, stage, user, token, timeout=DEFAULT_TIMEOUT):
+    print(
+        f"Waiting for {len(expected_packages)} {package_type} package(s) "
+        f"to appear in {stage} repo metadata ..."
+    )
     start_time = time.time()
+    last_log = -60
 
-    # wait for the metadata to change from the pre-upload snapshot.
-    last_md5 = orig_md5
     while True:
         elapsed = int(time.time() - start_time)
         assert elapsed < timeout, (
-            f"Timed out after {elapsed}s waiting for {url} to be updated "
-            f"(MD5 still {orig_md5})"
+            f"Timed out after {elapsed}s waiting for {package_type} metadata "
+            f"to reference: {expected_packages}"
         )
 
-        new_md5 = get_md5_from_artifactory(url, user, token)
+        try:
+            missing = get_missing_packages_from_metadata(package_type, expected_packages, stage, user, token)
+        except Exception as err:
+            missing = [f"metadata not ready: {err}"]
 
-        if new_md5 and str(orig_md5).lower() != str(new_md5).lower():
-            last_md5 = new_md5
-            print(
-                f"Metadata updated after {int(time.time() - start_time)}s "
-                f"(new MD5: {new_md5}); reconfirming it has settled ..."
-            )
-            break
-
-        if elapsed > 0 and elapsed % 60 == 0:
-            print(f"  Still waiting after {elapsed}s (MD5 unchanged: {new_md5}) ...")
-
-        time.sleep(5)
-
-    # Require the metadata to stay unchanged across a settle window
-    # before treating it as final. Artifactory recalculates metadata
-    # asynchronously and may run more than one calculation pass for a batch, so
-    # returning on the first change can capture an intermediate snapshot that a
-    # later pass overwrites whose detached signature would no longer match the
-    # published metadata and break repo_gpgcheck for clients. If it changes again
-    # during the window, adopt the new value and keep waiting.
-    while True:
-        elapsed = int(time.time() - start_time)
-        assert elapsed + settle_delay <= timeout, (
-            f"Timed out after {elapsed}s waiting for {url} to settle "
-            f"(last seen MD5: {last_md5})"
-        )
-
-        print(f"Waiting {settle_delay}s to confirm the metadata has settled ...")
-        time.sleep(settle_delay)
-        new_md5 = get_md5_from_artifactory(url, user, token)
-        if new_md5 and str(new_md5).lower() == str(last_md5).lower():
-            print(
-                f"Metadata settled after {int(time.time() - start_time)}s "
-                f"(unchanged for {settle_delay}s, MD5: {new_md5})"
-            )
+        if not missing:
+            print(f"All expected {package_type} package(s) are present in repo metadata.")
             return
-        print(
-            f"Metadata changed again during settle window "
-            f"(MD5 {last_md5} -> {new_md5}); reconfirming ..."
-        )
-        last_md5 = new_md5
+
+        if elapsed - last_log >= 60:
+            print(f"  Still waiting after {elapsed}s. Missing: {missing}")
+            last_log = elapsed
+        time.sleep(10)
+
+
+def get_missing_packages_from_metadata(package_type, expected_packages, stage, user, token):
+    missing = []
+    for arch in sorted({package["arch"] for package in expected_packages}):
+        expected_for_arch = [package for package in expected_packages if package["arch"] == arch]
+        if package_type == "deb":
+            live_packages = get_deb_packages_from_metadata(stage, arch, user, token)
+            for expected in expected_for_arch:
+                if not any(
+                    package.get("Package") == expected["name"]
+                    and package.get("Version") == expected["version"]
+                    and package.get("Architecture") == expected["arch"]
+                    for package in live_packages
+                ):
+                    missing.append(expected)
+        elif package_type == "rpm":
+            live_packages = get_rpm_packages_from_metadata(stage, arch, user, token)
+            for expected in expected_for_arch:
+                if not any(
+                    package.get("name") == expected["name"]
+                    and package.get("version") == expected["version"]
+                    and package.get("release") == expected["release"]
+                    and package.get("arch") == expected["arch"]
+                    for package in live_packages
+                ):
+                    missing.append(expected)
+        else:
+            raise AssertionError(f"Unsupported package metadata type: {package_type}")
+    return missing
 
 
 def upload_package_to_artifactory(
@@ -211,11 +330,6 @@ def upload_package_to_artifactory(
     dest_url,
     user,
     token,
-    metadata_api_url,
-    metadata_url,
-    sign_metadata=True,
-    timeout=DEFAULT_TIMEOUT,
-    calculate_url=None,
 ):
     local_md5 = get_checksum(path, hashlib.md5())
     clean_url = dest_url.split(";")[0]
@@ -234,38 +348,17 @@ def upload_package_to_artifactory(
     content_changed = pre_upload_md5 is None or pre_upload_md5.lower() != local_md5.lower()
     print(f"Content changed:               {content_changed}")
 
-    orig_md5 = None
-    if sign_metadata:
-        orig_md5 = get_md5_from_artifactory(metadata_api_url, user, token)
-        print(f"Pre-upload metadata MD5:       {orig_md5}")
-
     upload_file_to_artifactory(path, dest_url, user, token)
 
-    if sign_metadata:
-        if content_changed:
-            if calculate_url:
-                trigger_metadata_calculation(calculate_url, user, token, timeout=timeout)
-            wait_for_artifactory_metadata(metadata_api_url, orig_md5, user, token, timeout=timeout)
-        else:
-            print(
-                "Upload content is identical to existing file. "
-                "Repo metadata will not be regenerated — skipping metadata wait."
-            )
-        dest = os.path.join(REPO_DIR, os.path.basename(metadata_url))
-        download_file(metadata_url, dest, user, token)
 
-
-def release_deb_to_artifactory(asset, args):
+def release_deb_to_artifactory(asset, args, wait_for_metadata=True):
 
     user = args.artifactory_user
     token = args.artifactory_token
 
-    match = re.match(r".*_(amd64|arm64)\.deb$", asset.name)
-    assert match, f"Failed to get arch from {asset.path}!"
-    arch = match.groups()[0]
+    package_info = get_deb_package_info(asset)
+    arch = package_info["arch"]
 
-    metadata_api_url = f"{ARTIFACTORY_API_URL}/storage/{ARTIFACTORY_DEB_REPO}/dists/{args.stage}/Release"
-    metadata_url = f"{ARTIFACTORY_DEB_REPO_URL}/dists/{args.stage}/Release"
     deb_url = f"{ARTIFACTORY_DEB_REPO_URL}/pool/{args.stage}/{arch}/{asset.name}"
     dest_opts = f"deb.distribution={args.stage};deb.component=main;deb.architecture={arch}"
     dest_url = f"{deb_url};{dest_opts}"
@@ -275,34 +368,41 @@ def release_deb_to_artifactory(asset, args):
         if resp.lower() not in ("y", "yes"):
             sys.exit(1)
 
-    calculate_url = None
-    if getattr(args, "sync_calculate_metadata", False):
-        calculate_url = f"{ARTIFACTORY_API_URL}/deb/reindex/{ARTIFACTORY_DEB_REPO}?async=0"
-
     upload_package_to_artifactory(
         asset.path,
         dest_url,
         user,
         token,
-        metadata_api_url,
-        metadata_url,
-        sign_metadata=True,
-        timeout=args.timeout,
-        calculate_url=calculate_url,
+    )
+
+    if wait_for_metadata:
+        wait_for_packages_in_metadata("deb", [package_info], args.stage, user, token, args.timeout)
+
+    return package_info
+
+
+def release_debs_to_artifactory(assets, args):
+    expected_packages = []
+    for asset in assets:
+        expected_packages.append(release_deb_to_artifactory(asset, args, wait_for_metadata=False))
+
+    wait_for_packages_in_metadata(
+        "deb",
+        expected_packages,
+        args.stage,
+        args.artifactory_user,
+        args.artifactory_token,
+        args.timeout,
     )
 
 
-
-def release_rpm_to_artifactory(asset, args):
+def release_rpm_to_artifactory(asset, args, wait_for_metadata=True):
     user = args.artifactory_user
     token = args.artifactory_token
 
-    match = re.match(r".*\.(x86_64|aarch64)\.rpm$", asset.name)
-    assert match, f"Failed to get arch from {asset.path}!"
-    arch = match.groups()[0]
+    package_info = get_rpm_package_info(asset)
+    arch = package_info["arch"]
 
-    metadata_api_url = f"{ARTIFACTORY_API_URL}/storage/{ARTIFACTORY_RPM_REPO}/{args.stage}/{arch}/repodata/repomd.xml"
-    metadata_url = f"{ARTIFACTORY_RPM_REPO_URL}/{args.stage}/{arch}/repodata/repomd.xml"
     dest_url = f"{ARTIFACTORY_RPM_REPO_URL}/{args.stage}/{arch}/{asset.name}"
 
     if not args.force and artifactory_file_exists(dest_url, user, token):
@@ -310,20 +410,34 @@ def release_rpm_to_artifactory(asset, args):
         if resp.lower() not in ("y", "yes"):
             sys.exit(1)
 
-    calculate_url = None
-    if getattr(args, "sync_calculate_metadata", False):
-        calculate_url = f"{ARTIFACTORY_API_URL}/yum/{ARTIFACTORY_RPM_REPO}/{args.stage}/{arch}?async=0"
-
     upload_package_to_artifactory(
         asset.path,
         dest_url,
         user,
         token,
-        metadata_api_url,
-        metadata_url,
-        sign_metadata=True,
-        timeout=args.timeout,
-        calculate_url=calculate_url,
+    )
+
+    if wait_for_metadata:
+        wait_for_packages_in_metadata("rpm", [package_info], args.stage, user, token, args.timeout)
+
+    return package_info
+
+
+def release_rpms_to_artifactory(assets, args):
+    expected_packages = []
+    arch = get_rpm_package_info(assets[0])["arch"]
+    for asset in assets:
+        package_info = get_rpm_package_info(asset)
+        assert package_info["arch"] == arch, "RPM batch must use a single arch"
+        expected_packages.append(release_rpm_to_artifactory(asset, args, wait_for_metadata=False))
+
+    wait_for_packages_in_metadata(
+        "rpm",
+        expected_packages,
+        args.stage,
+        args.artifactory_user,
+        args.artifactory_token,
+        args.timeout,
     )
 
 

--- a/packaging/release/helpers/util.py
+++ b/packaging/release/helpers/util.py
@@ -26,10 +26,8 @@ import boto3
 import requests
 
 from .constants import (
-    ARTIFACTORY_API_URL,
     ARTIFACTORY_DEB_REPO_URL,
     ARTIFACTORY_RPM_REPO_URL,
-    ARTIFACTORY_URL,
     CLOUDFRONT_DISTRIBUTION_ID,
     DEFAULT_TIMEOUT,
     EXTENSIONS,
@@ -127,21 +125,6 @@ def delete_artifactory_file(url, user, token):
     assert resp.status_code == 204, f"delete failed:\n{resp.reason}\n{resp.text}"
 
 
-def get_md5_from_artifactory(url, user, token):
-    if not artifactory_file_exists(url, user, token):
-        return None
-
-    resp = requests.get(url, auth=(user, token))
-
-    assert resp.status_code == 200, f"md5 request failed:\n{resp.reason}\n{resp.text}"
-
-    md5 = resp.json().get("checksums", {}).get("md5", "")
-
-    assert md5, f"md5 not found in response:\n{resp.text}"
-
-    return md5
-
-
 def verify_bytes_checksum(data, checksum_type, expected_checksum, expected_size=None):
     if expected_size is not None:
         assert len(data) == int(expected_size), (
@@ -207,6 +190,9 @@ def parse_deb_packages(packages_text):
 
 
 def get_deb_packages_from_metadata(stage, arch, user, token):
+    # Verify the Packages index through the signed Release metadata before
+    # using it. This mirrors what apt relies on after Artifactory recalculates
+    # repo metadata, and avoids treating a transient metadata update as done.
     release_url = f"{ARTIFACTORY_DEB_REPO_URL}/dists/{stage}/Release"
     release_text = get_url_bytes(release_url, user, token).decode("utf-8")
     checksums = parse_deb_release_sha256(release_text)
@@ -226,6 +212,9 @@ def get_deb_packages_from_metadata(stage, arch, user, token):
 
 
 def get_rpm_packages_from_metadata(stage, arch, user, token):
+    # Resolve the current primary metadata from repomd.xml and verify its
+    # checksum before checking packages. This follows the same repo metadata
+    # chain dnf uses, so the release waits for the customer-visible index.
     repomd_url = f"{ARTIFACTORY_RPM_REPO_URL}/{stage}/{arch}/repodata/repomd.xml"
     repomd_bytes = get_url_bytes(repomd_url, user, token)
     repo_ns = "{http://linux.duke.edu/metadata/repo}"
@@ -331,23 +320,9 @@ def upload_package_to_artifactory(
     user,
     token,
 ):
-    local_md5 = get_checksum(path, hashlib.md5())
     clean_url = dest_url.split(";")[0]
-    storage_api_url = clean_url.replace(
-        ARTIFACTORY_URL + "/", ARTIFACTORY_API_URL + "/storage/", 1
-    )
-
-    pre_upload_md5 = None
     if artifactory_file_exists(clean_url, user, token):
-        pre_upload_md5 = get_md5_from_artifactory(storage_api_url, user, token)
-        print(f"Pre-upload file MD5 (remote): {pre_upload_md5}")
-    else:
-        print(f"File does not yet exist at {clean_url}")
-
-    print(f"Local file MD5:                {local_md5}")
-    content_changed = pre_upload_md5 is None or pre_upload_md5.lower() != local_md5.lower()
-    print(f"Content changed:               {content_changed}")
-
+        print(f"File already exists at {clean_url}; uploading replacement.")
     upload_file_to_artifactory(path, dest_url, user, token)
 
 

--- a/packaging/release/release.py
+++ b/packaging/release/release.py
@@ -18,17 +18,37 @@ import sys
 
 from helpers.release_args import get_args_and_asset
 from helpers.util import (
+    release_debs_to_artifactory,
     release_deb_to_artifactory,
     release_installers_to_s3,
     release_msi_to_s3,
+    release_rpms_to_artifactory,
     release_rpm_to_artifactory,
 )
 
 
 def main():
     args, asset = get_args_and_asset()
+    assets = getattr(args, "assets", [])
 
-    if asset:
+    if len(assets) > 1:
+        print(f"Releasing the following assets to the '{args.stage}' stage:")
+        for asset in assets:
+            print(asset.path)
+
+        if not args.force:
+            resp = input("Continue? [y/N]: ")
+            if resp.lower() not in ("y", "yes"):
+                sys.exit(1)
+
+        component = assets[0].component
+        if component == "deb":
+            release_debs_to_artifactory(assets, args)
+        elif component == "rpm":
+            release_rpms_to_artifactory(assets, args)
+        else:
+            raise AssertionError(f"Batch release is not supported for {component}")
+    elif asset:
         print(f"Releasing the following asset to the '{args.stage}' stage:")
         print(asset.path)
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Improves release timing and verification for RPM/DEB artifacts.

1. Instead of treating a repo metadata checksum change as proof that Artifactory finished indexing the upload, the release script now polls the repo metadata and verifies the expected packages are actually present:

- RPM: reads repodata/repomd.xml, follows the referenced primary metadata, verifies the primary metadata checksum, and checks package name/version/release/arch plus the package checksum published in primary metadata.
- DEB: reads Release, verifies the referenced Packages metadata checksum, and checks package name/version/arch plus the package SHA256 from Packages.

This makes the release step wait on the package index, which is a stronger signal than our current check of "metadata changed at least once."

2. The release jobs now upload the signed package batch first and poll metadata once for the full batch.

- RPM: each arch job uploads both RPMs for that arch, then waits until both are present in that arch’s metadata.
- DEB: the job uploads all signed debs, then waits until all expected debs are present in the deb metadata.

This avoids the old per-package pattern of upload -> wait for metadata change -> upload next package -> wait again, and gives Artifactory one metadata convergence window before verification.
