### PR TITLE
Add `sigv4auth` extension from contrib

### DIFF
--- a/.chloggen/add_sigv4authextension.yaml
+++ b/.chloggen/add_sigv4authextension.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: new_component
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: extension/sigv4auth
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Added `sigv4auth` extension component to the distribution."
+
+# One or more tracking issues related to the change
+issues: [7945]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Enables SigV4 request signing for HTTP exporters, required to send data to AWS services
+  such as Amazon OpenSearch and Amazon Managed Service for Prometheus.
+  See [README](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/sigv4authextension/README.md) for details.

--- a/docs/components.md
+++ b/docs/components.md
@@ -161,6 +161,7 @@ The distribution offers support for the following components.
 | [oauth2client](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oauth2clientauthextension)                                       | [beta]    |
 | [opamp](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/opampextension)                                                         | [alpha]   |
 | [pprof](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/pprofextension)                                                         | [beta]    |
+| [sigv4auth](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/sigv4authextension)                                                 | [beta]    |
 | [smartagent](../pkg/extension/smartagentextension)                                                                                                                    | [beta]    |
 | [text_encoding](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/textencodingextension)                                 | [beta]    |
 | [zpages](https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/zpagesextension)                                                               | [beta]    |

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.158.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.158.0

--- a/go.sum
+++ b/go.sum
@@ -1166,6 +1166,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextensi
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension v0.158.0/go.mod h1:bTLqlq3Te5/Dc2Pax9Y+H0SwfQ+M79vECgN9WCd8mgQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.158.0 h1:YtaRcYHBlDOyg7CU3LhB5YgTY5CS4YBEDAxCX4OS4QA=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.158.0/go.mod h1:a+LAGEhjiDDe/F6flCAAXITx6EM8JSUJ+K7B7ofiVE8=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.158.0 h1:s0ZyJ1a4ElgBLsGjFuU3/xj0BHKBsKkEh+WXyWt3/ls=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.158.0/go.mod h1:LHbA6DhhiAdZaVeaG3iFuwYAs3NI9d8REzMO0VLvRRY=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.158.0 h1:asbQxBgKc+5xeq4wqHviJ27lJYws90Q7ak0GeqsfEZQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.158.0/go.mod h1:W58DaPaohIMBoQ+yQYs14YsUYwz4MmjSrL+5oZEx/vA=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.158.0 h1:SarIYfc2ohvCldWRULQfW+pbG+LEt8Bp98qFjskYipQ=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -45,6 +45,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor"
@@ -198,6 +199,7 @@ func Get() (otelcol.Factories, error) {
 		oauth2clientauthextension.NewFactory(),
 		opampextension.NewFactory(),
 		pprofextension.NewFactory(),
+		sigv4authextension.NewFactory(),
 		smartagentextension.NewFactory(),
 		textencodingextension.NewFactory(),
 		zpagesextension.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -43,6 +43,7 @@ func TestDefaultComponents(t *testing.T) {
 		"oauth2client",
 		"opamp",
 		"pprof",
+		"sigv4auth",
 		"smartagent",
 		"text_encoding",
 		"zpages",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
  Adding the `sigv4auth` authenticator extension from opentelemetry-collector-contrib, which allows HTTP-based exporters (e.g. otlp_http) to sign requests with AWS Signature Version 4. This is required for sending data to
  AWS services that only accept SigV4-signed requests, such as Amazon OpenSearch.
  
**Link to Splunk idea:** [SFXIMMID-I-848: add the sigv4auth extension to splunk otel collector](https://ideas.splunk.com/ideas/SFXIMMID-I-848)

**Testing:** <Describe what testing was performed and which tests were added.>
- Has been tested with a splunk-otel-collector helm chart (w/ a custom-built image) deployed in an EKS cluster, with the `sigv4auth` extension enabled and attached to otlp_http exporters like so:

```yaml
extensions:
  sigv4auth:
    region: us-west-2
    service: osis
    assume_role:
      arn: arn:aws:iam::<account-id>:role/<ingestion-role>
      sts_region: us-west-2

exporters:
  otlp_http/opensearch_logs:
    endpoint: https://<pipeline-endpoint>.us-west-2.osis.amazonaws.com/<ingest-path>
    auth:
      authenticator: sigv4auth

service:
  extensions: [sigv4auth, file_storage, health_check, k8s_observer, zpages]
```

We have confirmed that logs are successfully delivered to Amazon OpenSearch Ingestion pipelines (which reject unsigned requests with 401), with AWS credentials resolved via IRSA.
  
**Documentation:** <Describe the documentation added.>
I've updated the list of components doc to include the `sigv4auth` extension, and added a changelog entry (as part of this PR).