### PR TITLE
[chore][ta] Doc need to add instance name when copying `default/inputs.conf`

### DIFF
--- a/cmd/ta-inputs-from-schema/generator.go
+++ b/cmd/ta-inputs-from-schema/generator.go
@@ -24,7 +24,11 @@ func generateInputsConf(scheme *Scheme, globalSettings, inputName string) string
 	var sb strings.Builder
 
 	// Write header with input name
-	sb.WriteString(fmt.Sprintf("[%s]\n\n", inputName))
+	sb.WriteString(fmt.Sprintf(
+		"# ATTENTION: If copying this file as base for your local/inputs.conf\n" + 
+		"# rename the stanza below to something in the form [%s://<data_input_name>]\n" +
+		"[%s]\n\n",
+		inputName, inputName))
 
 	// Write global settings
 	sb.WriteString(globalSettings)

--- a/cmd/ta-inputs-from-schema/generator.go
+++ b/cmd/ta-inputs-from-schema/generator.go
@@ -25,9 +25,9 @@ func generateInputsConf(scheme *Scheme, globalSettings, inputName string) string
 
 	// Write header with input name
 	sb.WriteString(fmt.Sprintf(
-		"# ATTENTION: If copying this file as base for your local/inputs.conf\n" + 
-		"# rename the stanza below to something in the form [%s://<data_input_name>]\n" +
-		"[%s]\n\n",
+		"# ATTENTION: If copying this file as base for your local/inputs.conf\n"+
+			"# rename the stanza below to something in the form [%s://<data_input_name>]\n"+
+			"[%s]\n\n",
 		inputName, inputName))
 
 	// Write global settings

--- a/packaging/ta-v2/assets/default/inputs.conf
+++ b/packaging/ta-v2/assets/default/inputs.conf
@@ -1,3 +1,5 @@
+# ATTENTION: If copying this file as base for your local/inputs.conf
+# rename the stanza below to something in the form [Splunk_TA_otel://<data_input_name>]
 [Splunk_TA_otel]
 
 # Global settings, see https://help.splunk.com/en/splunk-enterprise/administer/admin-manual/9.4/configuration-file-reference/9.4.1-configuration-file-reference/inputs.conf#global-settings-0

--- a/packaging/ta-v2/run-local-package-in-container.sh
+++ b/packaging/ta-v2/run-local-package-in-container.sh
@@ -21,7 +21,7 @@ APP_NAME="${APP_NAME:-Splunk_TA_otel_linux_x86_64}"
 ASSETS_DIR="${ASSETS_DIR:-${SCRIPT_DIR}/assets}"
 LOG_DIR="${SCRIPT_DIR}/local-test-logs/var/log/splunk"
 CONTAINER_NAME="${CONTAINER_NAME:-splunk-ta-otel-test}"
-SPLUNK_VERSION="${SPLUNK_VERSION:-9.4.0}"
+SPLUNK_VERSION="${SPLUNK_VERSION:-latest}"
 
 # Check if assets directory exists
 if [ ! -d "$ASSETS_DIR" ]; then


### PR DESCRIPTION
The current format of the "stanza" in the `default/inputs.conf` is correct, but users use that as a "starter" file to create their own `local/inputs.conf` and get puzzled when it doesn't work due to the lack of a instance name. Documenting this on the `default/inputs.conf` to reduce the chances of users repeating this issue while keeping a good experience for users using the Splunk UI.
