### PR TITLE
[telegraf/statsd] deprecate the monitor

### DIFF
--- a/.chloggen/deprecate_telegraf_statsd.yaml
+++ b/.chloggen/deprecate_telegraf_statsd.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type:
+change_type: deprecation
 
 # The name of the component, or a single word describing the area of concern, (e.g. crosslink)
 component: telegraf/statsd

--- a/.chloggen/deprecate_telegraf_statsd.yaml
+++ b/.chloggen/deprecate_telegraf_statsd.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: telegraf/statsd
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the monitor.
+
+# One or more tracking issues related to the change
+issues: [7861]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This monitor is deprecated and will be removed on or after October 2026. Please use the [statsd receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver) instead.

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/telegrafstatsd/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/telegrafstatsd/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the [statsd receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver) instead.**
     This monitor acts as a Telegraf StatsD listener for receiving telegrafstatsd metrics.
     This monitor is based on the Telegraf Statsd input plugin.  More information about the Telegraf plugin
     can be found [here](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd).

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/telegrafstatsd/statsd.go
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/telegrafstatsd/statsd.go
@@ -80,6 +80,7 @@ var factory = telegrafInputs.Inputs["statsd"]
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.logger = logger.WithField("monitorID", conf.MonitorID)
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026. Please use the [statsd receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver) instead.")
 	m.plugin = factory().(*telegrafPlugin.Statsd)
 
 	// copy configurations to the plugin


### PR DESCRIPTION
**Description:**
This monitor is deprecated and will be removed on or after October 2026. Please use the [statsd receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver) instead.