### PR TITLE
[chore] updates to rpm/deb release

### DIFF
--- a/packaging/release/helpers/util.py
+++ b/packaging/release/helpers/util.py
@@ -20,10 +20,10 @@ import sys
 import tempfile
 import time
 import urllib.parse
-import xml.etree.ElementTree as ET
 
 import boto3
 import requests
+from defusedxml import ElementTree as ET
 
 from .constants import (
     ARTIFACTORY_DEB_REPO_URL,
@@ -93,7 +93,7 @@ def upload_file_to_artifactory(src, dest, user, token):
     print(f"uploading {src} to {dest} ...")
 
     with open(src, "rb") as fd:
-        headers = {"X-Checksum-MD5": get_checksum(src, hashlib.md5())}
+        headers = {"X-Checksum-Sha256": get_checksum(src, hashlib.sha256())}
         resp = requests.put(dest, auth=(user, token), headers=headers, data=fd)
 
         assert resp.status_code == 201, f"upload failed:\n{resp.reason}\n{resp.text}"
@@ -181,6 +181,8 @@ def get_rpm_package_info(asset):
     )
     assert match, f"Failed to get rpm package info from {asset.path}!"
     package_info = match.groupdict()
+    # Artifactory RPM metadata may publish type="sha"; this is metadata comparison, not package trust.
+    # nosemgrep: tools.semgrep.rules.CCF.insecure-hash-algorithm-sha1
     package_info["sha1"] = get_checksum(asset.path, hashlib.sha1())
     package_info["sha256"] = get_checksum(asset.path, hashlib.sha256())
     return package_info

--- a/packaging/release/requirements.txt
+++ b/packaging/release/requirements.txt
@@ -1,4 +1,5 @@
 PyGithub==2.9.1
 boto3==1.43.40
+defusedxml==0.7.1
 docker==7.1.0
 requests==2.34.2


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Use safer XML parsing in the release metadata verifier by switching RPM metadata parsing to defusedxml (flagged by semgrep sast scanning).

Also updates Artifactory uploads to use the currently [documented](https://docs.jfrog.com/artifactory/reference/deployartifact#header-params) `X-Checksum-Sha256` integrity header instead of the legacy MD5 header, and keeps SHA1 metadata comparison only for Artifactory RPM metadata compatibility with a targeted Semgrep suppression.
