### PR TITLE
[telegraf/mssqlserver] deprecate the monitor

### DIFF
--- a/.chloggen/deprecate_telegraf_mssqlserver.yaml
+++ b/.chloggen/deprecate_telegraf_mssqlserver.yaml
@@ -14,4 +14,4 @@ issues: [7867]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  This monitor is deprecated and will be removed on or after October 2026. Please use the [sql server receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlserverreceiver) instead.
+  This monitor is deprecated and will be removed on or after October 2026. Please use the [SQL Server receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlserverreceiver) instead.

--- a/.chloggen/deprecate_telegraf_mssqlserver.yaml
+++ b/.chloggen/deprecate_telegraf_mssqlserver.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: telegraf/mssqlserver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the monitor
+
+# One or more tracking issues related to the change
+issues: [7867]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This monitor is deprecated and will be removed on or after October 2026. Please use the [sql server receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlserverreceiver) instead.

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/mssqlserver/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/mssqlserver/metadata.yaml
@@ -1,6 +1,7 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the [sql server receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlserverreceiver) instead.**
     This monitor reports metrics about Microsoft SQL servers.
     This monitor is based on the telegraf sqlserver plugin.  More information about the telegraf plugin
     can be found [here](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/sqlserver).

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/mssqlserver/mssqlserver.go
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/mssqlserver/mssqlserver.go
@@ -60,6 +60,7 @@ type Monitor struct {
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) error {
 	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026. Please use the [sql server receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlserverreceiver) instead.")
 
 	plugin := telegrafInputs.Inputs["sqlserver"]().(*telegrafPlugin.SQLServer)
 


### PR DESCRIPTION
**Description:**
This monitor is deprecated and will be removed on or after October 2026. Please use the [sql server receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlserverreceiver) instead.