### PR TITLE
Update launcher to be clear on unsupported platforms

### DIFF
--- a/cmd/otelcollauncher/main.go
+++ b/cmd/otelcollauncher/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"fmt"
+	"log"
 	"os"
 
 	"github.com/signalfx/splunk-otel-collector/internal/opampsupervisor/launcher"
@@ -23,7 +23,6 @@ import (
 
 func main() {
 	if err := run(os.Args[1:], os.Environ(), launcher.DefaultPaths()); err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }

--- a/cmd/otelcollauncher/main_linux.go
+++ b/cmd/otelcollauncher/main_linux.go
@@ -12,10 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !linux && !windows
+//go:build linux
 
-package launcher
+package main
 
-func DefaultPaths() Paths {
-	return Paths{}
+import (
+	"golang.org/x/sys/unix"
+
+	"github.com/signalfx/splunk-otel-collector/internal/opampsupervisor/launcher"
+)
+
+// run replaces the launcher process with the selected child process on Linux
+// so systemd tracks the collector or supervisor directly.
+func run(args, env []string, paths launcher.Paths) error {
+	cmd, err := launcher.PrepareCommand(args, env, paths)
+	if err != nil {
+		return err
+	}
+	return unix.Exec(cmd.Path, append([]string{cmd.Path}, cmd.Args...), cmd.Env)
 }

--- a/cmd/otelcollauncher/main_others.go
+++ b/cmd/otelcollauncher/main_others.go
@@ -12,22 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
+//go:build !linux && !windows
 
 package main
 
 import (
-	"golang.org/x/sys/unix"
+	"errors"
 
 	"github.com/signalfx/splunk-otel-collector/internal/opampsupervisor/launcher"
 )
 
-// run replaces the launcher process with the selected child process on POSIX
-// systems so systemd tracks the collector or supervisor directly.
-func run(args, env []string, paths launcher.Paths) error {
-	cmd, err := launcher.PrepareCommand(args, env, paths)
-	if err != nil {
-		return err
-	}
-	return unix.Exec(cmd.Path, append([]string{cmd.Path}, cmd.Args...), cmd.Env)
+func run(_, _ []string, _ launcher.Paths) error {
+	return errors.New("otelcollauncher is supported only on Linux and Windows")
 }

--- a/internal/opampsupervisor/launcher/paths_linux.go
+++ b/internal/opampsupervisor/launcher/paths_linux.go
@@ -1,0 +1,52 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package launcher
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// DefaultPaths returns collector, supervisor, and state locations for Linux
+// packages. Tar bundles use paths relative to the launcher executable.
+func DefaultPaths() Paths {
+	launcherExecutable, err := os.Executable()
+	if err != nil {
+		launcherExecutable = "/usr/bin/otelcollauncher"
+	}
+	return pathsForExecutable(launcherExecutable)
+}
+
+func pathsForExecutable(launcherExecutable string) Paths {
+	binDir := filepath.Dir(launcherExecutable)
+	configDir := "/etc/otel/collector"
+	if binDir != "/usr/bin" {
+		configDir = filepath.Join(filepath.Dir(binDir), "config")
+	}
+	supervisorConfigDir := filepath.Join(configDir, "supervisor")
+	return Paths{
+		CollectorExecutable:         filepath.Join(binDir, "otelcol"),
+		SupervisorExecutable:        filepath.Join(binDir, "opampsupervisor"),
+		SupervisorConfig:            filepath.Join(supervisorConfigDir, "supervisor_config.yaml"),
+		RuntimeSupervisorConfig:     filepath.Join(supervisorConfigDir, "supervisor_runtime_config.yaml"),
+		GeneratedCollectorConfigDir: supervisorConfigDir,
+		StorageDirectory:            "/var/lib/otelcol/supervisor",
+		DefaultAgentConfig:          filepath.Join(configDir, "agent_config.yaml"),
+		ConfigApplyTimeout:          "1m",
+		UseHUPConfigReload:          true,
+	}
+}

--- a/internal/opampsupervisor/launcher/paths_linux_test.go
+++ b/internal/opampsupervisor/launcher/paths_linux_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
+//go:build linux
 
 package launcher
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Followup changes from discussion on [previous PR](https://github.com/signalfx/splunk-otel-collector/pull/7851#discussion_r3686960681) to make unsupported platforms clearer

**Testing:** <Describe what testing was performed and which tests were added.>
Built mac launcher binary and verified it logged the error message then exited