### PR TITLE
[chore][ci] Add CI collector build to 2 architectures

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -148,7 +148,7 @@ jobs:
   cross-compile:
     strategy:
       matrix:
-        SYS_BINARIES: [ "binaries-darwin_amd64", "binaries-darwin_arm64", "binaries-linux_amd64", "binaries-linux_arm64", "binaries-windows_amd64", "binaries-windows_arm64", "binaries-linux_ppc64le" ]
+        SYS_BINARIES: [ "binaries-darwin_amd64", "binaries-darwin_arm64", "binaries-linux_amd64", "binaries-linux_arm64", "binaries-windows_amd64", "binaries-windows_arm64", "binaries-linux_ppc64le", "binaries-linux_s390x", "binaries-windows_386" ]
     uses: ./.github/workflows/reusable-compile.yml
     with:
       SYS_BINARY: ${{ matrix.SYS_BINARIES }}

--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ docker-otelcol:
 	ARCH=$(ARCH) FIPS=$(FIPS) SKIP_COMPILE=$(SKIP_COMPILE) DOCKER_REPO=$(DOCKER_REPO) ./packaging/docker-otelcol.sh
 
 .PHONY: binaries-all-sys
-binaries-all-sys: binaries-darwin_amd64 binaries-darwin_arm64 binaries-linux_amd64 binaries-linux_arm64 binaries-windows_amd64 binaries-linux_ppc64le binaries-windows_arm64
+binaries-all-sys: binaries-darwin_amd64 binaries-darwin_arm64 binaries-linux_amd64 binaries-linux_arm64 binaries-windows_amd64 binaries-linux_ppc64le binaries-windows_arm64 binaries-linux_s390x binaries-windows_386
 
 .PHONY: binaries-darwin_amd64
 binaries-darwin_amd64:
@@ -346,9 +346,17 @@ ifeq ($(WITH_OPAMP_SUPERVISOR), true)
 	GOOS=windows GOARCH=arm64 EXTENSION=.exe $(MAKE) opampsupervisor
 endif
 
+.PHONY: binaries-windows_386
+binaries-windows_386:
+	GOOS=windows GOARCH=386 EXTENSION=.exe $(MAKE) otelcol
+
 .PHONY: binaries-linux_ppc64le
 binaries-linux_ppc64le:
 	GOOS=linux GOARCH=ppc64le $(MAKE) otelcol
+
+.PHONY: binaries-linux_s390x
+binaries-linux_s390x:
+	GOOS=linux GOARCH=s390x $(MAKE) otelcol
 
 .PHONY: deb-rpm-tar-package
 %-package:


### PR DESCRIPTION
- Add Linux s390x and Windows 386 targets to system binary builds
- Include both architectures in the cross-compilation workflow matrix
