### PR TITLE
[telegraf/procstat] deprecate the monitor

### DIFF
--- a/.chloggen/deprecate_telegraf_procstat.yaml
+++ b/.chloggen/deprecate_telegraf_procstat.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: telegraf/procstat
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the monitor
+
+# One or more tracking issues related to the change
+issues: [7865]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This monitor is deprecated and will be removed on or after October 2026. Please use the [host_metrics receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) instead.

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/procstat/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/procstat/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the [host_metrics receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) instead.**
     This monitor reports metrics about processes.
     This monitor is based on the Telegraf procstat plugin.  More information about the Telegraf plugin
     can be found [here](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/procstat).

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/procstat/procstat.go
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/procstat/procstat.go
@@ -66,6 +66,7 @@ var factory = telegrafInputs.Inputs["procstat"]
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.logger = logger.WithField("monitorID", conf.MonitorID)
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026. Please use the [host_metrics receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) instead.")
 	plugin := factory().(*telegrafPlugin.Procstat)
 
 	// create the emitter


### PR DESCRIPTION
**Description:**
This monitor is deprecated and will be removed on or after October 2026. Please use the [host_metrics receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) instead.

