### PR TITLE
[chore] Make KVM unload reliable for Ansible Windows Vagrant tests

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -210,17 +210,26 @@ jobs:
           name: msi-build-amd64
           path: /tmp/msi-build
       # Workaround for https://github.com/actions/runner-images/issues/13202
-      - name: Unload KVM module (AMD)
+      # VirtualBox cannot grab VT-x/AMD-V while the KVM modules are loaded,
+      # which makes `vagrant up` fail with "VBoxManage: ... (VERR_NOT_AVAILABLE)".
+      # A single modprobe -r is racy: the module can be briefly held right after
+      # boot, so retry until kvm is gone and fail loudly if it never unloads.
+      - name: Unload KVM module
         run: |
-          # Check if KVM modules are loaded
-          lsmod | grep kvm
-          # Unload KVM modules if present (for Intel or AMD CPUs)
-          sudo modprobe -r kvm_intel || true
-          sudo modprobe -r kvm_amd || true
-          sudo rmmod kvm || true
-          # Verify KVM is unloaded
-          lsmod | grep kvm
-        continue-on-error: true
+          echo "KVM modules before unload:"
+          lsmod | grep kvm || echo "  (none loaded)"
+          for attempt in $(seq 1 10); do
+            sudo modprobe -r kvm_intel kvm_amd kvm 2>/dev/null || true
+            if ! lsmod | grep -q '^kvm'; then
+              echo "KVM unloaded after attempt ${attempt}."
+              exit 0
+            fi
+            echo "kvm still loaded, retrying (attempt ${attempt})..."
+            sleep 3
+          done
+          echo "ERROR: failed to unload KVM modules; VirtualBox will not be able to start VMs." >&2
+          lsmod | grep kvm >&2
+          exit 1
 
       - name: Install vagrant and virtualbox
         run: |


### PR DESCRIPTION
The Windows Ansible molecule jobs run under Vagrant/VirtualBox on `ubuntu-24.04` runners. Since runner image `20251013.424` ([actions/runner-images#13202](https://github.com/actions/runner-images/issues/13202)) VirtualBox cannot acquire VT-x/AMD-V while the KVM kernel modules are loaded, so `vagrant up` intermittently fails at `startvm` with:

```
VBoxManage: error: Something is not available or not working properly. (VERR_NOT_AVAILABLE)
```

This is why the same failure shows up across unrelated PRs (e.g. #7714 and other branches) regardless of their contents — it depends on the runner image assigned, not the change.

The existing "Unload KVM module (AMD)" step attempts a single `modprobe -r`, but the module can be briefly held right after boot, so the removal sometimes doesn't take. It also ran under `bash -e` with a trailing `lsmod | grep kvm` (exit 1 once kvm is gone) and was wrapped in `continue-on-error: true`, so a failed unload was silently ignored and only surfaced later as the VBoxManage error.

**Fix:** retry the unload until `kvm` is actually gone (up to 10 attempts), drop `continue-on-error`, and fail the step loudly with the current `lsmod` output if the modules never unload — so the real cause is visible instead of a confusing downstream VBoxManage failure.