### PR TITLE
[smartagent/disk-io] deprecate the windows implementation as it depends on telegraf which will be deprecated

### DIFF
--- a/.chloggen/deprecate-windows-disk-io.yaml
+++ b/.chloggen/deprecate-windows-disk-io.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: smartagent/disk-io/windows
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the Windows implementation of smartagent/disk-io monitor.
+
+# One or more tracking issues related to the change
+issues: [7951]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This deprecation affects only the Windows implementation of the smartagent/disk-io monitor. 
+  Users are encouraged to transition to the [disk scraper](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/internal/scraper/diskscraper/documentation.md) 
+  in the hostmetrics receiver for continued functionality.

--- a/internal/signalfx-agent/pkg/monitors/diskio/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/diskio/metadata.yaml
@@ -3,6 +3,7 @@ monitors:
     disk:
       description: The name of the disk that the metric describes
   doc: |
+    **The Windows implementation of this monitor is deprecated and will be removed on or after October 2026. Please use the [disk scraper in the hostmetrics receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/internal/scraper/diskscraper/documentation.md) instead.**
     This monitor reports I/O metrics about disks.
 
     On Linux hosts, this monitor relies on the `/proc` filesystem.


### PR DESCRIPTION
The windows implementation of the `smartagent/disk-io` monitor calls the telegraf's `winperfcounters` plugin https://github.com/signalfx/splunk-otel-collector/blob/main/internal/signalfx-agent/pkg/monitors/telegraf/monitors/winperfcounters/metadata.yaml#L4 which is already deprecated and scheduled for removal, which makes this functionality obsolete

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
