### PR TITLE
[chore] Prepare CHANGELOG.md for v0.156.0

### DIFF
--- a/.chloggen/deprecate-timestampprocessor.yaml
+++ b/.chloggen/deprecate-timestampprocessor.yaml
@@ -1,6 +1,0 @@
-change_type: deprecation
-component: timestampprocessor
-note: Deprecate the Splunk `timestamp` processor in favor of the upstream `transform` processor.
-issues: [7707]
-subtext: |
-  Use OTTL statements in the `transform` processor to apply timestamp offsets. See `docs/deprecations/timestampprocessor.md` for migration examples.

--- a/.chloggen/otl-4437-opamp-forwarder-token.yaml
+++ b/.chloggen/otl-4437-opamp-forwarder-token.yaml
@@ -1,5 +1,0 @@
-change_type: enhancement
-component: config
-note: Add the Splunk access token header to the default OpAMP HTTP forwarder egress config.
-issues: [4437]
-subtext:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,134 @@
 <!-- For unreleased changes, see entries in .chloggen -->
 <!-- next version -->
 
+## v0.156.0
+
+This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.156.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.156.0)
+and the [opentelemetry-collector-contrib v0.156.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.156.0) releases where appropriate.
+
+### 🛑 Breaking changes 🛑
+
+- (Contrib) `receiver/oracledb`: Enhanced Oracle SQL query plan details with runtime execution statistics. ([#49329](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49329))
+  This change requires the collector user to have access to V$SQL_PLAN_STATISTICS_ALL. Existing deployments that only grant access to V$SQL_PLAN
+  may experience query plan collection failures until the appropriate privileges are granted.
+  SQL query plan details are now retrieved from V$SQL_PLAN_STATISTICS_ALL instead of V$SQL_PLAN. Since V$SQL_PLAN_STATISTICS_ALL is a superset of V$SQL_PLAN,
+  this change is backward compatible with respect to the emitted plan detail fields while enabling collection of additional runtime execution statistics,
+  including OUTPUT_ROWS, LAST_OUTPUT_ROWS, LAST_ELAPSED_TIME, LAST_CR_BUFFER_GETS, LAST_CU_BUFFER_GETS, STARTS, and LAST_STARTS.
+
+### 🚩 Deprecations 🚩
+
+- (Contrib) `connector/routing`: Deprecate the `request` context in favor of `otelcol.*` OTTL paths. ([#44762](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44762))
+  The routing connector `request` context and `request["key"]` condition syntax are deprecated in favor of
+  `otelcol.client.metadata["key"][0]` for HTTP/client metadata and `otelcol.grpc.metadata["key"][0]` for gRPC metadata.
+  These paths work in all signal contexts and are documented in the [OTelCol OTTL context](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottlotelcol/README.md).
+  A warning is logged when the `request` context is still configured.
+- (Contrib) `receiver/aws_cloudwatch`: Rename to `aws_cloudwatch` with deprecated alias `awscloudwatch` ([#45339](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45339))
+
+### 💡 Enhancements 💡
+
+- (Splunk) `config`: Add the Splunk access token header to the default OpAMP HTTP forwarder egress config. ([#7765](https://github.com/signalfx/splunk-otel-collector/pull/7765))
+- (Core) `processor/memory_limiter`: Add health events for the memory limiter ([#14700](https://github.com/open-telemetry/opentelemetry-collector/issues/14700))
+  Publish a health event from the memory limiter using `componentstatus.ReportStatus`.
+- (Contrib) `connector/routing`: Add OTTL context inference support to routing connector. ([#38080](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38080))
+  The routing connector now supports OTTL context inference, allowing users to write clearer routing conditions using
+  context-qualified paths. Instead of relying on implicit context resolution, users can explicitly specify which
+  context's attributes they want to access (e.g., `resource.attributes["env"]` or `span.attributes["http.method"]`).
+  Unqualified paths like `attributes["key"]` continue to work and default to the resource context for backward compatibility.
+- (Contrib) `exporter/elasticsearch`: Support routing from data_stream attributes defined as scope attributes ([#49306](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49306))
+- (Contrib) `extension/file_storage`: Add `max_size` support to the file storage extension to cap per-component database growth. ([#38620](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38620))
+- (Contrib) `processor/transform`: Add `exemplar` context support to the transform processor, allowing `metric_statements` to read and modify exemplar fields on metric datapoints. ([#49022](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49022))
+- (Contrib) `receiver/mongodb`: Add Query Sample collection to the MongoDB receiver, emitting a `db.server.query_sample` log event for each currently executing operation. ([#48573](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48573))
+  Samples are collected via `$currentOp`, with idle connections and administrative commands
+  filtered out. Each event includes obfuscated query text and operation metadata.
+  The `logs` signal is at `development` stability; attribute names may change until OTel
+  `db.server.query_sample` conventions stabilize. The `metrics` signal remains at `beta`.
+- (Contrib) `receiver/oracledb`: Add `service.name` and `service.namespace` opt-in resource attributes and allow overriding any resource attribute via `override_value`. ([#47088](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47088))
+- (Contrib) `receiver/oracledb`: Add workload analysis metrics related to scans, enqueue, LOB, parse, sort, cursor, and session activity ([#48808](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48808))
+  Adds fourteen new opt-in metrics (disabled by default):
+    - `oracledb.call.count`, `oracledb.call.recursive.cpu.time`
+    - `oracledb.cursor.cache.hits`, `oracledb.cursor.cache.size`, `oracledb.cursor.open`
+    - `oracledb.db.time`
+    - `oracledb.enqueue.operations`
+    - `oracledb.lob.operations`
+    - `oracledb.parse.cpu.time`, `oracledb.parse.elapsed.time`
+    - `oracledb.scan.count`, `oracledb.scan.table.rows`
+    - `oracledb.sort.operations`, `oracledb.sort.rows`
+  No new SQL queries are issued; the existing v$sysstat scrape already returns
+  all required rows, so the receiver adds no additional load on the monitored
+  Oracle instance.
+- (Contrib) `receiver/oracledb`: Add buffer cache and Database Writer (DBWR) metrics ([#49061](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49061))
+  The new metrics are disabled by default.
+- (Contrib) `receiver/oracledb`: Add redo log metrics ([#49060](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49060))
+  The new metrics are disabled by default.
+- (Contrib) `receiver/postgresql`: Add default service.name and service.namespace resource attributes ([#47087](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47087))
+  Both attributes default to enabled: false. When enabled, service.name
+  defaults to unknown_service:postgresql and service.namespace defaults
+  to an empty string. Additionally, override_value is enabled for all
+  resource attributes, allowing users to set custom values via
+  override_value in the collector configuration.
+- (Contrib) `receiver/postgresql`: Add blocking session and lock attributes to `db.server.query_sample` events for PostgreSQL blocking session detection. Blocking attributes are always emitted (empty string / 0 when not blocked). ([#49028](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49028))
+  New attributes under postgresql.blocking.*: postgresql.blocking.pids, postgresql.blocking.start_time,
+  postgresql.blocking.wait_duration, postgresql.blocking.lock.mode, postgresql.blocking.lock.type,
+  postgresql.blocking.lock.relation, postgresql.blocking.transaction.start_time.
+  postgresql.blocking.pids contains the full array of blocking PIDs from pg_blocking_pids() (e.g. {5121,5122}).
+  postgresql.blocking.start_time uses pg_locks.waitstart (PostgreSQL 14+) to record when the lock wait began. waitstart is stable for the full duration of the wait — it is set once when the lock wait starts and is not affected by blockers joining or leaving.
+  postgresql.blocking.transaction.start_time provides a UTC timestamp (RFC3339) from xact_start representing when the transaction started, predating the lock contention itself.
+  Idle-in-transaction blocker sessions (holding locks without an active request) are captured via pg_blocking_pids subquery in the WHERE clause.
+  All blocking attributes are always present on every db.server.query_sample event; empty string / 0 values indicate no active blocking.
+  Requires PostgreSQL 14 or later.
+- (Contrib) `receiver/prometheus`: Promote `receiver.prometheusreceiver.IgnoreScopeInfoMetric` feature gate to beta. ([#47312](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47312))
+  The `otel_scope_info` metric is now ignored for scope attribute extraction by default.
+  To temporarily restore the previous behavior, disable the feature gate with `--feature-gates=-receiver.prometheusreceiver.IgnoreScopeInfoMetric`.
+- (Contrib) `receiver/sqlserver`: Add access methods and buffer pool metrics ([#49182](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49182))
+  Adds the following metrics, all disabled by default:
+    - `sqlserver.access.scan.rate`
+    - `sqlserver.extent.operation.rate`
+    - `sqlserver.ghost_record.skipped.rate`
+    - `sqlserver.page.allocation.rate`
+    - `sqlserver.page.compression.rate`
+    - `sqlserver.page.read_ahead.rate`
+    - `sqlserver.scan_point.revalidation.rate`
+    - `sqlserver.worktable.cache.hit_ratio`
+- (Contrib) `receiver/syslog`: Add support for RFC6587 Octet Counting framing with RFC3164 message format. ([#45216](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45216))
+
+### 🧰 Bug fixes 🧰
+
+- (Core) `exporter/otlp_http`: Treat errors parsing successful (2xx) HTTP response bodies as permanent errors to prevent retrying already-accepted data. ([#15386](https://github.com/open-telemetry/opentelemetry-collector/issues/15386))
+  When a server returns a 2xx status but the response body exceeds the 64kB read limit,
+  the body is truncated and proto unmarshaling fails. Previously this was treated as a
+  retryable error, causing duplicate data to be exported. Now it is marked as a permanent
+  error so the retry logic will not re-send data that was already accepted by the server.
+- (Core) `pkg/service`: Ensure receivers always start after all other components ([#15495](https://github.com/open-telemetry/opentelemetry-collector/pull/15495))
+  There was previously a race condition where multiple receivers using a shared internal implementation,
+  such as the OTLP receiver, could start sending telemetry into a pipeline before all its components had fully started.
+- (Core) `processor/memory_limiter`: Fix degenerate collector performance when exporter has problems causing permanent CPU-burning GC loop ([#4981](https://github.com/open-telemetry/opentelemetry-collector/issues/4981))
+  Forced GC runs now use exponential backoff when deemed ineffective
+  (still above soft limit and less than 5% reclaimed) to avoid preventing
+  recovery by overloading CPU with excessive GC runs. The cap on the
+  backoff interval is exposed via `max_gc_interval_when_soft_limited` and
+  `max_gc_interval_when_hard_limited` (both default `30s`); set either to
+  `0` to disable backoff on that path.
+- (Contrib) `connector/routing`: Fix duplicate routing table entry handling to correctly ignore duplicates instead of overwriting the original route ([#44762](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44762))
+  Previously, when duplicate routing table entries were encountered, the warning message indicated that the duplicate
+  would be ignored, but in fact the original entry was being overwritten by the duplicate.
+  This fix ensures that duplicates are properly ignored and the original route's consumer is preserved.
+- (Contrib) `exporter/file`: Fix path traversal vulnerability on Windows when using grouping file exporter ([#49194](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49194))
+- (Contrib) `processor/cumulativetodelta`: Align reset detection and dropping on histograms and exponential histograms ([#48278](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48278))
+  Histograms and exponential histograms where there is a drop in total count or on any bucket counts are now treated as a reset and dropped.
+- (Contrib) `processor/cumulativetodelta`: Fix non-deterministic order of valid metric types in error messages for invalid `metric_types` config values. ([#49120](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49120))
+- (Contrib) `processor/k8s_attributes`: Fix cache key memory leak in k8sattributesprocessor when a Pod's IP is missing or cleared from the delete event ([#48986](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48986))
+  When a Pod is deleted, if its IP address is missing or already cleared from the delete event status,
+  the processor now looks up the cached pod by its UID to retrieve the stored IP and correctly queue
+  all associated keys for deletion.
+- (Contrib) `processor/resource_detection`: Fix Docker resource detection failing to start when optional resource attributes are disabled, including container attributes when the hostname does not match a Docker container name. ([#46275](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46275))
+- (Contrib) `receiver/aws_cloudwatch`: Fix logs being skipped when AWS pagination returns an empty page ([#48577](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48577))
+- (Contrib) `receiver/prometheus`: Prometheus API server config/targets stay in sync with Target Allocator changing it if both are enabled. ([#48040](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48040))
+  Previously, the API server config and targets did not get the updates from the Target Allocator.
+- (Contrib) `receiver/tcp_log`: Fix TCP input operator emitting partial log data after a connection read error when `one_log_per_packet` is enabled ([#49199](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49199))
+  Previously, if a TCP connection was reset mid-read while `one_log_per_packet`
+  was set to true, the partial buffer was still processed and emitted as a log
+  entry. Now the read error causes the message to be discarded instead.
+
 ## v0.155.0
 
 This Splunk OpenTelemetry Collector release includes changes from the [opentelemetry-collector v0.155.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.155.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and the [opentelemetry-collector-contrib v0.156.0](https://github.com/open-telem
 
 ### 🚩 Deprecations 🚩
 
+- (Splunk) `timestampprocessor`: Deprecate the Splunk `timestamp` processor in favor of the upstream `transform` processor. ([#7707](https://github.com/signalfx/splunk-otel-collector/pull/7707))
+  Use OTTL statements in the `transform` processor to apply timestamp offsets. See `docs/deprecations/timestampprocessor.md` for migration examples.
+
 - (Contrib) `connector/routing`: Deprecate the `request` context in favor of `otelcol.*` OTTL paths. ([#44762](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44762))
   The routing connector `request` context and `request["key"]` condition syntax are deprecated in favor of
   `otelcol.client.metadata["key"][0]` for HTTP/client metadata and `otelcol.grpc.metadata["key"][0]` for gRPC metadata.


### PR DESCRIPTION
Prepare the v0.156.0 changelog from the pending distro entries and upstream Collector/Contrib notes, retaining only components shipped in this distribution. This includes the OpAMP access-token-header enhancement and the timestamp processor deprecation with migration guidance. The generated OpAMP entry points to its actual implementation PR, and the new OracleDB metric sets are documented as disabled by default.

Reviewer note: the Prometheus IgnoreScopeInfoMetric feature-gate promotion remains under enhancements, matching upstream, although it changes default scope-attribute extraction behavior.