### PR TITLE
Update launcher to support tar package dir structure

### DIFF
--- a/cmd/otelcollauncher/main_windows.go
+++ b/cmd/otelcollauncher/main_windows.go
@@ -212,10 +212,9 @@ type childResult struct {
 // childProcess wraps the immediate child selected by the launcher. The child is
 // either otelcol.exe in direct mode or opampsupervisor.exe in supervisor mode.
 type childProcess struct {
-	cmd *exec.Cmd
-	// outputClosers unblock StdoutPipe/StderrPipe forwarding during hard-stop cleanup.
-	outputClosers []io.ReadCloser
+	cmd           *exec.Cmd
 	done          <-chan childResult
+	outputClosers []io.ReadCloser
 }
 
 // startChild launches the selected binary in its own process group. Interactive

--- a/cmd/otelcollauncher/main_windows_test.go
+++ b/cmd/otelcollauncher/main_windows_test.go
@@ -64,8 +64,8 @@ func TestWaitForChildReturnsOutputAndWaitErrors(t *testing.T) {
 		return waitErr
 	})
 
-	assert.ErrorIs(t, result.outputErr, outputErr)
-	assert.ErrorIs(t, result.waitErr, waitErr)
+	require.ErrorIs(t, result.outputErr, outputErr)
+	require.ErrorIs(t, result.waitErr, waitErr)
 }
 
 func TestWaitForChildWithoutOutputForwardingWaitsImmediately(t *testing.T) {

--- a/internal/opampsupervisor/launcher/config.go
+++ b/internal/opampsupervisor/launcher/config.go
@@ -194,6 +194,11 @@ func PrepareCommand(args, environ []string, paths Paths) (Command, error) {
 // supervisor start and writes the runtime supervisor config with the current
 // launcher-managed agent fields.
 func prepareSupervisor(inputs supervisorInputs, env map[string]string, paths Paths) error {
+	supervisorDir := filepath.Dir(paths.SupervisorConfig)
+	if err := os.MkdirAll(supervisorDir, 0o700); err != nil {
+		return fmt.Errorf("create supervisor config directory %q: %w", supervisorDir, err)
+	}
+
 	collectorConfigs, err := loadCollectorConfigFiles(inputs.configFiles)
 	if err != nil {
 		return err

--- a/internal/opampsupervisor/launcher/config.go
+++ b/internal/opampsupervisor/launcher/config.go
@@ -196,7 +196,7 @@ func PrepareCommand(args, environ []string, paths Paths) (Command, error) {
 func prepareSupervisor(inputs supervisorInputs, env map[string]string, paths Paths) error {
 	supervisorDir := filepath.Dir(paths.SupervisorConfig)
 	if err := os.MkdirAll(supervisorDir, 0o700); err != nil {
-		return fmt.Errorf("create supervisor config directory %q: %w", supervisorDir, err)
+		return fmt.Errorf("failed to create supervisor config directory %q: %w", supervisorDir, err)
 	}
 
 	collectorConfigs, err := loadCollectorConfigFiles(inputs.configFiles)
@@ -212,7 +212,7 @@ func prepareSupervisor(inputs supervisorInputs, env map[string]string, paths Pat
 	_, statErr := os.Stat(paths.SupervisorConfig)
 	if statErr != nil {
 		if !errors.Is(statErr, fs.ErrNotExist) {
-			return fmt.Errorf("stat supervisor config %q: %w", paths.SupervisorConfig, statErr)
+			return fmt.Errorf("failed to access supervisor config file %q: %w", paths.SupervisorConfig, statErr)
 		}
 		initialConfig, initErr := initialSupervisorConfig(paths, collectorConfigs, env)
 		if initErr != nil {
@@ -438,11 +438,11 @@ func loadCollectorConfigFiles(paths []string) ([]collectorConfigInput, error) {
 func loadCollectorConfigFile(path string) (map[string]any, error) {
 	bytes, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read collector config %q: %w", path, err)
+		return nil, fmt.Errorf("failed to read collector config %q: %w", path, err)
 	}
 	var config map[string]any
 	if err := yaml.Unmarshal(bytes, &config); err != nil {
-		return nil, fmt.Errorf("parse collector config %q: %w", path, err)
+		return nil, fmt.Errorf("failed to parse collector config %q: %w", path, err)
 	}
 	if config == nil {
 		config = map[string]any{}
@@ -570,10 +570,10 @@ func derivedOpAMPEndpoint(env map[string]string) string {
 func writeYAML(path string, value any) error {
 	bytes, err := yaml.Marshal(value)
 	if err != nil {
-		return fmt.Errorf("marshal %q: %w", path, err)
+		return fmt.Errorf("failed to marshal %q: %w", path, err)
 	}
 	if err := os.WriteFile(path, bytes, 0o600); err != nil {
-		return fmt.Errorf("write %q: %w", path, err)
+		return fmt.Errorf("failed to write %q: %w", path, err)
 	}
 	return nil
 }
@@ -619,10 +619,10 @@ func writeInitialSupervisorConfig(path string, config SupervisorConfig) error {
 		"ManagedAgentComment": managedAgentComment,
 	}
 	if err := initialSupervisorConfigTemplate.Execute(&buf, data); err != nil {
-		return fmt.Errorf("marshal %q: %w", path, err)
+		return fmt.Errorf("failed to marshal %q: %w", path, err)
 	}
 	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
-		return fmt.Errorf("write %q: %w", path, err)
+		return fmt.Errorf("failed to write %q: %w", path, err)
 	}
 	return nil
 }
@@ -630,11 +630,11 @@ func writeInitialSupervisorConfig(path string, config SupervisorConfig) error {
 func loadSupervisorConfigFile(path string) (map[string]any, error) {
 	bytes, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read supervisor config %q: %w", path, err)
+		return nil, fmt.Errorf("failed to read supervisor config %q: %w", path, err)
 	}
 	var decoded any
 	if err := yaml.Unmarshal(bytes, &decoded); err != nil {
-		return nil, fmt.Errorf("parse supervisor config %q: %w", path, err)
+		return nil, fmt.Errorf("failed to parse supervisor config %q: %w", path, err)
 	}
 	config, ok := asMap(decoded)
 	if !ok {

--- a/internal/opampsupervisor/launcher/config_test.go
+++ b/internal/opampsupervisor/launcher/config_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,7 +41,7 @@ func TestSupervisorEnabled(t *testing.T) {
 }
 
 func TestPrepareCommandDirectMode(t *testing.T) {
-	paths := testPaths(t, t.TempDir())
+	paths := testPaths(t.TempDir())
 	env := []string{"A=B"}
 	args := []string{
 		"--config", "/etc/otel/collector/agent_config.yaml",
@@ -55,8 +54,10 @@ func TestPrepareCommandDirectMode(t *testing.T) {
 	assert.Equal(t, args, cmd.Args)
 	assert.Equal(t, env, cmd.Env)
 
+	_, err = os.Stat(filepath.Dir(paths.SupervisorConfig))
+	require.ErrorIs(t, err, os.ErrNotExist)
 	_, err = os.Stat(paths.StorageDirectory)
-	assert.ErrorIs(t, err, os.ErrNotExist)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestPrepareCommandSupervisorMode(t *testing.T) {
@@ -69,7 +70,7 @@ service:
   extensions: [health_check]
 `), 0o600))
 
-	paths := testPaths(t, dir)
+	paths := testPaths(dir)
 	paths.CollectorExecutable = filepath.Join(dir, "test-otelcol")
 
 	env := []string{
@@ -87,11 +88,15 @@ service:
 	assert.Equal(t, paths.SupervisorExecutable, cmd.Path)
 	assert.Equal(t, []string{"--config", paths.RuntimeSupervisorConfig}, cmd.Args)
 	assert.Equal(t, append(append([]string{}, env...), ListenInterfaceEnvVar+"="+defaultListenInterface), cmd.Env)
+	assert.FileExists(t, paths.SupervisorConfig)
+	assert.FileExists(t, paths.RuntimeSupervisorConfig)
+	_, err = os.Stat(paths.StorageDirectory)
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestPrepareCommandSupervisorModeDefaultAgentListenInterface(t *testing.T) {
 	dir := t.TempDir()
-	paths := testPaths(t, dir)
+	paths := testPaths(dir)
 	require.NoError(t, os.WriteFile(paths.DefaultAgentConfig, []byte(`service: {}`), 0o600))
 
 	env := []string{
@@ -110,7 +115,7 @@ func TestPrepareCommandSupervisorModePreservesExplicitListenInterface(t *testing
 	configPath := filepath.Join(dir, "collector.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
 
-	paths := testPaths(t, dir)
+	paths := testPaths(dir)
 	env := []string{
 		SupervisorEnabledEnvVar + "=true",
 		CollectorConfigEnvVar + "=" + configPath,
@@ -144,7 +149,7 @@ service:
   extensions: [health_check, opamp/splunk_o11y, http_forwarder/opamp_splunk_o11y, opamp/custom]
 `), 0o600))
 
-	paths := testPaths(t, dir)
+	paths := testPaths(dir)
 	err := prepareSupervisor(
 		supervisorInputs{
 			configFiles: []string{configPath},
@@ -247,7 +252,7 @@ service:
   extensions: [health_check]
 `), 0o600))
 
-	paths := testPaths(t, dir)
+	paths := testPaths(dir)
 	err := prepareSupervisor(
 		supervisorInputs{
 			configFiles: []string{baseConfigPath, overlayConfigPath, otherConfigPath},
@@ -295,7 +300,7 @@ service:
 
 func TestPrepareCommandPreservesExistingConfigAndRecomputesEnv(t *testing.T) {
 	dir := t.TempDir()
-	paths := testPaths(t, dir)
+	paths := testPaths(dir)
 	overlayPath := filepath.Join(dir, "overlay.yaml")
 	require.NoError(t, os.WriteFile(overlayPath, []byte(`extensions: {}`), 0o600))
 	sourceConfig := `
@@ -326,6 +331,7 @@ agent:
   passthrough_logs: false
   validate_config: false
 `
+	require.NoError(t, os.MkdirAll(filepath.Dir(paths.SupervisorConfig), 0o700))
 	require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte(sourceConfig), 0o600))
 	configPath := filepath.Join(dir, "collector.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte(`
@@ -376,31 +382,9 @@ service:
 	assert.Equal(t, append(append([]string{}, env...), ListenInterfaceEnvVar+"="+defaultListenInterface), cmd.Env)
 }
 
-func TestPrepareSupervisorConfigDoesNotRewriteExistingSourceConfig(t *testing.T) {
-	dir := t.TempDir()
-	paths := testPaths(t, dir)
-	configPath := filepath.Join(dir, "collector.yaml")
-	require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
-
-	args := []string{"--feature-gates=+splunk.opamp.enabled"}
-	inputs := supervisorInputs{configFiles: []string{configPath}, agentArgs: args}
-	env := map[string]string{IngestURLEnvVar: "https://ingest.example"}
-	require.NoError(t, prepareSupervisor(inputs, env, paths))
-	want := readFile(t, paths.SupervisorConfig)
-	oldTime := time.Unix(1000, 0)
-	require.NoError(t, os.Chtimes(paths.SupervisorConfig, oldTime, oldTime))
-
-	require.NoError(t, prepareSupervisor(inputs, env, paths))
-
-	assert.Equal(t, want, readFile(t, paths.SupervisorConfig))
-	info, err := os.Stat(paths.SupervisorConfig)
-	require.NoError(t, err)
-	assert.True(t, info.ModTime().Equal(oldTime))
-}
-
 func TestPrepareSupervisorConfigRefreshesRuntimeConfigFromCurrentInputs(t *testing.T) {
 	dir := t.TempDir()
-	paths := testPaths(t, dir)
+	paths := testPaths(dir)
 	baseConfigPath := filepath.Join(dir, "base.yaml")
 	overlayConfigPath := filepath.Join(dir, "overlay.yaml")
 	require.NoError(t, os.WriteFile(baseConfigPath, []byte(`service: {}`), 0o600))
@@ -417,6 +401,7 @@ agent:
   passthrough_logs: false
   validate_config: false
 `
+	require.NoError(t, os.MkdirAll(filepath.Dir(paths.SupervisorConfig), 0o700))
 	require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte(sourceConfig), 0o600))
 
 	err := prepareSupervisor(
@@ -446,7 +431,7 @@ agent:
 
 func TestPrepareSupervisorRuntimeConfigRemovesStaleArgsWhenCurrentArgsAreEmpty(t *testing.T) {
 	dir := t.TempDir()
-	paths := testPaths(t, dir)
+	paths := testPaths(dir)
 	configPath := filepath.Join(dir, "collector.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
 	sourceConfig := `
@@ -466,6 +451,7 @@ agent:
   passthrough_logs: false
   validate_config: false
 `
+	require.NoError(t, os.MkdirAll(filepath.Dir(paths.SupervisorConfig), 0o700))
 	require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte(sourceConfig), 0o600))
 
 	err := prepareSupervisor(supervisorInputs{configFiles: []string{configPath}}, map[string]string{}, paths)
@@ -486,6 +472,13 @@ func TestPrepareSupervisorConfigReturnsErrors(t *testing.T) {
 		setup   func(t *testing.T, dir string, paths Paths) (supervisorInputs, map[string]string)
 		wantErr string
 	}{
+		"Supervisor config directory creation": {
+			setup: func(t *testing.T, _ string, paths Paths) (supervisorInputs, map[string]string) {
+				require.NoError(t, os.WriteFile(filepath.Dir(paths.SupervisorConfig), []byte("not a directory"), 0o600))
+				return supervisorInputs{}, nil
+			},
+			wantErr: "create supervisor config directory",
+		},
 		"Collector config read": {
 			setup: func(_ *testing.T, dir string, _ Paths) (supervisorInputs, map[string]string) {
 				return supervisorInputs{configFiles: []string{filepath.Join(dir, "missing.yaml")}},
@@ -514,6 +507,7 @@ func TestPrepareSupervisorConfigReturnsErrors(t *testing.T) {
 			setup: func(t *testing.T, dir string, paths Paths) (supervisorInputs, map[string]string) {
 				configPath := filepath.Join(dir, "collector.yaml")
 				require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
+				require.NoError(t, os.MkdirAll(filepath.Dir(paths.SupervisorConfig), 0o700))
 				require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte("agent: ["), 0o600))
 				return supervisorInputs{configFiles: []string{configPath}},
 					map[string]string{IngestURLEnvVar: "https://ingest.example"}
@@ -524,6 +518,7 @@ func TestPrepareSupervisorConfigReturnsErrors(t *testing.T) {
 			setup: func(t *testing.T, dir string, paths Paths) (supervisorInputs, map[string]string) {
 				configPath := filepath.Join(dir, "collector.yaml")
 				require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
+				require.NoError(t, os.MkdirAll(filepath.Dir(paths.SupervisorConfig), 0o700))
 				require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte("server: {endpoint: https://user.example/v1/opamp}\n"), 0o600))
 				return supervisorInputs{configFiles: []string{configPath}},
 					map[string]string{IngestURLEnvVar: "https://ingest.example"}
@@ -534,6 +529,7 @@ func TestPrepareSupervisorConfigReturnsErrors(t *testing.T) {
 			setup: func(t *testing.T, dir string, paths Paths) (supervisorInputs, map[string]string) {
 				configPath := filepath.Join(dir, "collector.yaml")
 				require.NoError(t, os.WriteFile(configPath, []byte(`service: {}`), 0o600))
+				require.NoError(t, os.MkdirAll(filepath.Dir(paths.SupervisorConfig), 0o700))
 				require.NoError(t, os.WriteFile(paths.SupervisorConfig, []byte("agent: invalid\n"), 0o600))
 				return supervisorInputs{configFiles: []string{configPath}},
 					map[string]string{IngestURLEnvVar: "https://ingest.example"}
@@ -545,7 +541,7 @@ func TestPrepareSupervisorConfigReturnsErrors(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			dir := t.TempDir()
-			paths := testPaths(t, dir)
+			paths := testPaths(dir)
 			inputs, env := tt.setup(t, dir, paths)
 			err := prepareSupervisor(inputs, env, paths)
 			require.Error(t, err)
@@ -1099,11 +1095,8 @@ func assertMinimalCapabilitiesYAML(t *testing.T, path string) {
 	}, capabilities)
 }
 
-func testPaths(t *testing.T, dir string) Paths {
-	t.Helper()
-
+func testPaths(dir string) Paths {
 	supervisorConfig := filepath.Join(dir, "config", "supervisor_config.yaml")
-	require.NoError(t, os.MkdirAll(filepath.Dir(supervisorConfig), 0o700))
 	return Paths{
 		CollectorExecutable:         "otelcol",
 		SupervisorExecutable:        "opampsupervisor",

--- a/internal/opampsupervisor/launcher/paths_others.go
+++ b/internal/opampsupervisor/launcher/paths_others.go
@@ -16,17 +16,36 @@
 
 package launcher
 
-// DefaultPaths returns the installed collector, supervisor, and state
-// locations used by the package-managed service on Linux packages.
+import (
+	"os"
+	"path/filepath"
+)
+
+// DefaultPaths returns collector, supervisor, and state locations for Linux
+// packages. Tar bundles use paths relative to the launcher executable.
 func DefaultPaths() Paths {
+	launcherExecutable, err := os.Executable()
+	if err != nil {
+		launcherExecutable = "/usr/bin/otelcollauncher"
+	}
+	return pathsForExecutable(launcherExecutable)
+}
+
+func pathsForExecutable(launcherExecutable string) Paths {
+	binDir := filepath.Dir(launcherExecutable)
+	configDir := "/etc/otel/collector"
+	if binDir != "/usr/bin" {
+		configDir = filepath.Join(filepath.Dir(binDir), "config")
+	}
+	supervisorConfigDir := filepath.Join(configDir, "supervisor")
 	return Paths{
-		CollectorExecutable:         "/usr/bin/otelcol",
-		SupervisorExecutable:        "/usr/bin/opampsupervisor",
-		SupervisorConfig:            "/etc/otel/collector/supervisor/supervisor_config.yaml",
-		RuntimeSupervisorConfig:     "/etc/otel/collector/supervisor/supervisor_runtime_config.yaml",
-		GeneratedCollectorConfigDir: "/etc/otel/collector/supervisor",
+		CollectorExecutable:         filepath.Join(binDir, "otelcol"),
+		SupervisorExecutable:        filepath.Join(binDir, "opampsupervisor"),
+		SupervisorConfig:            filepath.Join(supervisorConfigDir, "supervisor_config.yaml"),
+		RuntimeSupervisorConfig:     filepath.Join(supervisorConfigDir, "supervisor_runtime_config.yaml"),
+		GeneratedCollectorConfigDir: supervisorConfigDir,
 		StorageDirectory:            "/var/lib/otelcol/supervisor",
-		DefaultAgentConfig:          "/etc/otel/collector/agent_config.yaml",
+		DefaultAgentConfig:          filepath.Join(configDir, "agent_config.yaml"),
 		ConfigApplyTimeout:          "1m",
 		UseHUPConfigReload:          true,
 	}

--- a/internal/opampsupervisor/launcher/paths_others_test.go
+++ b/internal/opampsupervisor/launcher/paths_others_test.go
@@ -1,0 +1,70 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package launcher
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathsForExecutable(t *testing.T) {
+	bundleDir := "/opt/splunk-otel-collector"
+	tests := []struct {
+		name       string
+		executable string
+		want       Paths
+	}{
+		{
+			name:       "installed package",
+			executable: "/usr/bin/otelcollauncher",
+			want: Paths{
+				CollectorExecutable:         "/usr/bin/otelcol",
+				SupervisorExecutable:        "/usr/bin/opampsupervisor",
+				SupervisorConfig:            "/etc/otel/collector/supervisor/supervisor_config.yaml",
+				RuntimeSupervisorConfig:     "/etc/otel/collector/supervisor/supervisor_runtime_config.yaml",
+				GeneratedCollectorConfigDir: "/etc/otel/collector/supervisor",
+				StorageDirectory:            "/var/lib/otelcol/supervisor",
+				DefaultAgentConfig:          "/etc/otel/collector/agent_config.yaml",
+				ConfigApplyTimeout:          "1m",
+				UseHUPConfigReload:          true,
+			},
+		},
+		{
+			name:       "tar bundle",
+			executable: filepath.Join(bundleDir, "bin", "otelcollauncher"),
+			want: Paths{
+				CollectorExecutable:         filepath.Join(bundleDir, "bin", "otelcol"),
+				SupervisorExecutable:        filepath.Join(bundleDir, "bin", "opampsupervisor"),
+				SupervisorConfig:            filepath.Join(bundleDir, "config", "supervisor", "supervisor_config.yaml"),
+				RuntimeSupervisorConfig:     filepath.Join(bundleDir, "config", "supervisor", "supervisor_runtime_config.yaml"),
+				GeneratedCollectorConfigDir: filepath.Join(bundleDir, "config", "supervisor"),
+				StorageDirectory:            "/var/lib/otelcol/supervisor",
+				DefaultAgentConfig:          filepath.Join(bundleDir, "config", "agent_config.yaml"),
+				ConfigApplyTimeout:          "1m",
+				UseHUPConfigReload:          true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, pathsForExecutable(test.executable))
+		})
+	}
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- Move creation of supervisor config dir to launcher (ensures supervisor dir only created when supervisor mode is enabled vs if done via packaging)
- Update launcher to support tar dir structure where binaries aren't in service installed `/usr/bin` dir

**Testing:** <Describe what testing was performed and which tests were added.>
- Local dev testing with tar package => ran launcher with supervisor mode, verified binaries/configs found and able to run