### PR TITLE
[chore] Fix missing -test.gocoverdir flag in test-with-codecov target

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -103,8 +103,8 @@ COVER_TESTING_INTEGRATION_OPTS?=$(COVER_OPTS) -args -test.gocoverdir="$(TEST_COV
 
 .PHONY: test-with-codecov
 test-with-codecov:
-	mkdir -p $(COVER_DIR)
-	$(GOTEST) $(GOTEST_OPT) ./... $(COVER_OPTS)
+	mkdir -p $(COVER_DIR_ABS)
+	$(GOTEST) $(GOTEST_OPT) ./... $(COVER_TESTING_OPTS)
 
 endif
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

`test-with-codecov` in `Makefile.Common` ran go test with `$(COVER_OPTS)`, which sets `-cover -coverpkg` but never passes `-test.gocoverdir`. Without that flag, Go computes coverage in memory but never persists counter files to disk, so `go tool covdata textfmt -i=./coverage` had nothing to convert. This silently zeroed out Codecov reporting for every package covered by this shared target (root module + all sub-Makefiles including `Makefile.Common`) — most visibly noticed as 0% patch coverage for gnmireceiver despite passing unit tests.

Fix: use `$(COVER_TESTING_OPTS)` (adds the missing `-test.gocoverdir` flag) instead of `$(COVER_OPTS)`, and create the coverage dir at the correct absolute path (`$(COVER_DIR_ABS)`) so it works regardless of which module directory the target runs from.
