### PR TITLE
[chore] Remove links to signalfx/gateway repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7826,8 +7826,7 @@ This Splunk OpenTelemetry Collector release includes changes from the [opentelem
 
 - `connector/forward` - Add support for the forward connector ([#3100](https://github.com/signalfx/splunk-otel-collector/pull/3100))
 - `receiver/signalfxgatewayprometheusremotewritereceiver` - Add new receiver that aims to be an otel-native version of
-  the SignalFx [Prometheus remote write](https://github.com/signalfx/gateway/blob/main/protocol/prometheus/prometheuslistener.go)
-  [gateway](https://github.com/signalfx/gateway/blob/main/README.md) ([#3064](https://github.com/signalfx/splunk-otel-collector/pull/3064))
+  the SignalFx Prometheus remote write gateway ([#3064](https://github.com/signalfx/splunk-otel-collector/pull/3064))
 - `signalfx-agent`: Relocate to be internal to the collector ([#3052](https://github.com/signalfx/splunk-otel-collector/pull/3052))
 
 ## v0.76.1

--- a/internal/receiver/signalfxgatewayprometheusremotewritereceiver/README.md
+++ b/internal/receiver/signalfxgatewayprometheusremotewritereceiver/README.md
@@ -1,16 +1,16 @@
 # SignalFx Gateway Prometheus remote write receiver
 
-This receiver aims to be an otel-native version of our signalfx [prometheus remote write](https://github.com/signalfx/gateway/blob/main/protocol/prometheus/prometheuslistener.go) [gateway](https://github.com/signalfx/gateway/blob/main/README.md).
+This receiver aims to be an otel-native version of our signalfx prometheus remote write gateway.
 
 ## Known limitations
-This receiver obsoletes the near-exact behavior of the [SignalFx Prometheus Remote-Writegateway](https://github.com/signalfx/gateway/blob/main/protocol/prometheus/prometheuslistener.go). The behavior of the Prometheus Remote-Write gateway predates the formalization of the Prometheus Remote-Write specification version 1, and differs in the following ways:
-- The receiver doesn't [remove suffixes](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/6658646e7705b74f13031c777fcd8dd1cd64c850/receiver/prometheusreceiver/internal/metricfamily.go#L316) as this is done in the otel-contrib `prometheusreceiver`.
-- The receiver transforms histograms [into counters](https://github.com/signalfx/gateway/blob/main/protocol/prometheus/prometheuslistener.go#L98).
+This receiver obsoletes the near-exact behavior of the SignalFx Prometheus Remote-Write gateway. The behavior of the Prometheus Remote-Write gateway predates the formalization of the Prometheus Remote-Write specification version 1, and differs in the following ways:
+- The receiver doesn't remove suffixes as this is done in the otel-contrib `prometheusreceiver`.
+- The receiver transforms histograms into counters.
 - The receiver transforms quantiles (summaries) into gauges.
 - If the representation of a float can be expressed as an integer without loss, the receiver sets the representation of a float as an integer.
-- If the representation of a sample is NaN, the receiver reports an additional counter with the metric name [`"prometheus.total_NAN_samples"`](https://github.com/signalfx/gateway/blob/main/protocol/prometheus/prometheuslistener.go#LL190C24-L190C53).
-- If the representation of a sample is missing a metric name, the receiver reports an additional counter with the metric name [`"prometheus.total_bad_datapoints"`](https://github.com/signalfx/gateway/blob/main/protocol/prometheus/prometheuslistener.go#LL191C24-L191C24).
-- Any errors in parsing the request report an additional counter,  [`"prometheus.invalid_requests"`](https://github.com/signalfx/gateway/blob/main/protocol/prometheus/prometheuslistener.go#LL189C80-L189C91).
+- If the representation of a sample is NaN, the receiver reports an additional counter with the metric name `"prometheus.total_NAN_samples"`.
+- If the representation of a sample is missing a metric name, the receiver reports an additional counter with the metric name `"prometheus.total_bad_datapoints"`.
+- Any errors in parsing the request report an additional counter, `"prometheus.invalid_requests"`.
 - Metadata from the `prompb.WriteRequest` is ignored.
   The following behavior from sfx gateway is not supported:
 - `"request_time.ns"` is no longer reported.  `obsreport` handles similar functionality.


### PR DESCRIPTION
These links are not public anymore, fixing related lychee failures.
