### PR TITLE
Fix RabbitMQ discovery defaults

### DIFF
--- a/.chloggen/fix-rabbitmq-discovery-defaults.yaml
+++ b/.chloggen/fix-rabbitmq-discovery-defaults.yaml
@@ -8,7 +8,7 @@ component: discovery
 note: Fix bundled RabbitMQ discovery defaults to target the HTTP management endpoint.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [7781]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix-rabbitmq-discovery-defaults.yaml
+++ b/.chloggen/fix-rabbitmq-discovery-defaults.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: discovery
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bundled RabbitMQ discovery defaults to target the HTTP management endpoint.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -332,7 +332,7 @@ jobs:
         id: get-matrix
         run: |
           includes=""
-          for service in "apache" "kafka-metrics" "mongodb" "nginx" "envoy" "oracledb" "mysql" "redis" "weaviate"; do
+          for service in "apache" "kafka-metrics" "mongodb" "nginx" "envoy" "oracledb" "mysql" "rabbitmq" "redis" "weaviate"; do
             for arch in "amd64" "arm64"; do
               if [ "$service" = "mongodb" ]; then
                 # go.mongodb.org/mongo-driver/v2 requires MongoDB 4.2 or newer.

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,14 @@ integration-test-nginx-discovery:
 integration-test-nginx-discovery-with-cover:
 	@make integration-test-cover-target TARGET='discovery_integration_nginx'
 
+.PHONY: integration-test-rabbitmq-discovery
+integration-test-rabbitmq-discovery:
+	@make integration-test-target TARGET='discovery_integration_rabbitmq'
+
+.PHONY: integration-test-rabbitmq-discovery-with-cover
+integration-test-rabbitmq-discovery-with-cover:
+	@make integration-test-cover-target TARGET='discovery_integration_rabbitmq'
+
 .PHONY: integration-test-redis-discovery
 integration-test-redis-discovery:
 	@make integration-test-target TARGET='discovery_integration_redis'

--- a/cmd/discoverybundler/metadata/receivers/rabbitmq.yaml
+++ b/cmd/discoverybundler/metadata/receivers/rabbitmq.yaml
@@ -3,12 +3,12 @@ service_type: rabbitmq
 properties_tmpl: |
   enabled: true
   rule:
-    docker_observer: type == "container" and any([name, image, command], {# matches "(?i)rabbitmq.*"}) and not (command matches "splunk.discovery")
-    host_observer: type == "hostport" and command matches "(?i)rabbitmq.*" and not (command matches "splunk.discovery")
-    k8s_observer: type == "port" and pod.name matches "(?i)rabbitmq.*"
+    docker_observer: type == "container" and port == 15672 and any([name, image, command], {# matches "(?i)rabbitmq.*"}) and not (command matches "splunk.discovery")
+    host_observer: type == "hostport" and port == 15672 and command matches "(?i)rabbitmq.*" and not (command matches "splunk.discovery")
+    k8s_observer: type == "port" and port == 15672 and pod.name matches "(?i)rabbitmq.*"
   config:
     default:
-      endpoint: '`endpoint`'
+      endpoint: 'http://`endpoint`'
       username: {{ defaultValue }}
       password: {{ defaultValue }}
       collection_interval: 10s

--- a/cmd/discoverybundler/metadata_test.go
+++ b/cmd/discoverybundler/metadata_test.go
@@ -1,0 +1,55 @@
+// Copyright  Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRabbitMQDiscoveryMetadataUsesManagementEndpoint(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("metadata", "receivers", "rabbitmq.yaml"))
+	require.NoError(t, err)
+
+	var metadata receiverMetadata
+	require.NoError(t, yaml.Unmarshal(data, &metadata))
+
+	tmpl, err := template.New("rabbitmq").Funcs(funcMap(metadata.ReceiverID)).Parse(metadata.PropertiesTmpl)
+	require.NoError(t, err)
+
+	var rendered bytes.Buffer
+	require.NoError(t, tmpl.Execute(&rendered, nil))
+
+	var properties struct {
+		Rule   map[string]string `yaml:"rule"`
+		Config struct {
+			Default struct {
+				Endpoint string `yaml:"endpoint"`
+			} `yaml:"default"`
+		} `yaml:"config"`
+	}
+	require.NoError(t, yaml.Unmarshal(rendered.Bytes(), &properties))
+
+	require.Equal(t, "http://`endpoint`", properties.Config.Default.Endpoint)
+	require.Equal(t, `type == "container" and port == 15672 and any([name, image, command], {# matches "(?i)rabbitmq.*"}) and not (command matches "splunk.discovery")`, properties.Rule["docker_observer"])
+	require.Equal(t, `type == "hostport" and port == 15672 and command matches "(?i)rabbitmq.*" and not (command matches "splunk.discovery")`, properties.Rule["host_observer"])
+	require.Equal(t, `type == "port" and port == 15672 and pod.name matches "(?i)rabbitmq.*"`, properties.Rule["k8s_observer"])
+}

--- a/cmd/otelcol/config/collector/config.d.linux/receivers/rabbitmq.discovery.yaml
+++ b/cmd/otelcol/config/collector/config.d.linux/receivers/rabbitmq.discovery.yaml
@@ -9,12 +9,12 @@
 # rabbitmq:
 #   enabled: true
 #   rule:
-#     docker_observer: type == "container" and any([name, image, command], {# matches "(?i)rabbitmq.*"}) and not (command matches "splunk.discovery")
-#     host_observer: type == "hostport" and command matches "(?i)rabbitmq.*" and not (command matches "splunk.discovery")
-#     k8s_observer: type == "port" and pod.name matches "(?i)rabbitmq.*"
+#     docker_observer: type == "container" and port == 15672 and any([name, image, command], {# matches "(?i)rabbitmq.*"}) and not (command matches "splunk.discovery")
+#     host_observer: type == "hostport" and port == 15672 and command matches "(?i)rabbitmq.*" and not (command matches "splunk.discovery")
+#     k8s_observer: type == "port" and port == 15672 and pod.name matches "(?i)rabbitmq.*"
 #   config:
 #     default:
-#       endpoint: '`endpoint`'
+#       endpoint: 'http://`endpoint`'
 #       username: splunk.discovery.default
 #       password: splunk.discovery.default
 #       collection_interval: 10s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -99,6 +99,21 @@ services:
     build: ./oracle
     ports:
       - "1521:1521"
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    profiles:
+      - integration-test-rabbitmq-discovery
+    environment:
+      RABBITMQ_DEFAULT_USER: splunk.discovery.default
+      RABBITMQ_DEFAULT_PASS: splunk.discovery.default
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
   redis_server:
     image: quay.io/splunko11ytest/redis_server:latest
     profiles:

--- a/internal/confmapprovider/discovery/bundle.d/receivers/rabbitmq.discovery.yaml
+++ b/internal/confmapprovider/discovery/bundle.d/receivers/rabbitmq.discovery.yaml
@@ -5,12 +5,12 @@
 rabbitmq:
   enabled: true
   rule:
-    docker_observer: type == "container" and any([name, image, command], {# matches "(?i)rabbitmq.*"}) and not (command matches "splunk.discovery")
-    host_observer: type == "hostport" and command matches "(?i)rabbitmq.*" and not (command matches "splunk.discovery")
-    k8s_observer: type == "port" and pod.name matches "(?i)rabbitmq.*"
+    docker_observer: type == "container" and port == 15672 and any([name, image, command], {# matches "(?i)rabbitmq.*"}) and not (command matches "splunk.discovery")
+    host_observer: type == "hostport" and port == 15672 and command matches "(?i)rabbitmq.*" and not (command matches "splunk.discovery")
+    k8s_observer: type == "port" and port == 15672 and pod.name matches "(?i)rabbitmq.*"
   config:
     default:
-      endpoint: '`endpoint`'
+      endpoint: 'http://`endpoint`'
       username: splunk.discovery.default
       password: splunk.discovery.default
       collection_interval: 10s

--- a/tests/receivers/rabbitmq/bundled_test.go
+++ b/tests/receivers/rabbitmq/bundled_test.go
@@ -1,0 +1,81 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build discovery_integration_rabbitmq
+
+package tests
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/signalfx/splunk-otel-collector/tests/testutils"
+)
+
+func TestRabbitMQDockerObserver(t *testing.T) {
+	testutils.SkipIfNotContainerTest(t)
+	dockerSocketProxy, err := testutils.CreateDockerSocketProxy(t)
+	require.NoError(t, err)
+
+	tc := testutils.NewTestcase(t)
+	defer tc.PrintLogsOnFailure()
+	defer tc.ShutdownOTLPReceiverSink()
+
+	_, shutdown := tc.SplunkOtelCollectorContainer("otlp_exporter.yaml", func(c testutils.Collector) testutils.Collector {
+		cc := c.(*testutils.CollectorContainer)
+		cc.Container = cc.Container.WillWaitForLogs("Everything is ready")
+		return cc.WithEnv(map[string]string{
+			"SPLUNK_DISCOVERY_LOG_LEVEL": "debug",
+		}).WithArgs(
+			"--discovery",
+			"--set", `splunk.discovery.extensions.k8s_observer.enabled=false`,
+			"--set", `splunk.discovery.extensions.host_observer.enabled=false`,
+			"--set", fmt.Sprintf("splunk.discovery.extensions.docker_observer.config.endpoint=tcp://%s", dockerSocketProxy.ContainerEndpoint),
+		)
+	})
+	defer shutdown()
+
+	expectedMetricNames := []string{
+		"rabbitmq.node.disk_free",
+		"rabbitmq.node.mem_used",
+		"rabbitmq.node.uptime",
+	}
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		foundMetricNames := metricNames(tc.OTLPReceiverSink.AllMetrics())
+		for _, metricName := range expectedMetricNames {
+			assert.Contains(tt, foundMetricNames, metricName)
+		}
+	}, 120*time.Second, time.Second)
+}
+
+func metricNames(metrics []pmetric.Metrics) map[string]struct{} {
+	names := map[string]struct{}{}
+	for _, md := range metrics {
+		for i := 0; i < md.ResourceMetrics().Len(); i++ {
+			rm := md.ResourceMetrics().At(i)
+			for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+				sm := rm.ScopeMetrics().At(j)
+				for k := 0; k < sm.Metrics().Len(); k++ {
+					names[sm.Metrics().At(k).Name()] = struct{}{}
+				}
+			}
+		}
+	}
+	return names
+}

--- a/tests/receivers/rabbitmq/testdata/otlp_exporter.yaml
+++ b/tests/receivers/rabbitmq/testdata/otlp_exporter.yaml
@@ -1,0 +1,13 @@
+exporters:
+  otlp_grpc:
+    endpoint: "${OTLP_ENDPOINT}"
+    tls:
+      insecure: true
+
+service:
+  telemetry:
+    logs:
+      level: debug
+  pipelines:
+    metrics:
+      exporters: [otlp_grpc]


### PR DESCRIPTION
**Description:**
The default RabbitMQ discovery config does not work because of 2 reasons:

- Passing `host:port` format endpoint to a config field expecting an URL with schema
  - Parsed in https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.155.0/receiver/rabbitmqreceiver/config.go#L48 using `url.Parse` which produces `first path segment in URL cannot contain colon` error if schema is not provided
- AQMP endpoint being passed instead of the HTTP management endpoint because the rule matched both

**Testing:**
Verified in a minimal local kind cluster setup with RabbitMQ deployed and collector discovery enabled that it encountered an error in logs without overrides, but not when using the following overrides:
```
agent:
  discovery:
    properties:
      receivers:
        rabbitmq:
          rule:
            k8s_observer: type == "port" and port == 15672 and pod.name matches "(?i)rabbitmq.*"
          config:
            default:
              endpoint: 'http://`endpoint`'
```

