### PR TITLE
Add OpAMP forwarder access token header

### DIFF
--- a/.chloggen/otl-4437-opamp-forwarder-token.yaml
+++ b/.chloggen/otl-4437-opamp-forwarder-token.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: config
+note: Add the Splunk access token header to the default OpAMP HTTP forwarder egress config.
+issues: [4437]
+subtext:

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -30,11 +30,11 @@ extensions:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
     egress:
       endpoint: "${SPLUNK_INGEST_URL}"
+      # Use instead when sending to gateway
+      #endpoint: "${SPLUNK_GATEWAY_URL}:4320"
       # Remove this header to use a token passed by the caller instead.
       headers:
         X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
-      # Use instead when sending to gateway
-      #endpoint: "${SPLUNK_GATEWAY_URL}:4320"
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -30,6 +30,9 @@ extensions:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
     egress:
       endpoint: "${SPLUNK_INGEST_URL}"
+      # Remove this header to use a token passed by the caller instead.
+      headers:
+        X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
       # Use instead when sending to gateway
       #endpoint: "${SPLUNK_GATEWAY_URL}:4320"
   # opamp/splunk_o11y is included in the default config, but startup removes it

--- a/cmd/otelcol/config/collector/ecs_ec2_config.yaml
+++ b/cmd/otelcol/config/collector/ecs_ec2_config.yaml
@@ -24,6 +24,9 @@ extensions:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
     egress:
       endpoint: "${SPLUNK_INGEST_URL}"
+      # Remove this header to use a token passed by the caller instead.
+      headers:
+        X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:

--- a/cmd/otelcol/config/collector/fargate_config.yaml
+++ b/cmd/otelcol/config/collector/fargate_config.yaml
@@ -19,6 +19,9 @@ extensions:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
     egress:
       endpoint: "${SPLUNK_INGEST_URL}"
+      # Remove this header to use a token passed by the caller instead.
+      headers:
+        X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:

--- a/cmd/otelcol/config/collector/full_config_linux.yaml
+++ b/cmd/otelcol/config/collector/full_config_linux.yaml
@@ -689,6 +689,9 @@ extensions:
       endpoint: 0.0.0.0:4320
     egress:
       endpoint: "https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com"
+      # Remove this header to use a token passed by the caller instead.
+      headers:
+        X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
 
   # Enables the host observer extension
   # Full configuration here: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/hostobserver

--- a/cmd/otelcol/config/collector/gateway_config.yaml
+++ b/cmd/otelcol/config/collector/gateway_config.yaml
@@ -28,6 +28,9 @@ extensions:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
     egress:
       endpoint: "https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com"
+      # Remove this header to use a token passed by the caller instead.
+      headers:
+        X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:

--- a/cmd/otelcol/config/collector/otlp_config_linux.yaml
+++ b/cmd/otelcol/config/collector/otlp_config_linux.yaml
@@ -105,6 +105,9 @@ extensions:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
     egress:
       endpoint: "https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com"
+      # Remove this header to use a token passed by the caller instead.
+      headers:
+        X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:

--- a/cmd/otelcol/config/collector/upstream_agent_config.yaml
+++ b/cmd/otelcol/config/collector/upstream_agent_config.yaml
@@ -34,6 +34,9 @@ extensions:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
     egress:
       endpoint: "${SPLUNK_INGEST_URL}"
+      # Remove this header to use a token passed by the caller instead.
+      headers:
+        X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:

--- a/cmd/otelcol/fips/config/agent_config.yaml
+++ b/cmd/otelcol/fips/config/agent_config.yaml
@@ -30,11 +30,11 @@ extensions:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
     egress:
       endpoint: "${SPLUNK_INGEST_URL}"
+      # Use instead when sending to gateway
+      #endpoint: "${SPLUNK_GATEWAY_URL}:4320"
       # Remove this header to use a token passed by the caller instead.
       headers:
         X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
-      # Use instead when sending to gateway
-      #endpoint: "${SPLUNK_GATEWAY_URL}:4320"
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:

--- a/cmd/otelcol/fips/config/agent_config.yaml
+++ b/cmd/otelcol/fips/config/agent_config.yaml
@@ -30,6 +30,9 @@ extensions:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
     egress:
       endpoint: "${SPLUNK_INGEST_URL}"
+      # Remove this header to use a token passed by the caller instead.
+      headers:
+        X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
       # Use instead when sending to gateway
       #endpoint: "${SPLUNK_GATEWAY_URL}:4320"
   # opamp/splunk_o11y is included in the default config, but startup removes it

--- a/cmd/otelcol/fips/config/ecs_ec2_config.yaml
+++ b/cmd/otelcol/fips/config/ecs_ec2_config.yaml
@@ -24,6 +24,9 @@ extensions:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
     egress:
       endpoint: "${SPLUNK_INGEST_URL}"
+      # Remove this header to use a token passed by the caller instead.
+      headers:
+        X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:

--- a/cmd/otelcol/fips/config/fargate_config.yaml
+++ b/cmd/otelcol/fips/config/fargate_config.yaml
@@ -19,6 +19,9 @@ extensions:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
     egress:
       endpoint: "${SPLUNK_INGEST_URL}"
+      # Remove this header to use a token passed by the caller instead.
+      headers:
+        X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:

--- a/cmd/otelcol/fips/config/gateway_config.yaml
+++ b/cmd/otelcol/fips/config/gateway_config.yaml
@@ -28,6 +28,9 @@ extensions:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
     egress:
       endpoint: "https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com"
+      # Remove this header to use a token passed by the caller instead.
+      headers:
+        X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:

--- a/cmd/otelcol/fips/config/otlp_config_linux.yaml
+++ b/cmd/otelcol/fips/config/otlp_config_linux.yaml
@@ -105,6 +105,9 @@ extensions:
       endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
     egress:
       endpoint: "https://ingest.${SPLUNK_REALM}.observability.splunkcloud.com"
+      # Remove this header to use a token passed by the caller instead.
+      headers:
+        X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
   # opamp/splunk_o11y is included in the default config, but startup removes it
   # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
   opamp/splunk_o11y:

--- a/tests/general/default_config_test.go
+++ b/tests/general/default_config_test.go
@@ -130,6 +130,9 @@ func TestDefaultGatewayConfig(t *testing.T) {
 					"http_forwarder/opamp_splunk_o11y": map[string]any{
 						"egress": map[string]any{
 							"endpoint": "https://ingest.not.real.observability.splunkcloud.com",
+							"headers": map[string]any{
+								"X-SF-Token": "<redacted>",
+							},
 						},
 						"ingress": map[string]any{
 							"endpoint": fmt.Sprintf("%s:4320", ip),
@@ -408,6 +411,9 @@ func TestDefaultAgentConfig(t *testing.T) {
 					"http_forwarder/opamp_splunk_o11y": map[string]any{
 						"egress": map[string]any{
 							"endpoint": "https://ingest.not.real.observability.splunkcloud.com",
+							"headers": map[string]any{
+								"X-SF-Token": "<redacted>",
+							},
 						},
 						"ingress": map[string]any{
 							"endpoint": fmt.Sprintf("%s:4320", ip),


### PR DESCRIPTION
Adds the default Splunk access token header to the OpAMP http_forwarder egress config so instrumentation agents can register through the Collector. Includes a config comment explaining that users can remove the header when they want to forward a caller-provided token instead