### PR TITLE
Fix Linux config dir ownership when running with custom service user/group

### DIFF
--- a/.chloggen/fix-custom-user-dir-ownership.yaml
+++ b/.chloggen/fix-custom-user-dir-ownership.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: packaging
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix Linux packaging to preserve the config directory ownership when running with a custom service user/group, instead of changing back to the default user/group.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/fix-custom-user-dir-ownership.yaml
+++ b/.chloggen/fix-custom-user-dir-ownership.yaml
@@ -8,7 +8,7 @@ component: packaging
 note: Fix Linux packaging to preserve the config directory ownership when running with a custom service user/group, instead of changing back to the default user/group.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [7789]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/packaging/fpm/postinstall.sh
+++ b/packaging/fpm/postinstall.sh
@@ -24,12 +24,27 @@ if command -v setcap >/dev/null 2>&1; then
     setcap CAP_SYS_PTRACE,CAP_DAC_READ_SEARCH=+eip /usr/bin/otelcol
 fi
 
-if [ -d /etc/otel/collector ]; then
-    chown -R splunk-otel-collector:splunk-otel-collector /etc/otel/collector
-fi
+service_user="splunk-otel-collector"
+service_group="splunk-otel-collector"
 
 if command -v systemctl >/dev/null 2>&1; then
     systemctl daemon-reload
+
+    configured_service_user="$(systemctl show --property=User splunk-otel-collector.service 2>/dev/null)"
+    configured_service_group="$(systemctl show --property=Group splunk-otel-collector.service 2>/dev/null)"
+    configured_service_user="${configured_service_user#User=}"
+    configured_service_group="${configured_service_group#Group=}"
+    if [ -n "$configured_service_user" ] && [ -n "$configured_service_group" ]; then
+        service_user="$configured_service_user"
+        service_group="$configured_service_group"
+    fi
+fi
+
+if [ -d /etc/otel/collector ]; then
+    chown -R "$service_user:$service_group" /etc/otel/collector
+fi
+
+if command -v systemctl >/dev/null 2>&1; then
     systemctl enable splunk-otel-collector.service
     if [ -f /etc/otel/collector/splunk-otel-collector.conf ]; then
         echo "Starting splunk-otel-collector service"

--- a/tests/package/package_test.go
+++ b/tests/package/package_test.go
@@ -147,6 +147,63 @@ func TestCollectorPackageUpgrade(t *testing.T) {
 	}
 }
 
+func TestCollectorPackageUpgradeWithCustomServiceOwner(t *testing.T) {
+	skipUnlessLinux(t)
+	packageType := skipUnlessPackageType(t, "deb", "rpm")
+
+	const (
+		customServiceUser  = "otel-custom-user"
+		customServiceGroup = "otel-custom-group"
+	)
+
+	for _, distro := range selectedDistros(t, packageType) {
+		for _, arch := range selectedArches(t) {
+			t.Run(fmt.Sprintf("%s/%s", distro, arch), func(t *testing.T) {
+				pkgPath := requirePackage(t, packageType, arch)
+				container := runDistroContainer(t, packageType, distro, arch)
+				defer logJournal(t, container)
+
+				copyFileToContainer(t, container, filepath.Join(repoRoot(t), "packaging", "installer", "install.sh"))
+				installCommand := fmt.Sprintf(
+					"VERIFY_ACCESS_TOKEN=false sh /test/install.sh -- testing123 --realm test --collector-version 0.35.0 --service-user %s --service-group %s",
+					customServiceUser,
+					customServiceGroup,
+				)
+				assertExec(t, container, 10*time.Minute, installCommand)
+
+				require.Eventually(t, func() bool {
+					return serviceIsRunningAs(t, container, customServiceUser)
+				}, 20*time.Second, time.Second)
+
+				copyFileToContainer(t, container, pkgPath)
+				upgradePackage(t, container, packageType, "/test/"+filepath.Base(pkgPath))
+
+				require.Equal(t, "User="+customServiceUser, strings.TrimSpace(assertExec(
+					t, container, time.Minute, "systemctl show --property=User "+serviceName,
+				)))
+				require.Equal(t, "Group="+customServiceGroup, strings.TrimSpace(assertExec(
+					t, container, time.Minute, "systemctl show --property=Group "+serviceName,
+				)))
+
+				expectedOwner := customServiceUser + ":" + customServiceGroup
+				require.Equal(t, expectedOwner, strings.TrimSpace(assertExec(
+					t, container, time.Minute, "stat -c '%U:%G' /etc/otel/collector",
+				)))
+				require.Equal(t, expectedOwner, strings.TrimSpace(assertExec(
+					t, container, time.Minute, "stat -c '%U:%G' "+envPath,
+				)))
+				require.Equal(t, "600", strings.TrimSpace(assertExec(
+					t, container, time.Minute, "stat -c '%a' "+envPath,
+				)))
+
+				require.Eventually(t, func() bool {
+					return serviceIsRunningAs(t, container, customServiceUser)
+				}, 20*time.Second, time.Second)
+			})
+		}
+	}
+}
+
 func skipUnlessLinux(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS != "linux" {
@@ -361,8 +418,13 @@ func uninstallPackage(t *testing.T, container *testutils.Container, packageType 
 
 func serviceIsRunning(t *testing.T, container *testutils.Container) bool {
 	t.Helper()
+	return serviceIsRunningAs(t, container, serviceOwner)
+}
+
+func serviceIsRunningAs(t *testing.T, container *testutils.Container, owner string) bool {
+	t.Helper()
 	systemctlCode, _, _ := exec(t, container, time.Minute, "systemctl status "+serviceName)
-	pgrepCode, _, _ := exec(t, container, time.Minute, "pgrep -a -u "+serviceOwner+" -f "+serviceProcess)
+	pgrepCode, _, _ := exec(t, container, time.Minute, "pgrep -a -u "+owner+" -f "+serviceProcess)
 	return systemctlCode == 0 && pgrepCode == 0
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Fixes bug where running a Linux service with custom user/group has the `/etc/otel/collector` config dir ownership reverted back to the default `splunk-otel-collector` user/group on upgrade (current collector is able to still run because the `cap_dac_read_search` capability). 

**Testing:** <Describe what testing was performed and which tests were added.>
- Added packaging test to verify dir after upgrade
- Local dev test: Installed current prod collector with custom user > upgraded to local build (verified dir ownership) > made changes to `agent_config.yaml` and restarted collector (verified changes picked up) > upgraded to another local build (verified dir ownership) 
- Local dev test: Installed local build with no custom user > upgraded to another local build (verified dir ownership)


Before fix
```
vagrant@ubuntu2204:~$ ps -fp 24970
UID          PID    PPID  C STIME TTY          TIME CMD
custom-+   24970       1  9 11:22 ?        00:00:04 /usr/bin/otelcol
vagrant@ubuntu2204:~$ ll /etc/otel/collector/
total 92
drwxr-xr-x 4 splunk-otel-collector splunk-otel-collector  4096 Jul 14 11:18 ./
drwxr-xr-x 3 custom-splunk-user    custom-splunk-user     4096 Jul 14 11:15 ../
-rwxr-xr-x 1 splunk-otel-collector splunk-otel-collector  9478 Jul 10 13:16 agent_config.yaml*
drwxr-xr-x 3 splunk-otel-collector splunk-otel-collector  4096 Jul 14 11:15 .cache/
```
After fix
```
vagrant@ubuntu2204:~/otelcol_custom_user$ ps -fp 29227
UID          PID    PPID  C STIME TTY          TIME CMD
custom-+   29227       1  8 09:35 ?        00:00:10 /usr/bin/otelcol
vagrant@ubuntu2204:~/otelcol_custom_user$ ll /etc/otel/collector
total 92
drwxr-xr-x 4 custom-test-user custom-test-group  4096 Jul 16 09:35 ./
drwxr-xr-x 3 custom-test-user custom-test-group  4096 Jul 16 09:31 ../
-rwxr-xr-x 1 custom-test-user custom-test-group  9478 Jul 10 13:16 agent_config.yaml*
drwxr-xr-x 3 custom-test-user custom-test-group  4096 Jul 16 09:32 .cache/
```