### PR TITLE
[telegraf/win_perf_counters] deprecate the monitor

### DIFF
--- a/.chloggen/deprecate_telegraf_windowsperfcounters.yaml
+++ b/.chloggen/deprecate_telegraf_windowsperfcounters.yaml
@@ -14,4 +14,4 @@ issues: [7859]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  This monitor is deprecated and will be removed on or after October 2026. Please use the windowsperfcounters receiver instead.
+  This monitor is deprecated and will be removed on or after October 2026. Please use the [windowsperfcounters receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowsperfcountersreceiver) instead.

--- a/.chloggen/deprecate_telegraf_windowsperfcounters.yaml
+++ b/.chloggen/deprecate_telegraf_windowsperfcounters.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: telegraf/win_perf_counters
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the monitor
+
+# One or more tracking issues related to the change
+issues: [7859]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This monitor is deprecated and will be removed on or after October 2026. Please use the windowsperfcounters receiver instead.

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/winperfcounters/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/winperfcounters/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the windowsperfcounters receiver instead.**
     This monitor reads Windows performance
     counters
 

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/winperfcounters/win_perf_counters_windows.go
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/winperfcounters/win_perf_counters_windows.go
@@ -62,6 +62,7 @@ func GetPlugin(conf *Config) (*telegrafPlugin.Win_PerfCounters, error) {
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) error {
 	m.logger = logger.WithField("monitorID", conf.MonitorID)
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026. Please use the windowsperfcounters receiver instead.")
 	plugin, err := GetPlugin(conf)
 	if err != nil {
 		return err


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This monitor is deprecated and will be removed on or after October 2026. Please use the windowsperfcounters receiver instead.
