### PR TITLE
[smartagent/conviva] deprecate conviva monitor

### DIFF
--- a/.chloggen/deprecate_conviva.yaml
+++ b/.chloggen/deprecate_conviva.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/conviva
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the monitor
+
+# One or more tracking issues related to the change
+issues: [7816]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This monitor is deprecated and will be removed on or after October 2026

--- a/internal/signalfx-agent/pkg/monitors/conviva/conviva.go
+++ b/internal/signalfx-agent/pkg/monitors/conviva/conviva.go
@@ -55,6 +55,7 @@ func init() {
 // Configure monitor
 func (m *Monitor) Configure(conf *Config) error {
 	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026")
 	m.timeout = time.Duration(conf.TimeoutSeconds) * time.Second
 	m.client = newConvivaClient(&http.Client{
 		Transport: &http.Transport{

--- a/internal/signalfx-agent/pkg/monitors/conviva/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/conviva/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026**
     This monitor uses version 2.4 of the Conviva Experience Insights REST APIs to pull
     `Real-Time/Live` video playing experience metrics from Conviva.
 


### PR DESCRIPTION
**Description:** 
This monitor is deprecated and will be removed on or after October 2026
