### PR TITLE
[chore] Collapse base-image 7-Zip/SQLite grype ignores to per-location rules

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -11,40 +11,18 @@ ignore:
       name: MimeKit
       type: dotnet
       location: "**/MimeKitLite.dll"
-  - vulnerability: CVE-2025-53816
-    reason: Coming from Windows base image, tracking via https://github.com/microsoft/Windows-Containers/issues/610
+  # 7-Zip and SQLite ship inside the Windows servercore base image and are not
+  # components we install, invoke, or ship. We cannot patch the base-image DLLs;
+  # fixes must come from Microsoft. Ignore all findings for these two paths
+  # rather than tracking individual CVE IDs that churn on every base-image bump.
+  # Tracking via https://github.com/microsoft/Windows-Containers/issues/610
+  - reason: Coming from Windows base image, tracking via https://github.com/microsoft/Windows-Containers/issues/610
     package:
       name: 7-Zip
       type: binary
       location: "/Files/Windows/WinSxS/**/7z.dll"
-  - vulnerability: CVE-2025-53817
-    reason: Coming from Windows base image, tracking via https://github.com/microsoft/Windows-Containers/issues/610
-    package:
-      name: 7-Zip
-      type: binary
-      location: "/Files/Windows/WinSxS/**/7z.dll"
-  - vulnerability: CVE-2025-55188
-    reason: Coming from Windows base image, tracking via https://github.com/microsoft/Windows-Containers/issues/610
-    package:
-      name: 7-Zip
-      type: binary
-      location: "/Files/Windows/WinSxS/**/7z.dll"
-  - vulnerability: CVE-2025-3277
-    reason: Coming from Windows base image, tracking via https://github.com/microsoft/Windows-Containers/issues/610
+  - reason: Coming from Windows base image, tracking via https://github.com/microsoft/Windows-Containers/issues/610
     package:
       name: SQLite
       type: binary
       location: "**/Files/Windows/**/winsqlite3.dll"
-  - vulnerability: CVE-2025-6965
-    reason: Coming from Windows base image, tracking via https://github.com/microsoft/Windows-Containers/issues/610
-    package:
-      name: SQLite
-      type: binary
-      location: "**/Files/Windows/**/winsqlite3.dll"
-  - vulnerability: CVE-2025-29087
-    reason: Coming from Windows base image, tracking via https://github.com/microsoft/Windows-Containers/issues/610
-    package:
-      name: SQLite
-      type: binary
-      location: "**/Files/Windows/**/winsqlite3.dll"
-


### PR DESCRIPTION
The `anchore-win-image-scan` job (windows-2022 and windows-2025) fails on `main`. All findings come from the Windows `servercore` base image, not our code or Go deps:

- `7z.dll` (7-Zip) under `Files/Windows/WinSxS/...` — CVE-2026-48092, 48095, 48103, 48111
- `winsqlite3.dll` (SQLite) under `Files/Windows/...` — CVE-2025-70873, CVE-2026-11822, 11824

These are OS-layer DLLs we don't install, invoke, or ship, and can't patch. Fixes must come from Microsoft (tracking: [microsoft/Windows-Containers#610](https://github.com/microsoft/Windows-Containers/issues/610)). The Dockerfile already builds with `--pull` on the `ltsc*` tags, so builds pick up patched DLLs as soon as Microsoft ships them.

Every base-image bump introduces new CVE IDs for these same two DLLs, and `.grype.yaml`'s `ignore.vulnerability` field is exact-match only (no globs or lists), so the list grew by one entry per CVE. Omitting `vulnerability` makes a rule match **all** vulnerabilities for the given package + location.