### PR TITLE
[smartagent/logstash] deprecate the monitor

### DIFF
--- a/.chloggen/deprecate_logstash.yaml
+++ b/.chloggen/deprecate_logstash.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/logstash
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the monitor
+
+# One or more tracking issues related to the change
+issues: [7812]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This monitor is deprecated and will be removed on or after October 2026

--- a/internal/signalfx-agent/pkg/monitors/logstash/logstash/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/logstash/logstash/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026**
     Monitors the health and performance of Logstash deployments through 
     Logstash's [Monitoring APIs](https://www.elastic.co/guide/en/logstash/current/monitoring-logstash.html).
     

--- a/internal/signalfx-agent/pkg/monitors/logstash/logstash/monitor.go
+++ b/internal/signalfx-agent/pkg/monitors/logstash/logstash/monitor.go
@@ -62,6 +62,7 @@ type Monitor struct {
 // Configure the monitor and kick off volume metric syncing
 func (m *Monitor) Configure(conf *Config) error {
 	m.logger = utils.NewThrottledLogger(log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID}), 30*time.Second)
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026")
 	m.ctx, m.cancel = context.WithCancel(context.Background())
 	m.conf = conf
 	m.metricTypeMap = conf.getMetricTypeMap()


### PR DESCRIPTION
**Description:**
Deprecate the logstash monitor, to be removed on or after October 2026.