### PR TITLE
[chore] Add monitoring Windows Scheduled Task example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -46,6 +46,14 @@ This example showcases how the collector can monitor a script run periodically v
 
 [Read more...](./systemd-timer-monitoring)
 
+## [Monitoring a Windows Scheduled Task](./windows-task-scheduler-monitoring)
+
+This example showcases how the collector can monitor a script run periodically via Windows Task Scheduler,
+using the `windows_event_log` receiver to capture scheduler and application logs and a generic PowerShell
+wrapper to report the exit status of any scheduled task as a metric.
+
+[Read more...](./windows-task-scheduler-monitoring)
+
 # Dependencies
 
 - docker

--- a/examples/windows-task-scheduler-monitoring/.gitignore
+++ b/examples/windows-task-scheduler-monitoring/.gitignore
@@ -1,0 +1,1 @@
+otelcol.exe

--- a/examples/windows-task-scheduler-monitoring/Dockerfile
+++ b/examples/windows-task-scheduler-monitoring/Dockerfile
@@ -1,0 +1,22 @@
+ARG BASE_IMAGE=mcr.microsoft.com/windows/servercore:ltsc2022
+
+FROM ${BASE_IMAGE}
+
+SHELL ["powershell", "-NoProfile", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+WORKDIR "C:\\otelcol"
+COPY otelcol.exe .\\otelcol.exe
+COPY otel-collector-config.yaml .\\otel-collector-config.yaml
+
+WORKDIR "C:\\backup-job"
+COPY backup-job\\ .\\
+
+RUN New-EventLog -LogName Application -Source BackupJob
+
+WORKDIR "C:\\"
+COPY start-example.ps1 .\\start-example.ps1
+
+ENV INFLUXDB_ENDPOINT="http://127.0.0.1:8086/api/v2/write?org=example-org&bucket=example-bucket&precision=s"
+ENV OTLP_ENDPOINT="http://127.0.0.1:4318/v1/metrics"
+
+ENTRYPOINT ["powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "C:\\start-example.ps1"]

--- a/examples/windows-task-scheduler-monitoring/README.md
+++ b/examples/windows-task-scheduler-monitoring/README.md
@@ -1,0 +1,109 @@
+# Monitoring a Windows Scheduled Task with the Splunk OpenTelemetry Collector
+
+This example shows how to monitor a script that runs on a recurring schedule
+via the [Windows Task Scheduler](https://learn.microsoft.com/windows/win32/taskschd/task-scheduler-start-page),
+using the Splunk OpenTelemetry Collector.
+
+The `\BackupJob` scheduled task runs every minute (a short interval chosen for
+this demo; a real task would typically use a daily, weekly, or event-based
+trigger). The task runs [`backup-job.ps1`](./backup-job/backup-job.ps1), which
+stands in for a pre-existing job script: it logs progress to the Windows
+Application event log and reports its own `duration_seconds`/`size_bytes` as
+[InfluxDB line protocol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/)
+after each run. It has no other telemetry code, and in particular does not
+report whether the scheduled task succeeded or failed.
+
+Exit-status monitoring is added on top without touching that script, using
+[`run-scheduled-job-with-status.ps1`](./backup-job/run-scheduled-job-with-status.ps1),
+a generic wrapper configured as the scheduled task action. The wrapper runs the
+job script, preserves its exit code for Task Scheduler, and pushes a
+success/failure metric to the collector. The same wrapper can be reused for any
+other PowerShell script, cmd/bat script, or executable run by Task Scheduler.
+
+The collector is configured with four receivers:
+
+- [`windows_event_log`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/windowseventlogreceiver/README.md),
+  reading `Microsoft-Windows-TaskScheduler/Operational`. This captures task
+  lifecycle events such as task start, action launch, action completion with
+  return code, and task finish.
+- `windows_event_log`, reading `Application`. This captures the demo script's
+  own log entries from the `BackupJob` event source.
+- [`otlp`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md),
+  to receive the metrics `run-scheduled-job-with-status.ps1` pushes directly.
+- [`influxdb`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/influxdbreceiver/README.md),
+  to receive the `backup_job duration_seconds=...,size_bytes=...` line
+  protocol metric `backup-job.ps1` pushes directly.
+
+See [`otel-collector-config.yaml`](./otel-collector-config.yaml) for the full,
+minimal configuration. Both pipelines send to the `debug` exporter so you can
+see the results directly in the collector's logs.
+
+## Running the example
+
+This example runs a single Windows container instead of using Docker Compose.
+Before building the image, place a Windows collector binary named
+`otelcol.exe` in this directory.
+
+To download it from the
+[project's GitHub releases page](https://github.com/signalfx/splunk-otel-collector/releases),
+replace the version below with the release you want to use, then run from the
+repository root:
+
+```powershell
+$collectorVersion = '0.149.0'
+$asset = "agent-bundle_${collectorVersion}_windows_amd64.zip"
+$downloadUrl = "https://github.com/signalfx/splunk-otel-collector/releases/download/v${collectorVersion}/${asset}"
+$downloadPath = ".\examples\windows-task-scheduler-monitoring\$asset"
+$extractPath = ".\examples\windows-task-scheduler-monitoring\release"
+
+Invoke-WebRequest -Uri $downloadUrl -OutFile $downloadPath
+Expand-Archive -Path $downloadPath -DestinationPath $extractPath -Force
+Copy-Item (Get-ChildItem $extractPath -Recurse -Filter otelcol.exe | Select-Object -First 1).FullName .\examples\windows-task-scheduler-monitoring\otelcol.exe
+```
+
+Alternatively, build it locally from the repository root:
+
+```powershell
+$env:GOOS = 'windows'
+$env:GOARCH = 'amd64'
+$env:CGO_ENABLED = '0'
+go build -trimpath -o .\examples\windows-task-scheduler-monitoring\otelcol.exe .\cmd\otelcol
+```
+
+Or, if you already built the Windows binary under `bin`:
+
+```powershell
+Copy-Item .\bin\otelcol_windows_amd64.exe .\examples\windows-task-scheduler-monitoring\otelcol.exe
+```
+
+Then build and run the container:
+
+```powershell
+docker build -t windows-task-scheduler-monitoring .\examples\windows-task-scheduler-monitoring
+docker run --rm --name windows-task-scheduler-monitoring windows-task-scheduler-monitoring
+```
+
+The container starts the collector, enables the Task Scheduler Operational
+event log channel, registers `\BackupJob`, runs it once immediately, then lets
+Task Scheduler run it every minute.
+
+You should see `LogRecord` output for Task Scheduler events from
+`Microsoft-Windows-TaskScheduler/Operational`, `LogRecord` output for the
+script's `BackupJob` Application events, `windows_task_scheduler.job.successful_run`
+and `windows_task_scheduler.job.failed_run` metrics from the wrapper, and
+`backup_job_duration_seconds`/`backup_job_size_bytes` metrics from
+`backup-job.ps1`.
+
+## Notes on the setup
+
+- Windows Task Scheduler does not have a direct equivalent to systemd's
+  `ExecStopPost=`. This example uses a reusable wrapper as the scheduled task
+  action so exit-status metrics can be added without editing the existing job
+  script.
+- Task Scheduler's event log records action return codes but not a task
+  process's stdout/stderr. Scripts that need searchable execution logs should
+  write to an event log, a file collected by the `filelog` receiver, or another
+  existing logging destination.
+- The example uses `mcr.microsoft.com/windows/servercore:ltsc2022` as its base
+  image and copies in a local `otelcol.exe`, avoiding a multi-container Compose
+  setup for Windows containers.

--- a/examples/windows-task-scheduler-monitoring/backup-job/backup-job.ps1
+++ b/examples/windows-task-scheduler-monitoring/backup-job/backup-job.ps1
@@ -1,0 +1,34 @@
+# Stand-in for a pre-existing backup script, run periodically by the
+# \BackupJob scheduled task. Its only telemetry is writing progress to the
+# Windows Application event log and pushing its own duration/size metrics as
+# InfluxDB line protocol, the same way it might already report to an existing
+# InfluxDB/Telegraf setup; it knows nothing about the collector otherwise, and
+# nothing about its own exit status (see run-scheduled-job-with-status.ps1 and
+# its scheduled task action wiring for that).
+
+$ErrorActionPreference = 'Stop'
+
+$source = 'BackupJob'
+$influxDbEndpoint = if ($env:INFLUXDB_ENDPOINT) {
+    $env:INFLUXDB_ENDPOINT
+} else {
+    'http://127.0.0.1:8086/api/v2/write?org=example-org&bucket=example-bucket&precision=s'
+}
+
+Write-EventLog -LogName Application -Source $source -EntryType Information -EventId 1000 -Message 'backup-job: starting backup of C:\Windows\System32\drivers\etc'
+
+$startTime = Get-Date
+$timestamp = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+$archive = "C:\Windows\Temp\etc-backup-$timestamp.zip"
+
+Compress-Archive -Path 'C:\Windows\System32\drivers\etc\*' -DestinationPath $archive -Force
+
+$durationSeconds = [Math]::Max(0, [int]((Get-Date) - $startTime).TotalSeconds)
+$sizeBytes = (Get-Item $archive).Length
+
+Write-EventLog -LogName Application -Source $source -EntryType Information -EventId 1001 -Message "backup-job: finished in ${durationSeconds}s, size ${sizeBytes} bytes"
+
+$body = "backup_job duration_seconds=${durationSeconds},size_bytes=${sizeBytes}"
+$response = Invoke-WebRequest -UseBasicParsing -Method Post -Uri $influxDbEndpoint -Body $body
+
+Write-EventLog -LogName Application -Source $source -EntryType Information -EventId 1002 -Message "backup-job: pushed metrics to $influxDbEndpoint, HTTP $($response.StatusCode)"

--- a/examples/windows-task-scheduler-monitoring/backup-job/run-scheduled-job-with-status.ps1
+++ b/examples/windows-task-scheduler-monitoring/backup-job/run-scheduled-job-with-status.ps1
@@ -1,0 +1,190 @@
+# Generic Windows Scheduled Task status reporter.
+#
+# Configure this wrapper as the action of any scheduled task to push a
+# success/failure metric for its last run without changing the job's own
+# script or executable at all:
+#
+#   powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\path\run-scheduled-job-with-status.ps1 -TaskName \YourTask -FilePath C:\path\your-existing-job.ps1
+#
+# The wrapper runs the target .ps1, .cmd/.bat, or .exe, maps its process exit
+# code to success/failure metrics, pushes those metrics to the collector over
+# OTLP HTTP, and exits with the same code so Task Scheduler still records the
+# original result.
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $TaskName,
+
+    [Parameter(Mandatory = $true)]
+    [string] $FilePath,
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $JobArguments = @()
+)
+
+$ErrorActionPreference = 'Continue'
+
+function ConvertTo-CommandLineArgument {
+    param(
+        [AllowEmptyString()]
+        [string] $Argument
+    )
+
+    if ($Argument.Length -gt 0 -and $Argument -notmatch '[\s"]') {
+        return $Argument
+    }
+
+    $quoted = '"'
+    $backslashes = 0
+
+    foreach ($char in $Argument.ToCharArray()) {
+        if ($char -eq '\') {
+            $backslashes++
+            continue
+        }
+
+        if ($char -eq '"') {
+            $quoted += ('\' * (($backslashes * 2) + 1))
+            $quoted += '"'
+            $backslashes = 0
+            continue
+        }
+
+        if ($backslashes -gt 0) {
+            $quoted += ('\' * $backslashes)
+            $backslashes = 0
+        }
+        $quoted += $char
+    }
+
+    if ($backslashes -gt 0) {
+        $quoted += ('\' * ($backslashes * 2))
+    }
+
+    $quoted += '"'
+    return $quoted
+}
+
+function Join-CommandLineArguments {
+    param(
+        [string[]] $Arguments
+    )
+
+    return (($Arguments | ForEach-Object { ConvertTo-CommandLineArgument $_ }) -join ' ')
+}
+
+function Invoke-ScheduledJob {
+    param(
+        [string] $TargetPath,
+        [string[]] $TargetArguments
+    )
+
+    $extension = [System.IO.Path]::GetExtension($TargetPath).ToLowerInvariant()
+    switch ($extension) {
+        '.ps1' {
+            $processPath = 'powershell.exe'
+            $processArguments = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $TargetPath) + $TargetArguments
+        }
+        { $_ -in @('.cmd', '.bat') } {
+            $processPath = 'cmd.exe'
+            $processArguments = @('/d', '/c', $TargetPath) + $TargetArguments
+        }
+        default {
+            $processPath = $TargetPath
+            $processArguments = $TargetArguments
+        }
+    }
+
+    $process = Start-Process `
+        -FilePath $processPath `
+        -ArgumentList (Join-CommandLineArguments $processArguments) `
+        -NoNewWindow `
+        -Wait `
+        -PassThru `
+        -ErrorAction Stop
+
+    return $process.ExitCode
+}
+
+$otlpEndpoint = if ($env:OTLP_ENDPOINT) {
+    $env:OTLP_ENDPOINT
+} else {
+    'http://127.0.0.1:4318/v1/metrics'
+}
+
+try {
+    if (-not (Test-Path -LiteralPath $FilePath -PathType Leaf)) {
+        throw "File not found: $FilePath"
+    }
+    $exitCode = Invoke-ScheduledJob -TargetPath $FilePath -TargetArguments $JobArguments
+} catch {
+    Write-Host "run-scheduled-job-with-status: failed to run ${FilePath}: $($_.Exception.Message)"
+    $exitCode = 1
+}
+
+$successfulRun = 0
+$failedRun = 1
+if ($exitCode -eq 0) {
+    $successfulRun = 1
+    $failedRun = 0
+}
+
+Write-Host "run-scheduled-job-with-status: $TaskName exit_code=$exitCode"
+
+$nowUnixNano = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds() * 1000000
+$payload = @{
+    resourceMetrics = @(
+        @{
+            resource = @{
+                attributes = @(
+                    @{
+                        key = 'scheduler.provider'
+                        value = @{ stringValue = 'windows_task_scheduler' }
+                    },
+                    @{
+                        key = 'scheduler.task.name'
+                        value = @{ stringValue = $TaskName }
+                    }
+                )
+            }
+            scopeMetrics = @(
+                @{
+                    scope = @{ name = 'run-scheduled-job-with-status.ps1' }
+                    metrics = @(
+                        @{
+                            name = 'windows_task_scheduler.job.successful_run'
+                            gauge = @{
+                                dataPoints = @(
+                                    @{
+                                        timeUnixNano = "$nowUnixNano"
+                                        asInt = $successfulRun
+                                    }
+                                )
+                            }
+                        },
+                        @{
+                            name = 'windows_task_scheduler.job.failed_run'
+                            gauge = @{
+                                dataPoints = @(
+                                    @{
+                                        timeUnixNano = "$nowUnixNano"
+                                        asInt = $failedRun
+                                    }
+                                )
+                            }
+                        }
+                    )
+                }
+            )
+        }
+    )
+} | ConvertTo-Json -Depth 20 -Compress
+
+try {
+    $response = Invoke-WebRequest -UseBasicParsing -Method Post -Uri $otlpEndpoint -ContentType 'application/json' -Body $payload
+    Write-Host "run-scheduled-job-with-status: pushed metrics for $TaskName to $otlpEndpoint, HTTP $($response.StatusCode)"
+} catch {
+    Write-Host "run-scheduled-job-with-status: failed to push metrics for $TaskName to ${otlpEndpoint}: $($_.Exception.Message)"
+}
+
+exit $exitCode

--- a/examples/windows-task-scheduler-monitoring/otel-collector-config.yaml
+++ b/examples/windows-task-scheduler-monitoring/otel-collector-config.yaml
@@ -1,0 +1,55 @@
+receivers:
+  # Reads Windows Task Scheduler's Operational channel for task lifecycle
+  # events, including start, action launch, action completion, and task finish.
+  # Enable this channel before collecting it; start-example.ps1 does that for
+  # this container.
+  windows_event_log/task_scheduler:
+    query: |
+      <QueryList>
+        <Query Id="0">
+          <Select Path="Microsoft-Windows-TaskScheduler/Operational">*[EventData[Data[@Name='TaskName']='\BackupJob']]</Select>
+        </Query>
+      </QueryList>
+    start_at: beginning
+    raw: true
+
+  # Reads the demo job's own application log entries. In a real deployment,
+  # use the log channel where the scheduled task already writes.
+  windows_event_log/application:
+    query: |
+      <QueryList>
+        <Query Id="0">
+          <Select Path="Application">*[System[Provider[@Name='BackupJob']]]</Select>
+        </Query>
+      </QueryList>
+    start_at: beginning
+    raw: true
+
+  # Receives the exit-status metrics that run-scheduled-job-with-status.ps1
+  # pushes after each task run.
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+  # Receives the duration/size metrics that backup-job.ps1 pushes directly
+  # after each run, as InfluxDB line protocol.
+  # See https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/influxdbreceiver/README.md
+  influxdb:
+    endpoint: 0.0.0.0:8086
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    logs/task_scheduler:
+      receivers: [windows_event_log/task_scheduler]
+      exporters: [debug]
+    logs/application:
+      receivers: [windows_event_log/application]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp, influxdb]
+      exporters: [debug]

--- a/examples/windows-task-scheduler-monitoring/start-example.ps1
+++ b/examples/windows-task-scheduler-monitoring/start-example.ps1
@@ -1,0 +1,43 @@
+# Container entrypoint for the Windows Task Scheduler monitoring example.
+#
+# Starts the collector, enables the Task Scheduler Operational event log
+# channel, registers the demo \BackupJob scheduled task, runs it once
+# immediately, and keeps the container alive by waiting on the collector.
+
+$ErrorActionPreference = 'Stop'
+
+$collector = Start-Process `
+    -FilePath 'C:\otelcol\otelcol.exe' `
+    -ArgumentList '--config=C:\otelcol\otel-collector-config.yaml' `
+    -NoNewWindow `
+    -PassThru
+
+try {
+    wevtutil.exe sl Microsoft-Windows-TaskScheduler/Operational /e:true
+
+    $deadline = (Get-Date).AddSeconds(30)
+    do {
+        try {
+            $client = [System.Net.Sockets.TcpClient]::new()
+            $client.Connect('127.0.0.1', 4318)
+            $client.Close()
+            break
+        } catch {
+            if ((Get-Date) -ge $deadline) {
+                throw 'Timed out waiting for the collector OTLP HTTP endpoint.'
+            }
+            Start-Sleep -Seconds 1
+        }
+    } while ($true)
+
+    $taskAction = 'powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\backup-job\run-scheduled-job-with-status.ps1 -TaskName \BackupJob -FilePath C:\backup-job\backup-job.ps1'
+    schtasks.exe /Create /TN \BackupJob /SC MINUTE /MO 1 /TR $taskAction /RU SYSTEM /F
+    schtasks.exe /Run /TN \BackupJob
+
+    Write-Host 'BackupJob is scheduled to run every minute. Collector output follows.'
+    Wait-Process -Id $collector.Id
+} finally {
+    if (-not $collector.HasExited) {
+        Stop-Process -Id $collector.Id -Force
+    }
+}


### PR DESCRIPTION
Same pattern as #7825 but adapted to Windows Scheduled Tasks. The main difference is that this example is just a Windows container image, since we couldn't run a Docker compose for Windows images. As on the PR for the systemd timer example, the Windows example shows a legacy script publishing InfluxDB metrics and being executed and monitored, via logs and metrics, by the Splunk OpenTelemetry collector.
