### PR TITLE
[chore] Add splunkprivate build tag to allow private components

### DIFF
--- a/.github/workflows/auto-instrumentation.yml
+++ b/.github/workflows/auto-instrumentation.yml
@@ -33,7 +33,6 @@ jobs:
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
-    secrets: inherit
 
   build-package:
     runs-on: ${{ matrix.ARCH == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,9 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
-        with:
-          private-modules: 'true'
-          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: gofmt
         run: |
@@ -57,9 +54,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
-        with:
-          private-modules: 'true'
-          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: generate-metrics
         run: |
@@ -90,9 +84,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
-        with:
-          private-modules: 'true'
-          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - run: echo "GOLANGCI_LINT_CACHE=${HOME}/.cache/golangci-lint" >> "$GITHUB_ENV"
 
@@ -140,9 +131,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
-        with:
-          private-modules: 'true'
-          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Free up disk space for next step
         run: .github/workflows/scripts/free-disk-space.sh
@@ -167,10 +155,22 @@ jobs:
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
-    secrets: inherit
 
   latest-dockerd-test:
     # Run this as a separate test to avoid affecting other tests with the dockerd upgrade.
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup-environment
+
+      - name: dockerd test
+        working-directory: ./internal/signalfx-agent/pkg/monitors/docker
+        run: |
+          go test -v -tags=dockerd -timeout 3m ./...
+
+  # Prototype build of the collector with private components enabled via the `splunkprivate` build tag.
+  splunkprivate-build:
+    name: splunkprivate-build
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -179,7 +179,5 @@ jobs:
           private-modules: 'true'
           private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
-      - name: dockerd test
-        working-directory: ./internal/signalfx-agent/pkg/monitors/docker
-        run: |
-          go test -v -tags=dockerd -timeout 3m ./...
+      - name: Build otelcol with splunkprivate tag
+        run: make otelcol-splunkprivate

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -23,9 +23,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-environment
-        with:
-          private-modules: 'true'
-          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
       - run: make binaries-linux_${{ matrix.ARCH }} COVER_TESTING=true
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
-        with:
-          private-modules: 'true'
-          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Lint
         run: |

--- a/.github/workflows/linux-package-test.yml
+++ b/.github/workflows/linux-package-test.yml
@@ -35,7 +35,6 @@ jobs:
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
-    secrets: inherit
 
   build-package:
     needs: [cross-compile]

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -39,9 +39,6 @@ jobs:
 
       - name: Set up environment
         uses: ./.github/actions/setup-environment
-        with:
-          private-modules: 'true'
-          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build Docker image from local changes
         run: |

--- a/.github/workflows/reusable-compile.yml
+++ b/.github/workflows/reusable-compile.yml
@@ -17,9 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
-        with:
-          private-modules: 'true'
-          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build Collector
         run: |

--- a/.github/workflows/reusable-unit-test.yml
+++ b/.github/workflows/reusable-unit-test.yml
@@ -25,9 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
-        with:
-          private-modules: 'true'
-          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Set CGO_ENABLED
         # Currently, CGO enabled is required for:

--- a/.github/workflows/ta-v2.yaml
+++ b/.github/workflows/ta-v2.yaml
@@ -36,9 +36,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
-        with:
-          private-modules: 'true'
-          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Build collector binaries (linux & windows)
         run: |

--- a/.github/workflows/vuln-scans.yml
+++ b/.github/workflows/vuln-scans.yml
@@ -51,9 +51,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up environment
         uses: ./.github/actions/setup-environment
-        with:
-          private-modules: 'true'
-          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
       - run: |
           make docker-otelcol ARCH=${{ matrix.ARCH }} FIPS="${{ matrix.FIPS }}"
         env:
@@ -72,7 +69,6 @@ jobs:
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
-    secrets: inherit
 
   anchore-image-scan:
     if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'Run vulnerabilities scan') }}
@@ -238,9 +234,6 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-environment
-        with:
-          private-modules: 'true'
-          private-modules-token: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
 
       - name: Echo `govulncheck` version
         continue-on-error: true

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -36,7 +36,6 @@ jobs:
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
-    secrets: inherit
 
   msi-custom-actions:
     uses: ./.github/workflows/reusable-msi-custom-actions.yml

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -29,17 +29,6 @@ jobs:
           $ErrorActionPreference = 'Continue'
           & ${{ github.workspace }}\.github\workflows\scripts\win-required-ports.ps1
 
-      - name: Configure private Go module access
-        env:
-          PRIVATE_MODULES_TOKEN: ${{ secrets.OTELCOL_PRIVATE_MODULES_TOKEN }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if (-not $env:PRIVATE_MODULES_TOKEN) {
-            throw "OTELCOL_PRIVATE_MODULES_TOKEN is required to fetch private Go modules"
-          }
-          git config --global url."https://x-access-token:$($env:PRIVATE_MODULES_TOKEN)@github.com/".insteadOf "https://github.com/"
-          "GOPRIVATE=github.com/signalfx/splunk-otel-collector-components" | Out-File -FilePath $env:GITHUB_ENV -Append
-
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,14 @@ install-test-tools:
 integration-test-split: install-test-tools
 	@set -e; cd tests && gotesplit --total=$(GOTESPLIT_TOTAL) --index=$(GOTESPLIT_INDEX) ./... -- -p 1 $(BUILD_INFO_TESTS) --tags=integration -v -timeout 5m -count 1
 
+# otelcol-splunkprivate builds a prototype collector that includes closed-source
+# components from github.com/signalfx/splunk-otel-collector-components via the
+# `splunkprivate` build tag. Assumes GOPRIVATE and git credentials are already
+# configured for github.com/signalfx/splunk-otel-collector-components.
+.PHONY: otelcol-splunkprivate
+otelcol-splunkprivate:
+	GOFLAGS="-tags=splunkprivate" $(MAKE) otelcol
+
 .PHONY: otelcol-fips
 otelcol-fips:
 ifeq ($(GOOS), linux)

--- a/go.mod
+++ b/go.mod
@@ -141,6 +141,9 @@ require (
 	github.com/prometheus/common v0.69.0
 	github.com/prometheus/prometheus v0.312.0
 	github.com/shirou/gopsutil/v4 v4.26.5
+	github.com/signalfx/splunk-otel-collector-components/exporter/s2sexporter v0.1.0
+	github.com/signalfx/splunk-otel-collector-components/processor/linebreakprocessor v0.0.0-20260707233042-6c1972e556bf
+	github.com/signalfx/splunk-otel-collector-components/receiver/wineventlogreceiver v0.1.0
 	github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension v0.83.0
 	github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocessor v0.0.0-00010101000000-000000000000
 	github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver v0.0.0-00010101000000-000000000000
@@ -161,6 +164,7 @@ require (
 	go.opentelemetry.io/collector/connector v0.156.0
 	go.opentelemetry.io/collector/connector/forwardconnector v0.156.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.156.0
+	go.opentelemetry.io/collector/exporter v1.62.0
 	go.opentelemetry.io/collector/exporter/debugexporter v0.156.0
 	go.opentelemetry.io/collector/exporter/nopexporter v0.156.0
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.156.0
@@ -519,7 +523,6 @@ require (
 	go.opentelemetry.io/collector/consumer/consumererror v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.156.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.156.0 // indirect
-	go.opentelemetry.io/collector/exporter v1.62.0 // indirect
 	go.opentelemetry.io/collector/exporter/exporterhelper v0.156.0 // indirect
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.156.0 // indirect
 	go.opentelemetry.io/collector/exporter/exportertest v0.156.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1890,6 +1890,12 @@ github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083 h1:WsShHmu12Z
 github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083/go.mod h1:adPDS6s7WaajdFBV9mQ7i0dKfQ8xiDnF9ZNETVPpp7c=
 github.com/signalfx/golib/v3 v3.5.0 h1:QkhT8P/iMkTRg7Zec+w8iLEQzzCEIfHHz/A4NJgLQyg=
 github.com/signalfx/golib/v3 v3.5.0/go.mod h1:yze2t+zCjUjUdtSPEmCyg2UDU7jCyIqJV++eprc9OeE=
+github.com/signalfx/splunk-otel-collector-components/exporter/s2sexporter v0.1.0 h1:xo3F4hL/8JDyvkhqvsKwmQHgIRu7TrhBa8eh47pXT7Y=
+github.com/signalfx/splunk-otel-collector-components/exporter/s2sexporter v0.1.0/go.mod h1:06K3scrLdaIXcX0nQFVt16SR3vHjrO1IAS2+AMy+Xyw=
+github.com/signalfx/splunk-otel-collector-components/processor/linebreakprocessor v0.0.0-20260707233042-6c1972e556bf h1:o4Fj5bPKKjuibWiqU/CeRjjvDatgrZbM+JrNI8eq5LQ=
+github.com/signalfx/splunk-otel-collector-components/processor/linebreakprocessor v0.0.0-20260707233042-6c1972e556bf/go.mod h1:X6dQuM8lajvDKUchHdyXlcEGFsSC1r2h6SPqsnlphcA=
+github.com/signalfx/splunk-otel-collector-components/receiver/wineventlogreceiver v0.1.0 h1:kWZ68zt6539sapvavZ73lf3odiVmqKWNxJT4IV/95WM=
+github.com/signalfx/splunk-otel-collector-components/receiver/wineventlogreceiver v0.1.0/go.mod h1:it62YG8OzCbWpN8giquV4U1sMziwAouw7m8gPQhHF/Y=
 github.com/signalfx/telegraf v0.10.2-0.20250228233359-931557f78bed h1:UnMojeBM2skhiZm8Iol3RBQpUHWvAkt993NxWhiV/70=
 github.com/signalfx/telegraf v0.10.2-0.20250228233359-931557f78bed/go.mod h1:1gnMOcwGO3lAxfoMq28M8gjooF2MqVwquPVEvgZ1its=
 github.com/sijms/go-ora/v2 v2.9.0 h1:+iQbUeTeCOFMb5BsOMgUhV8KWyrv9yjKpcK4x7+MFrg=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -16,6 +16,8 @@
 package components
 
 import (
+	"fmt"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
@@ -137,10 +139,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver"
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/connector/forwardconnector"
+	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/debugexporter"
 	"go.opentelemetry.io/collector/exporter/nopexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
+	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/zpagesextension"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.opentelemetry.io/collector/processor"
@@ -160,6 +164,16 @@ import (
 	"github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension"
 	"github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocessor"
 	"github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver"
+)
+
+// Component factories populated only when the `splunkprivate` build tag is set.
+// See components_splunkprivate.go / components_splunkprivate_stub.go.
+var (
+	privateExtensionFactories []extension.Factory
+	privateReceiverFactories  []receiver.Factory
+	privateProcessorFactories []processor.Factory
+	privateExporterFactories  []exporter.Factory
+	privateConnectorFactories []connector.Factory
 )
 
 func Get() (otelcol.Factories, error) {
@@ -340,5 +354,53 @@ func Get() (otelcol.Factories, error) {
 		Telemetry:  otelconftelemetry.NewFactory(),
 	}
 
+	if err := mergePrivateFactories(&factories); err != nil {
+		errs = append(errs, err)
+	}
+
 	return factories, multierr.Combine(errs...)
+}
+
+func mergePrivateFactories(factories *otelcol.Factories) error {
+	var errs []error
+	for _, f := range privateExtensionFactories {
+		if _, ok := factories.Extensions[f.Type()]; ok {
+			errs = append(errs, duplicateFactoryError("extension", f.Type().String()))
+			continue
+		}
+		factories.Extensions[f.Type()] = f
+	}
+	for _, f := range privateReceiverFactories {
+		if _, ok := factories.Receivers[f.Type()]; ok {
+			errs = append(errs, duplicateFactoryError("receiver", f.Type().String()))
+			continue
+		}
+		factories.Receivers[f.Type()] = f
+	}
+	for _, f := range privateProcessorFactories {
+		if _, ok := factories.Processors[f.Type()]; ok {
+			errs = append(errs, duplicateFactoryError("processor", f.Type().String()))
+			continue
+		}
+		factories.Processors[f.Type()] = f
+	}
+	for _, f := range privateExporterFactories {
+		if _, ok := factories.Exporters[f.Type()]; ok {
+			errs = append(errs, duplicateFactoryError("exporter", f.Type().String()))
+			continue
+		}
+		factories.Exporters[f.Type()] = f
+	}
+	for _, f := range privateConnectorFactories {
+		if _, ok := factories.Connectors[f.Type()]; ok {
+			errs = append(errs, duplicateFactoryError("connector", f.Type().String()))
+			continue
+		}
+		factories.Connectors[f.Type()] = f
+	}
+	return multierr.Combine(errs...)
+}
+
+func duplicateFactoryError(kind, name string) error {
+	return fmt.Errorf("duplicate %s factory %q from private components", kind, name)
 }

--- a/internal/components/components_splunkprivate.go
+++ b/internal/components/components_splunkprivate.go
@@ -1,0 +1,42 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build splunkprivate
+
+package components
+
+import (
+	"github.com/signalfx/splunk-otel-collector-components/exporter/s2sexporter"
+	"github.com/signalfx/splunk-otel-collector-components/processor/linebreakprocessor"
+	"github.com/signalfx/splunk-otel-collector-components/receiver/wineventlogreceiver"
+	"go.opentelemetry.io/collector/connector"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/receiver"
+)
+
+func init() {
+	privateExtensionFactories = []extension.Factory{}
+	privateReceiverFactories = []receiver.Factory{
+		wineventlogreceiver.NewFactory(),
+	}
+	privateProcessorFactories = []processor.Factory{
+		linebreakprocessor.NewFactory(),
+	}
+	privateExporterFactories = []exporter.Factory{
+		s2sexporter.NewFactory(),
+	}
+	privateConnectorFactories = []connector.Factory{}
+}

--- a/internal/components/components_splunkprivate.go
+++ b/internal/components/components_splunkprivate.go
@@ -17,14 +17,15 @@
 package components
 
 import (
-	"github.com/signalfx/splunk-otel-collector-components/exporter/s2sexporter"
-	"github.com/signalfx/splunk-otel-collector-components/processor/linebreakprocessor"
-	"github.com/signalfx/splunk-otel-collector-components/receiver/wineventlogreceiver"
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/receiver"
+
+	"github.com/signalfx/splunk-otel-collector-components/exporter/s2sexporter"
+	"github.com/signalfx/splunk-otel-collector-components/processor/linebreakprocessor"
+	"github.com/signalfx/splunk-otel-collector-components/receiver/wineventlogreceiver"
 )
 
 func init() {

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -21,6 +21,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/connector"
+	"go.opentelemetry.io/collector/connector/forwardconnector"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/nopexporter"
+	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/extension/zpagesextension"
+	"go.opentelemetry.io/collector/otelcol"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/batchprocessor"
+	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/nopreceiver"
 )
 
 func TestDefaultComponents(t *testing.T) {
@@ -286,4 +297,78 @@ func TestDefaultComponents(t *testing.T) {
 		require.True(t, ok, "Missing expected connector alias "+alias)
 		assert.Equal(t, actual, v.Type().String())
 	}
+}
+
+func TestMergePrivateFactories(t *testing.T) {
+	extFactory := zpagesextension.NewFactory()
+	recvFactory := receiver.Factory(nopreceiver.NewFactory())
+	procFactory := batchprocessor.NewFactory()
+	expFactory := nopexporter.NewFactory()
+	connFactory := connector.Factory(forwardconnector.NewFactory())
+
+	swapPrivateFactories(t,
+		[]extension.Factory{extFactory},
+		[]receiver.Factory{recvFactory},
+		[]processor.Factory{procFactory},
+		[]exporter.Factory{expFactory},
+		[]connector.Factory{connFactory},
+	)
+
+	t.Run("merges into empty factories", func(t *testing.T) {
+		factories := emptyFactories()
+		require.NoError(t, mergePrivateFactories(&factories))
+		_, ok := factories.Extensions[extFactory.Type()]
+		assert.True(t, ok)
+		_, ok = factories.Receivers[recvFactory.Type()]
+		assert.True(t, ok)
+		_, ok = factories.Processors[procFactory.Type()]
+		assert.True(t, ok)
+		_, ok = factories.Exporters[expFactory.Type()]
+		assert.True(t, ok)
+		_, ok = factories.Connectors[connFactory.Type()]
+		assert.True(t, ok)
+	})
+
+	t.Run("reports duplicates per kind", func(t *testing.T) {
+		factories := emptyFactories()
+		factories.Extensions[extFactory.Type()] = extFactory
+		factories.Receivers[recvFactory.Type()] = recvFactory
+		factories.Processors[procFactory.Type()] = procFactory
+		factories.Exporters[expFactory.Type()] = expFactory
+		factories.Connectors[connFactory.Type()] = connFactory
+
+		err := mergePrivateFactories(&factories)
+		require.Error(t, err)
+		msg := err.Error()
+		for _, kind := range []string{"extension", "receiver", "processor", "exporter", "connector"} {
+			assert.Contains(t, msg, "duplicate "+kind)
+		}
+	})
+}
+
+func emptyFactories() otelcol.Factories {
+	return otelcol.Factories{
+		Extensions: map[component.Type]extension.Factory{},
+		Receivers:  map[component.Type]receiver.Factory{},
+		Processors: map[component.Type]processor.Factory{},
+		Exporters:  map[component.Type]exporter.Factory{},
+		Connectors: map[component.Type]connector.Factory{},
+	}
+}
+
+func swapPrivateFactories(t *testing.T, exts []extension.Factory, recvs []receiver.Factory, procs []processor.Factory, exps []exporter.Factory, conns []connector.Factory) {
+	t.Helper()
+	origExts, origRecvs, origProcs, origExps, origConns := privateExtensionFactories, privateReceiverFactories, privateProcessorFactories, privateExporterFactories, privateConnectorFactories
+	privateExtensionFactories = exts
+	privateReceiverFactories = recvs
+	privateProcessorFactories = procs
+	privateExporterFactories = exps
+	privateConnectorFactories = conns
+	t.Cleanup(func() {
+		privateExtensionFactories = origExts
+		privateReceiverFactories = origRecvs
+		privateProcessorFactories = origProcs
+		privateExporterFactories = origExps
+		privateConnectorFactories = origConns
+	})
 }


### PR DESCRIPTION
A build-flag-gated collector build that includes the closed-source components from [signalfx/splunk-otel-collector-components](https://github.com/signalfx/splunk-otel-collector-components) (`s2sexporter`, `linebreakprocessor`, `wineventlogreceiver`). Follows on from #7674.

- `internal/components/components_splunkprivate.go` `//go:build splunkprivate`; imports the three private modules and populates package-level factory slices via `init()`.
- `internal/components/components.go` declares nil-default `private*Factories` slices and merges them into the returned `otelcol.Factories` map with duplicate detection. Non-tagged builds get an empty merge (no-op).
- `Makefile` `otelcol-splunkprivate` target is a one-liner wrapping `make otelcol` with `GOFLAGS=-tags=splunkprivate`.
- `.github/workflows/build-and-test.yml` new `splunkprivate-build` job: single Ubuntu runner, builds with the tag, that's it. Intentionally not extended to cross-compile / package / vuln-scan matrices.

Also removed `private-modules: 'true'` from jobs that only exercise default-tag Go code (gofmt, generate-metrics, lint, coverage, latest-dockerd-test, reusable-compile, reusable-unit-test, lint-examples, nomad, ta-v2, integration-test, vuln-scans docker/govulncheck, windows-test). Kept for `tidy`, which scans every file regardless of tag. Dropped now-unused `secrets: inherit` from the corresponding reusable workflow callers.
