### PR TITLE
[telegraf/varnish] deprecate the monitor

### DIFF
--- a/.chloggen/deprecate_telegraf_varnish.yaml
+++ b/.chloggen/deprecate_telegraf_varnish.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: telegraf/varnish
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the monitor
+
+# One or more tracking issues related to the change
+issues: [7860]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This monitor is deprecated and will be removed on or after October 2026. Please use https://docs.varnish-software.com/varnish-otel/ instead.

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/varnish/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/varnish/metadata.yaml
@@ -1,5 +1,6 @@
 monitors:
 - doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use https://docs.varnish-software.com/varnish-otel/ instead.**
     This is an embedded form of the [Telegraf Varnish
     plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/varnish).
 

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/varnish/varnish.go
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/varnish/varnish.go
@@ -50,7 +50,7 @@ type Emitter struct {
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
-
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026. Please use https://docs.varnish-software.com/varnish-otel/ instead.")
 	plugin := telegrafInputs.Inputs["varnish"]().(*telegrafPlugin.Varnish)
 	plugin.UseSudo = conf.UseSudo
 	plugin.Binary = conf.Binary


### PR DESCRIPTION
**Description:**
This monitor is deprecated and will be removed on or after October 2026. Please use https://docs.varnish-software.com/varnish-otel/ instead.