### PR TITLE
[chore][ci] Add CI collector build for `freebsd/amd64`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -152,6 +152,7 @@ jobs:
           - binaries-aix_ppc64
           - binaries-darwin_amd64
           - binaries-darwin_arm64
+          - binaries-freebsd_amd64
           - binaries-linux_amd64
           - binaries-linux_arm64
           - binaries-linux_ppc64le

--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,7 @@ docker-otelcol:
 binaries-all-sys: binaries-aix_ppc64 \
 	binaries-darwin_amd64 \
 	binaries-darwin_arm64 \
+	binaries-freebsd_amd64 \
 	binaries-linux_amd64 \
 	binaries-linux_arm64 \
 	binaries-linux_ppc64le \
@@ -321,26 +322,30 @@ binaries-aix_ppc64:
 
 .PHONY: binaries-darwin_amd64
 binaries-darwin_amd64:
-	GOOS=darwin  GOARCH=amd64 $(MAKE) otelcol
+	GOOS=darwin GOARCH=amd64 $(MAKE) otelcol
 
 .PHONY: binaries-darwin_arm64
 binaries-darwin_arm64:
-	GOOS=darwin  GOARCH=arm64 $(MAKE) otelcol
+	GOOS=darwin GOARCH=arm64 $(MAKE) otelcol
+
+.PHONY: binaries-freebsd_amd64
+binaries-freebsd_amd64:
+	GOOS=freebsd GOARCH=amd64 $(MAKE) otelcol
 
 .PHONY: binaries-linux_amd64
 binaries-linux_amd64:
-	GOOS=linux   GOARCH=amd64 $(MAKE) otelcol
+	GOOS=linux GOARCH=amd64 $(MAKE) otelcol
 ifeq ($(WITH_OPAMP_SUPERVISOR), true)
-	GOOS=linux   GOARCH=amd64 $(MAKE) otelcollauncher
-	GOOS=linux   GOARCH=amd64 $(MAKE) opampsupervisor
+	GOOS=linux GOARCH=amd64 $(MAKE) otelcollauncher
+	GOOS=linux GOARCH=amd64 $(MAKE) opampsupervisor
 endif
 
 .PHONY: binaries-linux_arm64
 binaries-linux_arm64:
-	GOOS=linux   GOARCH=arm64 $(MAKE) otelcol
+	GOOS=linux GOARCH=arm64 $(MAKE) otelcol
 ifeq ($(WITH_OPAMP_SUPERVISOR), true)
-	GOOS=linux   GOARCH=arm64 $(MAKE) otelcollauncher
-	GOOS=linux   GOARCH=arm64 $(MAKE) opampsupervisor
+	GOOS=linux GOARCH=arm64 $(MAKE) otelcollauncher
+	GOOS=linux GOARCH=arm64 $(MAKE) opampsupervisor
 endif
 
 .PHONY: binaries-linux_ppc64le

--- a/internal/signalfx-agent/pkg/core/modules.go
+++ b/internal/signalfx-agent/pkg/core/modules.go
@@ -1,4 +1,4 @@
-//go:build !aix
+//go:build !aix && !freebsd
 
 package core
 

--- a/internal/signalfx-agent/pkg/core/modules_freebsd.go
+++ b/internal/signalfx-agent/pkg/core/modules_freebsd.go
@@ -1,0 +1,3 @@
+package core
+
+// No legacy monitors are supported by new platforms


### PR DESCRIPTION
* Add `freebsd/amd64` target to system binary builds
* Include it in the cross-compilation workflow matrix

Not supported components:
* Any SignalFx Agent legacy components