### PR TITLE
Add private Unified Collector components

### DIFF
--- a/.chloggen/add-private-unified-collector-components.yaml
+++ b/.chloggen/add-private-unified-collector-components.yaml
@@ -1,0 +1,9 @@
+change_type: new_component
+
+component: s2s exporter and wineventlog receiver
+
+note: Add the private Unified Collector components to the Splunk distribution.
+
+issues: [7674]
+
+subtext:

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -2,11 +2,8 @@ name: 'setup environment'
 description: 'setup go environment'
 
 inputs:
-  private-modules-user:
-    description: 'GitLab deploy-token username with read access to private Go module repositories'
-    required: true
   private-modules-token:
-    description: 'GitLab deploy token with read access to private Go module repositories'
+    description: 'GitHub token with read access to private Go module repositories'
     required: true
 
 runs:
@@ -15,16 +12,15 @@ runs:
     - name: Configure private Go module access
       shell: bash
       env:
-        PRIVATE_MODULES_USER: ${{ inputs.private-modules-user }}
         PRIVATE_MODULES_TOKEN: ${{ inputs.private-modules-token }}
       run: |
-        if [ -z "$PRIVATE_MODULES_USER" ] || [ -z "$PRIVATE_MODULES_TOKEN" ]; then
-          echo "private-modules-user and private-modules-token are required to fetch private Go modules" >&2
+        if [ -z "$PRIVATE_MODULES_TOKEN" ]; then
+          echo "private-modules-token is required to fetch private Go modules" >&2
           exit 1
         fi
-        git config --global url."https://${PRIVATE_MODULES_USER}:${PRIVATE_MODULES_TOKEN}@cd.splunkdev.com/".insteadOf "https://cd.splunkdev.com/"
-        echo "GOPRIVATE=cd.splunkdev.com/gdi/unified-collector" >> "$GITHUB_ENV"
-        echo "GONOSUMDB=cd.splunkdev.com/gdi/unified-collector" >> "$GITHUB_ENV"
+        git config --global url."https://x-access-token:${PRIVATE_MODULES_TOKEN}@github.com/".insteadOf "https://github.com/"
+        echo "GOPRIVATE=github.com/signalfx/splunk-otel-collector-components" >> "$GITHUB_ENV"
+        echo "GONOSUMDB=github.com/signalfx/splunk-otel-collector-components" >> "$GITHUB_ENV"
 
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,9 +1,31 @@
 name: 'setup environment'
 description: 'setup go environment'
 
+inputs:
+  private-modules-user:
+    description: 'GitLab deploy-token username with read access to private Go module repositories'
+    required: true
+  private-modules-token:
+    description: 'GitLab deploy token with read access to private Go module repositories'
+    required: true
+
 runs:
   using: "composite"
   steps:
+    - name: Configure private Go module access
+      shell: bash
+      env:
+        PRIVATE_MODULES_USER: ${{ inputs.private-modules-user }}
+        PRIVATE_MODULES_TOKEN: ${{ inputs.private-modules-token }}
+      run: |
+        if [ -z "$PRIVATE_MODULES_USER" ] || [ -z "$PRIVATE_MODULES_TOKEN" ]; then
+          echo "private-modules-user and private-modules-token are required to fetch private Go modules" >&2
+          exit 1
+        fi
+        git config --global url."https://${PRIVATE_MODULES_USER}:${PRIVATE_MODULES_TOKEN}@cd.splunkdev.com/".insteadOf "https://cd.splunkdev.com/"
+        echo "GOPRIVATE=cd.splunkdev.com/gdi/unified-collector" >> "$GITHUB_ENV"
+        echo "GONOSUMDB=cd.splunkdev.com/gdi/unified-collector" >> "$GITHUB_ENV"
+
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
       with:

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -35,6 +35,7 @@ jobs:
       matrix:
         SYS_BINARIES: [ "binaries-linux_amd64", "binaries-windows_amd64" ]
     uses: ./.github/workflows/reusable-compile.yml
+    secrets: inherit
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
 

--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -31,6 +31,7 @@ jobs:
       matrix:
         SYS_BINARIES: [ "binaries-linux_amd64", "binaries-linux_arm64" ]
     uses: ./.github/workflows/reusable-compile.yml
+    secrets: inherit
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
-          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: tidy
@@ -40,7 +39,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
-          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: gofmt
@@ -58,7 +56,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
-          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: generate-metrics
@@ -91,7 +88,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
-          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - run: echo "GOLANGCI_LINT_CACHE=${HOME}/.cache/golangci-lint" >> "$GITHUB_ENV"
@@ -141,7 +137,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
-          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Free up disk space for next step
@@ -176,7 +171,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
-          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: dockerd test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: tidy
         run: |
@@ -36,6 +39,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: gofmt
         run: |
@@ -51,6 +57,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: generate-metrics
         run: |
@@ -81,6 +90,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - run: echo "GOLANGCI_LINT_CACHE=${HOME}/.cache/golangci-lint" >> "$GITHUB_ENV"
 
@@ -128,6 +140,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Free up disk space for next step
         run: .github/workflows/scripts/free-disk-space.sh
@@ -150,6 +165,7 @@ jobs:
       matrix:
         SYS_BINARIES: [ "binaries-darwin_amd64", "binaries-darwin_arm64", "binaries-linux_amd64", "binaries-linux_arm64", "binaries-windows_amd64", "binaries-windows_arm64", "binaries-linux_ppc64le" ]
     uses: ./.github/workflows/reusable-compile.yml
+    secrets: inherit
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
 
@@ -159,6 +175,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: dockerd test
         working-directory: ./internal/signalfx-agent/pkg/monitors/docker

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -35,6 +35,7 @@ jobs:
       matrix:
         SYS_BINARIES: [ "binaries-linux_amd64", "binaries-windows_amd64" ]
     uses: ./.github/workflows/reusable-compile.yml
+    secrets: inherit
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
 

--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
-          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Lint

--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Lint
         run: |

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         SYS_BINARIES: [ "binaries-linux_amd64", "binaries-linux_arm64", "binaries-linux_ppc64le" ]
     uses: ./.github/workflows/reusable-compile.yml
+    secrets: inherit
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
 

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -39,6 +39,9 @@ jobs:
 
       - name: Set up environment
         uses: ./.github/actions/setup-environment
+        with:
+          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build Docker image from local changes
         run: |

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-environment
         with:
-          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build Docker image from local changes

--- a/.github/workflows/otelcol-fips.yml
+++ b/.github/workflows/otelcol-fips.yml
@@ -56,7 +56,6 @@ jobs:
         env:
           GOOS: ${{ matrix.GOOS }}
           GOARCH: ${{ matrix.GOARCH }}
-          OTELCOL_PRIVATE_MODULES_USER: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           OTELCOL_PRIVATE_MODULES_TOKEN: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/otelcol-fips.yml
+++ b/.github/workflows/otelcol-fips.yml
@@ -56,6 +56,8 @@ jobs:
         env:
           GOOS: ${{ matrix.GOOS }}
           GOARCH: ${{ matrix.GOARCH }}
+          OTELCOL_PRIVATE_MODULES_USER: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          OTELCOL_PRIVATE_MODULES_TOKEN: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: otelcol-fips-${{ matrix.GOOS }}-${{ matrix.GOARCH }}

--- a/.github/workflows/puppet-test.yml
+++ b/.github/workflows/puppet-test.yml
@@ -84,6 +84,7 @@ jobs:
   # Build Linux binary for package building
   puppet-build-linux-binary:
     uses: ./.github/workflows/reusable-compile.yml
+    secrets: inherit
     with:
       SYS_BINARY: binaries-linux_amd64
 
@@ -215,6 +216,7 @@ jobs:
   # Use existing reusable workflows for building Windows artifacts
   puppet-build-windows-binary:
     uses: ./.github/workflows/reusable-compile.yml
+    secrets: inherit
     with:
       SYS_BINARY: binaries-windows_amd64
 

--- a/.github/workflows/reusable-compile.yml
+++ b/.github/workflows/reusable-compile.yml
@@ -3,8 +3,6 @@ name: compile
 on:
   workflow_call:
     secrets:
-      OTELCOL_PRIVATE_MODULES_USER:
-        required: true
       OTELCOL_PRIVATE_MODULES_TOKEN:
         required: true
     inputs:
@@ -23,7 +21,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
-          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build Collector

--- a/.github/workflows/reusable-compile.yml
+++ b/.github/workflows/reusable-compile.yml
@@ -2,6 +2,11 @@ name: compile
 
 on:
   workflow_call:
+    secrets:
+      OTELCOL_PRIVATE_MODULES_USER:
+        required: true
+      OTELCOL_PRIVATE_MODULES_TOKEN:
+        required: true
     inputs:
       SYS_BINARY:
         required: true
@@ -17,6 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build Collector
         run: |

--- a/.github/workflows/reusable-unit-test.yml
+++ b/.github/workflows/reusable-unit-test.yml
@@ -2,6 +2,13 @@ name: unit-test
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+      OTELCOL_PRIVATE_MODULES_USER:
+        required: true
+      OTELCOL_PRIVATE_MODULES_TOKEN:
+        required: true
     inputs:
       OS:
         required: true
@@ -25,6 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Set CGO_ENABLED
         # Currently, CGO enabled is required for:

--- a/.github/workflows/reusable-unit-test.yml
+++ b/.github/workflows/reusable-unit-test.yml
@@ -5,8 +5,6 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: false
-      OTELCOL_PRIVATE_MODULES_USER:
-        required: true
       OTELCOL_PRIVATE_MODULES_TOKEN:
         required: true
     inputs:
@@ -33,7 +31,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
-          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Set CGO_ENABLED

--- a/.github/workflows/ta-v2.yaml
+++ b/.github/workflows/ta-v2.yaml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
+        with:
+          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build collector binaries (linux & windows)
         run: |
@@ -432,4 +435,3 @@ jobs:
           $splunkdLog = "${Env:ProgramFiles}\SplunkUniversalForwarder\var\log\splunk\splunkd.log"
           Write-Host "`n======= splunkd.log contents ======="
           Get-Content $splunkdLog -ErrorAction SilentlyContinue
-

--- a/.github/workflows/ta-v2.yaml
+++ b/.github/workflows/ta-v2.yaml
@@ -37,7 +37,6 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:
-          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build collector binaries (linux & windows)

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -51,10 +51,15 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up environment
         uses: ./.github/actions/setup-environment
+        with:
+          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
       - run: |
           make docker-otelcol ARCH=${{ matrix.ARCH }} FIPS="${{ matrix.FIPS }}"
         env:
           DOCKER_BUILDKIT: '1'
+          OTELCOL_PRIVATE_MODULES_USER: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          OTELCOL_PRIVATE_MODULES_TOKEN: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
       - run: mkdir -p dist && docker save -o dist/image.tar otelcol${{ matrix.FIPS == true && '-fips' || '' }}:latest
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -67,6 +72,7 @@ jobs:
       matrix:
         SYS_BINARIES: [ "binaries-windows_amd64" ]
     uses: ./.github/workflows/reusable-compile.yml
+    secrets: inherit
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
 
@@ -234,6 +240,9 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
+        with:
+          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Echo `govulncheck` version
         continue-on-error: true

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -52,13 +52,11 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-environment
         with:
-          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
       - run: |
           make docker-otelcol ARCH=${{ matrix.ARCH }} FIPS="${{ matrix.FIPS }}"
         env:
           DOCKER_BUILDKIT: '1'
-          OTELCOL_PRIVATE_MODULES_USER: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           OTELCOL_PRIVATE_MODULES_TOKEN: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
       - run: mkdir -p dist && docker save -o dist/image.tar otelcol${{ matrix.FIPS == true && '-fips' || '' }}:latest
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -241,7 +239,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
         with:
-          private-modules-user: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Echo `govulncheck` version

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -34,6 +34,7 @@ jobs:
       matrix:
         SYS_BINARIES: [ "binaries-windows_amd64", "binaries-windows_arm64" ]
     uses: ./.github/workflows/reusable-compile.yml
+    secrets: inherit
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
 

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -29,6 +29,19 @@ jobs:
           $ErrorActionPreference = 'Continue'
           & ${{ github.workspace }}\.github\workflows\scripts\win-required-ports.ps1
 
+      - name: Configure private Go module access
+        env:
+          PRIVATE_MODULES_USER: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
+          PRIVATE_MODULES_TOKEN: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not $env:PRIVATE_MODULES_USER -or -not $env:PRIVATE_MODULES_TOKEN) {
+            throw "OTELCOL_PRIVATE_MODULES_USER and OTELCOL_PRIVATE_MODULES_TOKEN are required to fetch private Go modules"
+          }
+          git config --global url."https://$($env:PRIVATE_MODULES_USER):$($env:PRIVATE_MODULES_TOKEN)@cd.splunkdev.com/".insteadOf "https://cd.splunkdev.com/"
+          "GOPRIVATE=cd.splunkdev.com/gdi/unified-collector" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "GONOSUMDB=cd.splunkdev.com/gdi/unified-collector" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -31,16 +31,15 @@ jobs:
 
       - name: Configure private Go module access
         env:
-          PRIVATE_MODULES_USER: ${{ secrets.OTELCOL_PRIVATE_MODULES_USER }}
           PRIVATE_MODULES_TOKEN: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
         run: |
           $ErrorActionPreference = 'Stop'
-          if (-not $env:PRIVATE_MODULES_USER -or -not $env:PRIVATE_MODULES_TOKEN) {
-            throw "OTELCOL_PRIVATE_MODULES_USER and OTELCOL_PRIVATE_MODULES_TOKEN are required to fetch private Go modules"
+          if (-not $env:PRIVATE_MODULES_TOKEN) {
+            throw "OTELCOL_PRIVATE_MODULES_TOKEN is required to fetch private Go modules"
           }
-          git config --global url."https://$($env:PRIVATE_MODULES_USER):$($env:PRIVATE_MODULES_TOKEN)@cd.splunkdev.com/".insteadOf "https://cd.splunkdev.com/"
-          "GOPRIVATE=cd.splunkdev.com/gdi/unified-collector" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "GONOSUMDB=cd.splunkdev.com/gdi/unified-collector" | Out-File -FilePath $env:GITHUB_ENV -Append
+          git config --global url."https://x-access-token:$($env:PRIVATE_MODULES_TOKEN)@github.com/".insteadOf "https://github.com/"
+          "GOPRIVATE=github.com/signalfx/splunk-otel-collector-components" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "GONOSUMDB=github.com/signalfx/splunk-otel-collector-components" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6

--- a/Makefile
+++ b/Makefile
@@ -53,22 +53,19 @@ DOCKER_REPO?=docker.io
 GOTESPLIT_TOTAL?=1
 GOTESPLIT_INDEX?=0
 
-PRIVATE_MODULES?=cd.splunkdev.com/gdi/unified-collector
-PRIVATE_MODULES_USER_FILE?=/run/secrets/private_modules_user
+PRIVATE_MODULES?=github.com/signalfx/splunk-otel-collector-components
 PRIVATE_MODULES_TOKEN_FILE?=/run/secrets/private_modules_token
 WITH_PRIVATE_MODULES = \
-	private_modules_user_file="$(PRIVATE_MODULES_USER_FILE)"; \
 	private_modules_token_file="$(PRIVATE_MODULES_TOKEN_FILE)"; \
-	if [ -s "$$private_modules_user_file" ] && [ -s "$$private_modules_token_file" ]; then \
-		private_modules_user="$$(cat "$$private_modules_user_file")"; \
+	if [ -s "$$private_modules_token_file" ]; then \
 		private_modules_token="$$(cat "$$private_modules_token_file")"; \
 		export GOPRIVATE="$${GOPRIVATE:-$(PRIVATE_MODULES)}"; \
 		export GONOSUMDB="$${GONOSUMDB:-$(PRIVATE_MODULES)}"; \
 		export GIT_CONFIG_COUNT=1; \
-		export GIT_CONFIG_KEY_0="url.https://$${private_modules_user}:$${private_modules_token}@cd.splunkdev.com/.insteadOf"; \
-		export GIT_CONFIG_VALUE_0="https://cd.splunkdev.com/"; \
+		export GIT_CONFIG_KEY_0="url.https://x-access-token:$${private_modules_token}@github.com/.insteadOf"; \
+		export GIT_CONFIG_VALUE_0="https://github.com/"; \
 	elif [ "$${OTELCOL_REQUIRE_PRIVATE_MODULES_TOKEN:-false}" = "true" ]; then \
-		echo "private_modules_user and private_modules_token BuildKit secrets are required to fetch private Go modules" >&2; \
+		echo "private_modules_token BuildKit secret is required to fetch private Go modules" >&2; \
 		exit 1; \
 	fi;
 
@@ -374,7 +371,6 @@ endif
 	docker buildx build --pull \
 		--tag otelcol-fips-builder-$(GOOS)-$(GOARCH) \
 		--platform linux/$(GOARCH) \
-		--secret id=private_modules_user,env=OTELCOL_PRIVATE_MODULES_USER \
 		--secret id=private_modules_token,env=OTELCOL_PRIVATE_MODULES_TOKEN \
 		--build-arg DOCKER_REPO=$(DOCKER_REPO) \
 		--build-arg BUILD_INFO='$(BUILD_INFO)' \

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,25 @@ DOCKER_REPO?=docker.io
 GOTESPLIT_TOTAL?=1
 GOTESPLIT_INDEX?=0
 
+PRIVATE_MODULES?=cd.splunkdev.com/gdi/unified-collector
+PRIVATE_MODULES_USER_FILE?=/run/secrets/private_modules_user
+PRIVATE_MODULES_TOKEN_FILE?=/run/secrets/private_modules_token
+WITH_PRIVATE_MODULES = \
+	private_modules_user_file="$(PRIVATE_MODULES_USER_FILE)"; \
+	private_modules_token_file="$(PRIVATE_MODULES_TOKEN_FILE)"; \
+	if [ -s "$$private_modules_user_file" ] && [ -s "$$private_modules_token_file" ]; then \
+		private_modules_user="$$(cat "$$private_modules_user_file")"; \
+		private_modules_token="$$(cat "$$private_modules_token_file")"; \
+		export GOPRIVATE="$${GOPRIVATE:-$(PRIVATE_MODULES)}"; \
+		export GONOSUMDB="$${GONOSUMDB:-$(PRIVATE_MODULES)}"; \
+		export GIT_CONFIG_COUNT=1; \
+		export GIT_CONFIG_KEY_0="url.https://$${private_modules_user}:$${private_modules_token}@cd.splunkdev.com/.insteadOf"; \
+		export GIT_CONFIG_VALUE_0="https://cd.splunkdev.com/"; \
+	elif [ "$${OTELCOL_REQUIRE_PRIVATE_MODULES_TOKEN:-false}" = "true" ]; then \
+		echo "private_modules_user and private_modules_token BuildKit secrets are required to fetch private Go modules" >&2; \
+		exit 1; \
+	fi;
+
 ### TARGETS
 
 .DEFAULT_GOAL := all
@@ -257,11 +276,11 @@ generate-metrics:
 
 .PHONY: otelcol
 otelcol:
-	go generate ./...
+	@$(WITH_PRIVATE_MODULES) go generate ./...
 ifeq ($(COVER_TESTING), true)
-	GO111MODULE=on CGO_ENABLED=$(CGO_ENABLED) go build $(COVER_OPTS) -trimpath -o ./bin/otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) $(BUILD_INFO) ./cmd/otelcol
+	@$(WITH_PRIVATE_MODULES) GO111MODULE=on CGO_ENABLED=$(CGO_ENABLED) go build $(COVER_OPTS) -trimpath -o ./bin/otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) $(BUILD_INFO) ./cmd/otelcol
 else
-	GO111MODULE=on CGO_ENABLED=$(CGO_ENABLED) go build -trimpath -o ./bin/otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) $(BUILD_INFO) ./cmd/otelcol
+	@$(WITH_PRIVATE_MODULES) GO111MODULE=on CGO_ENABLED=$(CGO_ENABLED) go build -trimpath -o ./bin/otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) $(BUILD_INFO) ./cmd/otelcol
 endif
 ifeq ($(OS), Windows_NT)
 	$(LINK_CMD) .\bin\otelcol$(EXTENSION) .\bin\otelcol_$(GOOS)_$(GOARCH)$(EXTENSION)
@@ -355,6 +374,8 @@ endif
 	docker buildx build --pull \
 		--tag otelcol-fips-builder-$(GOOS)-$(GOARCH) \
 		--platform linux/$(GOARCH) \
+		--secret id=private_modules_user,env=OTELCOL_PRIVATE_MODULES_USER \
+		--secret id=private_modules_token,env=OTELCOL_PRIVATE_MODULES_TOKEN \
 		--build-arg DOCKER_REPO=$(DOCKER_REPO) \
 		--build-arg BUILD_INFO='$(BUILD_INFO)' \
 		--file cmd/otelcol/fips/build/Dockerfile.$(GOOS) ./

--- a/cmd/otelcol/fips/build/Dockerfile.linux
+++ b/cmd/otelcol/fips/build/Dockerfile.linux
@@ -21,6 +21,5 @@ ENV OTELCOL_REQUIRE_PRIVATE_MODULES_TOKEN=true
 
 WORKDIR /src
 RUN --mount=type=cache,target=${GOMODCACHE} \
-    --mount=type=secret,id=private_modules_user \
     --mount=type=secret,id=private_modules_token \
     make otelcol BUILD_INFO="${BUILD_INFO}"

--- a/cmd/otelcol/fips/build/Dockerfile.linux
+++ b/cmd/otelcol/fips/build/Dockerfile.linux
@@ -17,6 +17,10 @@ ENV GOOS=linux
 ENV GOARCH=${TARGETARCH}
 ENV GOFLAGS="-tags=requirefips"
 ENV GOMODCACHE=/go/pkg/mod
+ENV OTELCOL_REQUIRE_PRIVATE_MODULES_TOKEN=true
 
 WORKDIR /src
-RUN --mount=type=cache,target=${GOMODCACHE} make otelcol BUILD_INFO="${BUILD_INFO}"
+RUN --mount=type=cache,target=${GOMODCACHE} \
+    --mount=type=secret,id=private_modules_user \
+    --mount=type=secret,id=private_modules_token \
+    make otelcol BUILD_INFO="${BUILD_INFO}"

--- a/cmd/otelcol/fips/build/Dockerfile.windows
+++ b/cmd/otelcol/fips/build/Dockerfile.windows
@@ -19,6 +19,10 @@ ENV GOMODCACHE=/go/pkg/mod
 ENV GOFLAGS="-tags=requirefips"
 ENV GOEXPERIMENT=systemcrypto
 ENV EXTENSION=.exe
+ENV OTELCOL_REQUIRE_PRIVATE_MODULES_TOKEN=true
 
 WORKDIR /src
-RUN --mount=type=cache,target=${GOMODCACHE} make otelcol BUILD_INFO="${BUILD_INFO}"
+RUN --mount=type=cache,target=${GOMODCACHE} \
+    --mount=type=secret,id=private_modules_user \
+    --mount=type=secret,id=private_modules_token \
+    make otelcol BUILD_INFO="${BUILD_INFO}"

--- a/cmd/otelcol/fips/build/Dockerfile.windows
+++ b/cmd/otelcol/fips/build/Dockerfile.windows
@@ -23,6 +23,5 @@ ENV OTELCOL_REQUIRE_PRIVATE_MODULES_TOKEN=true
 
 WORKDIR /src
 RUN --mount=type=cache,target=${GOMODCACHE} \
-    --mount=type=secret,id=private_modules_user \
     --mount=type=secret,id=private_modules_token \
     make otelcol BUILD_INFO="${BUILD_INFO}"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/signalfx/splunk-otel-collector
 go 1.26.4
 
 require (
+	cd.splunkdev.com/gdi/unified-collector/exporter/s2sexporter v0.1.0
+	cd.splunkdev.com/gdi/unified-collector/receiver/wineventlogreceiver v0.1.0
 	github.com/alecthomas/participle/v2 v2.1.4
 	github.com/antonmedv/expr v1.15.5
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module github.com/signalfx/splunk-otel-collector
 go 1.26.4
 
 require (
-	cd.splunkdev.com/gdi/unified-collector/exporter/s2sexporter v0.1.0
-	cd.splunkdev.com/gdi/unified-collector/receiver/wineventlogreceiver v0.1.0
 	github.com/alecthomas/participle/v2 v2.1.4
 	github.com/antonmedv/expr v1.15.5
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -143,6 +141,8 @@ require (
 	github.com/prometheus/common v0.69.0
 	github.com/prometheus/prometheus v0.312.0
 	github.com/shirou/gopsutil/v4 v4.26.5
+	github.com/signalfx/splunk-otel-collector-components/exporter/s2sexporter v0.0.0-20260707233042-6c1972e556bf
+	github.com/signalfx/splunk-otel-collector-components/receiver/wineventlogreceiver v0.0.0-20260707233042-6c1972e556bf
 	github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension v0.83.0
 	github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocessor v0.0.0-00010101000000-000000000000
 	github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+cd.splunkdev.com/gdi/unified-collector/exporter/s2sexporter v0.1.0 h1:6R3ulM1X6ntpaFKF6Gpm8arymYA44jEhyfUV8BBO7yA=
+cd.splunkdev.com/gdi/unified-collector/exporter/s2sexporter v0.1.0/go.mod h1:gxV/UkJo7xUnBBD2BWu7rUaO057ePZ7AXpPn4BFkods=
+cd.splunkdev.com/gdi/unified-collector/receiver/wineventlogreceiver v0.1.0 h1:1Cwvp8kAw/ViL57eGIepB07/bmSXBVnbebt0M1tVni4=
+cd.splunkdev.com/gdi/unified-collector/receiver/wineventlogreceiver v0.1.0/go.mod h1:ovzL9eo45NRBhGI8uAMpOqwvh3Eoy8h4S+CONdhPyCU=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-cd.splunkdev.com/gdi/unified-collector/exporter/s2sexporter v0.1.0 h1:6R3ulM1X6ntpaFKF6Gpm8arymYA44jEhyfUV8BBO7yA=
-cd.splunkdev.com/gdi/unified-collector/exporter/s2sexporter v0.1.0/go.mod h1:gxV/UkJo7xUnBBD2BWu7rUaO057ePZ7AXpPn4BFkods=
-cd.splunkdev.com/gdi/unified-collector/receiver/wineventlogreceiver v0.1.0 h1:1Cwvp8kAw/ViL57eGIepB07/bmSXBVnbebt0M1tVni4=
-cd.splunkdev.com/gdi/unified-collector/receiver/wineventlogreceiver v0.1.0/go.mod h1:ovzL9eo45NRBhGI8uAMpOqwvh3Eoy8h4S+CONdhPyCU=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -1894,6 +1890,10 @@ github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083 h1:WsShHmu12Z
 github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083/go.mod h1:adPDS6s7WaajdFBV9mQ7i0dKfQ8xiDnF9ZNETVPpp7c=
 github.com/signalfx/golib/v3 v3.5.0 h1:QkhT8P/iMkTRg7Zec+w8iLEQzzCEIfHHz/A4NJgLQyg=
 github.com/signalfx/golib/v3 v3.5.0/go.mod h1:yze2t+zCjUjUdtSPEmCyg2UDU7jCyIqJV++eprc9OeE=
+github.com/signalfx/splunk-otel-collector-components/exporter/s2sexporter v0.0.0-20260707233042-6c1972e556bf h1:8HR+60PWhiqqJfV5loFZwGcv2u9KsVEgCx9bvnCJWVg=
+github.com/signalfx/splunk-otel-collector-components/exporter/s2sexporter v0.0.0-20260707233042-6c1972e556bf/go.mod h1:06K3scrLdaIXcX0nQFVt16SR3vHjrO1IAS2+AMy+Xyw=
+github.com/signalfx/splunk-otel-collector-components/receiver/wineventlogreceiver v0.0.0-20260707233042-6c1972e556bf h1:SX6MSHpXYAKly/mNQ9MpssuHmDeScjLnqi0mYtxQoi8=
+github.com/signalfx/splunk-otel-collector-components/receiver/wineventlogreceiver v0.0.0-20260707233042-6c1972e556bf/go.mod h1:it62YG8OzCbWpN8giquV4U1sMziwAouw7m8gPQhHF/Y=
 github.com/signalfx/telegraf v0.10.2-0.20250228233359-931557f78bed h1:UnMojeBM2skhiZm8Iol3RBQpUHWvAkt993NxWhiV/70=
 github.com/signalfx/telegraf v0.10.2-0.20250228233359-931557f78bed/go.mod h1:1gnMOcwGO3lAxfoMq28M8gjooF2MqVwquPVEvgZ1its=
 github.com/sijms/go-ora/v2 v2.9.0 h1:+iQbUeTeCOFMb5BsOMgUhV8KWyrv9yjKpcK4x7+MFrg=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -160,6 +160,9 @@ import (
 	"github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension"
 	"github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocessor"
 	"github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver"
+
+	"cd.splunkdev.com/gdi/unified-collector/exporter/s2sexporter"
+	"cd.splunkdev.com/gdi/unified-collector/receiver/wineventlogreceiver"
 )
 
 func Get() (otelcol.Factories, error) {
@@ -266,6 +269,7 @@ func Get() (otelcol.Factories, error) {
 		udplogreceiver.NewFactory(),
 		vcenterreceiver.NewFactory(),
 		wavefrontreceiver.NewFactory(),
+		wineventlogreceiver.NewFactory(),
 		windowseventlogreceiver.NewFactory(),
 		windowsperfcountersreceiver.NewFactory(),
 		windowsservicereceiver.NewFactory(),
@@ -289,6 +293,7 @@ func Get() (otelcol.Factories, error) {
 		otlphttpexporter.NewFactory(),
 		prometheusremotewriteexporter.NewFactory(),
 		pulsarexporter.NewFactory(),
+		s2sexporter.NewFactory(),
 		signalfxexporter.NewFactory(),
 		splunkhecexporter.NewFactory(),
 	)

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -161,8 +161,8 @@ import (
 	"github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocessor"
 	"github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver"
 
-	"cd.splunkdev.com/gdi/unified-collector/exporter/s2sexporter"
-	"cd.splunkdev.com/gdi/unified-collector/receiver/wineventlogreceiver"
+	"github.com/signalfx/splunk-otel-collector-components/exporter/s2sexporter"
+	"github.com/signalfx/splunk-otel-collector-components/receiver/wineventlogreceiver"
 )
 
 func Get() (otelcol.Factories, error) {

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -128,6 +128,7 @@ func TestDefaultComponents(t *testing.T) {
 		"windows_event_log",
 		"windowsperfcounters",
 		"windows_service",
+		"wineventlog",
 		"yang_grpc",
 		"zipkin",
 		"zookeeper",
@@ -197,6 +198,7 @@ func TestDefaultComponents(t *testing.T) {
 		"otlp_http",
 		"prometheus_remote_write",
 		"pulsar",
+		"s2s",
 		"signalfx",
 		"splunk_hec",
 	}


### PR DESCRIPTION
Adds the private Unified Collector S2S exporter and Windows Event Log receiver to the distribution. Updates GitHub Actions and FIPS/Docker builds to authenticate to the GitLab-hosted modules using deploy-token credentials.
