### PR TITLE
[config generation] YAML overlays

### DIFF
--- a/.chloggen/generate_yaml_overlay.yaml
+++ b/.chloggen/generate_yaml_overlay.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: config
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Generate agent config using YAML overlays
+
+# One or more tracking issues related to the change
+issues: [7847]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,6 +45,21 @@ jobs:
             exit 1
           fi
 
+  generate-configs:
+    name: generate-configs
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup-environment
+
+      - name: generate-configs
+        run: |
+          make generate-configs
+          if ! git diff --exit-code; then
+            echo "Generated configs are out of date. Run 'make generate-configs' and push the changes."
+            exit 1
+          fi
+
   generate-metrics:
     name: generate-metrics
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,10 @@ install-tools:
 	cd ./internal/tools && go install go.opentelemetry.io/build-tools/chloggen
 	cd ./internal/tools && go install mvdan.cc/gofumpt
 
+.PHONY: generate-configs
+generate-configs:
+	cd $(SRC_ROOT)/cmd/default-config-generator && $(GOCMD) run .
+
 .PHONY: generate-metrics
 generate-metrics:
 	go generate -tags mdatagen ./...

--- a/cmd/default-config-generator/config/agent_config.yaml
+++ b/cmd/default-config-generator/config/agent_config.yaml
@@ -1,0 +1,264 @@
+# Default configuration file for the Linux (deb/rpm) and Windows MSI collector packages
+
+# If the collector is installed without the Linux/Windows installer script, the following
+# environment variables are required to be manually defined or configured below:
+# - SPLUNK_ACCESS_TOKEN: The Splunk access token to authenticate requests
+# - SPLUNK_API_URL: The Splunk API URL, e.g. https://api.us0.observability.splunkcloud.com
+# - SPLUNK_HEC_TOKEN: The Splunk HEC authentication token
+# - SPLUNK_HEC_URL: The Splunk HEC endpoint URL, e.g. https://http-inputs-acme.splunkcloud.com/services/collector
+# - SPLUNK_INGEST_URL: The Splunk ingest URL, e.g. https://ingest.us0.observability.splunkcloud.com
+# - SPLUNK_LISTEN_INTERFACE: The network interface the agent receivers listen on.
+
+extensions:
+  headers_setter:
+    headers:
+      - action: upsert
+        key: X-SF-TOKEN
+        from_context: X-SF-TOKEN
+        default_value: "${SPLUNK_ACCESS_TOKEN}"
+  health_check:
+    endpoint: "${SPLUNK_LISTEN_INTERFACE}:13133"
+  http_forwarder:
+    ingress:
+      endpoint: "${SPLUNK_LISTEN_INTERFACE}:6060"
+    egress:
+      endpoint: "${SPLUNK_API_URL}"
+      # Use instead when sending to gateway
+      #endpoint: "${SPLUNK_GATEWAY_URL}"
+  http_forwarder/opamp_splunk_o11y:
+    ingress:
+      endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
+    egress:
+      endpoint: "${SPLUNK_INGEST_URL}"
+      # Use instead when sending to gateway
+      #endpoint: "${SPLUNK_GATEWAY_URL}:4320"
+      # Remove this header to use a token passed by the caller instead.
+      headers:
+        X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
+  # opamp/splunk_o11y is included in the default config, but startup removes it
+  # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
+  opamp/splunk_o11y:
+    agent_description:
+      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
+      include_resource_attributes: true
+    server:
+      http:
+        endpoint: "${SPLUNK_INGEST_URL}/v1/opamp"
+        # Use instead when sending to gateway (assuming the gateway is running http_forwarder/signalfx on port 4320)
+        #endpoint: "${SPLUNK_GATEWAY_URL}:4320/v1/opamp"
+        polling_interval: 30s
+        headers:
+          X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
+  zpages:
+    #endpoint: "${SPLUNK_LISTEN_INTERFACE}:55679"
+    expvar:
+      enabled: true
+
+receivers:
+  fluent_forward:
+    endpoint: "${SPLUNK_LISTEN_INTERFACE}:8006"
+  host_metrics:
+    collection_interval: 10s
+    scrapers:
+      cpu:
+      disk:
+      filesystem:
+      memory:
+      network:
+      # System load average metrics https://en.wikipedia.org/wiki/Load_(computing)
+      load:
+      # Paging/Swap space utilization and I/O metrics
+      paging:
+      # Aggregated system process count metrics
+      processes:
+      # System processes metrics, disabled by default
+      # process:
+  jaeger:
+    protocols:
+      grpc:
+        endpoint: "${SPLUNK_LISTEN_INTERFACE}:14250"
+      thrift_binary:
+        endpoint: "${SPLUNK_LISTEN_INTERFACE}:6832"
+      thrift_compact:
+        endpoint: "${SPLUNK_LISTEN_INTERFACE}:6831"
+      thrift_http:
+        endpoint: "${SPLUNK_LISTEN_INTERFACE}:14268"
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "${SPLUNK_LISTEN_INTERFACE}:4317"
+        # Uncomment below config to preserve incoming access token and use it instead of the token value set in exporter config
+        # include_metadata: true
+      http:
+        endpoint: "${SPLUNK_LISTEN_INTERFACE}:4318"
+        # Uncomment below config to preserve incoming access token and use it instead of the token value set in exporter config
+        # include_metadata: true
+  # This section is used to collect the OpenTelemetry Collector metrics
+  # Even if just a Splunk APM customer, these metrics are included
+  prometheus/internal:
+    config:
+      scrape_configs:
+      - job_name: 'otel-collector'
+        scrape_interval: 10s
+        static_configs:
+        - targets: ["0.0.0.0:8888"]
+        metric_relabel_configs:
+          - source_labels: [ __name__ ]
+            regex: 'promhttp_metric_handler_errors.*'
+            action: drop
+          - source_labels: [ __name__ ]
+            regex: 'otelcol_processor_batch_.*'
+            action: drop
+  smartagent/processlist:
+    type: processlist
+  zipkin:
+    endpoint: "${SPLUNK_LISTEN_INTERFACE}:9411"
+  nop:
+
+processors:
+  batch:
+    metadata_keys:
+      - X-SF-Token
+  # Enabling the memory_limiter is strongly recommended for every pipeline.
+  # Configuration is based on the amount of memory allocated to the collector.
+  # For more information about memory limiter, see
+  # https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiter/README.md
+  memory_limiter:
+    check_interval: 2s
+    limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+
+  # Detect if the collector is running on a cloud system, which is important for creating unique cloud provider dimensions.
+  # Detector order is important: the `system` detector goes last so it can't preclude cloud detectors from setting host/os info.
+  # Resource detection processor is configured to override all host and cloud attributes because instrumentation
+  # libraries can send wrong values from container environments.
+  # https://docs.splunk.com/Observability/gdi/opentelemetry/components/resourcedetection-processor.html#ordering-considerations
+  resource_detection:
+    detectors: [gcp, ecs, ec2, azure, system]
+    override: true
+
+  # Optional: The following processor can be used to add a default "deployment.environment.name" attribute to the logs and
+  # traces when it's not populated by instrumentation libraries.
+  # If enabled, make sure to enable this processor in a pipeline.
+  # To use the deprecated attribute, change the key to "deployment.environment".
+  # For more information, see https://docs.splunk.com/Observability/gdi/opentelemetry/components/resource-processor.html
+  #resource/add_environment:
+    #attributes:
+      #- action: insert
+        #value: staging/production/...
+        #key: deployment.environment.name
+
+exporters:
+  # Traces
+  otlp_http:
+    traces_endpoint: "${SPLUNK_INGEST_URL}/v2/trace/otlp"
+    headers:
+      "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"
+    auth:
+      authenticator: headers_setter
+  # Metrics + Events
+  signalfx:
+    access_token: "${SPLUNK_ACCESS_TOKEN}"
+    api_url: "${SPLUNK_API_URL}"
+    ingest_url: "${SPLUNK_INGEST_URL}"
+    # Use instead when sending to gateway
+    #api_url: http://${SPLUNK_GATEWAY_URL}:6060
+    #ingest_url: http://${SPLUNK_GATEWAY_URL}:9943
+    sync_host_metadata: true
+    correlation:
+  # Entities (applicable only if discovery mode is enabled)
+  otlp_http/entities:
+    logs_endpoint: "${SPLUNK_INGEST_URL}/v3/event"
+    headers:
+      "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"
+    auth:
+      authenticator: headers_setter
+  # Logs
+  splunk_hec:
+    token: "${SPLUNK_HEC_TOKEN}"
+    endpoint: "${SPLUNK_HEC_URL}"
+    source: "otel"
+    sourcetype: "otel"
+    profiling_data_enabled: false
+  # Profiling
+  splunk_hec/profiling:
+    token: "${SPLUNK_ACCESS_TOKEN}"
+    endpoint: "${SPLUNK_INGEST_URL}/v1/log"
+    log_data_enabled: false
+  # Send to gateway
+  otlp_grpc/gateway:
+    endpoint: "${SPLUNK_GATEWAY_URL}:4317"
+    tls:
+      insecure: true
+    auth:
+      authenticator: headers_setter
+  # Debug
+  debug:
+    verbosity: detailed
+
+service:
+  telemetry:
+    logs:
+      level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+    # Resource attributes attached to the Collector's internal telemetry. These
+    # are also exposed via OpAMP when the opamp/splunk_o11y extension is enabled
+    # with agent_description.include_resource_attributes set to true.
+    resource:
+      attributes:
+        - name: otelcol.service.mode
+          value: agent
+        # Optional: Add a deployment environment to the Collector's internal telemetry.
+        # To use the deprecated attribute, change the key to "deployment.environment".
+        # - name: deployment.environment.name
+        #   value: staging/production/...
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '127.0.0.1'
+                port: 8888
+  extensions: [headers_setter, health_check, http_forwarder, http_forwarder/opamp_splunk_o11y, opamp/splunk_o11y, zpages]
+  pipelines:
+    traces:
+      receivers: [jaeger, otlp, zipkin]
+      processors:
+      - memory_limiter
+      - batch
+      - resource_detection
+      #- resource/add_environment
+      exporters: [otlp_http]
+      # Use instead when sending to gateway
+      #exporters: [otlp_grpc/gateway]
+    metrics:
+      receivers: [host_metrics, otlp]
+      processors: [memory_limiter, batch, resource_detection]
+      exporters: [signalfx]
+      # Use instead when sending to gateway
+      #exporters: [otlp_grpc/gateway]
+    metrics/internal:
+      receivers: [prometheus/internal]
+      processors: [memory_limiter, batch, resource_detection]
+      # When sending to gateway, at least one metrics pipeline needs
+      # to use signalfx exporter so host metadata gets emitted
+      exporters: [signalfx]
+    logs/signalfx:
+      receivers: [smartagent/processlist]
+      processors: [memory_limiter, batch, resource_detection]
+      exporters: [signalfx]
+    logs/entities:
+      # Receivers are dynamically added if discovery mode is enabled
+      receivers: [nop]
+      processors: [memory_limiter, batch, resource_detection]
+      exporters: [otlp_http/entities]
+      # Use instead when sending to gateway
+      #exporters: [otlp_grpc/gateway]
+    logs:
+      receivers: [fluent_forward, otlp]
+      processors:
+      - memory_limiter
+      - batch
+      - resource_detection
+      #- resource/add_environment
+      exporters: [splunk_hec, splunk_hec/profiling]
+      # Use instead when sending to gateway
+      #exporters: [otlp_grpc/gateway]

--- a/cmd/default-config-generator/config/agent_to_gateway_overlay.yaml
+++ b/cmd/default-config-generator/config/agent_to_gateway_overlay.yaml
@@ -1,0 +1,4 @@
+extensions:
+  http_forwarder:
+    egress:
+      endpoint: "${SPLUNK_GATEWAY_URL}"

--- a/cmd/default-config-generator/main.go
+++ b/cmd/default-config-generator/main.go
@@ -1,0 +1,65 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/knadh/koanf"
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/file"
+)
+
+type configGenerator struct {
+	basePath    string
+	outputPath  string
+	overlayPath string
+}
+
+func main() {
+	configs := []configGenerator{
+		configGenerator{
+			basePath:    filepath.Join("config", "agent_config.yaml"),
+			overlayPath: filepath.Join("config", "agent_to_backend_overlay.yaml"),
+			outputPath:  filepath.Join("..", "otelcol", "config", "collector", "agent_config.yaml"),
+		},
+	}
+
+	for _, overlay := range configs {
+		mergedConfig := koanf.New(".")
+		if err := mergedConfig.Load(file.Provider(overlay.basePath), yaml.Parser()); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to load base config %q: %v\n", overlay.basePath, err)
+			os.Exit(1)
+		}
+
+		if err := mergedConfig.Load(file.Provider(overlay.overlayPath), yaml.Parser()); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to merge overlay config %q: %v\n", overlay.overlayPath, err)
+			os.Exit(1)
+		}
+
+		mergedContents, err := mergedConfig.Marshal(yaml.Parser())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to marshal merged config for %q: %v\n", overlay.outputPath, err)
+			os.Exit(1)
+		}
+
+		if err := os.WriteFile(overlay.outputPath, mergedContents, 0o600); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to write merged config %q: %v\n", overlay.outputPath, err)
+			os.Exit(1)
+		}
+	}
+}

--- a/cmd/default-config-generator/main.go
+++ b/cmd/default-config-generator/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,12 +23,32 @@ import (
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/file"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 type configGenerator struct {
 	basePath    string
 	outputPath  string
 	overlayPath string
+}
+
+type twoSpaceYAMLParser struct{}
+
+func (p twoSpaceYAMLParser) Unmarshal(b []byte) (map[string]interface{}, error) {
+	return yaml.Parser().Unmarshal(b)
+}
+
+func (p twoSpaceYAMLParser) Marshal(config map[string]interface{}) ([]byte, error) {
+	out := bytes.Buffer{}
+	encoder := yamlv3.NewEncoder(&out)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(config); err != nil {
+		return nil, err
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
 }
 
 func main() {
@@ -56,7 +77,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		mergedContents, err := mergedConfig.Marshal(yaml.Parser())
+		mergedContents, err := mergedConfig.Marshal(twoSpaceYAMLParser{})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to marshal merged config for %q: %v\n", overlay.outputPath, err)
 			os.Exit(1)

--- a/cmd/default-config-generator/main.go
+++ b/cmd/default-config-generator/main.go
@@ -37,6 +37,11 @@ func main() {
 			overlayPath: filepath.Join("config", "agent_to_backend_overlay.yaml"),
 			outputPath:  filepath.Join("..", "otelcol", "config", "collector", "agent_config.yaml"),
 		},
+		{
+			basePath:    filepath.Join("config", "agent_config.yaml"),
+			overlayPath: filepath.Join("config", "agent_to_gateway_overlay.yaml"),
+			outputPath:  filepath.Join("..", "otelcol", "config", "collector", "agent_to_gateway_config.yaml"),
+		},
 	}
 
 	for _, overlay := range configs {

--- a/cmd/default-config-generator/main.go
+++ b/cmd/default-config-generator/main.go
@@ -32,7 +32,7 @@ type configGenerator struct {
 
 func main() {
 	configs := []configGenerator{
-		configGenerator{
+		{
 			basePath:    filepath.Join("config", "agent_config.yaml"),
 			overlayPath: filepath.Join("config", "agent_to_backend_overlay.yaml"),
 			outputPath:  filepath.Join("..", "otelcol", "config", "collector", "agent_config.yaml"),

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -1,219 +1,219 @@
 exporters:
-    debug:
-        verbosity: detailed
-    otlp_grpc/gateway:
-        auth:
-            authenticator: headers_setter
-        endpoint: ${SPLUNK_GATEWAY_URL}:4317
-        tls:
-            insecure: true
-    otlp_http:
-        auth:
-            authenticator: headers_setter
-        headers:
-            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
-        traces_endpoint: ${SPLUNK_INGEST_URL}/v2/trace/otlp
-    otlp_http/entities:
-        auth:
-            authenticator: headers_setter
-        headers:
-            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
-        logs_endpoint: ${SPLUNK_INGEST_URL}/v3/event
-    signalfx:
-        access_token: ${SPLUNK_ACCESS_TOKEN}
-        api_url: ${SPLUNK_API_URL}
-        correlation: null
-        ingest_url: ${SPLUNK_INGEST_URL}
-        sync_host_metadata: true
-    splunk_hec:
-        endpoint: ${SPLUNK_HEC_URL}
-        profiling_data_enabled: false
-        source: otel
-        sourcetype: otel
-        token: ${SPLUNK_HEC_TOKEN}
-    splunk_hec/profiling:
-        endpoint: ${SPLUNK_INGEST_URL}/v1/log
-        log_data_enabled: false
-        token: ${SPLUNK_ACCESS_TOKEN}
+  debug:
+    verbosity: detailed
+  otlp_grpc/gateway:
+    auth:
+      authenticator: headers_setter
+    endpoint: ${SPLUNK_GATEWAY_URL}:4317
+    tls:
+      insecure: true
+  otlp_http:
+    auth:
+      authenticator: headers_setter
+    headers:
+      X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+    traces_endpoint: ${SPLUNK_INGEST_URL}/v2/trace/otlp
+  otlp_http/entities:
+    auth:
+      authenticator: headers_setter
+    headers:
+      X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+    logs_endpoint: ${SPLUNK_INGEST_URL}/v3/event
+  signalfx:
+    access_token: ${SPLUNK_ACCESS_TOKEN}
+    api_url: ${SPLUNK_API_URL}
+    correlation: null
+    ingest_url: ${SPLUNK_INGEST_URL}
+    sync_host_metadata: true
+  splunk_hec:
+    endpoint: ${SPLUNK_HEC_URL}
+    profiling_data_enabled: false
+    source: otel
+    sourcetype: otel
+    token: ${SPLUNK_HEC_TOKEN}
+  splunk_hec/profiling:
+    endpoint: ${SPLUNK_INGEST_URL}/v1/log
+    log_data_enabled: false
+    token: ${SPLUNK_ACCESS_TOKEN}
 extensions:
-    headers_setter:
+  headers_setter:
+    headers:
+      - action: upsert
+        default_value: ${SPLUNK_ACCESS_TOKEN}
+        from_context: X-SF-TOKEN
+        key: X-SF-TOKEN
+  health_check:
+    endpoint: ${SPLUNK_LISTEN_INTERFACE}:13133
+  http_forwarder:
+    egress:
+      endpoint: ${SPLUNK_API_URL}
+    ingress:
+      endpoint: ${SPLUNK_LISTEN_INTERFACE}:6060
+  http_forwarder/opamp_splunk_o11y:
+    egress:
+      endpoint: ${SPLUNK_INGEST_URL}
+      headers:
+        X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+    ingress:
+      endpoint: ${SPLUNK_LISTEN_INTERFACE}:4320
+  opamp/splunk_o11y:
+    agent_description:
+      include_resource_attributes: true
+    server:
+      http:
+        endpoint: ${SPLUNK_INGEST_URL}/v1/opamp
         headers:
-            - action: upsert
-              default_value: ${SPLUNK_ACCESS_TOKEN}
-              from_context: X-SF-TOKEN
-              key: X-SF-TOKEN
-    health_check:
-        endpoint: ${SPLUNK_LISTEN_INTERFACE}:13133
-    http_forwarder:
-        egress:
-            endpoint: ${SPLUNK_API_URL}
-        ingress:
-            endpoint: ${SPLUNK_LISTEN_INTERFACE}:6060
-    http_forwarder/opamp_splunk_o11y:
-        egress:
-            endpoint: ${SPLUNK_INGEST_URL}
-            headers:
-                X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
-        ingress:
-            endpoint: ${SPLUNK_LISTEN_INTERFACE}:4320
-    opamp/splunk_o11y:
-        agent_description:
-            include_resource_attributes: true
-        server:
-            http:
-                endpoint: ${SPLUNK_INGEST_URL}/v1/opamp
-                headers:
-                    X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
-                polling_interval: 30s
-    zpages:
-        expvar:
-            enabled: true
+          X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        polling_interval: 30s
+  zpages:
+    expvar:
+      enabled: true
 processors:
-    batch:
-        metadata_keys:
-            - X-SF-Token
-    memory_limiter:
-        check_interval: 2s
-        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
-    resource_detection:
-        detectors:
-            - gcp
-            - ecs
-            - ec2
-            - azure
-            - system
-        override: true
+  batch:
+    metadata_keys:
+      - X-SF-Token
+  memory_limiter:
+    check_interval: 2s
+    limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+  resource_detection:
+    detectors:
+      - gcp
+      - ecs
+      - ec2
+      - azure
+      - system
+    override: true
 receivers:
-    fluent_forward:
-        endpoint: ${SPLUNK_LISTEN_INTERFACE}:8006
-    host_metrics:
-        collection_interval: 10s
-        scrapers:
-            cpu: null
-            disk: null
-            filesystem: null
-            load: null
-            memory: null
-            network: null
-            paging: null
-            processes: null
-    jaeger:
-        protocols:
-            grpc:
-                endpoint: ${SPLUNK_LISTEN_INTERFACE}:14250
-            thrift_binary:
-                endpoint: ${SPLUNK_LISTEN_INTERFACE}:6832
-            thrift_compact:
-                endpoint: ${SPLUNK_LISTEN_INTERFACE}:6831
-            thrift_http:
-                endpoint: ${SPLUNK_LISTEN_INTERFACE}:14268
-    nop: null
-    otlp:
-        protocols:
-            grpc:
-                endpoint: ${SPLUNK_LISTEN_INTERFACE}:4317
-            http:
-                endpoint: ${SPLUNK_LISTEN_INTERFACE}:4318
-    prometheus/internal:
-        config:
-            scrape_configs:
-                - job_name: otel-collector
-                  metric_relabel_configs:
-                    - action: drop
-                      regex: promhttp_metric_handler_errors.*
-                      source_labels:
-                        - __name__
-                    - action: drop
-                      regex: otelcol_processor_batch_.*
-                      source_labels:
-                        - __name__
-                  scrape_interval: 10s
-                  static_configs:
-                    - targets:
-                        - 0.0.0.0:8888
-    smartagent/processlist:
-        type: processlist
-    zipkin:
-        endpoint: ${SPLUNK_LISTEN_INTERFACE}:9411
+  fluent_forward:
+    endpoint: ${SPLUNK_LISTEN_INTERFACE}:8006
+  host_metrics:
+    collection_interval: 10s
+    scrapers:
+      cpu: null
+      disk: null
+      filesystem: null
+      load: null
+      memory: null
+      network: null
+      paging: null
+      processes: null
+  jaeger:
+    protocols:
+      grpc:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:14250
+      thrift_binary:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:6832
+      thrift_compact:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:6831
+      thrift_http:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:14268
+  nop: null
+  otlp:
+    protocols:
+      grpc:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:4317
+      http:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:4318
+  prometheus/internal:
+    config:
+      scrape_configs:
+        - job_name: otel-collector
+          metric_relabel_configs:
+            - action: drop
+              regex: promhttp_metric_handler_errors.*
+              source_labels:
+                - __name__
+            - action: drop
+              regex: otelcol_processor_batch_.*
+              source_labels:
+                - __name__
+          scrape_interval: 10s
+          static_configs:
+            - targets:
+                - 0.0.0.0:8888
+  smartagent/processlist:
+    type: processlist
+  zipkin:
+    endpoint: ${SPLUNK_LISTEN_INTERFACE}:9411
 service:
-    extensions:
-        - headers_setter
-        - health_check
-        - http_forwarder
-        - http_forwarder/opamp_splunk_o11y
-        - opamp/splunk_o11y
-        - zpages
-    pipelines:
-        logs:
-            exporters:
-                - splunk_hec
-                - splunk_hec/profiling
-            processors:
-                - memory_limiter
-                - batch
-                - resource_detection
-            receivers:
-                - fluent_forward
-                - otlp
-        logs/entities:
-            exporters:
-                - otlp_http/entities
-            processors:
-                - memory_limiter
-                - batch
-                - resource_detection
-            receivers:
-                - nop
-        logs/signalfx:
-            exporters:
-                - signalfx
-            processors:
-                - memory_limiter
-                - batch
-                - resource_detection
-            receivers:
-                - smartagent/processlist
-        metrics:
-            exporters:
-                - signalfx
-            processors:
-                - memory_limiter
-                - batch
-                - resource_detection
-            receivers:
-                - host_metrics
-                - otlp
-        metrics/internal:
-            exporters:
-                - signalfx
-            processors:
-                - memory_limiter
-                - batch
-                - resource_detection
-            receivers:
-                - prometheus/internal
-        traces:
-            exporters:
-                - otlp_http
-            processors:
-                - memory_limiter
-                - batch
-                - resource_detection
-            receivers:
-                - jaeger
-                - otlp
-                - zipkin
-    telemetry:
-        logs:
-            level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
-        metrics:
-            readers:
-                - pull:
-                    exporter:
-                        prometheus:
-                            host: 127.0.0.1
-                            port: 8888
-        resource:
-            attributes:
-                - name: otelcol.service.mode
-                  value: agent
+  extensions:
+    - headers_setter
+    - health_check
+    - http_forwarder
+    - http_forwarder/opamp_splunk_o11y
+    - opamp/splunk_o11y
+    - zpages
+  pipelines:
+    logs:
+      exporters:
+        - splunk_hec
+        - splunk_hec/profiling
+      processors:
+        - memory_limiter
+        - batch
+        - resource_detection
+      receivers:
+        - fluent_forward
+        - otlp
+    logs/entities:
+      exporters:
+        - otlp_http/entities
+      processors:
+        - memory_limiter
+        - batch
+        - resource_detection
+      receivers:
+        - nop
+    logs/signalfx:
+      exporters:
+        - signalfx
+      processors:
+        - memory_limiter
+        - batch
+        - resource_detection
+      receivers:
+        - smartagent/processlist
+    metrics:
+      exporters:
+        - signalfx
+      processors:
+        - memory_limiter
+        - batch
+        - resource_detection
+      receivers:
+        - host_metrics
+        - otlp
+    metrics/internal:
+      exporters:
+        - signalfx
+      processors:
+        - memory_limiter
+        - batch
+        - resource_detection
+      receivers:
+        - prometheus/internal
+    traces:
+      exporters:
+        - otlp_http
+      processors:
+        - memory_limiter
+        - batch
+        - resource_detection
+      receivers:
+        - jaeger
+        - otlp
+        - zipkin
+  telemetry:
+    logs:
+      level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 127.0.0.1
+                port: 8888
+    resource:
+      attributes:
+        - name: otelcol.service.mode
+          value: agent

--- a/cmd/otelcol/config/collector/agent_config.yaml
+++ b/cmd/otelcol/config/collector/agent_config.yaml
@@ -1,264 +1,219 @@
-# Default configuration file for the Linux (deb/rpm) and Windows MSI collector packages
-
-# If the collector is installed without the Linux/Windows installer script, the following
-# environment variables are required to be manually defined or configured below:
-# - SPLUNK_ACCESS_TOKEN: The Splunk access token to authenticate requests
-# - SPLUNK_API_URL: The Splunk API URL, e.g. https://api.us0.observability.splunkcloud.com
-# - SPLUNK_HEC_TOKEN: The Splunk HEC authentication token
-# - SPLUNK_HEC_URL: The Splunk HEC endpoint URL, e.g. https://http-inputs-acme.splunkcloud.com/services/collector
-# - SPLUNK_INGEST_URL: The Splunk ingest URL, e.g. https://ingest.us0.observability.splunkcloud.com
-# - SPLUNK_LISTEN_INTERFACE: The network interface the agent receivers listen on.
-
-extensions:
-  headers_setter:
-    headers:
-      - action: upsert
-        key: X-SF-TOKEN
-        from_context: X-SF-TOKEN
-        default_value: "${SPLUNK_ACCESS_TOKEN}"
-  health_check:
-    endpoint: "${SPLUNK_LISTEN_INTERFACE}:13133"
-  http_forwarder:
-    ingress:
-      endpoint: "${SPLUNK_LISTEN_INTERFACE}:6060"
-    egress:
-      endpoint: "${SPLUNK_API_URL}"
-      # Use instead when sending to gateway
-      #endpoint: "${SPLUNK_GATEWAY_URL}"
-  http_forwarder/opamp_splunk_o11y:
-    ingress:
-      endpoint: "${SPLUNK_LISTEN_INTERFACE}:4320"
-    egress:
-      endpoint: "${SPLUNK_INGEST_URL}"
-      # Use instead when sending to gateway
-      #endpoint: "${SPLUNK_GATEWAY_URL}:4320"
-      # Remove this header to use a token passed by the caller instead.
-      headers:
-        X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
-  # opamp/splunk_o11y is included in the default config, but startup removes it
-  # from service.extensions unless --feature-gates=+splunk.opamp.enabled is set.
-  opamp/splunk_o11y:
-    agent_description:
-      # Include the Collector's resource attributes as OpAMP non-identifying attributes.
-      include_resource_attributes: true
-    server:
-      http:
-        endpoint: "${SPLUNK_INGEST_URL}/v1/opamp"
-        # Use instead when sending to gateway (assuming the gateway is running http_forwarder/signalfx on port 4320)
-        #endpoint: "${SPLUNK_GATEWAY_URL}:4320/v1/opamp"
-        polling_interval: 30s
-        headers:
-          X-SF-Token: "${SPLUNK_ACCESS_TOKEN}"
-  zpages:
-    #endpoint: "${SPLUNK_LISTEN_INTERFACE}:55679"
-    expvar:
-      enabled: true
-
-receivers:
-  fluent_forward:
-    endpoint: "${SPLUNK_LISTEN_INTERFACE}:8006"
-  host_metrics:
-    collection_interval: 10s
-    scrapers:
-      cpu:
-      disk:
-      filesystem:
-      memory:
-      network:
-      # System load average metrics https://en.wikipedia.org/wiki/Load_(computing)
-      load:
-      # Paging/Swap space utilization and I/O metrics
-      paging:
-      # Aggregated system process count metrics
-      processes:
-      # System processes metrics, disabled by default
-      # process:
-  jaeger:
-    protocols:
-      grpc:
-        endpoint: "${SPLUNK_LISTEN_INTERFACE}:14250"
-      thrift_binary:
-        endpoint: "${SPLUNK_LISTEN_INTERFACE}:6832"
-      thrift_compact:
-        endpoint: "${SPLUNK_LISTEN_INTERFACE}:6831"
-      thrift_http:
-        endpoint: "${SPLUNK_LISTEN_INTERFACE}:14268"
-  otlp:
-    protocols:
-      grpc:
-        endpoint: "${SPLUNK_LISTEN_INTERFACE}:4317"
-        # Uncomment below config to preserve incoming access token and use it instead of the token value set in exporter config
-        # include_metadata: true
-      http:
-        endpoint: "${SPLUNK_LISTEN_INTERFACE}:4318"
-        # Uncomment below config to preserve incoming access token and use it instead of the token value set in exporter config
-        # include_metadata: true
-  # This section is used to collect the OpenTelemetry Collector metrics
-  # Even if just a Splunk APM customer, these metrics are included
-  prometheus/internal:
-    config:
-      scrape_configs:
-      - job_name: 'otel-collector'
-        scrape_interval: 10s
-        static_configs:
-        - targets: ["0.0.0.0:8888"]
-        metric_relabel_configs:
-          - source_labels: [ __name__ ]
-            regex: 'promhttp_metric_handler_errors.*'
-            action: drop
-          - source_labels: [ __name__ ]
-            regex: 'otelcol_processor_batch_.*'
-            action: drop
-  smartagent/processlist:
-    type: processlist
-  zipkin:
-    endpoint: "${SPLUNK_LISTEN_INTERFACE}:9411"
-  nop:
-
-processors:
-  batch:
-    metadata_keys:
-      - X-SF-Token
-  # Enabling the memory_limiter is strongly recommended for every pipeline.
-  # Configuration is based on the amount of memory allocated to the collector.
-  # For more information about memory limiter, see
-  # https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiter/README.md
-  memory_limiter:
-    check_interval: 2s
-    limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
-
-  # Detect if the collector is running on a cloud system, which is important for creating unique cloud provider dimensions.
-  # Detector order is important: the `system` detector goes last so it can't preclude cloud detectors from setting host/os info.
-  # Resource detection processor is configured to override all host and cloud attributes because instrumentation
-  # libraries can send wrong values from container environments.
-  # https://docs.splunk.com/Observability/gdi/opentelemetry/components/resourcedetection-processor.html#ordering-considerations
-  resource_detection:
-    detectors: [gcp, ecs, ec2, azure, system]
-    override: true
-
-  # Optional: The following processor can be used to add a default "deployment.environment.name" attribute to the logs and
-  # traces when it's not populated by instrumentation libraries.
-  # If enabled, make sure to enable this processor in a pipeline.
-  # To use the deprecated attribute, change the key to "deployment.environment".
-  # For more information, see https://docs.splunk.com/Observability/gdi/opentelemetry/components/resource-processor.html
-  #resource/add_environment:
-    #attributes:
-      #- action: insert
-        #value: staging/production/...
-        #key: deployment.environment.name
-
 exporters:
-  # Traces
-  otlp_http:
-    traces_endpoint: "${SPLUNK_INGEST_URL}/v2/trace/otlp"
-    headers:
-      "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"
-    auth:
-      authenticator: headers_setter
-  # Metrics + Events
-  signalfx:
-    access_token: "${SPLUNK_ACCESS_TOKEN}"
-    api_url: "${SPLUNK_API_URL}"
-    ingest_url: "${SPLUNK_INGEST_URL}"
-    # Use instead when sending to gateway
-    #api_url: http://${SPLUNK_GATEWAY_URL}:6060
-    #ingest_url: http://${SPLUNK_GATEWAY_URL}:9943
-    sync_host_metadata: true
-    correlation:
-  # Entities (applicable only if discovery mode is enabled)
-  otlp_http/entities:
-    logs_endpoint: "${SPLUNK_INGEST_URL}/v3/event"
-    headers:
-      "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"
-    auth:
-      authenticator: headers_setter
-  # Logs
-  splunk_hec:
-    token: "${SPLUNK_HEC_TOKEN}"
-    endpoint: "${SPLUNK_HEC_URL}"
-    source: "otel"
-    sourcetype: "otel"
-    profiling_data_enabled: false
-  # Profiling
-  splunk_hec/profiling:
-    token: "${SPLUNK_ACCESS_TOKEN}"
-    endpoint: "${SPLUNK_INGEST_URL}/v1/log"
-    log_data_enabled: false
-  # Send to gateway
-  otlp_grpc/gateway:
-    endpoint: "${SPLUNK_GATEWAY_URL}:4317"
-    tls:
-      insecure: true
-    auth:
-      authenticator: headers_setter
-  # Debug
-  debug:
-    verbosity: detailed
-
+    debug:
+        verbosity: detailed
+    otlp_grpc/gateway:
+        auth:
+            authenticator: headers_setter
+        endpoint: ${SPLUNK_GATEWAY_URL}:4317
+        tls:
+            insecure: true
+    otlp_http:
+        auth:
+            authenticator: headers_setter
+        headers:
+            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        traces_endpoint: ${SPLUNK_INGEST_URL}/v2/trace/otlp
+    otlp_http/entities:
+        auth:
+            authenticator: headers_setter
+        headers:
+            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        logs_endpoint: ${SPLUNK_INGEST_URL}/v3/event
+    signalfx:
+        access_token: ${SPLUNK_ACCESS_TOKEN}
+        api_url: ${SPLUNK_API_URL}
+        correlation: null
+        ingest_url: ${SPLUNK_INGEST_URL}
+        sync_host_metadata: true
+    splunk_hec:
+        endpoint: ${SPLUNK_HEC_URL}
+        profiling_data_enabled: false
+        source: otel
+        sourcetype: otel
+        token: ${SPLUNK_HEC_TOKEN}
+    splunk_hec/profiling:
+        endpoint: ${SPLUNK_INGEST_URL}/v1/log
+        log_data_enabled: false
+        token: ${SPLUNK_ACCESS_TOKEN}
+extensions:
+    headers_setter:
+        headers:
+            - action: upsert
+              default_value: ${SPLUNK_ACCESS_TOKEN}
+              from_context: X-SF-TOKEN
+              key: X-SF-TOKEN
+    health_check:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:13133
+    http_forwarder:
+        egress:
+            endpoint: ${SPLUNK_API_URL}
+        ingress:
+            endpoint: ${SPLUNK_LISTEN_INTERFACE}:6060
+    http_forwarder/opamp_splunk_o11y:
+        egress:
+            endpoint: ${SPLUNK_INGEST_URL}
+            headers:
+                X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        ingress:
+            endpoint: ${SPLUNK_LISTEN_INTERFACE}:4320
+    opamp/splunk_o11y:
+        agent_description:
+            include_resource_attributes: true
+        server:
+            http:
+                endpoint: ${SPLUNK_INGEST_URL}/v1/opamp
+                headers:
+                    X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+                polling_interval: 30s
+    zpages:
+        expvar:
+            enabled: true
+processors:
+    batch:
+        metadata_keys:
+            - X-SF-Token
+    memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+    resource_detection:
+        detectors:
+            - gcp
+            - ecs
+            - ec2
+            - azure
+            - system
+        override: true
+receivers:
+    fluent_forward:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:8006
+    host_metrics:
+        collection_interval: 10s
+        scrapers:
+            cpu: null
+            disk: null
+            filesystem: null
+            load: null
+            memory: null
+            network: null
+            paging: null
+            processes: null
+    jaeger:
+        protocols:
+            grpc:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:14250
+            thrift_binary:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:6832
+            thrift_compact:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:6831
+            thrift_http:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:14268
+    nop: null
+    otlp:
+        protocols:
+            grpc:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:4317
+            http:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:4318
+    prometheus/internal:
+        config:
+            scrape_configs:
+                - job_name: otel-collector
+                  metric_relabel_configs:
+                    - action: drop
+                      regex: promhttp_metric_handler_errors.*
+                      source_labels:
+                        - __name__
+                    - action: drop
+                      regex: otelcol_processor_batch_.*
+                      source_labels:
+                        - __name__
+                  scrape_interval: 10s
+                  static_configs:
+                    - targets:
+                        - 0.0.0.0:8888
+    smartagent/processlist:
+        type: processlist
+    zipkin:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:9411
 service:
-  telemetry:
-    logs:
-      level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
-    # Resource attributes attached to the Collector's internal telemetry. These
-    # are also exposed via OpAMP when the opamp/splunk_o11y extension is enabled
-    # with agent_description.include_resource_attributes set to true.
-    resource:
-      attributes:
-        - name: otelcol.service.mode
-          value: agent
-        # Optional: Add a deployment environment to the Collector's internal telemetry.
-        # To use the deprecated attribute, change the key to "deployment.environment".
-        # - name: deployment.environment.name
-        #   value: staging/production/...
-    metrics:
-      readers:
-        - pull:
-            exporter:
-              prometheus:
-                host: '127.0.0.1'
-                port: 8888
-  extensions: [headers_setter, health_check, http_forwarder, http_forwarder/opamp_splunk_o11y, opamp/splunk_o11y, zpages]
-  pipelines:
-    traces:
-      receivers: [jaeger, otlp, zipkin]
-      processors:
-      - memory_limiter
-      - batch
-      - resource_detection
-      #- resource/add_environment
-      exporters: [otlp_http]
-      # Use instead when sending to gateway
-      #exporters: [otlp_grpc/gateway]
-    metrics:
-      receivers: [host_metrics, otlp]
-      processors: [memory_limiter, batch, resource_detection]
-      exporters: [signalfx]
-      # Use instead when sending to gateway
-      #exporters: [otlp_grpc/gateway]
-    metrics/internal:
-      receivers: [prometheus/internal]
-      processors: [memory_limiter, batch, resource_detection]
-      # When sending to gateway, at least one metrics pipeline needs
-      # to use signalfx exporter so host metadata gets emitted
-      exporters: [signalfx]
-    logs/signalfx:
-      receivers: [smartagent/processlist]
-      processors: [memory_limiter, batch, resource_detection]
-      exporters: [signalfx]
-    logs/entities:
-      # Receivers are dynamically added if discovery mode is enabled
-      receivers: [nop]
-      processors: [memory_limiter, batch, resource_detection]
-      exporters: [otlp_http/entities]
-      # Use instead when sending to gateway
-      #exporters: [otlp_grpc/gateway]
-    logs:
-      receivers: [fluent_forward, otlp]
-      processors:
-      - memory_limiter
-      - batch
-      - resource_detection
-      #- resource/add_environment
-      exporters: [splunk_hec, splunk_hec/profiling]
-      # Use instead when sending to gateway
-      #exporters: [otlp_grpc/gateway]
+    extensions:
+        - headers_setter
+        - health_check
+        - http_forwarder
+        - http_forwarder/opamp_splunk_o11y
+        - opamp/splunk_o11y
+        - zpages
+    pipelines:
+        logs:
+            exporters:
+                - splunk_hec
+                - splunk_hec/profiling
+            processors:
+                - memory_limiter
+                - batch
+                - resource_detection
+            receivers:
+                - fluent_forward
+                - otlp
+        logs/entities:
+            exporters:
+                - otlp_http/entities
+            processors:
+                - memory_limiter
+                - batch
+                - resource_detection
+            receivers:
+                - nop
+        logs/signalfx:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - resource_detection
+            receivers:
+                - smartagent/processlist
+        metrics:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - resource_detection
+            receivers:
+                - host_metrics
+                - otlp
+        metrics/internal:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - resource_detection
+            receivers:
+                - prometheus/internal
+        traces:
+            exporters:
+                - otlp_http
+            processors:
+                - memory_limiter
+                - batch
+                - resource_detection
+            receivers:
+                - jaeger
+                - otlp
+                - zipkin
+    telemetry:
+        logs:
+            level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+        metrics:
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 127.0.0.1
+                            port: 8888
+        resource:
+            attributes:
+                - name: otelcol.service.mode
+                  value: agent

--- a/cmd/otelcol/config/collector/agent_to_gateway_config.yaml
+++ b/cmd/otelcol/config/collector/agent_to_gateway_config.yaml
@@ -1,0 +1,219 @@
+exporters:
+    debug:
+        verbosity: detailed
+    otlp_grpc/gateway:
+        auth:
+            authenticator: headers_setter
+        endpoint: ${SPLUNK_GATEWAY_URL}:4317
+        tls:
+            insecure: true
+    otlp_http:
+        auth:
+            authenticator: headers_setter
+        headers:
+            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        traces_endpoint: ${SPLUNK_INGEST_URL}/v2/trace/otlp
+    otlp_http/entities:
+        auth:
+            authenticator: headers_setter
+        headers:
+            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        logs_endpoint: ${SPLUNK_INGEST_URL}/v3/event
+    signalfx:
+        access_token: ${SPLUNK_ACCESS_TOKEN}
+        api_url: ${SPLUNK_API_URL}
+        correlation: null
+        ingest_url: ${SPLUNK_INGEST_URL}
+        sync_host_metadata: true
+    splunk_hec:
+        endpoint: ${SPLUNK_HEC_URL}
+        profiling_data_enabled: false
+        source: otel
+        sourcetype: otel
+        token: ${SPLUNK_HEC_TOKEN}
+    splunk_hec/profiling:
+        endpoint: ${SPLUNK_INGEST_URL}/v1/log
+        log_data_enabled: false
+        token: ${SPLUNK_ACCESS_TOKEN}
+extensions:
+    headers_setter:
+        headers:
+            - action: upsert
+              default_value: ${SPLUNK_ACCESS_TOKEN}
+              from_context: X-SF-TOKEN
+              key: X-SF-TOKEN
+    health_check:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:13133
+    http_forwarder:
+        egress:
+            endpoint: ${SPLUNK_GATEWAY_URL}
+        ingress:
+            endpoint: ${SPLUNK_LISTEN_INTERFACE}:6060
+    http_forwarder/opamp_splunk_o11y:
+        egress:
+            endpoint: ${SPLUNK_INGEST_URL}
+            headers:
+                X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        ingress:
+            endpoint: ${SPLUNK_LISTEN_INTERFACE}:4320
+    opamp/splunk_o11y:
+        agent_description:
+            include_resource_attributes: true
+        server:
+            http:
+                endpoint: ${SPLUNK_INGEST_URL}/v1/opamp
+                headers:
+                    X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+                polling_interval: 30s
+    zpages:
+        expvar:
+            enabled: true
+processors:
+    batch:
+        metadata_keys:
+            - X-SF-Token
+    memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+    resource_detection:
+        detectors:
+            - gcp
+            - ecs
+            - ec2
+            - azure
+            - system
+        override: true
+receivers:
+    fluent_forward:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:8006
+    host_metrics:
+        collection_interval: 10s
+        scrapers:
+            cpu: null
+            disk: null
+            filesystem: null
+            load: null
+            memory: null
+            network: null
+            paging: null
+            processes: null
+    jaeger:
+        protocols:
+            grpc:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:14250
+            thrift_binary:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:6832
+            thrift_compact:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:6831
+            thrift_http:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:14268
+    nop: null
+    otlp:
+        protocols:
+            grpc:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:4317
+            http:
+                endpoint: ${SPLUNK_LISTEN_INTERFACE}:4318
+    prometheus/internal:
+        config:
+            scrape_configs:
+                - job_name: otel-collector
+                  metric_relabel_configs:
+                    - action: drop
+                      regex: promhttp_metric_handler_errors.*
+                      source_labels:
+                        - __name__
+                    - action: drop
+                      regex: otelcol_processor_batch_.*
+                      source_labels:
+                        - __name__
+                  scrape_interval: 10s
+                  static_configs:
+                    - targets:
+                        - 0.0.0.0:8888
+    smartagent/processlist:
+        type: processlist
+    zipkin:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:9411
+service:
+    extensions:
+        - headers_setter
+        - health_check
+        - http_forwarder
+        - http_forwarder/opamp_splunk_o11y
+        - opamp/splunk_o11y
+        - zpages
+    pipelines:
+        logs:
+            exporters:
+                - splunk_hec
+                - splunk_hec/profiling
+            processors:
+                - memory_limiter
+                - batch
+                - resource_detection
+            receivers:
+                - fluent_forward
+                - otlp
+        logs/entities:
+            exporters:
+                - otlp_http/entities
+            processors:
+                - memory_limiter
+                - batch
+                - resource_detection
+            receivers:
+                - nop
+        logs/signalfx:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - resource_detection
+            receivers:
+                - smartagent/processlist
+        metrics:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - resource_detection
+            receivers:
+                - host_metrics
+                - otlp
+        metrics/internal:
+            exporters:
+                - signalfx
+            processors:
+                - memory_limiter
+                - batch
+                - resource_detection
+            receivers:
+                - prometheus/internal
+        traces:
+            exporters:
+                - otlp_http
+            processors:
+                - memory_limiter
+                - batch
+                - resource_detection
+            receivers:
+                - jaeger
+                - otlp
+                - zipkin
+    telemetry:
+        logs:
+            level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+        metrics:
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 127.0.0.1
+                            port: 8888
+        resource:
+            attributes:
+                - name: otelcol.service.mode
+                  value: agent

--- a/cmd/otelcol/config/collector/agent_to_gateway_config.yaml
+++ b/cmd/otelcol/config/collector/agent_to_gateway_config.yaml
@@ -1,219 +1,219 @@
 exporters:
-    debug:
-        verbosity: detailed
-    otlp_grpc/gateway:
-        auth:
-            authenticator: headers_setter
-        endpoint: ${SPLUNK_GATEWAY_URL}:4317
-        tls:
-            insecure: true
-    otlp_http:
-        auth:
-            authenticator: headers_setter
-        headers:
-            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
-        traces_endpoint: ${SPLUNK_INGEST_URL}/v2/trace/otlp
-    otlp_http/entities:
-        auth:
-            authenticator: headers_setter
-        headers:
-            X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
-        logs_endpoint: ${SPLUNK_INGEST_URL}/v3/event
-    signalfx:
-        access_token: ${SPLUNK_ACCESS_TOKEN}
-        api_url: ${SPLUNK_API_URL}
-        correlation: null
-        ingest_url: ${SPLUNK_INGEST_URL}
-        sync_host_metadata: true
-    splunk_hec:
-        endpoint: ${SPLUNK_HEC_URL}
-        profiling_data_enabled: false
-        source: otel
-        sourcetype: otel
-        token: ${SPLUNK_HEC_TOKEN}
-    splunk_hec/profiling:
-        endpoint: ${SPLUNK_INGEST_URL}/v1/log
-        log_data_enabled: false
-        token: ${SPLUNK_ACCESS_TOKEN}
+  debug:
+    verbosity: detailed
+  otlp_grpc/gateway:
+    auth:
+      authenticator: headers_setter
+    endpoint: ${SPLUNK_GATEWAY_URL}:4317
+    tls:
+      insecure: true
+  otlp_http:
+    auth:
+      authenticator: headers_setter
+    headers:
+      X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+    traces_endpoint: ${SPLUNK_INGEST_URL}/v2/trace/otlp
+  otlp_http/entities:
+    auth:
+      authenticator: headers_setter
+    headers:
+      X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+    logs_endpoint: ${SPLUNK_INGEST_URL}/v3/event
+  signalfx:
+    access_token: ${SPLUNK_ACCESS_TOKEN}
+    api_url: ${SPLUNK_API_URL}
+    correlation: null
+    ingest_url: ${SPLUNK_INGEST_URL}
+    sync_host_metadata: true
+  splunk_hec:
+    endpoint: ${SPLUNK_HEC_URL}
+    profiling_data_enabled: false
+    source: otel
+    sourcetype: otel
+    token: ${SPLUNK_HEC_TOKEN}
+  splunk_hec/profiling:
+    endpoint: ${SPLUNK_INGEST_URL}/v1/log
+    log_data_enabled: false
+    token: ${SPLUNK_ACCESS_TOKEN}
 extensions:
-    headers_setter:
+  headers_setter:
+    headers:
+      - action: upsert
+        default_value: ${SPLUNK_ACCESS_TOKEN}
+        from_context: X-SF-TOKEN
+        key: X-SF-TOKEN
+  health_check:
+    endpoint: ${SPLUNK_LISTEN_INTERFACE}:13133
+  http_forwarder:
+    egress:
+      endpoint: ${SPLUNK_GATEWAY_URL}
+    ingress:
+      endpoint: ${SPLUNK_LISTEN_INTERFACE}:6060
+  http_forwarder/opamp_splunk_o11y:
+    egress:
+      endpoint: ${SPLUNK_INGEST_URL}
+      headers:
+        X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+    ingress:
+      endpoint: ${SPLUNK_LISTEN_INTERFACE}:4320
+  opamp/splunk_o11y:
+    agent_description:
+      include_resource_attributes: true
+    server:
+      http:
+        endpoint: ${SPLUNK_INGEST_URL}/v1/opamp
         headers:
-            - action: upsert
-              default_value: ${SPLUNK_ACCESS_TOKEN}
-              from_context: X-SF-TOKEN
-              key: X-SF-TOKEN
-    health_check:
-        endpoint: ${SPLUNK_LISTEN_INTERFACE}:13133
-    http_forwarder:
-        egress:
-            endpoint: ${SPLUNK_GATEWAY_URL}
-        ingress:
-            endpoint: ${SPLUNK_LISTEN_INTERFACE}:6060
-    http_forwarder/opamp_splunk_o11y:
-        egress:
-            endpoint: ${SPLUNK_INGEST_URL}
-            headers:
-                X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
-        ingress:
-            endpoint: ${SPLUNK_LISTEN_INTERFACE}:4320
-    opamp/splunk_o11y:
-        agent_description:
-            include_resource_attributes: true
-        server:
-            http:
-                endpoint: ${SPLUNK_INGEST_URL}/v1/opamp
-                headers:
-                    X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
-                polling_interval: 30s
-    zpages:
-        expvar:
-            enabled: true
+          X-SF-Token: ${SPLUNK_ACCESS_TOKEN}
+        polling_interval: 30s
+  zpages:
+    expvar:
+      enabled: true
 processors:
-    batch:
-        metadata_keys:
-            - X-SF-Token
-    memory_limiter:
-        check_interval: 2s
-        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
-    resource_detection:
-        detectors:
-            - gcp
-            - ecs
-            - ec2
-            - azure
-            - system
-        override: true
+  batch:
+    metadata_keys:
+      - X-SF-Token
+  memory_limiter:
+    check_interval: 2s
+    limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+  resource_detection:
+    detectors:
+      - gcp
+      - ecs
+      - ec2
+      - azure
+      - system
+    override: true
 receivers:
-    fluent_forward:
-        endpoint: ${SPLUNK_LISTEN_INTERFACE}:8006
-    host_metrics:
-        collection_interval: 10s
-        scrapers:
-            cpu: null
-            disk: null
-            filesystem: null
-            load: null
-            memory: null
-            network: null
-            paging: null
-            processes: null
-    jaeger:
-        protocols:
-            grpc:
-                endpoint: ${SPLUNK_LISTEN_INTERFACE}:14250
-            thrift_binary:
-                endpoint: ${SPLUNK_LISTEN_INTERFACE}:6832
-            thrift_compact:
-                endpoint: ${SPLUNK_LISTEN_INTERFACE}:6831
-            thrift_http:
-                endpoint: ${SPLUNK_LISTEN_INTERFACE}:14268
-    nop: null
-    otlp:
-        protocols:
-            grpc:
-                endpoint: ${SPLUNK_LISTEN_INTERFACE}:4317
-            http:
-                endpoint: ${SPLUNK_LISTEN_INTERFACE}:4318
-    prometheus/internal:
-        config:
-            scrape_configs:
-                - job_name: otel-collector
-                  metric_relabel_configs:
-                    - action: drop
-                      regex: promhttp_metric_handler_errors.*
-                      source_labels:
-                        - __name__
-                    - action: drop
-                      regex: otelcol_processor_batch_.*
-                      source_labels:
-                        - __name__
-                  scrape_interval: 10s
-                  static_configs:
-                    - targets:
-                        - 0.0.0.0:8888
-    smartagent/processlist:
-        type: processlist
-    zipkin:
-        endpoint: ${SPLUNK_LISTEN_INTERFACE}:9411
+  fluent_forward:
+    endpoint: ${SPLUNK_LISTEN_INTERFACE}:8006
+  host_metrics:
+    collection_interval: 10s
+    scrapers:
+      cpu: null
+      disk: null
+      filesystem: null
+      load: null
+      memory: null
+      network: null
+      paging: null
+      processes: null
+  jaeger:
+    protocols:
+      grpc:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:14250
+      thrift_binary:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:6832
+      thrift_compact:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:6831
+      thrift_http:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:14268
+  nop: null
+  otlp:
+    protocols:
+      grpc:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:4317
+      http:
+        endpoint: ${SPLUNK_LISTEN_INTERFACE}:4318
+  prometheus/internal:
+    config:
+      scrape_configs:
+        - job_name: otel-collector
+          metric_relabel_configs:
+            - action: drop
+              regex: promhttp_metric_handler_errors.*
+              source_labels:
+                - __name__
+            - action: drop
+              regex: otelcol_processor_batch_.*
+              source_labels:
+                - __name__
+          scrape_interval: 10s
+          static_configs:
+            - targets:
+                - 0.0.0.0:8888
+  smartagent/processlist:
+    type: processlist
+  zipkin:
+    endpoint: ${SPLUNK_LISTEN_INTERFACE}:9411
 service:
-    extensions:
-        - headers_setter
-        - health_check
-        - http_forwarder
-        - http_forwarder/opamp_splunk_o11y
-        - opamp/splunk_o11y
-        - zpages
-    pipelines:
-        logs:
-            exporters:
-                - splunk_hec
-                - splunk_hec/profiling
-            processors:
-                - memory_limiter
-                - batch
-                - resource_detection
-            receivers:
-                - fluent_forward
-                - otlp
-        logs/entities:
-            exporters:
-                - otlp_http/entities
-            processors:
-                - memory_limiter
-                - batch
-                - resource_detection
-            receivers:
-                - nop
-        logs/signalfx:
-            exporters:
-                - signalfx
-            processors:
-                - memory_limiter
-                - batch
-                - resource_detection
-            receivers:
-                - smartagent/processlist
-        metrics:
-            exporters:
-                - signalfx
-            processors:
-                - memory_limiter
-                - batch
-                - resource_detection
-            receivers:
-                - host_metrics
-                - otlp
-        metrics/internal:
-            exporters:
-                - signalfx
-            processors:
-                - memory_limiter
-                - batch
-                - resource_detection
-            receivers:
-                - prometheus/internal
-        traces:
-            exporters:
-                - otlp_http
-            processors:
-                - memory_limiter
-                - batch
-                - resource_detection
-            receivers:
-                - jaeger
-                - otlp
-                - zipkin
-    telemetry:
-        logs:
-            level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
-        metrics:
-            readers:
-                - pull:
-                    exporter:
-                        prometheus:
-                            host: 127.0.0.1
-                            port: 8888
-        resource:
-            attributes:
-                - name: otelcol.service.mode
-                  value: agent
+  extensions:
+    - headers_setter
+    - health_check
+    - http_forwarder
+    - http_forwarder/opamp_splunk_o11y
+    - opamp/splunk_o11y
+    - zpages
+  pipelines:
+    logs:
+      exporters:
+        - splunk_hec
+        - splunk_hec/profiling
+      processors:
+        - memory_limiter
+        - batch
+        - resource_detection
+      receivers:
+        - fluent_forward
+        - otlp
+    logs/entities:
+      exporters:
+        - otlp_http/entities
+      processors:
+        - memory_limiter
+        - batch
+        - resource_detection
+      receivers:
+        - nop
+    logs/signalfx:
+      exporters:
+        - signalfx
+      processors:
+        - memory_limiter
+        - batch
+        - resource_detection
+      receivers:
+        - smartagent/processlist
+    metrics:
+      exporters:
+        - signalfx
+      processors:
+        - memory_limiter
+        - batch
+        - resource_detection
+      receivers:
+        - host_metrics
+        - otlp
+    metrics/internal:
+      exporters:
+        - signalfx
+      processors:
+        - memory_limiter
+        - batch
+        - resource_detection
+      receivers:
+        - prometheus/internal
+    traces:
+      exporters:
+        - otlp_http
+      processors:
+        - memory_limiter
+        - batch
+        - resource_detection
+      receivers:
+        - jaeger
+        - otlp
+        - zipkin
+  telemetry:
+    logs:
+      level: ${env:SPLUNK_COLLECTOR_LOG_LEVEL:-info}
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 127.0.0.1
+                port: 8888
+    resource:
+      attributes:
+        - name: otelcol.service.mode
+          value: agent

--- a/go.sum
+++ b/go.sum
@@ -811,6 +811,7 @@ github.com/hetznercloud/hcloud-go/v2 v2.44.0 h1:1p9qwaZ/H55nLP9c7WfuwUA0LfsexS2Y
 github.com/hetznercloud/hcloud-go/v2 v2.44.0/go.mod h1:d0s2WLe7jSoStamv3eHoWgBSOxc/K17tYSXsqUkbse0=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/go-assert v1.1.5 h1:fjemmA7sSfYHJD7CUqs9qTwwfdNAx7/j2/ZlHXzNB3c=
@@ -1504,6 +1505,8 @@ github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
 github.com/petermattis/goid v0.0.0-20250721140440-ea1c0173183e h1:D0bJD+4O3G4izvrQUmzCL80zazlN7EwJ0PPDhpJWC/I=
 github.com/petermattis/goid v0.0.0-20250721140440-ea1c0173183e/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Limitations:
1. koanf drops all YAML comments, so the generated configs will no longer have comments
2. YAML maps are alphabetized by koanf. Not a bug or anything really wrong (since maps are unordered), but it means typical orderings will no longer exist in some cases. One relevant example, we're used to seeing `service:telemetry`, `service:extensions`, `service.pipelines` in that order. Now it'll be `service.extensions`, `service.pipelines`, `service.telemetry`.
3. koanf does not merge YAML lists, as explained in [another recent comment](https://github.com/signalfx/splunk-otel-collector/pull/7786#discussion_r3605010542). This means for any config list, the whole list will need to be included in the overlay, as the underlying list will be **fully overwritten** by whatever replacement is specified.