### PR TITLE
[smartagent/prometheusexporter] deprecate prometheusexporter 

### DIFF
--- a/.chloggen/deprecate_prometheusexporter.yaml
+++ b/.chloggen/deprecate_prometheusexporter.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/prometheusexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The monitor is deprecated.
+
+# One or more tracking issues related to the change
+issues: [7817]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The prometheusexporter monitor is deprecated, as well as all the submonitors (prometheus/redis, prometheus/prometheus, prometheus/postgres, prometheus/node, prometheus/nginx-vts, prometheus/nginx-ingress, prometheus/go).
+  For all those use cases, please use a dedicated receiver or use the [prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)

--- a/internal/signalfx-agent/pkg/monitors/prometheus/go/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/prometheus/go/metadata.yaml
@@ -2,6 +2,7 @@ goPackage: prometheusgo
 monitors:
 - monitorType: prometheus/go
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the Golang instrumentation SDK instead.**
     This monitor scrapes [Prometheus Go
     collector](https://godoc.org/github.com/prometheus/client_golang/prometheus#NewGoCollector)
     and [Prometheus process

--- a/internal/signalfx-agent/pkg/monitors/prometheus/nginxingress/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/prometheus/nginxingress/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - monitorType: prometheus/nginx-ingress
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the nginxreceiver instead.**
     This monitor gets metrics from [Ingress 
     Nginx](https://github.com/kubernetes/ingress-nginx).
     It is a wrapper around the [prometheus-exporter](./prometheus-exporter.md) 

--- a/internal/signalfx-agent/pkg/monitors/prometheus/nginxvts/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/prometheus/nginxvts/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - monitorType: prometheus/nginx-vts
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the nginxreceiver instead.**
     This monitor scrapes [Prometheus Nginx VTS
     exporter](https://github.com/hnlq715/nginx-vts-exporter) metrics from a
     Prometheus exporter and sends them to SignalFx.  It is a wrapper around the

--- a/internal/signalfx-agent/pkg/monitors/prometheus/node/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/prometheus/node/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - monitorType: prometheus/node
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the prometheusreceiver instead.**
     This monitor scrapes [Prometheus Node
     Exporter](https://github.com/prometheus/node_exporter) metrics and sends
     them to SignalFx.  It is a wrapper around the

--- a/internal/signalfx-agent/pkg/monitors/prometheus/postgres/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/prometheus/postgres/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - monitorType: prometheus/postgres
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the postgresqlreceiver instead.**
     This monitor scrapes [Prometheus PostgreSQL Server
     Exporter](https://github.com/wrouesnel/postgres_exporter) metrics and sends
     them to SignalFx.  It is a wrapper around the

--- a/internal/signalfx-agent/pkg/monitors/prometheus/prometheus/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/prometheus/prometheus/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - monitorType: prometheus/prometheus
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the prometheusreceiver instead.**
     This monitor scrapes [Prometheus server's own internal
     collector](https://prometheus.io/docs/prometheus/latest/getting_started/#configuring-prometheus-to-monitor-itself)
     metrics from a Prometheus exporter and sends them to SignalFx.  It is a

--- a/internal/signalfx-agent/pkg/monitors/prometheus/redis/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/prometheus/redis/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - monitorType: prometheus/redis
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the redisreceiver instead.**
     This monitor scrapes [Prometheus Redis
     Exporter](https://github.com/oliver006/redis_exporter) metrics and sends
     them to SignalFx.  It is a wrapper around the

--- a/internal/signalfx-agent/pkg/monitors/prometheusexporter/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/prometheusexporter/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the prometheusreceiver instead.**
     This monitor reads metrics from a [Prometheus
     exporter](https://prometheus.io/docs/instrumenting/exporters/) endpoint.
 

--- a/internal/signalfx-agent/pkg/monitors/prometheusexporter/prometheus.go
+++ b/internal/signalfx-agent/pkg/monitors/prometheusexporter/prometheus.go
@@ -98,7 +98,7 @@ type fetcher func() (io.ReadCloser, expfmt.Format, error)
 // Configure the monitor and kick off volume metric syncing
 func (m *Monitor) Configure(conf *Config) error {
 	m.logger = logrus.WithFields(logrus.Fields{"monitorType": m.monitorName, "monitorID": conf.MonitorID})
-
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026. Please use the prometheusreceiver instead.")
 	var bearerToken string
 
 	if conf.UseServiceAccount {


### PR DESCRIPTION
**Description:** 
The prometheusexporter monitor is deprecated, as well as all the submonitors (prometheus/redis, prometheus/prometheus, prometheus/postgres, prometheus/node, prometheus/nginx-vts, prometheus/nginx-ingress, prometheus/go).
  For all those use cases, please use a dedicated receiver or use the [prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)
