### PR TITLE
[chore] Update golang version to resolve govulncheck task failure

### DIFF
--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_VERSION: '3.13'
   PIP_VERSION: '24.2'
   REQUIREMENTS_PATH: "packaging/tests/requirements.txt"
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   cross-compile:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   tidy:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   changelog:

--- a/.github/workflows/dotnet-instr-deployer-add-on.yml
+++ b/.github/workflows/dotnet-instr-deployer-add-on.yml
@@ -23,7 +23,7 @@ on:
         default: '6b4ebe426ca6'
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
   # Provide default values for non-manually triggered executions
   splunk_uf_version: ${{ github.event.inputs.splunk_uf_version || '9.4.0' }}
   splunk_uf_build_hash: ${{ github.event.inputs.splunk_uf_build_hash || '6b4ebe426ca6' }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 jobs:
   otelcol:
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   lint:

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   cross-compile:

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -20,7 +20,7 @@ defaults:
     working-directory: 'deployments/nomad'
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
 

--- a/.github/workflows/otelcol-fips.yml
+++ b/.github/workflows/otelcol-fips.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   otelcol-fips:

--- a/.github/workflows/reusable-build-package.yml
+++ b/.github/workflows/reusable-build-package.yml
@@ -15,7 +15,7 @@ on:
         value: ${{ jobs.build-package.outputs.version }}
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   build-package:

--- a/.github/workflows/reusable-compile.yml
+++ b/.github/workflows/reusable-compile.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   compile:

--- a/.github/workflows/reusable-msi-build.yml
+++ b/.github/workflows/reusable-msi-build.yml
@@ -12,7 +12,7 @@ on:
         value: ${{ jobs.msi-build.outputs.version }}
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   msi-build:

--- a/.github/workflows/reusable-unit-test.yml
+++ b/.github/workflows/reusable-unit-test.yml
@@ -14,7 +14,7 @@ on:
         type: boolean
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   unit-test:

--- a/.github/workflows/ta-v2.yaml
+++ b/.github/workflows/ta-v2.yaml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   ta-v2-build-packages:

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -16,7 +16,7 @@ on:
     - cron: '0 0 * * 1-5' # Every weekday at midnight UTC
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 concurrency:
   group: vuln-scans-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -26,7 +26,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   cross-compile:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 concurrency:
   group: windows-test-${{ github.event.pull_request.number || github.ref }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ variables:
   DRY_RUN:
     value: ""
     description: "Set to 'true' to do a dry-run of most jobs, publishing dev images and test packages when appropriate."
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
   WIN_2019_BASE_IMAGE: mcr.microsoft.com/windows/servercore:ltsc2019
   WIN_2022_BASE_IMAGE: mcr.microsoft.com/windows/servercore:ltsc2022
   SPLUNK_OTELCOL_DOWNLOAD_BASE:

--- a/cmd/otelcol/fips/build/Dockerfile.linux
+++ b/cmd/otelcol/fips/build/Dockerfile.linux
@@ -1,5 +1,5 @@
 ARG DOCKER_REPO=docker.io
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 FROM ${DOCKER_REPO}/golang:${GO_VERSION}
 
 COPY cmd /src/cmd

--- a/cmd/otelcol/fips/build/Dockerfile.windows
+++ b/cmd/otelcol/fips/build/Dockerfile.windows
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 FROM mcr.microsoft.com/oss/go/microsoft/golang:${GO_VERSION}
 
 ARG TARGETARCH

--- a/examples/prometheus-federation/prom-counter/Dockerfile
+++ b/examples/prometheus-federation/prom-counter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-bookworm
+FROM golang:1.26.5-bookworm
 
 WORKDIR /go/src/app
 

--- a/examples/prometheus-federation/prom-counter/go.mod
+++ b/examples/prometheus-federation/prom-counter/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/prometheus-federation/prom-counter
 
-go 1.26.4
+go 1.26.5
 
 require (
 	go.opentelemetry.io/otel v1.0.0-RC1

--- a/examples/splunk-hec-traces/tracing/Dockerfile
+++ b/examples/splunk-hec-traces/tracing/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-bookworm
+FROM golang:1.26.5-bookworm
 
 WORKDIR /go/src/app
 

--- a/examples/splunk-hec-traces/tracing/go.mod
+++ b/examples/splunk-hec-traces/tracing/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/splunk-hec-traces/tracing
 
-go 1.26.4
+go 1.26.5
 
 require (
 	go.opentelemetry.io/otel v1.44.0

--- a/examples/splunk-hec/logging/Dockerfile
+++ b/examples/splunk-hec/logging/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-bookworm
+FROM golang:1.26.5-bookworm
 
 WORKDIR /go/src/app
 

--- a/examples/splunk-hec/logging/go.mod
+++ b/examples/splunk-hec/logging/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/examples/splunk-hec/logging
 
-go 1.26.4
+go 1.26.5
 
 require go.uber.org/zap v1.28.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4

--- a/internal/signalfx-agent/go.mod
+++ b/internal/signalfx-agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/signalfx-agent
 
-go 1.26.4
+go 1.26.5
 
 replace (
 	code.cloudfoundry.org/go-loggregator => github.com/signalfx/go-loggregator v1.0.1-0.20200205155641-5ba5ca92118d

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/internal/tools
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/packaging/dotnet-instr-deployer-add-on/go.mod
+++ b/packaging/dotnet-instr-deployer-add-on/go.mod
@@ -1,6 +1,6 @@
 module github.com/splunk/splunk_otel_dotnet_deployer
 
-go 1.26.4
+go 1.26.5
 
 require github.com/signalfx/splunk-otel-collector v0.0.0
 

--- a/packaging/ta-v2/tests/go.mod
+++ b/packaging/ta-v2/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/packaging/ta-v2/tests
 
-go 1.26.4
+go 1.26.5
 
 require github.com/stretchr/testify v1.11.1
 

--- a/pkg/extension/smartagentextension/go.mod
+++ b/pkg/extension/smartagentextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657

--- a/pkg/processor/timestampprocessor/go.mod
+++ b/pkg/processor/timestampprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocessor
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/receiver/smartagentreceiver/go.mod
+++ b/pkg/receiver/smartagentreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.156.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/tests
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/containerd/platforms v0.2.1

--- a/tests/receivers/smartagent/telegraf-exec/testdata/exec/Dockerfile
+++ b/tests/receivers/smartagent/telegraf-exec/testdata/exec/Dockerfile
@@ -1,6 +1,6 @@
 ARG SPLUNK_OTEL_COLLECTOR_IMAGE
 
-FROM golang:1.26.4 AS golang
+FROM golang:1.26.5 AS golang
 ARG IMAGE_PLATFORM
 COPY telegraf-exec.go /opt/telegraf-exec.go
 RUN cd /opt && go mod init telegraf-exec && go mod tidy && \

--- a/tests/tools/go.mod
+++ b/tests/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/splunk-otel-collector/tests/tools
 
-go 1.26.4
+go 1.26.5
 
 require github.com/Songmu/gotesplit v0.3.1
 


### PR DESCRIPTION
**Description:** Bumps Go from 1.26.4 to 1.26.5 to pick up upstream security fixes reported by govulncheck, including GO-2026-5856 in crypto/tls and GO-2026-4970 in os.
Updates the Go version across module directives and CI/build configuration so local and CI builds use the patched toolchain consistently.
Validated with govulncheck and relevant build/test workflow checks.

**Link to Splunk idea:** 7763

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
