### PR TITLE
[chore][ci][ansible] Use instrumentation package built from sources

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -50,6 +50,28 @@ jobs:
       SYS_PACKAGE: ${{ matrix.SYS_PACKAGE }}
       ARCH: ${{ matrix.ARCH }}
 
+  build-auto-instrumentation-package:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        SYS_PACKAGE: [ "deb", "rpm" ]
+        ARCH: [ "amd64" ]
+      fail-fast: false
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Build ${{ matrix.ARCH }} ${{ matrix.SYS_PACKAGE }} auto-instrumentation package
+        run: make -C instrumentation/ ${{ matrix.SYS_PACKAGE }}-package ARCH="${{ matrix.ARCH }}"
+
+      - name: Upload ${{ matrix.ARCH }} ${{ matrix.SYS_PACKAGE }} auto-instrumentation package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: splunk-otel-auto-instrumentation-${{ matrix.ARCH }}-${{ matrix.SYS_PACKAGE }}
+          path: ./instrumentation/dist/*.${{ matrix.SYS_PACKAGE }}
+
   msi-custom-actions:
     needs: lint
     uses: ./.github/workflows/reusable-msi-custom-actions.yml
@@ -100,7 +122,7 @@ jobs:
 
   linux-test:
     name: Linux Test
-    needs: [ lint, build-package ]
+    needs: [ lint, build-package, build-auto-instrumentation-package ]
     runs-on: ubuntu-24.04
     defaults:
       run:

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/roles/collector/defaults/main.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/roles/collector/defaults/main.yml
@@ -85,5 +85,6 @@ splunk_dotnet_auto_instrumentation_iisreset: true
 splunk_dotnet_auto_instrumentation_additional_options: {}
 
 # Variables to be used only for testing
-# Used to test locally built artifacts instead of remotely downloaded version. Overrides splunk_otel_collector_version.
+# Used to test locally built artifacts instead of remotely downloaded versions.
+# Overrides splunk_otel_collector_version and splunk_otel_auto_instrumentation_version.
 local_artifact_testing_enabled: false

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/roles/collector/tasks/apt_install_auto_instrumentation.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/roles/collector/tasks/apt_install_auto_instrumentation.yml
@@ -1,5 +1,5 @@
 ---
-# Install Splunk OpenTelemetry Auto Instrumentation from apt repository
+# Install Splunk OpenTelemetry Auto Instrumentation with apt package manager
 
 - name: Install Splunk OpenTelemetry Auto Instrumentation via apt package manager
   ansible.builtin.apt:
@@ -9,3 +9,29 @@
     force: yes
     update_cache: yes
   register: apt_instrumentation_package
+  when: not local_artifact_testing_enabled
+
+- name: Copy Splunk OpenTelemetry Auto Instrumentation DEB artifact to remote machine
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: /etc/otel/
+    mode: '644'
+  loop: "{{ query('ansible.builtin.fileglob', auto_instrumentation_deb_artifact_pattern) }}"
+  vars:
+    auto_instrumentation_deb_artifact_pattern: >-
+      /tmp/splunk-otel-auto-instrumentation-{% if ansible_architecture == 'aarch64' %}arm64{% else %}amd64{% endif %}-deb/*.deb
+  register: local_apt_instrumentation_artifact
+  when: local_artifact_testing_enabled
+
+- name: Ensure local Splunk OpenTelemetry Auto Instrumentation DEB artifact was copied
+  ansible.builtin.assert:
+    that:
+      - local_apt_instrumentation_artifact.results | length == 1
+    fail_msg: Failed to find exactly one local Splunk OpenTelemetry Auto Instrumentation DEB artifact.
+  when: local_artifact_testing_enabled
+
+- name: Install Splunk OpenTelemetry Auto Instrumentation via local DEB artifact
+  ansible.builtin.apt:
+    deb: "{{ local_apt_instrumentation_artifact.results[0].dest }}"
+  register: apt_instrumentation_package
+  when: local_artifact_testing_enabled

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/roles/collector/tasks/yum_install_auto_instrumentation.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/roles/collector/tasks/yum_install_auto_instrumentation.yml
@@ -1,5 +1,5 @@
 ---
-# Install Splunk OpenTelemetry Auto Instrumentation from yum repository
+# Install Splunk OpenTelemetry Auto Instrumentation with yum package manager
 
 - name: Install Splunk OpenTelemetry Auto Instrumentation via yum package manager
   ansible.builtin.dnf:
@@ -9,3 +9,30 @@
     allow_downgrade: yes
     update_cache: yes
   register: yum_instrumentation_package
+  when: not local_artifact_testing_enabled
+
+- name: Copy Splunk OpenTelemetry Auto Instrumentation RPM artifact to remote machine
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: /etc/otel/
+    mode: '644'
+  loop: "{{ query('ansible.builtin.fileglob', auto_instrumentation_rpm_artifact_pattern) }}"
+  vars:
+    auto_instrumentation_rpm_artifact_pattern: >-
+      /tmp/splunk-otel-auto-instrumentation-{% if ansible_architecture == 'aarch64' %}arm64{% else %}amd64{% endif %}-rpm/*.rpm
+  register: local_yum_instrumentation_artifact
+  when: local_artifact_testing_enabled
+
+- name: Ensure local Splunk OpenTelemetry Auto Instrumentation RPM artifact was copied
+  ansible.builtin.assert:
+    that:
+      - local_yum_instrumentation_artifact.results | length == 1
+    fail_msg: Failed to find exactly one local Splunk OpenTelemetry Auto Instrumentation RPM artifact.
+  when: local_artifact_testing_enabled
+
+- name: Install Splunk OpenTelemetry Auto Instrumentation via local RPM artifact
+  ansible.builtin.dnf:
+    name: "{{ local_yum_instrumentation_artifact.results[0].dest }}"
+    disable_gpg_check: true
+  register: yum_instrumentation_package
+  when: local_artifact_testing_enabled

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/roles/collector/tasks/zypper_install_auto_instrumentation.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/roles/collector/tasks/zypper_install_auto_instrumentation.yml
@@ -1,5 +1,5 @@
 ---
-# Install Splunk OpenTelemetry Auto Instrumentation from zypper repository
+# Install Splunk OpenTelemetry Auto Instrumentation with zypper package manager
 
 - name: Install Splunk OpenTelemetry Auto Instrumentation via zypper package manager
   community.general.zypper:
@@ -9,3 +9,30 @@
     oldpackage: yes
     update_cache: yes
   register: zypper_instrumentation_package
+  when: not local_artifact_testing_enabled
+
+- name: Copy Splunk OpenTelemetry Auto Instrumentation RPM artifact to remote machine
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: /etc/otel/
+    mode: '644'
+  loop: "{{ query('ansible.builtin.fileglob', auto_instrumentation_rpm_artifact_pattern) }}"
+  vars:
+    auto_instrumentation_rpm_artifact_pattern: >-
+      /tmp/splunk-otel-auto-instrumentation-{% if ansible_architecture == 'aarch64' %}arm64{% else %}amd64{% endif %}-rpm/*.rpm
+  register: local_zypper_instrumentation_artifact
+  when: local_artifact_testing_enabled
+
+- name: Ensure local Splunk OpenTelemetry Auto Instrumentation RPM artifact was copied
+  ansible.builtin.assert:
+    that:
+      - local_zypper_instrumentation_artifact.results | length == 1
+    fail_msg: Failed to find exactly one local Splunk OpenTelemetry Auto Instrumentation RPM artifact.
+  when: local_artifact_testing_enabled
+
+- name: Install Splunk OpenTelemetry Auto Instrumentation via local RPM artifact
+  community.general.zypper:
+    name: "{{ local_zypper_instrumentation_artifact.results[0].dest }}"
+    disable_gpg_check: true
+  register: zypper_instrumentation_package
+  when: local_artifact_testing_enabled


### PR DESCRIPTION
## Summary

- Build amd64 DEB and RPM auto-instrumentation packages in CI.
- Make Linux Ansible tests consume the built packages through the existing local artifact testing path.
- Support local package installation with apt, dnf, and zypper.

## Testing

- Ansible Linux tests will run after the auto-instrumentation packages are built and uploaded.
- Unit tests: Not run (not requested)