### PR TITLE
Fix config dir ownership when using custom service owner during Chef or Puppet installation

### DIFF
--- a/deployments/chef/Berksfile
+++ b/deployments/chef/Berksfile
@@ -3,4 +3,5 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'nodejs'
+cookbook 'nodejs', '~> 11.0'
+cookbook 'nodejs_test', path: 'test/cookbooks/nodejs_test'

--- a/deployments/chef/CHANGELOG.md
+++ b/deployments/chef/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Bug fix: Ensure fresh installations set the collector config directory ownership to the custom service user and group (if configured) rather than the default service owner (Linux only) 
+- Bug fix: Ensure the collector config directory ownership is set to the custom service user and group (if configured) rather than the default service owner (Linux only)
 
 ## chef-v0.19.0
 

--- a/deployments/chef/CHANGELOG.md
+++ b/deployments/chef/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bug fix: Ensure fresh installations set the collector config directory ownership to the custom service user and group (if configured) rather than the default service owner (Linux only) 
+
 ## chef-v0.19.0
 
 ### 🛑 Breaking changes 🛑

--- a/deployments/chef/kitchen.yml
+++ b/deployments/chef/kitchen.yml
@@ -118,15 +118,9 @@ suites:
 
   - name: with_default_preload_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[nodejs_test]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs: &nodejs_options
-        install_method: binary
-        version: 18.20.8
-        binary:
-          append_env_path: false  # required for idempotence
-          checksum: c9193e6c414891694759febe846f4f023bf48410a6924a8b1520c46565859665
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test
@@ -134,11 +128,9 @@ suites:
 
   - name: with_custom_preload_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[nodejs_test]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs:
-        *nodejs_options
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test
@@ -156,11 +148,9 @@ suites:
 
   - name: with_default_systemd_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[nodejs_test]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs:
-        *nodejs_options
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test
@@ -169,11 +159,9 @@ suites:
 
   - name: with_custom_systemd_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[nodejs_test]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs:
-        *nodejs_options
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test
@@ -261,11 +249,9 @@ suites:
 
   - name: with_default_preload_node_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[nodejs_test]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs:
-        *nodejs_options
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test
@@ -275,11 +261,9 @@ suites:
 
   - name: with_custom_preload_node_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[nodejs_test]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs:
-        *nodejs_options
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test
@@ -299,11 +283,9 @@ suites:
 
   - name: with_default_systemd_node_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[nodejs_test]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs:
-        *nodejs_options
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test
@@ -314,11 +296,9 @@ suites:
 
   - name: with_custom_systemd_node_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[nodejs_test]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs:
-        *nodejs_options
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test

--- a/deployments/chef/recipes/collector_service_owner.rb
+++ b/deployments/chef/recipes/collector_service_owner.rb
@@ -16,6 +16,13 @@ user node['splunk_otel_collector']['user'] do
   not_if "getent passwd #{node['splunk_otel_collector']['user']}"
 end
 
+directory '/etc/otel/collector' do
+  owner node['splunk_otel_collector']['user']
+  group node['splunk_otel_collector']['group']
+  mode '0755'
+  action :create
+end
+
 execute 'systemctl daemon-reload' do
   notifies :restart, 'service[splunk-otel-collector]', :delayed
   action :nothing

--- a/deployments/chef/test/cookbooks/nodejs_test/metadata.rb
+++ b/deployments/chef/test/cookbooks/nodejs_test/metadata.rb
@@ -1,0 +1,4 @@
+name 'nodejs_test'
+version '0.1.0'
+
+depends 'nodejs'

--- a/deployments/chef/test/cookbooks/nodejs_test/recipes/default.rb
+++ b/deployments/chef/test/cookbooks/nodejs_test/recipes/default.rb
@@ -4,7 +4,7 @@ nodejs_install 'nodejs' do
   install_method 'binary'
   version '18.20.8'
   binary_checksums(
-    'linux_x64' => 'c9193e6c414891694759febe846f4f023bf48410a6924a8b1520c46565859665'
+    'linux_x64' => '27a9f3f14d5e99ad05a07ed3524ba3ee92f8ff8b6db5ff80b00f9feb5ec8097a'
   )
   append_env_path false
 end

--- a/deployments/chef/test/cookbooks/nodejs_test/recipes/default.rb
+++ b/deployments/chef/test/cookbooks/nodejs_test/recipes/default.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+nodejs_install 'nodejs' do
+  install_method 'binary'
+  version '18.20.8'
+  binary_checksums(
+    'linux_x64' => 'c9193e6c414891694759febe846f4f023bf48410a6924a8b1520c46565859665'
+  )
+  append_env_path false
+end

--- a/deployments/chef/test/integration/custom_vars/test.rb
+++ b/deployments/chef/test/integration/custom_vars/test.rb
@@ -45,6 +45,12 @@ if os[:family] == 'windows'
   end
 else
   config_path = '/etc/otel/collector/agent_config.yaml'
+  describe file('/etc/otel/collector') do
+    it { should be_directory }
+    its('owner') { should eq 'custom-user' }
+    its('group') { should eq 'custom-group' }
+    its('mode') { should cmp '0755' }
+  end
   describe file('/etc/otel/collector/splunk-otel-collector.conf') do
     its('content') { should match /^SPLUNK_ACCESS_TOKEN=#{splunk_access_token}$/ }
     its('content') { should match /^SPLUNK_API_URL=#{splunk_api_url}$/ }
@@ -58,6 +64,9 @@ else
     its('content') { should match /^MY_CUSTOM_VAR1=value1$/ }
     its('content') { should match /^MY_CUSTOM_VAR2=value2$/ }
     its('content') { should match /^OTELCOL_OPTIONS=--discovery --set=processors.batch.timeout=10s$/ }
+  end
+  describe command("su -s /bin/sh -c 'test -w /etc/otel/collector' custom-user") do
+    its('exit_status') { should eq 0 }
   end
   describe file('/etc/systemd/system/splunk-otel-collector.service.d/service-owner.conf') do
     its('content') { should match /^User=custom-user$/ }

--- a/deployments/puppet/CHANGELOG.md
+++ b/deployments/puppet/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bug fix: Ensure fresh installations set the collector config directory ownership to the custom service user and group (if configured) rather than the default service owner (Linux only) 
+
 ## puppet-v0.21.0
 
 ### 🛑 Breaking changes 🛑

--- a/deployments/puppet/CHANGELOG.md
+++ b/deployments/puppet/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Bug fix: Ensure fresh installations set the collector config directory ownership to the custom service user and group (if configured) rather than the default service owner (Linux only) 
+- Bug fix: Ensure the collector config directory ownership is set to the custom service user and group (if configured) rather than the default service owner (Linux only) 
 
 ## puppet-v0.21.0
 

--- a/deployments/puppet/manifests/collector_service_owner.pp
+++ b/deployments/puppet/manifests/collector_service_owner.pp
@@ -34,6 +34,15 @@ class splunk_otel_collector::collector_service_owner ($service_name, $service_us
     }
   }
 
+  file { '/etc/otel/collector':
+    ensure  => directory,
+    owner   => $service_user,
+    group   => $service_group,
+    mode    => '0755',
+    require => User[$service_user],
+    before  => Service[$service_name],
+  }
+
   case $::service_provider {
     'systemd': {
       $tmpfile_path = "/etc/tmpfiles.d/${service_name}.conf"

--- a/packaging/tests/deployments/puppet/puppet_test.py
+++ b/packaging/tests/deployments/puppet/puppet_test.py
@@ -48,6 +48,8 @@ PKG_NAME = "splunk-otel-collector"
 SPLUNK_ENV_PATH = f"{CONFIG_DIR}/splunk-otel-collector.conf"
 SPLUNK_ACCESS_TOKEN = "testing123"
 SPLUNK_REALM = "test"
+CUSTOM_SERVICE_OWNER = "custom-user"
+CUSTOM_SERVICE_GROUP = "custom-group"
 SPLUNK_INGEST_URL = f"https://ingest.{SPLUNK_REALM}.observability.splunkcloud.com"
 SPLUNK_API_URL = f"https://api.{SPLUNK_REALM}.observability.splunkcloud.com"
 PUPPET_RELEASE = os.environ.get("PUPPET_RELEASE", "8").split(",")
@@ -201,6 +203,8 @@ class {{ splunk_otel_collector:
     collector_version => '$version',
     collector_command_line_args => '--discovery --set=processors.batch.timeout=10s',
     collector_additional_env_vars => {{ 'MY_CUSTOM_VAR1' => 'value1', 'MY_CUSTOM_VAR2' => 'value2' }},
+    service_user => '{CUSTOM_SERVICE_OWNER}',
+    service_group => '{CUSTOM_SERVICE_GROUP}',
 }}
 """
 )
@@ -236,7 +240,13 @@ def test_puppet_with_custom_vars(distro, puppet_release):
             verify_config_file(container, SPLUNK_ENV_PATH, "OTELCOL_OPTIONS", "--discovery --set=processors.batch.timeout=10s")
             verify_config_file(container, SPLUNK_ENV_PATH, "MY_CUSTOM_VAR1", "value1")
             verify_config_file(container, SPLUNK_ENV_PATH, "MY_CUSTOM_VAR2", "value2")
-            assert wait_for(lambda: service_is_running(container))
+            assert wait_for(lambda: service_is_running(container, service_owner=CUSTOM_SERVICE_OWNER))
+            code, output = container.exec_run(f"stat -c '%U:%G:%a' {CONFIG_DIR}")
+            assert code == 0
+            assert output.decode("utf-8").strip() == f"{CUSTOM_SERVICE_OWNER}:{CUSTOM_SERVICE_GROUP}:755"
+            assert container.exec_run(
+                f"su -s /bin/sh -c 'test -w {CONFIG_DIR}' {CUSTOM_SERVICE_OWNER}"
+            ).exit_code == 0
         finally:
             run_container_cmd(container, f"journalctl -u {SERVICE_NAME} --no-pager")
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- Currently the Chef and Puppet new installs of the collector using a custom service owner will not update the `/etc/otel/collector` config dir to be owned by the custom user/group. [Ansible](https://github.com/signalfx/splunk-otel-collector/blob/main/deployments/ansible_collections/signalfx/splunk_otel_collector/roles/collector/tasks/collector_service_owner.yml#L17-L23) and [Salt](https://github.com/signalfx/splunk-otel-collector/blob/main/deployments/salt/splunk-otel-collector/service.sls#L7-L20) implementations handle this already. Added dir creation for chef and pupet in the collector service owner handling, similar to ansible.
- Fixed failing linux chef tests due to latest nodejs cookbook [breaking change](https://supermarket.chef.io/cookbooks/nodejs/versions/11.0.1#changelog) where it migrated from recipes to custom resources. Added a wrapper recipe to handle the nodejs setup from before

**Testing:** <Describe what testing was performed and which tests were added.>
- Added integration tests to verify ownership
- Local dev testing: installed local build puppet module and ran with custom user
Before fix
```
vagrant@ubuntu2204:~/puppet_test$ sudo /opt/puppetlabs/bin/puppet apply --detailed-exitcodes /tmp/otel-test.pp
Notice: /Stage[main]/Splunk_otel_collector/Exec[create collector config directory]/returns: executed successfully
...
Notice: /Stage[main]/Splunk_otel_collector::Collector_service_owner/Group[custom-test-group]/ensure: created
Notice: /Stage[main]/Splunk_otel_collector::Collector_service_owner/User[custom-test-user]/ensure: created
Notice: /Stage[main]/Splunk_otel_collector::Collector_service_owner/Exec[systemctl stop splunk-otel-collector]: Triggered 'refresh' from 1 event
vagrant@ubuntu2204:~/puppet_test$ ll /etc/otel
total 12
drwxr-xr-x   3 root                  root                  4096 Jul 17 12:14 ./
drwxr-xr-x 106 root                  root                  4096 Jul 17 12:15 ../
drwxr-xr-x   3 splunk-otel-collector splunk-otel-collector 4096 Jul 17 12:15 collector/
```
After fix
```
vagrant@ubuntu2204:~$ sudo /opt/puppetlabs/bin/puppet apply --modulepath="$LOCAL_MODULES" --detailed-exitcodes /tmp/otel-test.pp
Notice: /Stage[main]/Splunk_otel_collector/Exec[create collector config directory]/returns: executed successfully
...
Notice: /Stage[main]/Splunk_otel_collector::Collector_service_owner/Group[custom-test-group]/ensure: created
Notice: /Stage[main]/Splunk_otel_collector::Collector_service_owner/User[custom-test-user]/ensure: created
Notice: /Stage[main]/Splunk_otel_collector::Collector_service_owner/File[/etc/otel/collector]/owner: owner changed 'splunk-otel-collector' to 'custom-test-user'
Notice: /Stage[main]/Splunk_otel_collector::Collector_service_owner/File[/etc/otel/collector]/group: group changed 'splunk-otel-collector' to 'custom-test-group'
Notice: /Stage[main]/Splunk_otel_collector::Collector_service_owner/Exec[systemctl stop splunk-otel-collector]: Triggered 'refresh' from 1 event
vagrant@ubuntu2204:~$ ll /etc/otel/
total 12
drwxr-xr-x   3 root             root              4096 Jul 17 13:39 ./
drwxr-xr-x 106 root             root              4096 Jul 17 13:40 ../
drwxr-xr-x   3 custom-test-user custom-test-group 4096 Jul 17 13:40 collector/
```
