### PR TITLE
[chore] Add a splunk_inputs example for Windows

### DIFF
--- a/examples/splunkinputs-on-windows/.gitignore
+++ b/examples/splunkinputs-on-windows/.gitignore
@@ -1,0 +1,2 @@
+otelcol.exe
+ta/

--- a/examples/splunkinputs-on-windows/Dockerfile
+++ b/examples/splunkinputs-on-windows/Dockerfile
@@ -1,0 +1,14 @@
+ARG BASE_IMAGE=mcr.microsoft.com/windows/servercore:ltsc2022
+
+FROM ${BASE_IMAGE}
+
+SHELL ["powershell", "-NoProfile", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+WORKDIR "C:\\otelcol"
+COPY otelcol.exe .\\otelcol.exe
+COPY otel-collector-config.yaml .\\otel-collector-config.yaml
+
+WORKDIR "C:\\"
+COPY start-example.ps1 .\\start-example.ps1
+
+ENTRYPOINT ["powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "C:\\start-example.ps1"]

--- a/examples/splunkinputs-on-windows/README.md
+++ b/examples/splunkinputs-on-windows/README.md
@@ -1,0 +1,116 @@
+# Example of deployment with a Splunk Universal Forwarder add-on, on Windows
+
+This is the Windows counterpart to the [`splunkinputs`](../splunkinputs/README.md)
+example. It uses the [`splunk_inputs`](https://github.com/splunk/tarunner/tree/main/pkg/splunkinputsreceiver)
+receiver to read a TA's `inputs.conf`, `transforms.conf`, and `props.conf`
+directly, emulating its modular input(s) without running a real `splunkd`.
+Like `splunkinputs`'s `/var/ta`, `C:\var\ta` is a generic mount point for any
+TA; this example just happens to use the
+[Splunk Add-on for Microsoft Windows](https://splunkbase.splunk.com/app/742)
+as its example TA.
+
+Docker Compose does not support Windows containers, so this example follows
+a single-container pattern instead.
+
+Because this example runs standalone, it has no local Splunk instance to send
+data to like `splunkinputs` does. You must provide the HEC endpoint URL and
+token of a Splunk instance (Splunk Cloud, Splunk Enterprise, or Splunk
+Observability Cloud) that will receive the collected events; there is no way
+for this example to know that in advance.
+
+## Download a TA
+
+`run-example.ps1` (below) takes the path to a TA package, extracts it to
+`C:\var\ta` in the container, and enables its inputs for you. This example
+uses the Splunk Add-on for Microsoft Windows, but any TA compatible with the
+`splunk_inputs` receiver can be used instead. The receiver only reads a
+single TA per configured path, so only one TA package can be used at a time.
+
+By default every stanza in the TA's `inputs.conf` is enabled. To keep some
+disabled, pass their stanza names (the part of the bracketed header before
+`://`, or the whole bracketed string if there is no `://`) via
+`-DisabledStanzaNames`, e.g. `-DisabledStanzaNames 'powershell','script'`.
+
+Splunkbase requires a login, so the Windows add-on can't be downloaded
+automatically. Download it yourself as a `.tgz`/`.spl` file from
+[splunkbase.splunk.com/app/742](https://splunkbase.splunk.com/app/742).
+
+## Get a Windows collector binary
+
+Before building the image, place a Windows collector binary named
+`otelcol.exe` in this directory.
+
+The `splunk_inputs` receiver this example depends on is only registered from
+`v0.158.0` onward (see the `enableTARunner` feature gate in
+[`internal/components/components.go`](../../internal/components/components.go)),
+so download the latest release from the
+[project's GitHub releases page](https://github.com/signalfx/splunk-otel-collector/releases)
+and fail fast if it predates that version:
+
+```powershell
+$minVersion = [version]'0.158.0'
+$release = Invoke-RestMethod -Uri 'https://api.github.com/repos/signalfx/splunk-otel-collector/releases/latest'
+$collectorVersion = $release.tag_name -replace '^v', ''
+if ([version]$collectorVersion -lt $minVersion) {
+    Write-Host "Error: latest release is v$collectorVersion, but the splunk_inputs receiver requires v$minVersion or newer." -ForegroundColor Red
+    exit 1
+}
+
+$downloadUrl = "https://github.com/signalfx/splunk-otel-collector/releases/download/v${collectorVersion}/otelcol_windows_amd64.exe"
+Invoke-WebRequest -Uri $downloadUrl -OutFile .\examples\splunkinputs-on-windows\otelcol.exe
+```
+
+Alternatively, build it locally from the repository root:
+
+```powershell
+$env:GOOS = 'windows'
+$env:GOARCH = 'amd64'
+$env:CGO_ENABLED = '0'
+go build -trimpath -o .\examples\splunkinputs-on-windows\otelcol.exe .\cmd\otelcol
+```
+
+Or, if you already built the Windows binary under `bin`:
+
+```powershell
+Copy-Item .\bin\otelcol_windows_amd64.exe .\examples\splunkinputs-on-windows\otelcol.exe
+```
+
+## Run the example
+
+From this directory, run `run-example.ps1` with the path to the TA package
+you downloaded and the HEC endpoint/token to send data to:
+
+```powershell
+.\run-example.ps1 `
+    -TaPackagePath 'C:\Users\you\Downloads\splunk-add-on-for-microsoft-windows_1100.spl' `
+    -SplunkHecUrl 'https://your-splunk-host:8088/services/collector/event' `
+    -SplunkHecToken '00000000-0000-0000-0000-0000000000000'
+```
+
+This extracts the TA to a local `ta` folder, copies its `default/` directory
+to `local/` and enables every input by rewriting `disabled = 1` to
+`disabled = 0`, then builds and runs the container with that folder mounted at
+`C:\var\ta` and the HEC endpoint/token passed in as environment variables.
+
+The container waits for the mounted TA, then starts the collector with the
+`splunk_inputs` receiver reading it and exporting to `splunk_hec`. See
+[`otel-collector-config.yaml`](./otel-collector-config.yaml) for the full
+configuration.
+
+## Notes on the setup
+
+- Unlike `splunkinputs`, which deploys a real `splunk/splunk` container as
+  destination via Docker Compose, this example has no bundled destination.
+  Point `-SplunkHecUrl`/`-SplunkHecToken` at any HEC endpoint reachable from
+  the container, including a Splunk instance running on the host.
+- Like `splunkinputs`'s `/var/ta`, `C:\var\ta` is a generic mount point for
+  any TA compatible with the `splunk_inputs` receiver, not just the Splunk
+  Add-on for Microsoft Windows used here. The receiver reads a single TA per
+  configured path, so only one TA can be mounted there at a time.
+- The `splunk_inputs` receiver parses the TA's configuration files directly;
+  no Splunk Universal Forwarder process runs in this container. See
+  [`packaging/ta-v2`](../../packaging/ta-v2/) for examples that install and
+  run a real Universal Forwarder on Windows.
+- The example uses `mcr.microsoft.com/windows/servercore:ltsc2022` as its base
+  image and copies in a local `otelcol.exe`, avoiding a multi-container
+  Compose setup, since Windows containers don't support Docker Compose.

--- a/examples/splunkinputs-on-windows/otel-collector-config.yaml
+++ b/examples/splunkinputs-on-windows/otel-collector-config.yaml
@@ -1,0 +1,20 @@
+receivers:
+  # Reads a Splunk TA's inputs.conf, transforms.conf, and props.conf directly
+  # from C:\var\ta, emulating its modular input(s). C:\var\ta is a generic
+  # mount point; this example happens to mount the Splunk Add-on for
+  # Microsoft Windows there, but any TA can be used instead.
+  splunk_inputs:
+    path: C:\var\ta
+
+exporters:
+  splunk_hec:
+    endpoint: ${env:SPLUNK_HEC_URL}
+    token: ${env:SPLUNK_HEC_TOKEN}
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    logs:
+      receivers: [splunk_inputs]
+      exporters: [debug, splunk_hec]

--- a/examples/splunkinputs-on-windows/run-example.ps1
+++ b/examples/splunkinputs-on-windows/run-example.ps1
@@ -1,0 +1,111 @@
+# Prepares a TA (by default, the Splunk Add-on for Microsoft Windows) and
+# runs this example in a single Windows container. See README.md for the
+# manual download step this script depends on.
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$TaPackagePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$SplunkHecUrl,
+
+    [Parameter(Mandatory = $true)]
+    [string]$SplunkHecToken,
+
+    # Stanza names to keep disabled instead of enabling. A stanza name is the
+    # part of the bracketed header before "://" (e.g. "script", "monitor"),
+    # or the whole bracketed string if it has no "://".
+    [string[]]$DisabledStanzaNames = @()
+)
+
+$ErrorActionPreference = 'Stop'
+
+$SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
+$CONTAINER_NAME = if ($env:CONTAINER_NAME) { $env:CONTAINER_NAME } else { "splunkinputs-on-windows" }
+$IMAGE_TAG = if ($env:IMAGE_TAG) { $env:IMAGE_TAG } else { "latest" }
+# Local staging directory for the extracted TA; mounted into the container at
+# C:\var\ta, the generic TA location the receiver reads.
+$TA_DIR = Join-Path $SCRIPT_DIR "ta"
+
+$resolvedTaPackagePath = Resolve-Path -ErrorAction SilentlyContinue $TaPackagePath
+if (-not $resolvedTaPackagePath) {
+    Write-Host "Error: TaPackagePath '$TaPackagePath' could not be resolved." -ForegroundColor Red
+    exit 1
+}
+
+$otelcolPath = Join-Path $SCRIPT_DIR "otelcol.exe"
+if (-not (Test-Path $otelcolPath)) {
+    Write-Host "Error: otelcol.exe not found at $otelcolPath" -ForegroundColor Red
+    Write-Host "Place a Windows collector binary there first. See README.md for download/build instructions." -ForegroundColor Red
+    exit 1
+}
+
+# Extract the TA and enable its inputs
+if (Test-Path $TA_DIR) {
+    Write-Host "Removing previous extracted TA at $TA_DIR"
+    Remove-Item -Path $TA_DIR -Recurse -Force
+}
+New-Item -ItemType Directory -Path $TA_DIR -Force | Out-Null
+
+Write-Host "Extracting $($resolvedTaPackagePath.Path) to $TA_DIR"
+tar -xzf $resolvedTaPackagePath.Path -C $TA_DIR --strip-components=1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Failed to extract $($resolvedTaPackagePath.Path)" -ForegroundColor Red
+    exit 1
+}
+
+$defaultDir = Join-Path $TA_DIR "default"
+$localDir = Join-Path $TA_DIR "local"
+Write-Host "Copying default/ to local/ and enabling inputs"
+Copy-Item -Path $defaultDir -Destination $localDir -Recurse -Force
+
+$localInputsConf = Join-Path $localDir "inputs.conf"
+$currentStanzaDisabled = $false
+$updatedLines = foreach ($line in Get-Content -Path $localInputsConf) {
+    if ($line -match '^\s*\[(.+)\]\s*$') {
+        $stanzaHeader = $Matches[1]
+        $stanzaName = ($stanzaHeader -split '://', 2)[0]
+        $currentStanzaDisabled = $DisabledStanzaNames -contains $stanzaName
+        $line
+    } elseif ($line -match '^disabled\s*=\s*\d\s*$') {
+        if ($currentStanzaDisabled) { 'disabled = 1' } else { 'disabled = 0' }
+    } else {
+        $line
+    }
+}
+$updatedLines | Set-Content -Path $localInputsConf
+
+# Stop and remove existing container if it exists
+$existingContainer = docker ps -a --format "{{.Names}}" | Where-Object { $_ -eq $CONTAINER_NAME }
+if ($existingContainer) {
+    Write-Host "Stopping and removing existing container: $CONTAINER_NAME"
+    docker rm -f $CONTAINER_NAME | Out-Null
+}
+
+Write-Host "Building image splunkinputs-on-windows:$IMAGE_TAG"
+docker build -t "splunkinputs-on-windows:$IMAGE_TAG" $SCRIPT_DIR
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Failed to build image" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Launching container: $CONTAINER_NAME"
+docker run -d --name $CONTAINER_NAME `
+    -e SPLUNK_HEC_URL=$SplunkHecUrl `
+    -e SPLUNK_HEC_TOKEN=$SplunkHecToken `
+    -v "${TA_DIR}:C:\var\ta" `
+    "splunkinputs-on-windows:$IMAGE_TAG"
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Failed to launch container" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Container launched successfully!" -ForegroundColor Green
+Write-Host ""
+Write-Host "Useful commands:" -ForegroundColor Cyan
+Write-Host "  View collector logs: docker logs -f $CONTAINER_NAME"
+Write-Host "  Stop container: docker stop $CONTAINER_NAME"
+Write-Host "  Remove container: docker rm -f $CONTAINER_NAME"
+Write-Host "  Docker exec shell: docker exec -it $CONTAINER_NAME powershell"
+Write-Host ""

--- a/examples/splunkinputs-on-windows/start-example.ps1
+++ b/examples/splunkinputs-on-windows/start-example.ps1
@@ -1,0 +1,20 @@
+# Container entrypoint for the splunkinputs-on-windows example.
+#
+# Waits for a TA to be mounted at C:\var\ta (see run-example.ps1), then starts
+# the collector with the splunk_inputs receiver, which reads that TA's
+# inputs.conf, transforms.conf, and props.conf directly, emulating its
+# modular input(s) without running a real splunkd.
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $env:SPLUNK_HEC_URL) {
+    Write-Host 'Error: SPLUNK_HEC_URL environment variable is required.' -ForegroundColor Red
+    exit 1
+}
+if (-not $env:SPLUNK_HEC_TOKEN) {
+    Write-Host 'Error: SPLUNK_HEC_TOKEN environment variable is required.' -ForegroundColor Red
+    exit 1
+}
+
+& C:\otelcol\otelcol.exe --config=C:\otelcol\otel-collector-config.yaml --feature-gates=+enableTARunner
+exit $LASTEXITCODE


### PR DESCRIPTION
Adds an example running `splunk_inputs`, aka tarunner, on Windows.
