### PR TITLE
[chore] Mitigate Windows runner disk space exhaustion issue

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,6 +1,12 @@
 name: 'setup environment'
 description: 'setup go environment'
 
+inputs:
+  install_tools:
+    description: 'Install all development tools'
+    required: false
+    default: 'true'
+
 runs:
   using: "composite"
   steps:
@@ -11,6 +17,7 @@ runs:
         cache-dependency-path: '**/go.sum'
 
     - name: Installing required tools
+      if: inputs.install_tools == 'true'
       working-directory: ${{ github.workspace }}
       run: |
         make install-tools

--- a/.github/workflows/reusable-unit-test.yml
+++ b/.github/workflows/reusable-unit-test.yml
@@ -24,7 +24,25 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Report disk space before environment setup
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Get-PSDrive -PSProvider FileSystem |
+            Select-Object Name,
+              @{Name='UsedGB'; Expression={[math]::Round($_.Used / 1GB, 2)}},
+              @{Name='FreeGB'; Expression={[math]::Round($_.Free / 1GB, 2)}} |
+            Format-Table -AutoSize
+
       - uses: ./.github/actions/setup-environment
+        with:
+          install_tools: 'false'
+
+      - name: Install unit test reporting tool
+        if: ${{ inputs.COVERAGE }}
+        working-directory: ./internal/tools
+        run: go install github.com/jstemmer/go-junit-report
 
       - name: Set CGO_ENABLED
         # Currently, CGO enabled is required for:
@@ -46,6 +64,16 @@ jobs:
             exit 1
           fi
 
+      - name: Report disk space before unit tests
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Get-PSDrive -PSProvider FileSystem |
+            Select-Object Name,
+              @{Name='UsedGB'; Expression={[math]::Round($_.Used / 1GB, 2)}},
+              @{Name='FreeGB'; Expression={[math]::Round($_.Free / 1GB, 2)}} |
+            Format-Table -AutoSize
+
       - name: Unit tests
         run: |
           set -o pipefail
@@ -57,6 +85,16 @@ jobs:
           else
             make test-all
           fi
+
+      - name: Report disk space after unit tests
+        if: ${{ always() && runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          Get-PSDrive -PSProvider FileSystem |
+            Select-Object Name,
+              @{Name='UsedGB'; Expression={[math]::Round($_.Used / 1GB, 2)}},
+              @{Name='FreeGB'; Expression={[math]::Round($_.Free / 1GB, 2)}} |
+            Format-Table -AutoSize
 
       - name: Uploading artifacts
         if: ${{ inputs.COVERAGE }}

--- a/.github/workflows/reusable-unit-test.yml
+++ b/.github/workflows/reusable-unit-test.yml
@@ -35,6 +35,16 @@ jobs:
               @{Name='FreeGB'; Expression={[math]::Round($_.Free / 1GB, 2)}} |
             Format-Table -AutoSize
 
+      - name: Configure Windows Go temporary directory
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $goTmp = Join-Path $env:RUNNER_TEMP 'go-tmp'
+          New-Item -ItemType Directory -Force -Path $goTmp | Out-Null
+          "GOTMPDIR=$goTmp" >> $env:GITHUB_ENV
+          "TMP=$goTmp" >> $env:GITHUB_ENV
+          "TEMP=$goTmp" >> $env:GITHUB_ENV
+
       - uses: ./.github/actions/setup-environment
         with:
           install_tools: 'false'
@@ -57,12 +67,17 @@ jobs:
           fi
 
       - name: bundle.d
+        if: ${{ !inputs.TEST_RACE }}
         run: |
           make bundle.d
           if ! git diff --exit-code; then
             echo "Discovery bundle.d config has changed. Run 'make bundle.d' and push the changes or ensure correct .tmpl updated."
             exit 1
           fi
+
+      - name: Clear Go build cache before Windows race tests
+        if: ${{ runner.os == 'Windows' && inputs.TEST_RACE }}
+        run: go clean -cache
 
       - name: Report disk space before unit tests
         if: runner.os == 'Windows'
@@ -82,6 +97,9 @@ jobs:
             mkdir -p unit-test-results-${{ inputs.OS }}/junit
             trap "go-junit-report  -set-exit-code < unit-test-results-${{ inputs.OS }}/go-unit-tests.out > unit-test-results-${{ inputs.OS }}/junit/results.xml" EXIT
             COVER_TESTING=true make gotest-with-codecov | tee unit-test-results-${{ inputs.OS }}/go-unit-tests.out
+          elif [[ "${{ runner.os }}" == "Windows" && "${{ inputs.TEST_RACE }}" == "true" ]]; then
+            echo "Limiting Go package parallelism to 3 to reduce peak disk usage"
+            GOFLAGS=-p=3 make test-all
           else
             make test-all
           fi


### PR DESCRIPTION
Specifically during race detection tests, Windows runners sometimes failed with disk space exhaustion. Took several measures at once to reduce peak disk space usage so that it would likely not reoccur. Contains the following changes:

* On Windows, force Go temporary files to go to the directory that the runner has designated for temporary files. On previous runs where this issue occurred, runner had designated D: as the destination for temporary files, but the build might not have respected that. Since in those cases, it was C: drive that ran out of disk space, some more temporary files being written to D: instead should mitigate that.
* Skip additional tool installation for race condition tests (except for junit-report tool which is installed explicitly then), as it seems this test might actually not use any of the others. Saves both time and disk space if hypothesis turns out to be true.
* On Windows race condition tests, delete prior build results before running the race condition test. As this test requires rebuilding them anyway, this should not slow down the test, but will only remove some files that would have gone unused otherwise (both the non-race-test cache and race-test cache existed side-by-side, increased disk usage).
* `bundle.d` is not run for race test configuration. It is still run on every platform, but it is unaffected by race test being enabled, so it was just running the same test on the same platform twice. Skipping this speeds up the testing without any loss in per-platform test coverage.
* Limit package parallelism to 3 for Windows race condition test. With current runners, it would have otherwise very likely allowed 4 at a time. Might cause it to be slightly slower, but other changes reduced total time taken so likely still net speed-up for the whole set of changes.

Added some disk space reporting, may be helpful in the future if this should be a problem again.