### PR TITLE
[chore][ci][chef] Use instrumentation package built from sources

### DIFF
--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -8,12 +8,14 @@ on:
     paths:
       - '.github/workflows/chef-test.yml'
       - 'deployments/chef/**'
+      - 'instrumentation/**'
       - 'packaging/msi/**'
       - '!**.md'
   pull_request:
     paths:
       - '.github/workflows/chef-test.yml'
       - 'deployments/chef/**'
+      - 'instrumentation/**'
       - 'packaging/msi/**'
       - '!**.md'
   schedule:
@@ -49,6 +51,29 @@ jobs:
     with:
       SYS_PACKAGE: ${{ matrix.SYS_PACKAGE }}
       ARCH: ${{ matrix.ARCH }}
+
+  build-auto-instrumentation-package:
+    needs: [ chef-lint-spec-test ]
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        SYS_PACKAGE: [ "deb", "rpm" ]
+        ARCH: [ "amd64" ]
+      fail-fast: false
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Build ${{ matrix.ARCH }} ${{ matrix.SYS_PACKAGE }} auto-instrumentation package
+        run: make -C instrumentation/ ${{ matrix.SYS_PACKAGE }}-package ARCH="${{ matrix.ARCH }}"
+
+      - name: Upload ${{ matrix.ARCH }} ${{ matrix.SYS_PACKAGE }} auto-instrumentation package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: splunk-otel-auto-instrumentation-${{ matrix.ARCH }}-${{ matrix.SYS_PACKAGE }}
+          path: ./instrumentation/dist/*.${{ matrix.SYS_PACKAGE }}
 
   msi-custom-actions:
     needs: [ chef-lint-spec-test ]
@@ -116,7 +141,7 @@ jobs:
 
   chef-kitchen-linux:
     runs-on: ubuntu-24.04
-    needs: [ chef-lint-spec-test, chef-kitchen-matrix, build-package ]
+    needs: [ chef-lint-spec-test, chef-kitchen-matrix, build-package, build-auto-instrumentation-package ]
     defaults:
       run:
         working-directory: 'deployments/chef'
@@ -149,6 +174,10 @@ jobs:
           mv "$deb_path" ./files/soc.deb
           rpm_path=$(find /tmp/rpm-amd64-package/splunk-otel-collector*x86_64.rpm)
           mv "$rpm_path" ./files/soc.rpm
+          auto_deb_path=$(find /tmp/splunk-otel-auto-instrumentation-amd64-deb/splunk-otel-auto-instrumentation*amd64.deb)
+          mv "$auto_deb_path" ./files/soai.deb
+          auto_rpm_path=$(find /tmp/splunk-otel-auto-instrumentation-amd64-rpm/splunk-otel-auto-instrumentation*x86_64.rpm)
+          mv "$auto_rpm_path" ./files/soai.rpm
 
       - name: Install chef
         uses: actionshub/chef-install@f3b35943a257c25f3ca69e3b773fa4e0e99b58d6 # 6.0.0

--- a/deployments/chef/kitchen.yml
+++ b/deployments/chef/kitchen.yml
@@ -127,6 +127,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -137,6 +138,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -157,6 +159,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -168,6 +171,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -258,6 +262,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -270,6 +275,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -292,6 +298,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true
@@ -305,6 +312,7 @@ suites:
       - recipe[splunk_otel_collector]
     attributes:
       splunk_otel_collector:
+        local_artifact_testing_enabled: true
         splunk_access_token: testing123
         splunk_realm: test
         with_auto_instrumentation: true

--- a/deployments/chef/recipes/auto_instrumentation.rb
+++ b/deployments/chef/recipes/auto_instrumentation.rb
@@ -55,17 +55,67 @@ ruby_block 'install splunk-otel-js' do
   only_if { with_nodejs }
 end
 
-package 'splunk-otel-auto-instrumentation' do
-  action :install
-  version node['splunk_otel_collector']['auto_instrumentation_version'] if node['splunk_otel_collector']['auto_instrumentation_version'] != 'latest'
-  flush_cache [ :before ] if platform_family?('amazon', 'rhel')
-  options '--allow-downgrades' if platform_family?('debian') \
-    && node['packages'] \
-    && node['packages']['apt'] \
-    && Gem::Version.new(node['packages']['apt']['version'].split('~').first) >= Gem::Version.new('1.1.0')
-  allow_downgrade true if platform_family?('amazon', 'rhel', 'suse')
-  notifies :reload, 'ohai[reload packages]', :immediately
-  notifies :run, 'ruby_block[install splunk-otel-js]', :immediately
+if node['splunk_otel_collector']['local_artifact_testing_enabled']
+  if platform_family?('debian')
+    file_name = 'soai.deb'
+    deb_install_path = '/tmp/' + file_name
+
+    cookbook_file deb_install_path do
+      source file_name
+      mode '0644'
+    end
+
+    dpkg_package 'splunk-otel-auto-instrumentation' do
+      source deb_install_path
+      action :install
+      notifies :reload, 'ohai[reload packages]', :immediately
+      notifies :run, 'ruby_block[install splunk-otel-js]', :immediately
+    end
+  elsif platform_family?('rhel', 'amazon')
+    file_name = 'soai.rpm'
+    rpm_install_path = '/tmp/' + file_name
+
+    cookbook_file rpm_install_path do
+      source file_name
+      mode '0644'
+    end
+
+    rpm_package 'splunk-otel-auto-instrumentation' do
+      source rpm_install_path
+      action :install
+      notifies :reload, 'ohai[reload packages]', :immediately
+      notifies :run, 'ruby_block[install splunk-otel-js]', :immediately
+    end
+  elsif platform_family?('suse')
+    file_name = 'soai.rpm'
+    rpm_install_path = '/tmp/' + file_name
+
+    cookbook_file rpm_install_path do
+      source file_name
+      mode '0644'
+    end
+
+    zypper_package 'splunk-otel-auto-instrumentation' do
+      source rpm_install_path
+      gpg_check false
+      action :install
+      notifies :reload, 'ohai[reload packages]', :immediately
+      notifies :run, 'ruby_block[install splunk-otel-js]', :immediately
+    end
+  end
+else
+  package 'splunk-otel-auto-instrumentation' do
+    action :install
+    version node['splunk_otel_collector']['auto_instrumentation_version'] if node['splunk_otel_collector']['auto_instrumentation_version'] != 'latest'
+    flush_cache [ :before ] if platform_family?('amazon', 'rhel')
+    options '--allow-downgrades' if platform_family?('debian') \
+      && node['packages'] \
+      && node['packages']['apt'] \
+      && Gem::Version.new(node['packages']['apt']['version'].split('~').first) >= Gem::Version.new('1.1.0')
+    allow_downgrade true if platform_family?('amazon', 'rhel', 'suse')
+    notifies :reload, 'ohai[reload packages]', :immediately
+    notifies :run, 'ruby_block[install splunk-otel-js]', :immediately
+  end
 end
 
 if with_systemd

--- a/deployments/chef/spec/unit/recipes/default_spec.rb
+++ b/deployments/chef/spec/unit/recipes/default_spec.rb
@@ -85,6 +85,72 @@ describe 'splunk_otel_collector::default' do
       it_behaves_like 'splunk-otel-collector linux service status'
       it_behaves_like 'install splunk-otel-collector package'
     end
+
+    context 'with local auto-instrumentation artifact on debian-family distro' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '22.04') do |node|
+          node.normal['splunk_otel_collector'] = {
+            'splunk_access_token' => 'test123',
+            'splunk_realm' => 'test',
+            'local_artifact_testing_enabled' => true,
+            'with_auto_instrumentation' => true,
+            'with_auto_instrumentation_sdks' => %w(java),
+          }
+        end.converge described_recipe
+      end
+
+      it 'installs the local auto-instrumentation deb package' do
+        stub_command('getent group splunk-otel-collector').and_return(true)
+        stub_command('getent passwd splunk-otel-collector').and_return(true)
+        stub_command("bash -c 'command -v npm'").and_return(false)
+        expect(chef_run).to create_cookbook_file('/tmp/soai.deb').with(source: 'soai.deb', mode: '0644')
+        expect(chef_run).to install_dpkg_package('splunk-otel-auto-instrumentation').with(source: '/tmp/soai.deb')
+      end
+    end
+
+    context 'with local auto-instrumentation artifact on RedHat-family distro' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'centos', version: '7') do |node|
+          node.normal['splunk_otel_collector'] = {
+            'splunk_access_token' => 'test123',
+            'splunk_realm' => 'test',
+            'local_artifact_testing_enabled' => true,
+            'with_auto_instrumentation' => true,
+            'with_auto_instrumentation_sdks' => %w(java),
+          }
+        end.converge described_recipe
+      end
+
+      it 'installs the local auto-instrumentation rpm package' do
+        stub_command('getent group splunk-otel-collector').and_return(true)
+        stub_command('getent passwd splunk-otel-collector').and_return(true)
+        stub_command("bash -c 'command -v npm'").and_return(false)
+        expect(chef_run).to create_cookbook_file('/tmp/soai.rpm').with(source: 'soai.rpm', mode: '0644')
+        expect(chef_run).to install_rpm_package('splunk-otel-auto-instrumentation').with(source: '/tmp/soai.rpm')
+      end
+    end
+
+    context 'with local auto-instrumentation artifact on suse-family distro' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'suse', version: '15') do |node|
+          node.normal['splunk_otel_collector'] = {
+            'splunk_access_token' => 'test123',
+            'splunk_realm' => 'test',
+            'local_artifact_testing_enabled' => true,
+            'with_auto_instrumentation' => true,
+            'with_auto_instrumentation_sdks' => %w(java),
+          }
+        end.converge described_recipe
+      end
+
+      it 'installs the local auto-instrumentation rpm package with zypper' do
+        stub_command('getent group splunk-otel-collector').and_return(true)
+        stub_command('getent passwd splunk-otel-collector').and_return(true)
+        stub_command("bash -c 'command -v npm'").and_return(false)
+        expect(chef_run).to create_cookbook_file('/tmp/soai.rpm').with(source: 'soai.rpm', mode: '0644')
+        expect(chef_run).to install_zypper_package('splunk-otel-auto-instrumentation').with(source: '/tmp/soai.rpm', gpg_check: false)
+      end
+    end
   end
   context 'on the Windows platform family' do
     context 'on windows-family distro' do

--- a/deployments/chef/test/integration/with_custom_preload_dotnet_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_preload_dotnet_instrumentation/test.rb
@@ -1,5 +1,5 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+,deployment.environment.name=test'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?,deployment.environment.name=test'
 otlp_endpoint = 'http://0.0.0.0:4317'
 ld_preload_line = '# my extra library'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'

--- a/deployments/chef/test/integration/with_custom_preload_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_preload_instrumentation/test.rb
@@ -1,7 +1,7 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
 node_options = '-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+,deployment.environment.name=test'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?,deployment.environment.name=test'
 otlp_endpoint = 'http://0.0.0.0:4317'
 ld_preload_line = '# my extra library'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'

--- a/deployments/chef/test/integration/with_custom_preload_java_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_preload_java_instrumentation/test.rb
@@ -1,6 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+,deployment.environment.name=test'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?,deployment.environment.name=test'
 otlp_endpoint = 'http://0.0.0.0:4317'
 ld_preload_line = '# my extra library'
 

--- a/deployments/chef/test/integration/with_custom_preload_node_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_preload_node_instrumentation/test.rb
@@ -1,6 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 node_options = '-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+,deployment.environment.name=test'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?,deployment.environment.name=test'
 otlp_endpoint = 'http://0.0.0.0:4317'
 ld_preload_line = '# my extra library'
 

--- a/deployments/chef/test/integration/with_custom_systemd_dotnet_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_systemd_dotnet_instrumentation/test.rb
@@ -1,5 +1,5 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+-systemd,deployment.environment.name=test'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?-systemd,deployment.environment.name=test'
 otlp_endpoint = 'http://0.0.0.0:4317'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'
 

--- a/deployments/chef/test/integration/with_custom_systemd_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_systemd_instrumentation/test.rb
@@ -1,7 +1,7 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
 node_options = '-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+-systemd,deployment.environment.name=test'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?-systemd,deployment.environment.name=test'
 otlp_endpoint = 'http://0.0.0.0:4317'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'
 

--- a/deployments/chef/test/integration/with_custom_systemd_java_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_systemd_java_instrumentation/test.rb
@@ -1,6 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+-systemd,deployment.environment.name=test'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?-systemd,deployment.environment.name=test'
 otlp_endpoint = 'http://0.0.0.0:4317'
 
 describe package('splunk-otel-auto-instrumentation') do

--- a/deployments/chef/test/integration/with_custom_systemd_node_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_custom_systemd_node_instrumentation/test.rb
@@ -1,6 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 node_options = '-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+-systemd,deployment.environment.name=test'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?-systemd,deployment.environment.name=test'
 otlp_endpoint = 'http://0.0.0.0:4317'
 
 describe package('splunk-otel-auto-instrumentation') do

--- a/deployments/chef/test/integration/with_default_preload_dotnet_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_dotnet_instrumentation/test.rb
@@ -1,5 +1,5 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'
 
 describe package('splunk-otel-auto-instrumentation') do

--- a/deployments/chef/test/integration/with_default_preload_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_instrumentation/test.rb
@@ -1,7 +1,7 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
 node_options = '-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'
 
 describe package('splunk-otel-auto-instrumentation') do

--- a/deployments/chef/test/integration/with_default_preload_instrumentation_without_npm/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_instrumentation_without_npm/test.rb
@@ -1,6 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'
 
 describe package('splunk-otel-auto-instrumentation') do

--- a/deployments/chef/test/integration/with_default_preload_java_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_java_instrumentation/test.rb
@@ -1,6 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?'
 
 describe package('splunk-otel-auto-instrumentation') do
   it { should be_installed }

--- a/deployments/chef/test/integration/with_default_preload_node_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_preload_node_instrumentation/test.rb
@@ -1,6 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 node_options = '-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?'
 
 describe package('splunk-otel-auto-instrumentation') do
   it { should be_installed }

--- a/deployments/chef/test/integration/with_default_systemd_dotnet_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_dotnet_instrumentation/test.rb
@@ -1,5 +1,5 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+-systemd'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?-systemd'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'
 
 describe package('splunk-otel-auto-instrumentation') do

--- a/deployments/chef/test/integration/with_default_systemd_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_instrumentation/test.rb
@@ -1,7 +1,7 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
 node_options = '-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+-systemd'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?-systemd'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'
 
 describe package('splunk-otel-auto-instrumentation') do

--- a/deployments/chef/test/integration/with_default_systemd_instrumentation_without_npm/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_instrumentation_without_npm/test.rb
@@ -1,6 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+-systemd'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?-systemd'
 dotnet_home = '/usr/lib/splunk-instrumentation/splunk-otel-dotnet'
 
 describe package('splunk-otel-auto-instrumentation') do

--- a/deployments/chef/test/integration/with_default_systemd_java_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_java_instrumentation/test.rb
@@ -1,6 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 java_tool_options = '-javaagent:/usr/lib/splunk-instrumentation/splunk-otel-javaagent.jar'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+-systemd'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?-systemd'
 
 describe package('splunk-otel-auto-instrumentation') do
   it { should be_installed }

--- a/deployments/chef/test/integration/with_default_systemd_node_instrumentation/test.rb
+++ b/deployments/chef/test/integration/with_default_systemd_node_instrumentation/test.rb
@@ -1,6 +1,6 @@
 libsplunk_path = '/usr/lib/splunk-instrumentation/libsplunk.so'
 node_options = '-r /usr/lib/splunk-instrumentation/splunk-otel-js/node_modules/@splunk/otel/instrument'
-resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+-systemd'
+resource_attributes = 'splunk.zc.method=splunk-otel-auto-instrumentation-\d+\.\d+\.\d+(?:[-+._~][A-Za-z0-9.+_~-]*)?-systemd'
 
 describe package('splunk-otel-auto-instrumentation') do
   it { should be_installed }


### PR DESCRIPTION
## Summary

- Build Debian and RPM auto-instrumentation packages in CI.
- Install the locally built artifacts during Chef Kitchen Linux tests.
- Add ChefSpec coverage for Debian, Red Hat, and SUSE package installation.

## Testing

- Added unit tests covering local package installation across supported Linux families.