### PR TITLE
[chore] remove misleading line from the linux docs Readme

### DIFF
--- a/docs/advanced/linux-platform-metrics.md
+++ b/docs/advanced/linux-platform-metrics.md
@@ -6,7 +6,6 @@
 
 - A running Splunk Platform instance (Splunk Enterprise or Splunk Cloud) with a metrics index
 - A HEC token with write permissions to the target metrics index. See <https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector>.
-- The Splunk Distribution of OpenTelemetry Collector installed on a Linux host
 
 ## Install the Collector with metrics collection enabled
 

--- a/docs/advanced/linux-platform-metrics.md
+++ b/docs/advanced/linux-platform-metrics.md
@@ -39,7 +39,7 @@ sudo sh /tmp/splunk-otel-collector.sh --realm <realm> \
 
 ## What gets collected
 
-By default, the Collector uses the `host_metrics` receiver to collect system metrics from the Linux host at a `10s` collection interval. The default scrapers collect CPU, disk, filesystem, memory, network, load, paging, and process count metrics.
+By default, the Collector uses the `host_metrics` receiver to collect system metrics from the Linux host at a `10s` collection interval. The default scrapers collect CPU, disk, filesystem, memory, network, load, paging, and process count metrics. The full configuration is installed at `/etc/otel/collector/splunk_metrics_config_linux.yaml`.
 
 | **Scraper**  | **Description**                                                                                                                                                                                                                                                  |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -127,4 +127,10 @@ host_metrics:
 
 ```
 | mpreview index="<your-metrics-index>" | search source=otel
+```
+
+To view the Collector's own logs:
+
+```sh
+sudo journalctl -u splunk-otel-collector -f
 ```

--- a/docs/getting-started/linux-logs.md
+++ b/docs/getting-started/linux-logs.md
@@ -5,7 +5,6 @@
 ## Prerequisites
 
 - A HEC token with write permissions to the target index. See <https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector>.
-- The Splunk Distribution of OpenTelemetry Collector installed on a Linux host
 
 ## Install the Collector with log collection enabled
 

--- a/docs/getting-started/linux-logs.md
+++ b/docs/getting-started/linux-logs.md
@@ -42,7 +42,7 @@ sudo sh /tmp/splunk-otel-collector.sh --realm <realm> \
 
 By default, the Collector tails files under `/var/log` matching common log patterns (`*.log`, `*log`, `*auth*`, `*secure*`, `*messages*`, and others). This mirrors the behavior of the Splunk Add-on for Unix and Linux.
 
-For the full list of included paths and all available receivers, see the [default configuration](https://github.com/signalfx/splunk-otel-collector/blob/main/cmd/otelcol/config/collector/splunk_logs_config_linux.yaml).
+The full configuration is installed at `/etc/otel/collector/splunk_logs_config_linux.yaml`. For the full list of included paths and all available receivers, see the [default configuration](https://github.com/signalfx/splunk-otel-collector/blob/main/cmd/otelcol/config/collector/splunk_logs_config_linux.yaml).
 
 Additional receivers are defined in the config but disabled by default:
 
@@ -124,3 +124,13 @@ To see all sourcetypes currently being ingested:
 ```
 index="<your-index>" sourcetype="linux:*" | stats count by sourcetype
 ```
+
+To view the Collector's own logs:
+
+```sh
+sudo journalctl -u splunk-otel-collector -f
+```
+
+## Troubleshooting
+
+For help diagnosing common log collection issues, see the [Troubleshoot log collection](https://help.splunk.com/en/splunk-observability-cloud/manage-data/splunk-distribution-of-the-opentelemetry-collector/get-started-with-the-splunk-distribution-of-the-opentelemetry-collector/troubleshooting/troubleshoot-log-collection) guide.


### PR DESCRIPTION
**Description:** Remove misleading line from `linux-logs.md`. Splunk OTel Collector package will be installed when user runs the installation script, add link to the logs troubleshooting section, add information about how to get logs and where is the config present.
