### PR TITLE
[smartagent/elasticsearch-query] deprecate the monitor

### DIFF
--- a/.chloggen/deprecate_elasticsearch-query.yaml
+++ b/.chloggen/deprecate_elasticsearch-query.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/elasticsearch-query
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: This monitor is deprecated and will be removed on or after October 2026.
+
+# One or more tracking issues related to the change
+issues: [7819]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/signalfx-agent/pkg/monitors/elasticsearch/query/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/elasticsearch/query/metadata.yaml
@@ -1,7 +1,7 @@
 monitors:
   - monitorType: elasticsearch-query
     doc: |
-      **This monitor is in beta.**
+      **This monitor is deprecated and will be removed on or after October 2026.**
 
       This monitor metricizes aggregated responses from Elasticsearch. The monitor
       constructs SignalFx datapoints based on Elasticsearch aggregation types and

--- a/internal/signalfx-agent/pkg/monitors/elasticsearch/query/monitor.go
+++ b/internal/signalfx-agent/pkg/monitors/elasticsearch/query/monitor.go
@@ -48,6 +48,7 @@ func init() {
 // Configure monitor
 func (m *Monitor) Configure(config *Config) error {
 	m.logger = logger.WithField("monitorID", config.MonitorID)
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026.")
 	httpClient, err := config.HTTPConfig.Build()
 	if err != nil {
 		return err


### PR DESCRIPTION
**Description:**

 This monitor is deprecated and will be removed on or after October 2026.