### PR TITLE
Ubuntu 26.04 support

### DIFF
--- a/.chloggen/support-ubuntu-resolute.yaml
+++ b/.chloggen/support-ubuntu-resolute.yaml
@@ -4,6 +4,6 @@ component: installer
 
 note: Add Ubuntu 26.04 (Resolute) support to the Linux installer and CI coverage.
 
-issues: []
+issues: [7761]
 
 subtext:

--- a/.chloggen/support-ubuntu-resolute.yaml
+++ b/.chloggen/support-ubuntu-resolute.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+
+component: installer
+
+note: Add Ubuntu 26.04 (Resolute) support to the Linux installer and CI coverage.
+
+issues: []
+
+subtext:

--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -5,6 +5,9 @@ self-hosted-runner:
     - ubuntu-24.04-arm-16core
     - otel-windows
     - otel-windows-arm
+    # This is a GitHub-hosted preview runner, not self-hosted. Keep it here
+    # until actionlint's built-in GitHub runner labels catch up.
+    - ubuntu-26.04
 
 # Path-specific configurations.
 paths:

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -122,6 +122,7 @@ jobs:
           - oraclelinux10
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - opensuse16
 
     steps:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -247,7 +247,7 @@ jobs:
     needs: [ "otelcol" ]
     strategy:
       matrix:
-        RUNNER: [ "ubuntu-22.04", "ubuntu-24.04" ]
+        RUNNER: [ "ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04" ]
         PROFILE: [ "integration", "smartagent" ]
       fail-fast: false
     env:

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/README.md
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/README.md
@@ -25,7 +25,7 @@ Currently, the following Linux distributions and versions are supported:
 - Debian: 11, 12, 13
 - Oracle: 9, 10
 - SUSE: 16
-- Ubuntu: 22.04, 24.04
+- Ubuntu: 22.04, 24.04, 26.04
 
 ### Windows
 

--- a/deployments/chef/README.md
+++ b/deployments/chef/README.md
@@ -21,7 +21,7 @@ Currently, the following Linux distributions and versions are supported:
 - Oracle: 8, 9, 10
 - Debian: 11, 12, 13
 - SUSE: 15, 16
-- Ubuntu: 22.04, 24.04
+- Ubuntu: 22.04, 24.04, 26.04
 
 ## Windows
 

--- a/deployments/chef/kitchen.yml
+++ b/deployments/chef/kitchen.yml
@@ -94,7 +94,7 @@ platforms:
   - name: ubuntu-26.04
     driver:
       image: dokken/ubuntu-26.04
-      pid_one_command: /bin/systemd
+      pid_one_command: /usr/lib/systemd/systemd
 
 suites:
   - name: default

--- a/deployments/chef/kitchen.yml
+++ b/deployments/chef/kitchen.yml
@@ -91,6 +91,11 @@ platforms:
       image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd
 
+  - name: ubuntu-26.04
+    driver:
+      image: dokken/ubuntu-26.04
+      pid_one_command: /bin/systemd
+
 suites:
   - name: default
     run_list:

--- a/deployments/salt/README.md
+++ b/deployments/salt/README.md
@@ -13,7 +13,7 @@ Currently, the following Linux distributions and versions are supported:
 - Oracle: 8, 9, 10
 - Debian: 11, 12
 - SUSE: 15, 16
-- Ubuntu: 22.04, 24.04
+- Ubuntu: 22.04, 24.04, 26.04
 
 ## Prerequisites
 

--- a/deployments/salt/splunk-otel-collector/install.sls
+++ b/deployments/salt/splunk-otel-collector/install.sls
@@ -2,6 +2,7 @@
 {% set splunk_repo_base_url = salt['pillar.get']('splunk-otel-collector:repo_base_url', 'https://splunk.jfrog.io/splunk') %}
 {% set package_stage = salt['pillar.get']('splunk-otel-collector:package_stage', 'release') %}
 {% set collector_version = salt['pillar.get']('splunk-otel-collector:collector_version', 'latest') %}
+{% set debian_gpg_key_path = '/etc/apt/keyrings/splunk-otel-collector.gpg' %}
 
 # Repository configuration.
 
@@ -23,14 +24,23 @@ Install setcap via yum package manager:
 
 {% elif os_family == 'Debian' %}
 
+/etc/apt/keyrings:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: '0755'
+
 Add Splunk OpenTelemetry Collector repo to apt source list:
   pkgrepo.managed:
-    - name: deb {{ splunk_repo_base_url }}/otel-collector-deb {{ package_stage }} main
+    - name: deb [signed-by={{ debian_gpg_key_path }}] {{ splunk_repo_base_url }}/otel-collector-deb {{ package_stage }} main
     - file: /etc/apt/sources.list.d/splunk-otel-collector.list
     - key_url: {{ splunk_repo_base_url }}/otel-collector-deb/splunk-B3CD4420.gpg
+    - aptkey: False
     - refresh: True
     - gpgcheck: 1
     - enabled: 1
+    - require:
+      - file: /etc/apt/keyrings
 
 Install apt dependencies for secure transport:
   pkg.latest:

--- a/packaging/installer/install.sh
+++ b/packaging/installer/install.sh
@@ -1226,7 +1226,7 @@ distro_is_supported() {
   case "$distro" in
     ubuntu)
       case "$distro_codename" in
-        bionic|focal|xenial|jammy|noble)
+        bionic|focal|xenial|jammy|noble|resolute)
           return 0
           ;;
       esac

--- a/packaging/tests/deployments/salt/images/Dockerfile.deb
+++ b/packaging/tests/deployments/salt/images/Dockerfile.deb
@@ -7,11 +7,11 @@ ENV SALT_VERSION=latest
 ENV NODE_VERSION=18.20.8
 
 RUN apt-get update && apt-get upgrade -y -o DPkg::Options::=--force-confold
-RUN apt-get install -y ca-certificates wget curl apt-transport-https python3-pip vim systemd procps
+RUN apt-get install -y ca-certificates wget curl apt-transport-https python3-pip vim systemd procps gnupg
 
 RUN mkdir -p /etc/apt/keyrings
-RUN curl -fsSL https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public | tee /etc/apt/keyrings/salt-archive-keyring.pgp
-RUN curl -fsSL https://github.com/saltstack/salt-install-guide/releases/${SALT_VERSION}/download/salt.sources | tee /etc/apt/sources.list.d/salt.sources
+RUN curl -fsSL https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public | gpg --dearmor -o /etc/apt/keyrings/salt-archive-keyring.gpg
+RUN curl -fsSL https://github.com/saltstack/salt-install-guide/releases/${SALT_VERSION}/download/salt.sources | sed 's#/etc/apt/keyrings/salt-archive-keyring.pgp#/etc/apt/keyrings/salt-archive-keyring.gpg#' | tee /etc/apt/sources.list.d/salt.sources
 RUN apt-get update
 RUN apt-get install -y salt-minion
 

--- a/packaging/tests/deployments/salt/images/distro_docker_opts.yaml
+++ b/packaging/tests/deployments/salt/images/distro_docker_opts.yaml
@@ -3,6 +3,7 @@ deb:
   debian-bookworm: ["DISTRO_IMAGE=debian:bookworm"]
   ubuntu-jammy: ["DISTRO_IMAGE=ubuntu:22.04"]
   ubuntu-noble: ["DISTRO_IMAGE=ubuntu:24.04"]
+  ubuntu-resolute: ["DISTRO_IMAGE=ubuntu:26.04"]
 
 rpm:
   amazonlinux-2023: ["DISTRO_IMAGE=amazonlinux:2023"]

--- a/packaging/tests/images/deb/Dockerfile.ubuntu-resolute
+++ b/packaging/tests/images/deb/Dockerfile.ubuntu-resolute
@@ -1,0 +1,24 @@
+# A ubuntu image with systemd enabled.  Must be run with:
+# `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
+FROM ubuntu:resolute
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update &&\
+    apt-get install -yq ca-certificates curl procps systemd wget
+
+ENV container=docker
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
+    "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+RUN systemctl set-default multi-user.target
+ENV init=/lib/systemd/systemd
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+ENTRYPOINT ["/lib/systemd/systemd"]

--- a/packaging/tests/instrumentation/images/deb/Dockerfile.ubuntu-resolute
+++ b/packaging/tests/instrumentation/images/deb/Dockerfile.ubuntu-resolute
@@ -1,0 +1,44 @@
+# A ubuntu image with systemd enabled.  Must be run with:
+# `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
+FROM tomcat:10-jre8 as tomcat
+
+FROM ubuntu:resolute
+
+ARG TARGETARCH
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update &&\
+    apt-get install -yq ca-certificates curl procps python3 systemd wget
+
+ENV container=docker
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
+    "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+COPY --from=tomcat /usr/local/tomcat /usr/local/tomcat
+COPY --from=tomcat /opt/java /opt/java
+COPY instrumentation/setup-tomcat.sh /opt/
+RUN bash /opt/setup-tomcat.sh
+
+ARG NODE_VERSION=v18
+COPY instrumentation/setup-express.sh /opt
+RUN bash /opt/setup-express.sh
+
+COPY instrumentation/setup-dotnet.sh /opt
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+    apt-get update && \
+    apt-get install -yq libicu-dev && \
+    bash /opt/setup-dotnet.sh; \
+    fi
+
+RUN systemctl set-default multi-user.target
+ENV init=/lib/systemd/systemd
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+ENTRYPOINT ["/lib/systemd/systemd"]


### PR DESCRIPTION
**Description:** Added Ubuntu 26.04 (resolute) to all tests and deployment files where 24.04 was supported. Puppet deployment test was modified significantly from the 22.04 version (there is no 24.04 version for some reason) because PuppetLabs does not provide an official package for it for download, so switched to using the version in Ubuntu "universe" repository instead. Other changes in the Dockerfiles are just from package renames.

**Testing:** Tested that the Docker images build, leaving the initial full run for CI. Creating as draft until they pass until I see them pass since issues are expected on initial run.

**Documentation:** Added mention of 26.04 it to README files in this repository where relevant. Documentation external to this repository has not been touched yet.