### PR TITLE
[chef] Migrate nodejs cookbook test setup

### DIFF
--- a/deployments/chef/Berksfile
+++ b/deployments/chef/Berksfile
@@ -3,4 +3,4 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'nodejs'
+cookbook 'splunk_otel_collector_test', path: 'test/fixtures/cookbooks/splunk_otel_collector_test'

--- a/deployments/chef/kitchen.yml
+++ b/deployments/chef/kitchen.yml
@@ -118,15 +118,9 @@ suites:
 
   - name: with_default_preload_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[splunk_otel_collector_test::nodejs]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs: &nodejs_options
-        install_method: binary
-        version: 18.20.8
-        binary:
-          append_env_path: false  # required for idempotence
-          checksum: c9193e6c414891694759febe846f4f023bf48410a6924a8b1520c46565859665
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test
@@ -134,11 +128,9 @@ suites:
 
   - name: with_custom_preload_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[splunk_otel_collector_test::nodejs]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs:
-        *nodejs_options
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test
@@ -156,11 +148,9 @@ suites:
 
   - name: with_default_systemd_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[splunk_otel_collector_test::nodejs]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs:
-        *nodejs_options
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test
@@ -169,11 +159,9 @@ suites:
 
   - name: with_custom_systemd_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[splunk_otel_collector_test::nodejs]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs:
-        *nodejs_options
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test
@@ -261,11 +249,9 @@ suites:
 
   - name: with_default_preload_node_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[splunk_otel_collector_test::nodejs]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs:
-        *nodejs_options
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test
@@ -275,11 +261,9 @@ suites:
 
   - name: with_custom_preload_node_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[splunk_otel_collector_test::nodejs]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs:
-        *nodejs_options
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test
@@ -299,11 +283,9 @@ suites:
 
   - name: with_default_systemd_node_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[splunk_otel_collector_test::nodejs]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs:
-        *nodejs_options
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test
@@ -314,11 +296,9 @@ suites:
 
   - name: with_custom_systemd_node_instrumentation
     run_list:
-      - recipe[nodejs]
+      - recipe[splunk_otel_collector_test::nodejs]
       - recipe[splunk_otel_collector]
     attributes:
-      nodejs:
-        *nodejs_options
       splunk_otel_collector:
         splunk_access_token: testing123
         splunk_realm: test

--- a/deployments/chef/test/fixtures/cookbooks/splunk_otel_collector_test/metadata.rb
+++ b/deployments/chef/test/fixtures/cookbooks/splunk_otel_collector_test/metadata.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+name 'splunk_otel_collector_test'
+version '0.1.0'
+
+depends 'nodejs'

--- a/deployments/chef/test/fixtures/cookbooks/splunk_otel_collector_test/recipes/nodejs.rb
+++ b/deployments/chef/test/fixtures/cookbooks/splunk_otel_collector_test/recipes/nodejs.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+nodejs_install 'nodejs' do
+  install_method 'binary'
+  version '18.20.8'
+  # Required for idempotence.
+  append_env_path false
+  binary_checksums(
+    'linux_x64' => '27a9f3f14d5e99ad05a07ed3524ba3ee92f8ff8b6db5ff80b00f9feb5ec8097a'
+  )
+end


### PR DESCRIPTION
Migrates the Chef Test Kitchen Node.js setup to the custom-resource API introduced in `nodejs` v11. The test fixture preserves the existing Node.js version and idempotence behavior while allowing Berkshelf to resolve the latest cookbook release.
