### PR TITLE
[telegraf/win_services] deprecate the monitor

### DIFF
--- a/.chloggen/deprecate_telegraf_winservices.yaml
+++ b/.chloggen/deprecate_telegraf_winservices.yaml
@@ -14,4 +14,4 @@ issues: [7858]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  This monitor is deprecated and will be removed on or after October 2026. Please use the windows_service receiver instead.
+  This monitor is deprecated and will be removed on or after October 2026. Please use the [windows_service receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowsservicereceiver/) instead.

--- a/.chloggen/deprecate_telegraf_winservices.yaml
+++ b/.chloggen/deprecate_telegraf_winservices.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: telegraf/winservices
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the monitor
+
+# One or more tracking issues related to the change
+issues: [7858]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This monitor is deprecated and will be removed on or after October 2026. Please use the windows_service receiver instead.

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/winservices/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/winservices/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the windows_service receiver instead.**
     (Windows Only) This monitor reports metrics about Windows services.
     This monitor is based on the Telegraf win_services plugin.  More information about the Telegraf plugin
     can be found [here](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/win_services).

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/winservices/winservices_windows.go
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/winservices/winservices_windows.go
@@ -21,6 +21,7 @@ var logger = logrus.WithField("monitorType", monitorType)
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.logger = logger.WithField("monitorID", conf.MonitorID)
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026. Please use the windows_service receiver instead.")
 	plugin := telegrafInputs.Inputs["win_services"]().(*telegrafPlugin.WinServices)
 
 	// create the emitter


### PR DESCRIPTION
**Description:**
This monitor is deprecated and will be removed on or after October 2026. Please use the windows_service receiver instead.
