### PR TITLE
[telegraf/tail] deprecate the monitor

### DIFF
--- a/.chloggen/deprecate_telegraf_tail.yaml
+++ b/.chloggen/deprecate_telegraf_tail.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: telegraf/tail
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the monitor
+
+# One or more tracking issues related to the change
+issues: [7864]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This monitor is deprecated and will be removed on or after October 2026. Please use the [count connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/countconnector) instead.

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/tail/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/tail/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the [count connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/countconnector) instead.**
     This monitor is based on the Telegraf tail plugin.  The monitor tails files and
     named pipes.  The Telegraf parser configured with this monitor extracts metrics in different
     [formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md)

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/tail/tail.go
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/tail/tail.go
@@ -57,6 +57,7 @@ var factory = telegrafInputs.Inputs["tail"]
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.logger = logger.WithField("monitorID", conf.MonitorID)
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026. Please use the [count connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/countconnector) instead.")
 	m.plugin = factory().(*telegrafPlugin.Tail)
 
 	// use the default config


### PR DESCRIPTION
**Description:** 
This monitor is deprecated and will be removed on or after October 2026. Please use the [count connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/countconnector) instead.
