### PR TITLE
[smartagent/netio] deprecate

### DIFF
--- a/.chloggen/deprecate_netio.yaml
+++ b/.chloggen/deprecate_netio.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/netio
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The monitor is deprecated.
+
+# One or more tracking issues related to the change
+issues: [7811]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The netio monitor is deprecated and will be removed on or after October 2026. Please use the hostmetricsreceiver instead.

--- a/internal/signalfx-agent/pkg/monitors/netio/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/netio/metadata.yaml
@@ -3,6 +3,7 @@ monitors:
     interface:
       description: The name of the network interface (e.g. `eth0`)
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Use the hostmetrics receiver instead.**
     This monitor reports I/O metrics about network interfaces.
 
     On Linux hosts, this monitor relies on the `/proc` filesystem.

--- a/internal/signalfx-agent/pkg/monitors/netio/netio.go
+++ b/internal/signalfx-agent/pkg/monitors/netio/netio.go
@@ -115,7 +115,7 @@ func (m *Monitor) EmitDatapoints() {
 // on a varied interval
 func (m *Monitor) Configure(conf *Config) error {
 	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
-
+	m.logger.Warn("The netio monitor is deprecated and will be removed on or after October 2026. Please use the hostmetricsreceiver instead.")
 	// create contexts for managing the plugin loop
 	var ctx context.Context
 	ctx, m.cancel = context.WithCancel(context.Background())


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Deprecate the netio monitor, to be removed on or after October 2026.
