### PR TITLE
[chore] Fix .NET zero config e2e tests

### DIFF
--- a/tests/zeroconfig/windows/testdata/expected/aspnetcore.yaml
+++ b/tests/zeroconfig/windows/testdata/expected/aspnetcore.yaml
@@ -46,6 +46,9 @@ resourceSpans:
             - key: process.pid
               value:
                 intValue: "800"
+            - key: process.creation.time
+              value:
+                stringValue: "2026-07-21T21:14:58.6003205+00:00"
             - key: process.runtime.description
               value:
                 stringValue: .NET 8.0.23

--- a/tests/zeroconfig/windows/testdata/expected/aspnetfx.yaml
+++ b/tests/zeroconfig/windows/testdata/expected/aspnetfx.yaml
@@ -43,6 +43,9 @@ resourceSpans:
             - key: process.pid
               value:
                 intValue: "2068"
+            - key: process.creation.time
+              value:
+                stringValue: "2026-07-21T21:16:01.0143557+00:00"
             - key: process.runtime.description
               value:
                 stringValue: .NET Framework 4.8.4775.0

--- a/tests/zeroconfig/windows/windows_iis_test.go
+++ b/tests/zeroconfig/windows/windows_iis_test.go
@@ -147,6 +147,7 @@ func testExpectedTracesForHTTPGetRequest(t *testing.T, otlp *testutils.OTLPRecei
 				ptracetest.IgnoreResourceAttributeValue("os.description"),
 				ptracetest.IgnoreResourceAttributeValue("process.owner"),
 				ptracetest.IgnoreResourceAttributeValue("process.pid"),
+				ptracetest.IgnoreResourceAttributeValue("process.creation.time"),
 				ptracetest.IgnoreResourceAttributeValue("process.runtime.description"),
 				ptracetest.IgnoreResourceAttributeValue("process.runtime.version"),
 				ptracetest.IgnoreResourceAttributeValue("service.instance.id"),


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Ignore newly added dynamic `process.creation.time` attribute values

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
