### PR TITLE
[telegraf/ntpq] Deprecate the monitor

### DIFF
--- a/.chloggen/deprecate_telegraf_ntpq.yaml
+++ b/.chloggen/deprecate_telegraf_ntpq.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: telegraf/ntpq
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the monitor
+
+# One or more tracking issues related to the change
+issues: [7866]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This monitor is deprecated and will be removed on or after October 2026. Please use the [ntp receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/ntpreceiver) instead.

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/ntpq/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/ntpq/metadata.yaml
@@ -1,5 +1,6 @@
 monitors:
 - doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the [ntp receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/ntpreceiver) instead.**
     This is an embedded form of the [Telegraf NTPQ
     plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/ntpq).
 

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/ntpq/ntpq.go
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/ntpq/ntpq.go
@@ -40,6 +40,7 @@ type Emitter struct {
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026. Please use the [ntp receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/ntpreceiver) instead.")
 
 	plugin := telegrafInputs.Inputs["ntpq"]().(*telegrafPlugin.NTPQ)
 	plugin.DNSLookup = *conf.DNSLookup


### PR DESCRIPTION
**Description:**
This monitor is deprecated and will be removed on or after October 2026. Please use the [ntp receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/ntpreceiver) instead.
