### PR TITLE
[chore] OTL-4454 fix misisng private-modules-token in pipeline

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -37,6 +37,7 @@ jobs:
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
+    secrets: inherit
 
   build-package:
     needs: [ cross-compile ]

--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -37,6 +37,7 @@ jobs:
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}
+    secrets: inherit
 
   build-package:
     needs: [ cross-compile ]

--- a/.github/workflows/puppet-test.yml
+++ b/.github/workflows/puppet-test.yml
@@ -86,6 +86,7 @@ jobs:
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: binaries-linux_amd64
+    secrets: inherit
 
   # Use reusable workflow for DEB package
   puppet-build-deb-local-package:
@@ -217,6 +218,7 @@ jobs:
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: binaries-windows_amd64
+    secrets: inherit
 
   puppet-build-windows-msi-custom-actions:
     uses: ./.github/workflows/reusable-msi-custom-actions.yml


### PR DESCRIPTION
**Description:** [ci] Pass private module token to reusable compile workflows

Forward repository secrets from the Ansible, Chef, and Puppet workflows so reusable compile jobs can access private Go modules.


