### PR TITLE
add windows container user

### DIFF
--- a/.chloggen/windows-container-user.yaml
+++ b/.chloggen/windows-container-user.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: packaging
+note: Run Windows Collector container images as ContainerUser by default.
+issues: [7788]
+subtext: Use `--user ContainerAdministrator` when running the container if administrator privileges are required.

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -414,7 +414,7 @@ jobs:
             if (-not $DockerOutput) {
               break
             }
-            $DockerLogs=$(docker logs otelcol 2>&1)
+            $DockerLogs=$(cmd /c "docker logs otelcol 2>&1")
             if ($DockerLogs -match 'Everything is ready\. Begin running and processing data\.') {
               $ready = $true
               break

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -390,6 +390,7 @@ jobs:
       - uses: ./.github/actions/win-wait-for-docker
 
       - name: Build docker image
+        shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
           Copy-Item .\bin\otelcol_windows_amd64.exe .\cmd\otelcol\otelcol.exe
@@ -402,6 +403,7 @@ jobs:
           Remove-Item .\cmd\otelcol\otelcol.exe
 
       - name: Run docker image
+        shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
           docker run -d -e SPLUNK_ACCESS_TOKEN=abc123 -e SPLUNK_REALM=fake-realm --name otelcol otelcol-windows:latest

--- a/.github/workflows/win-package-test.yml
+++ b/.github/workflows/win-package-test.yml
@@ -405,10 +405,21 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           docker run -d -e SPLUNK_ACCESS_TOKEN=abc123 -e SPLUNK_REALM=fake-realm --name otelcol otelcol-windows:latest
-          Start-Sleep 10
-          $DockerOutput=$(docker ps --filter=status=running --filter=name=otelcol -q)
-          if ( $DockerOutput -eq $null ) {
+          $ready = $false
+          for ($i = 0; $i -lt 12; $i++) {
+            Start-Sleep 5
+            $DockerOutput=$(docker ps --filter=status=running --filter=name=otelcol -q)
+            if (-not $DockerOutput) {
+              break
+            }
+            $DockerLogs=$(docker logs otelcol 2>&1)
+            if ($DockerLogs -match 'Everything is ready\. Begin running and processing data\.') {
+              $ready = $true
+              break
+            }
+          }
+          if (-not $ready) {
             docker logs otelcol
-            echo "Failing job execution: fail to start otelcol docker container in 10 seconds."
+            echo "Failing job execution: otelcol docker container did not report readiness within 60 seconds."
             exit 1
           }

--- a/cmd/otelcol/Dockerfile.windows
+++ b/cmd/otelcol/Dockerfile.windows
@@ -27,5 +27,7 @@ RUN Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-java
 # Setting environment variables
 ENV SPLUNK_CONFIG="C:\ProgramData\Splunk\OpenTelemetry Collector\gateway_config.yaml"
 
+USER ContainerUser
+
 ENTRYPOINT [ "otelcol.exe" ]
 EXPOSE 13133 14250 14268 4317 6060 8888 9411 9443 9080

--- a/cmd/otelcol/fips/Dockerfile.windows
+++ b/cmd/otelcol/fips/Dockerfile.windows
@@ -24,5 +24,7 @@ WORKDIR "C:\Program Files\Splunk\OpenTelemetry Collector"
 
 ENV SPLUNK_CONFIG="C:\ProgramData\Splunk\OpenTelemetry Collector\gateway_config.yaml"
 
+USER ContainerUser
+
 ENTRYPOINT [ "otelcol.exe" ]
 EXPOSE 13133 14250 14268 4317 6060 8888 9411 9443 9080

--- a/packaging/ta-v2/Dockerfile.windows
+++ b/packaging/ta-v2/Dockerfile.windows
@@ -22,4 +22,7 @@ RUN rm C:\splunk-uf.msi
 
 COPY windows-container-start-and-wait.ps1 C:\\windows-container-start-and-wait.ps1
 
+# This test-only Universal Forwarder image installs and runs Windows services.
+USER ContainerAdministrator
+
 CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass", "-File", "C:\windows-container-start-and-wait.ps1"]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Updates the Windows collector container images to run as `ContainerUser` instead of relying on the default Windows container user. Also tightens the Windows package smoke test so it waits up to 60 seconds for the collector readiness log, rather than only checking that the container is still running after 10 seconds.

The TA v2 Universal Forwarder Windows image is test-only and installs/runs Windows services, so it now explicitly sets `USER ContainerAdministrator` instead of relying on the implicit default.
