### PR TITLE
[telegraf/snmp] deprecate the monitor

### DIFF
--- a/.chloggen/deprecate_telegraf_snmp.yaml
+++ b/.chloggen/deprecate_telegraf_snmp.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: telegraf/snmp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the monitor
+
+# One or more tracking issues related to the change
+issues: [7862]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This monitor is deprecated and will be removed on or after October 2026. Please use the [snmpreceiver receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/snmpreceiver) instead.

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/telegrafsnmp/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/telegrafsnmp/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the [snmpreceiver receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/snmpreceiver) instead.**
     This monitor reports metrics from snmp agents.
     This monitor is based on the Telegraf SNMP plugin.  More information about the Telegraf plugin
     can be found [here](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/snmp).

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/telegrafsnmp/telegrafsnmp.go
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/telegrafsnmp/telegrafsnmp.go
@@ -129,7 +129,7 @@ func getTelegrafFields(incoming []Field) ([]telegrafPlugin.Field, error) {
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
-
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026. Please use the [snmpreceiver receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/snmpreceiver) instead.")
 	plugin := telegrafInputs.Inputs["snmp"]().(*telegrafPlugin.Snmp)
 
 	// create the emitter


### PR DESCRIPTION
**Description:** 
This monitor is deprecated and will be removed on or after October 2026. Please use the [snmpreceiver receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/snmpreceiver) instead.
