### PR TITLE
[smartagent/cgroups] deprecate the monitor

### DIFF
--- a/.chloggen/deprecate_cgroups.yaml
+++ b/.chloggen/deprecate_cgroups.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/cgroups
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the monitor
+
+# One or more tracking issues related to the change
+issues: [7818]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This monitor is deprecated and will be removed on or after October 2026. Please use the hostmetrics receiver instead.

--- a/internal/signalfx-agent/pkg/monitors/cgroups/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/cgroups/metadata.yaml
@@ -1,5 +1,6 @@
 monitors:
 - doc: |
+    **This monitor is deprecated and will be removed on or after October 2026**
     Reports statistics about cgroups on Linux.  This only supports cgroups v1
     and not the newer v2 unified implementation.
 

--- a/internal/signalfx-agent/pkg/monitors/cgroups/monitor.go
+++ b/internal/signalfx-agent/pkg/monitors/cgroups/monitor.go
@@ -51,6 +51,7 @@ type Monitor struct {
 // Configure the monitor and start collection
 func (m *Monitor) Configure(conf *Config) error {
 	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026")
 	var ctx context.Context
 	ctx, m.cancel = context.WithCancel(context.Background())
 


### PR DESCRIPTION
**Description:**
This monitor is deprecated and will be removed on or after October 2026. Please use the hostmetrics receiver instead.
