### PR TITLE
Update launcher to parse config flags and include additional supervisor configs

### DIFF
--- a/internal/opampsupervisor/launcher/config.go
+++ b/internal/opampsupervisor/launcher/config.go
@@ -15,12 +15,16 @@
 package launcher
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
+	"slices"
 	"strings"
+	"text/template"
 
 	"gopkg.in/yaml.v3"
 )
@@ -35,18 +39,40 @@ const (
 
 	defaultAgentListenInterface = "127.0.0.1"
 	defaultListenInterface      = "0.0.0.0"
+	mergeAppendFeatureGate      = "confmap.enableMergeAppendOption"
 	opampSplunkExtension        = "opamp/splunk_o11y"
+
+	managedAgentComment = "The launcher applies agent.executable, agent.config_files, and agent.args at runtime from the " +
+		"installed collector path and current collector command-line arguments. Edit other supervisor settings in this file."
 )
+
+var initialSupervisorConfigTemplate = template.Must(template.New("initial-supervisor-config").Funcs(template.FuncMap{
+	"indent": indentYAML,
+	"yaml":   marshalYAMLFragment,
+}).Parse(`server:
+{{ yaml .Server | indent 2 -}}
+storage:
+{{ yaml .Storage | indent 2 -}}
+# {{ .ManagedAgentComment }}
+agent:
+{{ yaml .Agent | indent 2 -}}
+capabilities:
+{{ yaml .Capabilities | indent 2 -}}
+telemetry:
+{{ yaml .Telemetry | indent 2 -}}
+`))
 
 // Paths contains package installation, supervisor config, and state paths.
 type Paths struct {
-	CollectorExecutable      string
-	SupervisorExecutable     string
-	SupervisorConfig         string
-	GeneratedCollectorConfig string
-	StorageDirectory         string
-	DefaultAgentConfig       string
-	UseHUPConfigReload       bool
+	CollectorExecutable         string
+	SupervisorExecutable        string
+	SupervisorConfig            string
+	RuntimeSupervisorConfig     string
+	GeneratedCollectorConfigDir string
+	StorageDirectory            string
+	DefaultAgentConfig          string
+	ConfigApplyTimeout          string
+	UseHUPConfigReload          bool
 }
 
 // Command is the executable, arguments, and environment the launcher should run.
@@ -61,6 +87,7 @@ type Command struct {
 type SupervisorConfig struct {
 	Server       supervisorServer       `yaml:"server"`
 	Storage      supervisorStorage      `yaml:"storage"`
+	Telemetry    supervisorTelemetry    `yaml:"telemetry"`
 	Agent        supervisorAgent        `yaml:"agent"`
 	Capabilities supervisorCapabilities `yaml:"capabilities"`
 }
@@ -85,15 +112,48 @@ type supervisorStorage struct {
 	Directory string `yaml:"directory"`
 }
 
-type supervisorAgent struct {
-	Env                map[string]string `yaml:"env,omitempty"`
-	Executable         string            `yaml:"executable"`
-	ConfigFiles        []string          `yaml:"config_files"`
-	Args               []string          `yaml:"args,omitempty"`
-	PassthroughLogs    bool              `yaml:"passthrough_logs"`
-	UseHUPConfigReload bool              `yaml:"use_hup_config_reload,omitempty"`
-	ValidateConfig     bool              `yaml:"validate_config"`
+type supervisorTelemetry struct {
+	Logs supervisorTelemetryLogs `yaml:"logs"`
 }
+
+type supervisorTelemetryLogs struct {
+	Encoding string `yaml:"encoding"`
+}
+
+type supervisorAgent struct {
+	Env                map[string]string          `yaml:"env,omitempty"`
+	Executable         string                     `yaml:"executable,omitempty"`
+	ConfigApplyTimeout string                     `yaml:"config_apply_timeout"`
+	ConfigFiles        []string                   `yaml:"config_files,omitempty"`
+	Args               []string                   `yaml:"args,omitempty"`
+	Description        supervisorAgentDescription `yaml:"description"`
+	PassthroughLogs    bool                       `yaml:"passthrough_logs"`
+	UseHUPConfigReload bool                       `yaml:"use_hup_config_reload,omitempty"`
+	ValidateConfig     bool                       `yaml:"validate_config"`
+}
+
+type supervisorAgentDescription struct {
+	IncludeResourceAttributes bool `yaml:"include_resource_attributes"`
+}
+
+type supervisorInputs struct {
+	configFiles []string
+	agentArgs   []string
+}
+
+type supervisorManagedAgentFields struct {
+	Executable  string
+	ConfigFiles []string
+	Args        []string
+}
+
+type collectorConfigInput struct {
+	Config map[string]any
+	Path   string
+}
+
+// From internal/settings parseURI, which mirrors OpenTelemetry Collector confmap URI parsing.
+var configURIRegexp = regexp.MustCompile(`(?s:^(?P<Scheme>[A-Za-z][A-Za-z0-9+.-]+):(?P<OpaqueValue>.*)$)`)
 
 // SupervisorEnabled reports whether the persisted service-scoped supervisor
 // switch is enabled in the provided environment.
@@ -114,140 +174,262 @@ func PrepareCommand(args, environ []string, paths Paths) (Command, error) {
 		}, nil
 	}
 
-	if err := PrepareSupervisor(args, env, paths); err != nil {
+	inputs, err := supervisorInputsFromArgs(args, env)
+	if err != nil {
 		return Command{}, err
+	}
+
+	if prepErr := prepareSupervisor(inputs, env, paths); prepErr != nil {
+		return Command{}, prepErr
 	}
 
 	return Command{
 		Path: paths.SupervisorExecutable,
-		Args: []string{"--config", paths.SupervisorConfig},
-		Env:  supervisorCommandEnv(environ, env, paths),
+		Args: []string{"--config", paths.RuntimeSupervisorConfig},
+		Env:  supervisorCommandEnv(environ, env, paths, inputs.configFiles),
 	}, nil
 }
 
-// PrepareSupervisor refreshes the launcher-managed collector config on every
-// supervisor start and writes the initial supervisor config only when it does
-// not already exist. Existing supervisor config is user-editable and preserved
-// across launcher restarts.
-func PrepareSupervisor(args []string, env map[string]string, paths Paths) error {
-	collectorConfigPath := strings.TrimSpace(env[CollectorConfigEnvVar])
-	if collectorConfigPath == "" {
-		return fmt.Errorf("%s must be set in supervisor mode", CollectorConfigEnvVar)
-	}
-
-	collectorConfig, err := loadCollectorConfigFile(collectorConfigPath)
+// prepareSupervisor refreshes the launcher-managed collector config on every
+// supervisor start and writes the runtime supervisor config with the current
+// launcher-managed agent fields.
+func prepareSupervisor(inputs supervisorInputs, env map[string]string, paths Paths) error {
+	collectorConfigs, err := loadCollectorConfigFiles(inputs.configFiles)
 	if err != nil {
 		return err
 	}
 
-	if writeErr := writeYAML(paths.GeneratedCollectorConfig, sanitizedCollectorConfig(collectorConfig)); writeErr != nil {
-		return writeErr
-	}
-
-	_, err = os.Stat(paths.SupervisorConfig)
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("stat supervisor config %q: %w", paths.SupervisorConfig, err)
-	}
-
-	server, err := supervisorServerFromConfig(collectorConfig, env)
+	configFiles, err := prepareManagedCollectorConfigs(collectorConfigs, paths.GeneratedCollectorConfigDir)
 	if err != nil {
 		return err
 	}
 
-	supervisorConfig := SupervisorConfig{
-		Server: server,
-		Capabilities: supervisorCapabilities{
-			ReportsEffectiveConfig:     true,
-			ReportsHealth:              true,
-			ReportsRemoteConfig:        true,
-			ReportsAvailableComponents: true,
-			AcceptsRemoteConfig:        true,
-			ReportsOwnMetrics:          false,
-			ReportsHeartbeat:           false,
-		},
-		Storage: supervisorStorage{Directory: paths.StorageDirectory},
-		Agent: supervisorAgent{
-			Executable:         paths.CollectorExecutable,
-			ConfigFiles:        []string{paths.GeneratedCollectorConfig},
-			Args:               args,
-			PassthroughLogs:    true,
-			UseHUPConfigReload: paths.UseHUPConfigReload,
-			ValidateConfig:     true,
-		},
-	}
-	if writeErr := writeYAML(paths.SupervisorConfig, supervisorConfig); writeErr != nil {
-		return writeErr
+	_, statErr := os.Stat(paths.SupervisorConfig)
+	if statErr != nil {
+		if !errors.Is(statErr, fs.ErrNotExist) {
+			return fmt.Errorf("stat supervisor config %q: %w", paths.SupervisorConfig, statErr)
+		}
+		initialConfig, initErr := initialSupervisorConfig(paths, collectorConfigs, env)
+		if initErr != nil {
+			return initErr
+		}
+		if writeErr := writeInitialSupervisorConfig(paths.SupervisorConfig, initialConfig); writeErr != nil {
+			return writeErr
+		}
 	}
 
-	return nil
+	sourceConfig, err := loadSupervisorConfigFile(paths.SupervisorConfig)
+	if err != nil {
+		return err
+	}
+	managedFields := supervisorManagedAgentFields{
+		Executable:  paths.CollectorExecutable,
+		ConfigFiles: configFiles,
+		Args:        inputs.agentArgs,
+	}
+	runtimeConfig := renderRuntimeConfig(sourceConfig, managedFields)
+	return writeYAML(paths.RuntimeSupervisorConfig, runtimeConfig)
 }
 
 // supervisorCommandEnv preserves the collector's package default listen
 // interface behavior when supervisor starts the collector from generated config.
-func supervisorCommandEnv(environ []string, env map[string]string, paths Paths) []string {
+func supervisorCommandEnv(environ []string, env map[string]string, paths Paths, collectorConfigPaths []string) []string {
 	if _, ok := env[ListenInterfaceEnvVar]; ok {
 		return environ
 	}
-	collectorConfigPath := strings.TrimSpace(env[CollectorConfigEnvVar])
-	if collectorConfigPath == "" {
+	if len(collectorConfigPaths) == 0 {
 		return environ
 	}
-	listenInterface := defaultListenInterfaceForConfig(collectorConfigPath, paths.DefaultAgentConfig)
+	listenInterface := defaultListenInterfaceForConfigs(collectorConfigPaths, paths.DefaultAgentConfig)
 	return append(environ, ListenInterfaceEnvVar+"="+listenInterface)
 }
 
-func defaultListenInterfaceForConfig(configPath, defaultAgentConfig string) string {
-	if filepath.Clean(configPath) == filepath.Clean(defaultAgentConfig) {
-		return defaultAgentListenInterface
+func defaultListenInterfaceForConfigs(configPaths []string, defaultAgentConfig string) string {
+	for _, configPath := range configPaths {
+		if filepath.Clean(configPath) == filepath.Clean(defaultAgentConfig) {
+			return defaultAgentListenInterface
+		}
 	}
 	return defaultListenInterface
 }
 
-// sanitizedCollectorConfig returns the collector config used as supervisor's
-// local base config, with only the direct Splunk OpAMP extension removed.
-func sanitizedCollectorConfig(config map[string]any) map[string]any {
-	out := cloneYAMLMap(config)
-	removeSplunkOpAMPFromExtensions(out)
-	removeSplunkOpAMPFromServiceExtensions(out)
-	return out
+// supervisorInputsFromArgs processes configs from flags/env values
+// and removes the merge append feature gate when in supervisor mode.
+func supervisorInputsFromArgs(args []string, env map[string]string) (supervisorInputs, error) {
+	inputs := supervisorInputs{agentArgs: make([]string, 0, len(args))}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "--config":
+			if i+1 >= len(args) {
+				return supervisorInputs{}, errors.New("missing value for --config")
+			}
+			path, err := normalizeLocalConfigPath(args[i+1])
+			if err != nil {
+				return supervisorInputs{}, err
+			}
+			inputs.configFiles = append(inputs.configFiles, path)
+			i++
+		case "--feature-gates":
+			if i+1 >= len(args) {
+				inputs.agentArgs = append(inputs.agentArgs, arg)
+				continue
+			}
+			if filtered, ok := filterFeatureGateValue(args[i+1]); ok {
+				inputs.agentArgs = append(inputs.agentArgs, arg, filtered)
+			}
+			i++
+		default:
+			if value, ok := strings.CutPrefix(arg, "--config="); ok {
+				path, err := normalizeLocalConfigPath(value)
+				if err != nil {
+					return supervisorInputs{}, err
+				}
+				inputs.configFiles = append(inputs.configFiles, path)
+				continue
+			}
+			if value, ok := strings.CutPrefix(arg, "--feature-gates="); ok {
+				filtered, ok := filterFeatureGateValue(value)
+				if ok {
+					inputs.agentArgs = append(inputs.agentArgs, "--feature-gates="+filtered)
+				}
+				continue
+			}
+			inputs.agentArgs = append(inputs.agentArgs, arg)
+		}
+	}
+
+	if len(inputs.configFiles) == 0 {
+		collectorConfigPath := strings.TrimSpace(env[CollectorConfigEnvVar])
+		if collectorConfigPath == "" {
+			return supervisorInputs{},
+				fmt.Errorf("supervisor mode requires at least one --config flag or %s", CollectorConfigEnvVar)
+		}
+		path, err := normalizeLocalConfigPath(collectorConfigPath)
+		if err != nil {
+			return supervisorInputs{}, err
+		}
+		inputs.configFiles = append(inputs.configFiles, path)
+	}
+
+	return inputs, nil
 }
 
-func removeSplunkOpAMPFromExtensions(config map[string]any) {
+// normalizeLocalConfigPath accepts plain local paths and "file:" URIs, returning
+// the filesystem path that the launcher can read and pass to supervisor.
+func normalizeLocalConfigPath(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", errors.New("collector config path is empty")
+	}
+
+	scheme, location, isURI := parseConfigURI(value)
+	if !isURI || isWindowsDrivePath(scheme) {
+		return value, nil
+	}
+	if scheme != "file" {
+		return "",
+			fmt.Errorf("unsupported config provider URI %q in supervisor mode; only local file paths and file: URIs are supported", value)
+	}
+
+	path := strings.TrimSpace(location)
+	if path == "" {
+		return "", errors.New("collector config path is empty")
+	}
+	return filepath.Clean(path), nil
+}
+
+func parseConfigURI(value string) (scheme, location string, isURI bool) {
+	submatches := configURIRegexp.FindStringSubmatch(value)
+	if len(submatches) != 3 {
+		return "", "", false
+	}
+	return submatches[1], submatches[2], true
+}
+
+func isWindowsDrivePath(scheme string) bool {
+	return len(scheme) == 1 && ((scheme[0] >= 'A' && scheme[0] <= 'Z') || (scheme[0] >= 'a' && scheme[0] <= 'z'))
+}
+
+func filterFeatureGateValue(value string) (string, bool) {
+	gates := strings.Split(value, ",")
+	filtered := make([]string, 0, len(gates))
+	for _, gate := range gates {
+		gate = strings.TrimSpace(gate)
+		if gate == "" {
+			continue
+		}
+		gateName := strings.TrimPrefix(strings.TrimPrefix(gate, "+"), "-")
+		if gateName == mergeAppendFeatureGate {
+			continue
+		}
+		filtered = append(filtered, gate)
+	}
+	return strings.Join(filtered, ","), len(filtered) > 0
+}
+
+// sanitizeCollectorConfig removes the splunk_o11y opamp extension definitions and service references
+func sanitizeCollectorConfig(config map[string]any) (map[string]any, bool) {
+	out := cloneYAMLMap(config)
+	removedExtension := removeSplunkOpAMPFromExtensions(out)
+	removedServiceExtension := removeSplunkOpAMPFromServiceExtensions(out)
+	return out, removedExtension || removedServiceExtension
+}
+
+func removeSplunkOpAMPFromExtensions(config map[string]any) bool {
 	extensions, ok := asMap(config["extensions"])
 	if !ok {
-		return
+		return false
+	}
+	if _, ok := extensions[opampSplunkExtension]; !ok {
+		return false
 	}
 	delete(extensions, opampSplunkExtension)
 	config["extensions"] = extensions
+	return true
 }
 
-func removeSplunkOpAMPFromServiceExtensions(config map[string]any) {
+func removeSplunkOpAMPFromServiceExtensions(config map[string]any) bool {
 	service, ok := asMap(config["service"])
 	if !ok {
-		return
+		return false
 	}
 	serviceExtensions, ok := asSlice(service["extensions"])
 	if !ok {
-		return
+		return false
 	}
 
 	filtered := make([]any, 0, len(serviceExtensions))
+	changed := false
 	for _, extension := range serviceExtensions {
 		if name, ok := extension.(string); ok && name == opampSplunkExtension {
+			changed = true
 			continue
 		}
 		filtered = append(filtered, extension)
 	}
+	if !changed {
+		return false
+	}
 	service["extensions"] = filtered
 	config["service"] = service
+	return true
 }
 
-// loadCollectorConfigFile reads a collector config into a generic map so direct
-// OpAMP settings can be copied into the generated supervisor config when
-// present.
+// loadCollectorConfigFiles reads in collector configs so OpAMP server settings
+// can be copied into the generated supervisor config when present.
+func loadCollectorConfigFiles(paths []string) ([]collectorConfigInput, error) {
+	configs := make([]collectorConfigInput, 0, len(paths))
+	for _, path := range paths {
+		config, err := loadCollectorConfigFile(path)
+		if err != nil {
+			return nil, err
+		}
+		configs = append(configs, collectorConfigInput{Path: path, Config: config})
+	}
+	return configs, nil
+}
+
 func loadCollectorConfigFile(path string) (map[string]any, error) {
 	bytes, err := os.ReadFile(path)
 	if err != nil {
@@ -263,17 +445,67 @@ func loadCollectorConfigFile(path string) (map[string]any, error) {
 	return config, nil
 }
 
-// supervisorServerFromConfig chooses the backend OpAMP endpoint. A direct
-// OpAMP endpoint already present in SPLUNK_CONFIG wins over package fallback
-// values.
-func supervisorServerFromConfig(config map[string]any, env map[string]string) (supervisorServer, error) {
-	if server, ok := configuredOpAMPServer(config); ok {
-		return server, nil
+// prepareManagedCollectorConfigs passes unchanged configs through and writes
+// managed copies only for configs that needed "opamp/splunk_o11y" extension removal.
+func prepareManagedCollectorConfigs(configs []collectorConfigInput, managedDir string) ([]string, error) {
+	configFiles := make([]string, 0, len(configs))
+	usedNames := map[string]struct{}{}
+	for _, input := range configs {
+		sanitized, changed := sanitizeCollectorConfig(input.Config)
+		if !changed {
+			configFiles = append(configFiles, input.Path)
+			continue
+		}
+
+		managedPath := managedCollectorConfigPath(managedDir, input.Path, usedNames)
+		if err := writeYAML(managedPath, sanitized); err != nil {
+			return nil, err
+		}
+		configFiles = append(configFiles, managedPath)
+	}
+	return configFiles, nil
+}
+
+// managedCollectorConfigPath creates managed filenames and de-dupes
+// names using case-insensitive keys for Windows-compatible behavior.
+func managedCollectorConfigPath(dir, sourcePath string, usedNames map[string]struct{}) string {
+	ext := filepath.Ext(sourcePath)
+	if ext == "" {
+		ext = ".yaml"
+	}
+	base := strings.TrimSuffix(filepath.Base(sourcePath), filepath.Ext(sourcePath))
+	if base == "" {
+		base = "config"
+	}
+	name := "managed_collector_" + base
+	for suffix := 1; ; suffix++ {
+		candidate := name + ext
+		if suffix > 1 {
+			candidate = fmt.Sprintf("%s_%d%s", name, suffix, ext)
+		}
+		key := strings.ToLower(candidate)
+		if _, ok := usedNames[key]; !ok {
+			usedNames[key] = struct{}{}
+			return filepath.Join(dir, candidate)
+		}
+	}
+}
+
+func supervisorServerFromConfigs(configs []collectorConfigInput, env map[string]string) (supervisorServer, error) {
+	for i := len(configs) - 1; i >= 0; i-- {
+		if server, ok := configuredOpAMPServer(configs[i].Config); ok {
+			return server, nil
+		}
 	}
 
+	return supervisorServerFromEnv(env)
+}
+
+func supervisorServerFromEnv(env map[string]string) (supervisorServer, error) {
 	endpoint := derivedOpAMPEndpoint(env)
 	if endpoint == "" {
-		return supervisorServer{}, fmt.Errorf("could not derive OpAMP endpoint: neither %s nor %s is set", IngestURLEnvVar, GatewayURLEnvVar)
+		return supervisorServer{},
+			fmt.Errorf("could not derive OpAMP endpoint: neither %s nor %s is set", IngestURLEnvVar, GatewayURLEnvVar)
 	}
 	return supervisorServer{
 		Endpoint: endpoint,
@@ -339,6 +571,107 @@ func writeYAML(path string, value any) error {
 		return fmt.Errorf("write %q: %w", path, err)
 	}
 	return nil
+}
+
+func initialSupervisorConfig(paths Paths, collectorConfigs []collectorConfigInput, env map[string]string) (SupervisorConfig, error) {
+	server, err := supervisorServerFromConfigs(collectorConfigs, env)
+	if err != nil {
+		return SupervisorConfig{}, err
+	}
+	return SupervisorConfig{
+		Server: server,
+		Capabilities: supervisorCapabilities{
+			ReportsEffectiveConfig:     true,
+			ReportsHealth:              true,
+			ReportsRemoteConfig:        true,
+			ReportsAvailableComponents: true,
+			AcceptsRemoteConfig:        true,
+			ReportsOwnMetrics:          false,
+			ReportsHeartbeat:           false,
+		},
+		Storage: supervisorStorage{Directory: paths.StorageDirectory},
+		Telemetry: supervisorTelemetry{
+			Logs: supervisorTelemetryLogs{Encoding: "console"},
+		},
+		Agent: supervisorAgent{
+			Description:        supervisorAgentDescription{IncludeResourceAttributes: true},
+			ConfigApplyTimeout: paths.ConfigApplyTimeout,
+			PassthroughLogs:    true,
+			UseHUPConfigReload: paths.UseHUPConfigReload,
+			ValidateConfig:     true,
+		},
+	}, nil
+}
+
+func writeInitialSupervisorConfig(path string, config SupervisorConfig) error {
+	var buf bytes.Buffer
+	data := map[string]any{
+		"Server":              config.Server,
+		"Storage":             config.Storage,
+		"Agent":               config.Agent,
+		"Capabilities":        config.Capabilities,
+		"Telemetry":           config.Telemetry,
+		"ManagedAgentComment": managedAgentComment,
+	}
+	if err := initialSupervisorConfigTemplate.Execute(&buf, data); err != nil {
+		return fmt.Errorf("marshal %q: %w", path, err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("write %q: %w", path, err)
+	}
+	return nil
+}
+
+func loadSupervisorConfigFile(path string) (map[string]any, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read supervisor config %q: %w", path, err)
+	}
+	var decoded any
+	if err := yaml.Unmarshal(bytes, &decoded); err != nil {
+		return nil, fmt.Errorf("parse supervisor config %q: %w", path, err)
+	}
+	config, ok := asMap(decoded)
+	if !ok {
+		return nil, fmt.Errorf("supervisor config %q must be a YAML mapping", path)
+	}
+	if _, ok := asMap(config["agent"]); !ok {
+		return nil, fmt.Errorf("supervisor config %q must contain agent mapping", path)
+	}
+	return config, nil
+}
+
+func renderRuntimeConfig(sourceConfig map[string]any, managedFields supervisorManagedAgentFields) map[string]any {
+	out := cloneYAMLMap(sourceConfig)
+	agent, _ := asMap(out["agent"])
+	agent["executable"] = managedFields.Executable
+	agent["config_files"] = slices.Clone(managedFields.ConfigFiles)
+	if len(managedFields.Args) == 0 {
+		delete(agent, "args")
+	} else {
+		agent["args"] = slices.Clone(managedFields.Args)
+	}
+	out["agent"] = agent
+	return out
+}
+
+func marshalYAMLFragment(value any) (string, error) {
+	bytes, err := yaml.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func indentYAML(spaces int, value string) string {
+	prefix := strings.Repeat(" ", spaces)
+	lines := strings.Split(strings.TrimRight(value, "\n"), "\n")
+	for i := range lines {
+		if lines[i] != "" {
+			lines[i] = prefix + lines[i]
+		}
+	}
+	return strings.Join(lines, "\n") + "\n"
 }
 
 // asMap normalizes YAML-decoded map shapes used by different decoders and test

--- a/internal/opampsupervisor/launcher/config_test.go
+++ b/internal/opampsupervisor/launcher/config_test.go
@@ -15,10 +15,12 @@
 package launcher
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,10 +44,15 @@ func TestSupervisorEnabled(t *testing.T) {
 func TestPrepareCommandDirectMode(t *testing.T) {
 	paths := testPaths(t, t.TempDir())
 	env := []string{"A=B"}
-	cmd, err := PrepareCommand([]string{"--discovery"}, env, paths)
+	args := []string{
+		"--config", "/etc/otel/collector/agent_config.yaml",
+		"--feature-gates=confmap.enableMergeAppendOption,+other.gate",
+		"--discovery",
+	}
+	cmd, err := PrepareCommand(args, env, paths)
 	require.NoError(t, err)
 	assert.Equal(t, "otelcol", cmd.Path)
-	assert.Equal(t, []string{"--discovery"}, cmd.Args)
+	assert.Equal(t, args, cmd.Args)
 	assert.Equal(t, env, cmd.Env)
 
 	_, err = os.Stat(paths.StorageDirectory)
@@ -78,7 +85,7 @@ service:
 	require.NoError(t, err)
 
 	assert.Equal(t, paths.SupervisorExecutable, cmd.Path)
-	assert.Equal(t, []string{"--config", paths.SupervisorConfig}, cmd.Args)
+	assert.Equal(t, []string{"--config", paths.RuntimeSupervisorConfig}, cmd.Args)
 	assert.Equal(t, append(append([]string{}, env...), ListenInterfaceEnvVar+"="+defaultListenInterface), cmd.Env)
 }
 
@@ -116,13 +123,7 @@ func TestPrepareCommandSupervisorModePreservesExplicitListenInterface(t *testing
 	assert.Equal(t, env, cmd.Env)
 }
 
-func TestPrepareCommandSupervisorModeErrors(t *testing.T) {
-	_, err := PrepareCommand(nil, []string{SupervisorEnabledEnvVar + "=true"}, testPaths(t, t.TempDir()))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), CollectorConfigEnvVar)
-}
-
-func TestPrepareSupervisorUsesConfiguredOpAMPEndpointAndOriginalCollectorConfig(t *testing.T) {
+func TestPrepareSupervisorConfigUsesConfiguredOpAMPEndpointAndOriginalCollectorConfig(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "collector.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte(`
@@ -144,39 +145,62 @@ service:
 `), 0o600))
 
 	paths := testPaths(t, dir)
-	err := PrepareSupervisor(
-		[]string{
-			"--feature-gates=+splunk.opamp.enabled,+other.gate",
-			"--set=processors.batch.timeout=2s",
+	err := prepareSupervisor(
+		supervisorInputs{
+			configFiles: []string{configPath},
+			agentArgs: []string{
+				"--feature-gates=+splunk.opamp.enabled,+other.gate",
+				"--set=processors.batch.timeout=2s",
+			},
 		},
-		map[string]string{CollectorConfigEnvVar: configPath, IngestURLEnvVar: "https://ingest.example"},
+		map[string]string{IngestURLEnvVar: "https://ingest.example"},
 		paths,
 	)
 	require.NoError(t, err)
 
 	var supervisorConfig SupervisorConfig
 	readYAML(t, paths.SupervisorConfig, &supervisorConfig)
+	supervisorYAML := readFile(t, paths.SupervisorConfig)
+	var runtimeConfig SupervisorConfig
+	readYAML(t, paths.RuntimeSupervisorConfig, &runtimeConfig)
+	runtimeYAML := readFile(t, paths.RuntimeSupervisorConfig)
+
 	assert.Equal(t, "https://custom.example/v1/opamp", supervisorConfig.Server.Endpoint)
 	assert.Equal(t, map[string]any{"X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"}, supervisorConfig.Server.Headers)
 	assert.Equal(t, map[string]any{"insecure_skip_verify": true}, supervisorConfig.Server.TLS)
-	assert.Contains(t, readFile(t, paths.SupervisorConfig), "X-SF-Token: ${SPLUNK_ACCESS_TOKEN}")
+	assert.Contains(t, supervisorYAML, "X-SF-Token: ${SPLUNK_ACCESS_TOKEN}")
 	assertMinimalCapabilities(t, supervisorConfig.Capabilities)
 	assertMinimalCapabilitiesYAML(t, paths.SupervisorConfig)
-	assert.Equal(t, []string{paths.GeneratedCollectorConfig}, supervisorConfig.Agent.ConfigFiles)
+	assert.True(t, supervisorConfig.Agent.Description.IncludeResourceAttributes)
+	assert.Equal(t, paths.ConfigApplyTimeout, supervisorConfig.Agent.ConfigApplyTimeout)
+	assert.Contains(t, supervisorYAML, "include_resource_attributes: true")
+	assert.Contains(t, supervisorYAML, "config_apply_timeout: "+paths.ConfigApplyTimeout)
+	assert.Contains(t, supervisorYAML, managedAgentComment)
+	assert.Contains(t, supervisorYAML, "# "+managedAgentComment+"\nagent:\n")
+	assert.Empty(t, supervisorConfig.Agent.Executable)
+	assert.Empty(t, supervisorConfig.Agent.ConfigFiles)
+	assert.Empty(t, supervisorConfig.Agent.Args)
+	assert.Equal(t, paths.CollectorExecutable, runtimeConfig.Agent.Executable)
+	require.Len(t, runtimeConfig.Agent.ConfigFiles, 1)
+	managedConfigPath := runtimeConfig.Agent.ConfigFiles[0]
 	assert.Equal(t, []string{
 		"--feature-gates=+splunk.opamp.enabled,+other.gate",
 		"--set=processors.batch.timeout=2s",
-	}, supervisorConfig.Agent.Args)
-	assert.Contains(t, readFile(t, paths.SupervisorConfig), paths.GeneratedCollectorConfig)
-	assert.NotContains(t, readFile(t, paths.SupervisorConfig), configPath)
+	}, runtimeConfig.Agent.Args)
+	assert.Contains(t, runtimeYAML, managedConfigPath)
+	assert.NotContains(t, runtimeYAML, configPath)
 	assert.Nil(t, supervisorConfig.Agent.Env)
-	assert.NotContains(t, readFile(t, paths.SupervisorConfig), "\nenv:")
+	assert.NotContains(t, supervisorYAML, "\nenv:")
 	assert.True(t, supervisorConfig.Agent.PassthroughLogs)
 	assert.True(t, supervisorConfig.Agent.UseHUPConfigReload)
 	assert.True(t, supervisorConfig.Agent.ValidateConfig)
+	assert.Equal(t, "console", supervisorConfig.Telemetry.Logs.Encoding)
+	assert.Equal(t, "console", runtimeConfig.Telemetry.Logs.Encoding)
+	assert.Contains(t, supervisorYAML, "telemetry:")
+	assert.Contains(t, supervisorYAML, "encoding: console")
 
 	var generatedConfig map[string]any
-	readYAML(t, paths.GeneratedCollectorConfig, &generatedConfig)
+	readYAML(t, managedConfigPath, &generatedConfig)
 	extensions := generatedConfig["extensions"].(map[string]any)
 	assert.Contains(t, extensions, "health_check")
 	assert.Contains(t, extensions, "http_forwarder/opamp_splunk_o11y")
@@ -191,12 +215,118 @@ service:
 	}, service["extensions"])
 }
 
+func TestPrepareSupervisorConfigUsesManagedLocalConfigs(t *testing.T) {
+	dir := t.TempDir()
+	baseConfigPath := filepath.Join(dir, "base.yaml")
+	overlayConfigPath := filepath.Join(dir, "overlay.yaml")
+	otherConfigPath := filepath.Join(dir, "other.yaml")
+	require.NoError(t, os.WriteFile(baseConfigPath, []byte(`
+extensions:
+  health_check: {}
+  opamp/splunk_o11y:
+    server:
+      http:
+        endpoint: "https://custom.example/v1/opamp"
+service:
+  extensions: [health_check, opamp/splunk_o11y]
+`), 0o600))
+	require.NoError(t, os.WriteFile(overlayConfigPath, []byte(`
+extensions:
+  zpages: {}
+  opamp/splunk_o11y:
+    server:
+      http:
+        endpoint: "https://overlay.example/v1/opamp"
+service:
+  extensions: [zpages, opamp/splunk_o11y]
+`), 0o600))
+	require.NoError(t, os.WriteFile(otherConfigPath, []byte(`
+extensions:
+  health_check: {}
+service:
+  extensions: [health_check]
+`), 0o600))
+
+	paths := testPaths(t, dir)
+	err := prepareSupervisor(
+		supervisorInputs{
+			configFiles: []string{baseConfigPath, overlayConfigPath, otherConfigPath},
+			agentArgs: []string{
+				"--feature-gates=+other.gate",
+				"--set=processors.batch.timeout=2s",
+			},
+		},
+		map[string]string{IngestURLEnvVar: "https://ingest.example"},
+		paths,
+	)
+	require.NoError(t, err)
+
+	var supervisorConfig SupervisorConfig
+	readYAML(t, paths.SupervisorConfig, &supervisorConfig)
+	assert.Equal(t, "https://overlay.example/v1/opamp", supervisorConfig.Server.Endpoint)
+
+	var runtimeConfig SupervisorConfig
+	readYAML(t, paths.RuntimeSupervisorConfig, &runtimeConfig)
+	require.Len(t, runtimeConfig.Agent.ConfigFiles, 3)
+	baseManagedPath := runtimeConfig.Agent.ConfigFiles[0]
+	overlayManagedPath := runtimeConfig.Agent.ConfigFiles[1]
+	assert.Equal(t, otherConfigPath, runtimeConfig.Agent.ConfigFiles[2])
+	assert.Equal(t, []string{
+		"--feature-gates=+other.gate",
+		"--set=processors.batch.timeout=2s",
+	}, runtimeConfig.Agent.Args)
+
+	var baseManagedConfig map[string]any
+	readYAML(t, baseManagedPath, &baseManagedConfig)
+	extensions := baseManagedConfig["extensions"].(map[string]any)
+	assert.Contains(t, extensions, "health_check")
+	assert.NotContains(t, extensions, opampSplunkExtension)
+	service := baseManagedConfig["service"].(map[string]any)
+	assert.Equal(t, []any{"health_check"}, service["extensions"])
+
+	var overlayManagedConfig map[string]any
+	readYAML(t, overlayManagedPath, &overlayManagedConfig)
+	extensions = overlayManagedConfig["extensions"].(map[string]any)
+	assert.Contains(t, extensions, "zpages")
+	assert.NotContains(t, extensions, opampSplunkExtension)
+	service = overlayManagedConfig["service"].(map[string]any)
+	assert.Equal(t, []any{"zpages"}, service["extensions"])
+}
+
 func TestPrepareCommandPreservesExistingConfigAndRecomputesEnv(t *testing.T) {
 	dir := t.TempDir()
 	paths := testPaths(t, dir)
-	require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte("user: edited\n"), 0o600))
-	require.NoError(t, os.WriteFile(paths.GeneratedCollectorConfig, []byte("old: generated\n"), 0o600))
-
+	overlayPath := filepath.Join(dir, "overlay.yaml")
+	require.NoError(t, os.WriteFile(overlayPath, []byte(`extensions: {}`), 0o600))
+	sourceConfig := `
+server:
+  # user-owned server setting
+  endpoint: https://user.example/v1/opamp
+  headers:
+    X-SF-Token: user-token
+storage:
+  directory: /custom/storage
+capabilities:
+  reports_effective_config: false
+  reports_health: false
+  reports_available_components: false
+  accepts_remote_config: false
+  reports_remote_config: false
+  reports_own_metrics: true
+  reports_heartbeat: true
+agent:
+  executable: old-otelcol
+  config_apply_timeout: 9m
+  config_files:
+    - old.yaml
+  args:
+    - --old
+  description:
+    include_resource_attributes: false
+  passthrough_logs: false
+  validate_config: false
+`
+	require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte(sourceConfig), 0o600))
 	configPath := filepath.Join(dir, "collector.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte(`
 extensions:
@@ -210,53 +340,205 @@ service:
 		SupervisorEnabledEnvVar + "=true",
 		CollectorConfigEnvVar + "=" + configPath,
 	}
-	cmd, err := PrepareCommand([]string{"--feature-gates=+splunk.opamp.enabled"}, env, paths)
+	cmd, err := PrepareCommand([]string{
+		"--config", configPath,
+		"--config", overlayPath,
+		"--feature-gates=+splunk.opamp.enabled",
+	}, env, paths)
 	require.NoError(t, err)
 
-	assert.Equal(t, "user: edited\n", readFile(t, paths.SupervisorConfig))
-	assert.NotContains(t, readFile(t, paths.GeneratedCollectorConfig), opampSplunkExtension)
-	assert.Contains(t, readFile(t, paths.GeneratedCollectorConfig), "health_check")
+	var supervisorConfig SupervisorConfig
+	readYAML(t, paths.SupervisorConfig, &supervisorConfig)
+	var runtimeConfig SupervisorConfig
+	readYAML(t, paths.RuntimeSupervisorConfig, &runtimeConfig)
+	assert.Equal(t, "https://user.example/v1/opamp", supervisorConfig.Server.Endpoint)
+	assert.Equal(t, map[string]any{"X-SF-Token": "user-token"}, supervisorConfig.Server.Headers)
+	assert.Equal(t, "/custom/storage", supervisorConfig.Storage.Directory)
+	assert.False(t, supervisorConfig.Capabilities.ReportsEffectiveConfig)
+	assert.True(t, supervisorConfig.Capabilities.ReportsOwnMetrics)
+	assert.Equal(t, "9m", supervisorConfig.Agent.ConfigApplyTimeout)
+	assert.False(t, supervisorConfig.Agent.Description.IncludeResourceAttributes)
+	assert.False(t, supervisorConfig.Agent.PassthroughLogs)
+	assert.False(t, supervisorConfig.Agent.ValidateConfig)
+	assert.Equal(t, "old-otelcol", supervisorConfig.Agent.Executable)
+	assert.Equal(t, []string{"old.yaml"}, supervisorConfig.Agent.ConfigFiles)
+	assert.Equal(t, []string{"--old"}, supervisorConfig.Agent.Args)
+	assert.Equal(t, paths.CollectorExecutable, runtimeConfig.Agent.Executable)
+	require.Len(t, runtimeConfig.Agent.ConfigFiles, 2)
+	managedConfigPath := runtimeConfig.Agent.ConfigFiles[0]
+	assert.Equal(t, overlayPath, runtimeConfig.Agent.ConfigFiles[1])
+	assert.Equal(t, []string{"--feature-gates=+splunk.opamp.enabled"}, runtimeConfig.Agent.Args)
+	supervisorYAML := readFile(t, paths.SupervisorConfig)
+	assert.True(t, bytes.Equal([]byte(sourceConfig), []byte(supervisorYAML)))
+	assert.Contains(t, supervisorYAML, "user-owned server setting")
+	assert.NotContains(t, readFile(t, managedConfigPath), opampSplunkExtension)
+	assert.Contains(t, readFile(t, managedConfigPath), "health_check")
 	assert.Equal(t, append(append([]string{}, env...), ListenInterfaceEnvVar+"="+defaultListenInterface), cmd.Env)
 }
 
-func TestPrepareSupervisorReturnsErrors(t *testing.T) {
+func TestPrepareSupervisorConfigDoesNotRewriteExistingSourceConfig(t *testing.T) {
+	dir := t.TempDir()
+	paths := testPaths(t, dir)
+	configPath := filepath.Join(dir, "collector.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
+
+	args := []string{"--feature-gates=+splunk.opamp.enabled"}
+	inputs := supervisorInputs{configFiles: []string{configPath}, agentArgs: args}
+	env := map[string]string{IngestURLEnvVar: "https://ingest.example"}
+	require.NoError(t, prepareSupervisor(inputs, env, paths))
+	want := readFile(t, paths.SupervisorConfig)
+	oldTime := time.Unix(1000, 0)
+	require.NoError(t, os.Chtimes(paths.SupervisorConfig, oldTime, oldTime))
+
+	require.NoError(t, prepareSupervisor(inputs, env, paths))
+
+	assert.Equal(t, want, readFile(t, paths.SupervisorConfig))
+	info, err := os.Stat(paths.SupervisorConfig)
+	require.NoError(t, err)
+	assert.True(t, info.ModTime().Equal(oldTime))
+}
+
+func TestPrepareSupervisorConfigRefreshesRuntimeConfigFromCurrentInputs(t *testing.T) {
+	dir := t.TempDir()
+	paths := testPaths(t, dir)
+	baseConfigPath := filepath.Join(dir, "base.yaml")
+	overlayConfigPath := filepath.Join(dir, "overlay.yaml")
+	require.NoError(t, os.WriteFile(baseConfigPath, []byte(`service: {}`), 0o600))
+	require.NoError(t, os.WriteFile(overlayConfigPath, []byte(`extensions: {}`), 0o600))
+	sourceConfig := `
+server:
+  endpoint: https://user.example/v1/opamp
+storage:
+  directory: /custom/storage
+agent:
+  description:
+    include_resource_attributes: false
+  config_apply_timeout: 9m
+  passthrough_logs: false
+  validate_config: false
+`
+	require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte(sourceConfig), 0o600))
+
+	err := prepareSupervisor(
+		supervisorInputs{
+			configFiles: []string{baseConfigPath, overlayConfigPath},
+			agentArgs:   []string{"--feature-gates=+splunk.opamp.enabled"},
+		},
+		map[string]string{IngestURLEnvVar: "https://ingest.example"},
+		paths,
+	)
+	require.NoError(t, err)
+
+	assert.True(t, bytes.Equal([]byte(sourceConfig), []byte(readFile(t, paths.SupervisorConfig))))
+	var runtimeConfig SupervisorConfig
+	readYAML(t, paths.RuntimeSupervisorConfig, &runtimeConfig)
+	assert.Equal(t, "https://user.example/v1/opamp", runtimeConfig.Server.Endpoint)
+	assert.Equal(t, "/custom/storage", runtimeConfig.Storage.Directory)
+	assert.False(t, runtimeConfig.Agent.Description.IncludeResourceAttributes)
+	assert.Equal(t, "9m", runtimeConfig.Agent.ConfigApplyTimeout)
+	assert.False(t, runtimeConfig.Agent.PassthroughLogs)
+	assert.False(t, runtimeConfig.Agent.ValidateConfig)
+	assert.Equal(t, paths.CollectorExecutable, runtimeConfig.Agent.Executable)
+	assert.Equal(t, []string{baseConfigPath, overlayConfigPath}, runtimeConfig.Agent.ConfigFiles)
+	assert.Equal(t, []string{"--feature-gates=+splunk.opamp.enabled"}, runtimeConfig.Agent.Args)
+	assertNoManagedCollectorConfigs(t, paths)
+}
+
+func TestPrepareSupervisorRuntimeConfigRemovesStaleArgsWhenCurrentArgsAreEmpty(t *testing.T) {
+	dir := t.TempDir()
+	paths := testPaths(t, dir)
+	configPath := filepath.Join(dir, "collector.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
+	sourceConfig := `
+server:
+  endpoint: https://user.example/v1/opamp
+storage:
+  directory: /custom/storage
+agent:
+  executable: old-otelcol
+  config_files:
+    - old.yaml
+  args:
+    - --old
+  description:
+    include_resource_attributes: false
+  config_apply_timeout: 9m
+  passthrough_logs: false
+  validate_config: false
+`
+	require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte(sourceConfig), 0o600))
+
+	err := prepareSupervisor(supervisorInputs{configFiles: []string{configPath}}, map[string]string{}, paths)
+	require.NoError(t, err)
+
+	assert.True(t, bytes.Equal([]byte(sourceConfig), []byte(readFile(t, paths.SupervisorConfig))))
+	var runtimeConfig SupervisorConfig
+	readYAML(t, paths.RuntimeSupervisorConfig, &runtimeConfig)
+	assert.Equal(t, paths.CollectorExecutable, runtimeConfig.Agent.Executable)
+	assert.Equal(t, []string{configPath}, runtimeConfig.Agent.ConfigFiles)
+	assert.Empty(t, runtimeConfig.Agent.Args)
+	assert.NotContains(t, readFile(t, paths.RuntimeSupervisorConfig), "\n  args:")
+	assertNoManagedCollectorConfigs(t, paths)
+}
+
+func TestPrepareSupervisorConfigReturnsErrors(t *testing.T) {
 	tests := map[string]struct {
-		setup   func(t *testing.T, dir string, paths Paths) map[string]string
+		setup   func(t *testing.T, dir string, paths Paths) (supervisorInputs, map[string]string)
 		wantErr string
 	}{
-		"Missing config path": {
-			setup: func(_ *testing.T, _ string, _ Paths) map[string]string {
-				return map[string]string{IngestURLEnvVar: "https://ingest.example"}
-			},
-			wantErr: CollectorConfigEnvVar,
-		},
 		"Collector config read": {
-			setup: func(_ *testing.T, dir string, _ Paths) map[string]string {
-				return map[string]string{
-					CollectorConfigEnvVar: filepath.Join(dir, "missing.yaml"),
-					IngestURLEnvVar:       "https://ingest.example",
-				}
+			setup: func(_ *testing.T, dir string, _ Paths) (supervisorInputs, map[string]string) {
+				return supervisorInputs{configFiles: []string{filepath.Join(dir, "missing.yaml")}},
+					map[string]string{IngestURLEnvVar: "https://ingest.example"}
 			},
 			wantErr: "read collector config",
 		},
 		"Collector config parse": {
-			setup: func(t *testing.T, dir string, _ Paths) map[string]string {
+			setup: func(t *testing.T, dir string, _ Paths) (supervisorInputs, map[string]string) {
 				configPath := filepath.Join(dir, "collector.yaml")
 				require.NoError(t, os.WriteFile(configPath, []byte("extensions: ["), 0o600))
-				return map[string]string{
-					CollectorConfigEnvVar: configPath,
-					IngestURLEnvVar:       "https://ingest.example",
-				}
+				return supervisorInputs{configFiles: []string{configPath}},
+					map[string]string{IngestURLEnvVar: "https://ingest.example"}
 			},
 			wantErr: "parse collector config",
 		},
 		"Missing endpoint inputs": {
-			setup: func(t *testing.T, dir string, _ Paths) map[string]string {
+			setup: func(t *testing.T, dir string, _ Paths) (supervisorInputs, map[string]string) {
 				configPath := filepath.Join(dir, "collector.yaml")
 				require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
-				return map[string]string{CollectorConfigEnvVar: configPath}
+				return supervisorInputs{configFiles: []string{configPath}}, map[string]string{}
 			},
 			wantErr: "could not derive OpAMP endpoint",
+		},
+		"Existing supervisor config parse": {
+			setup: func(t *testing.T, dir string, paths Paths) (supervisorInputs, map[string]string) {
+				configPath := filepath.Join(dir, "collector.yaml")
+				require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
+				require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte("agent: ["), 0o600))
+				return supervisorInputs{configFiles: []string{configPath}},
+					map[string]string{IngestURLEnvVar: "https://ingest.example"}
+			},
+			wantErr: "parse supervisor config",
+		},
+		"Existing supervisor config missing agent": {
+			setup: func(t *testing.T, dir string, paths Paths) (supervisorInputs, map[string]string) {
+				configPath := filepath.Join(dir, "collector.yaml")
+				require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
+				require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte("server: {endpoint: https://user.example/v1/opamp}\n"), 0o600))
+				return supervisorInputs{configFiles: []string{configPath}},
+					map[string]string{IngestURLEnvVar: "https://ingest.example"}
+			},
+			wantErr: "must contain agent mapping",
+		},
+		"Existing supervisor config invalid agent": {
+			setup: func(t *testing.T, dir string, paths Paths) (supervisorInputs, map[string]string) {
+				configPath := filepath.Join(dir, "collector.yaml")
+				require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
+				require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte("agent: invalid\n"), 0o600))
+				return supervisorInputs{configFiles: []string{configPath}},
+					map[string]string{IngestURLEnvVar: "https://ingest.example"}
+			},
+			wantErr: "must contain agent mapping",
 		},
 	}
 
@@ -264,7 +546,8 @@ func TestPrepareSupervisorReturnsErrors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			dir := t.TempDir()
 			paths := testPaths(t, dir)
-			err := PrepareSupervisor(nil, tt.setup(t, dir, paths), paths)
+			inputs, env := tt.setup(t, dir, paths)
+			err := prepareSupervisor(inputs, env, paths)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
@@ -284,40 +567,40 @@ func TestLoadCollectorConfigFileEmptyConfigReturnsEmptyMap(t *testing.T) {
 func TestSupervisorCommandEnv(t *testing.T) {
 	defaultAgentConfig := "/etc/otel/collector/agent_config.yaml"
 	tests := map[string]struct {
-		configPath string
-		env        []string
-		want       []string
+		configPaths []string
+		env         []string
+		want        []string
 	}{
-		"linux agent config": {
-			configPath: defaultAgentConfig,
+		"default agent config first": {
+			configPaths: []string{defaultAgentConfig, "/etc/otel/collector/custom.yaml"},
 			want: []string{
 				CollectorConfigEnvVar + "=" + defaultAgentConfig,
 				ListenInterfaceEnvVar + "=" + defaultAgentListenInterface,
 			},
 		},
-		"linux agent config cleaned path": {
-			configPath: "/etc/otel/collector/./agent_config.yaml",
+		"default agent config later": {
+			configPaths: []string{"/etc/otel/collector/custom.yaml", defaultAgentConfig},
+			want: []string{
+				CollectorConfigEnvVar + "=/etc/otel/collector/custom.yaml",
+				ListenInterfaceEnvVar + "=" + defaultAgentListenInterface,
+			},
+		},
+		"default agent config cleaned path": {
+			configPaths: []string{"/etc/otel/collector/./agent_config.yaml"},
 			want: []string{
 				CollectorConfigEnvVar + "=/etc/otel/collector/./agent_config.yaml",
 				ListenInterfaceEnvVar + "=" + defaultAgentListenInterface,
 			},
 		},
-		"linux gateway config": {
-			configPath: "/etc/otel/collector/gateway_config.yaml",
+		"gateway and custom configs": {
+			configPaths: []string{"/etc/otel/collector/gateway_config.yaml", "/etc/otel/collector/custom.yaml"},
 			want: []string{
 				CollectorConfigEnvVar + "=/etc/otel/collector/gateway_config.yaml",
 				ListenInterfaceEnvVar + "=" + defaultListenInterface,
 			},
 		},
-		"custom config": {
-			configPath: "/etc/otel/collector/custom.yaml",
-			want: []string{
-				CollectorConfigEnvVar + "=/etc/otel/collector/custom.yaml",
-				ListenInterfaceEnvVar + "=" + defaultListenInterface,
-			},
-		},
 		"existing listen interface": {
-			configPath: defaultAgentConfig,
+			configPaths: []string{defaultAgentConfig},
 			env: []string{
 				CollectorConfigEnvVar + "=" + defaultAgentConfig,
 				ListenInterfaceEnvVar + "=127.0.0.2",
@@ -328,7 +611,7 @@ func TestSupervisorCommandEnv(t *testing.T) {
 			},
 		},
 		"existing empty listen interface": {
-			configPath: defaultAgentConfig,
+			configPaths: []string{defaultAgentConfig},
 			env: []string{
 				CollectorConfigEnvVar + "=" + defaultAgentConfig,
 				ListenInterfaceEnvVar + "=",
@@ -344,11 +627,179 @@ func TestSupervisorCommandEnv(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			environ := tt.env
 			if environ == nil {
-				environ = []string{CollectorConfigEnvVar + "=" + tt.configPath}
+				environ = []string{CollectorConfigEnvVar + "=" + tt.configPaths[0]}
 			}
 			assert.Equal(t, tt.want, supervisorCommandEnv(environ, environToMap(environ), Paths{
 				DefaultAgentConfig: defaultAgentConfig,
-			}))
+			}, tt.configPaths))
+		})
+	}
+}
+
+func TestSupervisorInputsFromArgsFiltersFeatureGates(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "collector.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
+
+	tests := map[string]struct {
+		args     []string
+		wantArgs []string
+	}{
+		"split form removes merge append and preserves other gates": {
+			args: []string{
+				"--feature-gates", "confmap.enableMergeAppendOption,+other.gate",
+				"--set=processors.batch.timeout=2s",
+			},
+			wantArgs: []string{
+				"--feature-gates", "+other.gate",
+				"--set=processors.batch.timeout=2s",
+			},
+		},
+		"equals form removes signed merge append and preserves other gates": {
+			args:     []string{"--feature-gates=-confmap.enableMergeAppendOption,bare.gate,+other.gate"},
+			wantArgs: []string{"--feature-gates=bare.gate,+other.gate"},
+		},
+		"only merge append gate removes feature gate arg": {
+			args:     []string{"--feature-gates=confmap.enableMergeAppendOption", "--discovery"},
+			wantArgs: []string{"--discovery"},
+		},
+		"malformed split form is preserved": {
+			args:     []string{"--feature-gates"},
+			wantArgs: []string{"--feature-gates"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			inputs, err := supervisorInputsFromArgs(
+				tt.args,
+				map[string]string{CollectorConfigEnvVar: configPath},
+			)
+			require.NoError(t, err)
+			assert.Equal(t, []string{configPath}, inputs.configFiles)
+			assert.Equal(t, tt.wantArgs, inputs.agentArgs)
+		})
+	}
+}
+
+func TestSupervisorInputsFromArgsConsumesLocalConfigArgs(t *testing.T) {
+	dir := t.TempDir()
+	baseConfigPath := filepath.Join(dir, "base.yaml")
+	overlayConfigPath := filepath.Join(dir, "overlay.yaml")
+	envConfigPath := filepath.Join(dir, "env.yaml")
+
+	inputs, err := supervisorInputsFromArgs(
+		[]string{
+			"--config", baseConfigPath,
+			"--config=file:" + overlayConfigPath,
+			"--feature-gates=confmap.enableMergeAppendOption,+other.gate",
+			"--set=processors.batch.timeout=2s",
+		},
+		map[string]string{CollectorConfigEnvVar: envConfigPath},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{baseConfigPath, overlayConfigPath}, inputs.configFiles)
+	assert.Equal(t, []string{
+		"--feature-gates=+other.gate",
+		"--set=processors.batch.timeout=2s",
+	}, inputs.agentArgs)
+}
+
+func TestSupervisorInputsFromArgsReturnsErrors(t *testing.T) {
+	tests := map[string]struct {
+		env     map[string]string
+		wantErr string
+		args    []string
+	}{
+		"missing config path": {
+			env:     map[string]string{IngestURLEnvVar: "https://ingest.example"},
+			wantErr: "requires at least one --config flag or " + CollectorConfigEnvVar,
+		},
+		"missing config flag value": {
+			args:    []string{"--config"},
+			env:     map[string]string{IngestURLEnvVar: "https://ingest.example"},
+			wantErr: "missing value for --config",
+		},
+		"empty config flag value": {
+			args:    []string{"--config="},
+			env:     map[string]string{IngestURLEnvVar: "https://ingest.example"},
+			wantErr: "collector config path is empty",
+		},
+		"empty file URI config flag value": {
+			args:    []string{"--config=file:"},
+			env:     map[string]string{IngestURLEnvVar: "https://ingest.example"},
+			wantErr: "collector config path is empty",
+		},
+		"unsupported config provider URI": {
+			args:    []string{"--config", "env:SOME_CONFIG"},
+			env:     map[string]string{IngestURLEnvVar: "https://ingest.example"},
+			wantErr: "unsupported config provider URI",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := supervisorInputsFromArgs(tt.args, tt.env)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestNormalizeLocalConfigPath(t *testing.T) {
+	tests := map[string]struct {
+		input   string
+		want    string
+		wantErr string
+	}{
+		"plain local path": {
+			input: "/etc/otel/collector/agent_config.yaml",
+			want:  "/etc/otel/collector/agent_config.yaml",
+		},
+		"file URI absolute path": {
+			input: "file:/etc/otel/collector/agent_config.yaml",
+			want:  filepath.Clean("/etc/otel/collector/agent_config.yaml"),
+		},
+		"file URI cleaned path": {
+			input: "file:/etc/otel/collector/./agent_config.yaml",
+			want:  filepath.Clean("/etc/otel/collector/agent_config.yaml"),
+		},
+		"file URI relative path": {
+			input: "file:agent_config.yaml",
+			want:  "agent_config.yaml",
+		},
+		"file URI windows drive path": {
+			input: `file:C:\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml`,
+			want:  `C:\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml`,
+		},
+		"windows drive path": {
+			input: `C:\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml`,
+			want:  `C:\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml`,
+		},
+		"empty path": {
+			input:   " ",
+			wantErr: "collector config path is empty",
+		},
+		"empty file URI": {
+			input:   "file:",
+			wantErr: "collector config path is empty",
+		},
+		"unsupported provider": {
+			input:   "env:SOME_CONFIG",
+			wantErr: "unsupported config provider URI",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := normalizeLocalConfigPath(tt.input)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -373,13 +824,87 @@ func TestSupervisorServerFromConfigDerivesFallbackEndpoint(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			server, err := supervisorServerFromConfig(map[string]any{}, tt.env)
+			server, err := supervisorServerFromConfigs(nil, tt.env)
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantEndpoint, server.Endpoint)
 			assert.Equal(t, map[string]any{"X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"}, server.Headers)
 		})
 	}
+}
+
+func TestSupervisorServerFromConfigsUsesLastConfiguredEndpoint(t *testing.T) {
+	server, err := supervisorServerFromConfigs([]collectorConfigInput{
+		{
+			Path: "first.yaml",
+			Config: map[string]any{
+				"extensions": map[string]any{
+					opampSplunkExtension: map[string]any{
+						"server": map[string]any{
+							"http": map[string]any{"endpoint": "https://first.example/v1/opamp"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Path: "second.yaml",
+			Config: map[string]any{
+				"extensions": map[string]any{
+					opampSplunkExtension: map[string]any{
+						"server": map[string]any{
+							"http": map[string]any{
+								"endpoint": "https://second.example/v1/opamp",
+								"headers":  map[string]any{"X-SF-Token": "second-token"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, map[string]string{IngestURLEnvVar: "https://ingest.example"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://second.example/v1/opamp", server.Endpoint)
+	assert.Equal(t, map[string]any{"X-SF-Token": "second-token"}, server.Headers)
+}
+
+func TestSupervisorServerFromConfigsIgnoresLaterIncompleteFragments(t *testing.T) {
+	server, err := supervisorServerFromConfigs([]collectorConfigInput{
+		{
+			Path: "first.yaml",
+			Config: map[string]any{
+				"extensions": map[string]any{
+					opampSplunkExtension: map[string]any{
+						"server": map[string]any{
+							"http": map[string]any{
+								"endpoint": "https://first.example/v1/opamp",
+								"headers":  map[string]any{"X-SF-Token": "first-token"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Path: "second.yaml",
+			Config: map[string]any{
+				"extensions": map[string]any{
+					opampSplunkExtension: map[string]any{
+						"server": map[string]any{
+							"http": map[string]any{
+								"headers": map[string]any{"X-SF-Token": "second-token"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, map[string]string{IngestURLEnvVar: "https://ingest.example"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://first.example/v1/opamp", server.Endpoint)
+	assert.Equal(t, map[string]any{"X-SF-Token": "first-token"}, server.Headers)
 }
 
 func TestConfiguredOpAMPServerErrors(t *testing.T) {
@@ -423,6 +948,44 @@ func TestConfiguredOpAMPServerErrors(t *testing.T) {
 			assert.Empty(t, server)
 		})
 	}
+}
+
+func TestManagedCollectorConfigPath(t *testing.T) {
+	dir := t.TempDir()
+	usedNames := map[string]struct{}{}
+
+	assert.Equal(t,
+		filepath.Join(dir, "managed_collector_agent_config.yaml"),
+		managedCollectorConfigPath(dir, "/etc/otel/collector/agent_config.yaml", usedNames),
+	)
+	assert.Equal(t,
+		filepath.Join(dir, "managed_collector_agent_config_2.yaml"),
+		managedCollectorConfigPath(dir, "/custom/agent_config.yaml", usedNames),
+	)
+	assert.Equal(t,
+		filepath.Join(dir, "managed_collector_Agent_Config_3.yaml"),
+		managedCollectorConfigPath(dir, "/custom/Agent_Config.yaml", usedNames),
+	)
+	assert.Equal(t,
+		filepath.Join(dir, "managed_collector_splunk_logs_config_linux.yml"),
+		managedCollectorConfigPath(dir, "/etc/otel/collector/splunk_logs_config_linux.yml", usedNames),
+	)
+	assert.Equal(t,
+		filepath.Join(dir, "managed_collector_custom config.conf"),
+		managedCollectorConfigPath(dir, "/etc/otel/collector/custom config.conf", usedNames),
+	)
+	assert.Equal(t,
+		filepath.Join(dir, "managed_collector_no_extension.yaml"),
+		managedCollectorConfigPath(dir, "/etc/otel/collector/no_extension", usedNames),
+	)
+	assert.Equal(t,
+		filepath.Join(dir, "managed_collector_agent_config_2_2.yaml"),
+		managedCollectorConfigPath(dir, "/custom/agent_config_2.yaml", usedNames),
+	)
+	assert.Equal(t,
+		filepath.Join(dir, "managed_collector_config.yaml"),
+		managedCollectorConfigPath(dir, "/custom/.yaml", usedNames),
+	)
 }
 
 func TestAsMap(t *testing.T) {
@@ -486,6 +1049,27 @@ func TestWriteYAMLErrors(t *testing.T) {
 	}
 }
 
+func TestWriteInitialSupervisorConfigErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "supervisor_config.yaml")
+	err := writeInitialSupervisorConfig(path, SupervisorConfig{
+		Server: supervisorServer{
+			Endpoint: "https://example.com/v1/opamp",
+			TLS:      badYAML{},
+		},
+		Storage: supervisorStorage{Directory: "/var/lib/otelcol/supervisor"},
+		Agent: supervisorAgent{
+			Description:        supervisorAgentDescription{IncludeResourceAttributes: true},
+			ConfigApplyTimeout: "1m",
+			PassthroughLogs:    true,
+			ValidateConfig:     true,
+		},
+		Capabilities: supervisorCapabilities{ReportsEffectiveConfig: true},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marshal")
+	assert.Contains(t, err.Error(), "bad yaml")
+}
+
 func assertMinimalCapabilities(t *testing.T, capabilities supervisorCapabilities) {
 	t.Helper()
 
@@ -521,13 +1105,15 @@ func testPaths(t *testing.T, dir string) Paths {
 	supervisorConfig := filepath.Join(dir, "config", "supervisor_config.yaml")
 	require.NoError(t, os.MkdirAll(filepath.Dir(supervisorConfig), 0o700))
 	return Paths{
-		CollectorExecutable:      "otelcol",
-		SupervisorExecutable:     "opampsupervisor",
-		StorageDirectory:         filepath.Join(dir, "supervisor"),
-		SupervisorConfig:         supervisorConfig,
-		GeneratedCollectorConfig: filepath.Join(filepath.Dir(supervisorConfig), "collector_config.yaml"),
-		DefaultAgentConfig:       filepath.Join(dir, "agent_config.yaml"),
-		UseHUPConfigReload:       true,
+		CollectorExecutable:         "otelcol",
+		SupervisorExecutable:        "opampsupervisor",
+		StorageDirectory:            filepath.Join(dir, "supervisor"),
+		SupervisorConfig:            supervisorConfig,
+		RuntimeSupervisorConfig:     filepath.Join(filepath.Dir(supervisorConfig), "supervisor_runtime_config.yaml"),
+		GeneratedCollectorConfigDir: filepath.Dir(supervisorConfig),
+		DefaultAgentConfig:          filepath.Join(dir, "agent_config.yaml"),
+		ConfigApplyTimeout:          "1m",
+		UseHUPConfigReload:          true,
 	}
 }
 
@@ -543,4 +1129,12 @@ func readFile(t *testing.T, path string) string {
 	bytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 	return string(bytes)
+}
+
+func assertNoManagedCollectorConfigs(t *testing.T, paths Paths) {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(paths.GeneratedCollectorConfigDir, "managed_collector_*"))
+	require.NoError(t, err)
+	assert.Empty(t, matches)
 }

--- a/internal/opampsupervisor/launcher/paths_others.go
+++ b/internal/opampsupervisor/launcher/paths_others.go
@@ -20,12 +20,14 @@ package launcher
 // locations used by the package-managed service on Linux packages.
 func DefaultPaths() Paths {
 	return Paths{
-		CollectorExecutable:      "/usr/bin/otelcol",
-		SupervisorExecutable:     "/usr/bin/opampsupervisor",
-		SupervisorConfig:         "/etc/otel/collector/supervisor/supervisor_config.yaml",
-		GeneratedCollectorConfig: "/etc/otel/collector/supervisor/collector_config.yaml",
-		StorageDirectory:         "/var/lib/otelcol/supervisor",
-		DefaultAgentConfig:       "/etc/otel/collector/agent_config.yaml",
-		UseHUPConfigReload:       true,
+		CollectorExecutable:         "/usr/bin/otelcol",
+		SupervisorExecutable:        "/usr/bin/opampsupervisor",
+		SupervisorConfig:            "/etc/otel/collector/supervisor/supervisor_config.yaml",
+		RuntimeSupervisorConfig:     "/etc/otel/collector/supervisor/supervisor_runtime_config.yaml",
+		GeneratedCollectorConfigDir: "/etc/otel/collector/supervisor",
+		StorageDirectory:            "/var/lib/otelcol/supervisor",
+		DefaultAgentConfig:          "/etc/otel/collector/agent_config.yaml",
+		ConfigApplyTimeout:          "1m",
+		UseHUPConfigReload:          true,
 	}
 }

--- a/internal/opampsupervisor/launcher/paths_windows.go
+++ b/internal/opampsupervisor/launcher/paths_windows.go
@@ -36,12 +36,14 @@ func DefaultPaths() Paths {
 	stateDir := filepath.Join(programData, "Splunk", "OpenTelemetry Collector", "supervisor")
 	defaultAgentConfig := filepath.Join(programData, "Splunk", "OpenTelemetry Collector", "agent_config.yaml")
 	return Paths{
-		CollectorExecutable:      filepath.Join(installDir, "otelcol.exe"),
-		SupervisorExecutable:     filepath.Join(installDir, "opampsupervisor.exe"),
-		SupervisorConfig:         filepath.Join(stateDir, "supervisor_config.yaml"),
-		GeneratedCollectorConfig: filepath.Join(stateDir, "collector_config.yaml"),
-		StorageDirectory:         stateDir,
-		DefaultAgentConfig:       defaultAgentConfig,
-		UseHUPConfigReload:       false,
+		CollectorExecutable:         filepath.Join(installDir, "otelcol.exe"),
+		SupervisorExecutable:        filepath.Join(installDir, "opampsupervisor.exe"),
+		SupervisorConfig:            filepath.Join(stateDir, "supervisor_config.yaml"),
+		RuntimeSupervisorConfig:     filepath.Join(stateDir, "supervisor_runtime_config.yaml"),
+		GeneratedCollectorConfigDir: stateDir,
+		StorageDirectory:            stateDir,
+		DefaultAgentConfig:          defaultAgentConfig,
+		ConfigApplyTimeout:          "2m",
+		UseHUPConfigReload:          false,
 	}
 }

--- a/internal/opampsupervisor/launcher/paths_windows_test.go
+++ b/internal/opampsupervisor/launcher/paths_windows_test.go
@@ -35,9 +35,11 @@ func TestDefaultPathsWindowsFallbacksAlignWithInstaller(t *testing.T) {
 	assert.Equal(t, filepath.Join(installDir, "otelcol.exe"), paths.CollectorExecutable)
 	assert.Equal(t, filepath.Join(installDir, "opampsupervisor.exe"), paths.SupervisorExecutable)
 	assert.Equal(t, filepath.Join(stateDir, "supervisor_config.yaml"), paths.SupervisorConfig)
-	assert.Equal(t, filepath.Join(stateDir, "collector_config.yaml"), paths.GeneratedCollectorConfig)
+	assert.Equal(t, filepath.Join(stateDir, "supervisor_runtime_config.yaml"), paths.RuntimeSupervisorConfig)
+	assert.Equal(t, stateDir, paths.GeneratedCollectorConfigDir)
 	assert.Equal(t, stateDir, paths.StorageDirectory)
 	assert.Equal(t, filepath.Join(`\ProgramData`, "Splunk", "OpenTelemetry Collector", "agent_config.yaml"), paths.DefaultAgentConfig)
+	assert.Equal(t, "2m", paths.ConfigApplyTimeout)
 	assert.False(t, paths.UseHUPConfigReload)
 }
 
@@ -48,6 +50,7 @@ func TestDefaultListenInterfaceForWindowsAgentConfig(t *testing.T) {
 	agentConfig := filepath.Join(programData, "Splunk", "OpenTelemetry Collector", "agent_config.yaml")
 	gatewayConfig := filepath.Join(programData, "Splunk", "OpenTelemetry Collector", "gateway_config.yaml")
 
-	assert.Equal(t, defaultAgentListenInterface, defaultListenInterfaceForConfig(agentConfig, agentConfig))
-	assert.Equal(t, defaultListenInterface, defaultListenInterfaceForConfig(gatewayConfig, agentConfig))
+	assert.Equal(t, defaultAgentListenInterface, defaultListenInterfaceForConfigs([]string{agentConfig}, agentConfig))
+	assert.Equal(t, defaultAgentListenInterface, defaultListenInterfaceForConfigs([]string{gatewayConfig, agentConfig}, agentConfig))
+	assert.Equal(t, defaultListenInterface, defaultListenInterfaceForConfigs([]string{gatewayConfig}, agentConfig))
 }


### PR DESCRIPTION
Dupe of #7767 but not using fork so the new private module secrets can be pulled in the builds

**Description:**
Launcher (entrypoint for toggling between direct collector vs supervisor mode) parses configs flags/env, removes splunk opamp extension config, and passes the files to OpAMP Supervisor. Supervisor will merge configs and handle `service.extensions` list appending, which covers the req from the new splunk platform log/metric configs. This merge will not handle `pipelines.*.receivers/exporters` appending, but is an acceptable limitation from discussions with team (better merge support is being discussed upstream, will adopt when available).
1. Launcher updates to support `--config` flags and add flexibility (only affects supervisor mode)

Before | After | Reason
-- | -- | --
SPLUNK_CONFIG is required as value used for collector config | Parse `--config` flags, fallback to SPLUNK_CONFIG if no config flags. Reject non-file providers in supervisor mode (acceptable limitation from discussions). `enableMergeAppendOption` feature gate removed as it's a no-op in supervisor mode (supervisor owns configs and does merging) | SPLUNK_CONFIG is no longer present in certain install cases (all Windows, Linux unified ingestion)
collector_config.yaml created and passed to supervisor as sanitized version of SPLUNK_CONFIG value | Loop through configs and create a managed copy if `opamp/splunk_o11y` extension is seen in config. Naming scheme: `managed_collector_<filename><suffix-if-needed>.yaml` (e.g. managed_collector_agent_config.yaml) | Adds flexibility for multiple configs and ordering of configs |
supervisor `server` config pulled from `SPLUNK_CONFIG` | Loop through configs, last complete compatible `opamp/splunk_o11y.server.http.endpoint` block used | Adds flexibility for multiple configs and ordering of configs
`supervisor_config.yaml` created as one time migration output, allow user changes to persist (similar to agent_config.yaml) | `supervisor_config.yaml` still created once and changes preserved. New file `supervisor_runtime_config.yaml` created on start so launcher can own `agent.executable`, `agent.config_files`, and `agent.args` | Allows service args/config changes to be reflected without overwriting the user changes in `supervisor_config.yaml`

2. Updates to OpAMP Supervisor config:
- Include collector resource attributes
- Set log format to console for readability (supervisor default was json, but collector default is console)
- Set config apply timeout (default value was 5s, too short and would cause the supervisor to report failed remote config application even though it actually worked)

**Testing:** <Describe what testing was performed and which tests were added.>
1. Install collector (direct mode, no flags) ==> service starts, same as existing behavior
2. Update conf to enable supervisor ==> all expected supervisor files created, supervisor & collector running
4. Update to pass flags and edit `supervisor_config.yaml` ==> config persisted, flags forwarded 
5. Update to pass `--config` flag pointing to gateway config ==> `managed_collector_gateway_config.yaml` created, all flags except config flag forwarded
6. Update config flag to use unsupported provider type ==> service fails to start, error seen in logs
7. Fresh install with unified ingestion + supervisor mode ==> flags filtered (none forwarded as only had config and merge append feature gate), supervisor `config_files` list show managed agent_config, logs config, metrics config
8. Swap ordering of config files, add another feature gate ==> `config_files` list reflects updated order, feature gate flag forwarded (without merge append)
