### PR TITLE
Dynamically register components

### DIFF
--- a/.chloggen/otelcol-components-command.yaml
+++ b/.chloggen/otelcol-components-command.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: otelcol
+note: Add an `otelcol components` command that lists every receiver, processor, exporter, extension, and connector available in this collector distribution, along with their stability levels.
+issues: []
+subtext: null

--- a/.chloggen/pkg-components-registry.yaml
+++ b/.chloggen/pkg-components-registry.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: components
+note: Move the collector's component factories from internal/components to the new public pkg/components package. External Go programs can call pkg/components.NewRegistries to assemble their own set of component factories into an otelcol.Factories, without pulling in this distribution's full dependency graph. Programs that want this distribution's own default set of components can additionally import pkg/components/defaults and call RegisterDefaults.
+issues: []
+subtext: null

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - 'deployments/nomad/**'
       - '.github/workflows/nomad.yml'
-      - 'internal/components/**'
+      - 'pkg/components/**'
       - 'cmd/otelcol/**'
       - '!**.md'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,26 @@ Follow the AI-assisted contribution policy in
 your own words. Disclose significant AI assistance with an `Assisted-by:` commit message
 trailer, never `Co-authored-by:` (it breaks EasyCLA).
 
+## Validation
+
+Before considering any Go change complete, run `go build ./...` from the repo root and confirm
+it exits clean. Do this for every change, not just ones that touch `cmd/otelcol` or `pkg/`.
+
+- Use `go build ./...` or `go run ./cmd/otelcol -- <args>` (package path). Do not run
+  `go run cmd/otelcol/main.go`: `cmd/otelcol` splits platform-specific code (e.g. `run`) across
+  `main_others.go`/`main_windows.go`/`main_fipsonly.go`, and `go run` on a single file only
+  compiles that file, so it fails with `undefined: run` even when the package builds fine.
+- After `go build ./...` passes, run the relevant `go test ./...` packages for the area you
+  changed.
+- `go build ./...` only proves this module builds; it does not prove a package can be
+  imported from *outside* this module. This module's `go.mod` has local `replace` directives
+  (e.g. `github.com/signalfx/signalfx-agent => ./internal/signalfx-agent`) that only apply
+  when this module is the main module being built — an external importer's `go.mod` doesn't
+  get them. If you add a public package meant for external import (like `pkg/components`),
+  keep it free of any import chain that reaches a locally-replaced module, and if unsure,
+  validate by building it from a throwaway module elsewhere that only has a
+  `replace github.com/signalfx/splunk-otel-collector => <local path>` pointing at this repo.
+
 ## PR descriptions
 
 Keep PR descriptions concise. Do not repeat yourself. Do not add unimportant or unrelated text.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,10 +139,10 @@ Some people make be interested in adding and/or removing components. This can
 be accomplished by:
 
 1. Adding or removing components from the import in
-   [components.go](https://github.com/signalfx/splunk-otel-collector/blob/main/internal/components/components.go#L18)
-2. Adding or removing components from [Get function in components.go](https://github.com/signalfx/splunk-otel-collector/blob/main/internal/components/components.go#L75)
+   [defaults.go](https://github.com/signalfx/splunk-otel-collector/blob/main/pkg/components/defaults/defaults.go#L18)
+2. Adding or removing components from [RegisterDefaults in defaults.go](https://github.com/signalfx/splunk-otel-collector/blob/main/pkg/components/defaults/defaults.go#L168)
 3. Updating tests by adding or removing components from
-   [TestDefaultComponents](https://github.com/signalfx/splunk-otel-collector/blob/main/internal/components/components_test.go#L26)
+   [TestDefaultComponents](https://github.com/signalfx/splunk-otel-collector/blob/main/pkg/components/defaults/components_test.go#L26)
 4. Updating [components.md](docs/components.md) (only required if submitting PR to repository)
 
 > :warn: Adding or removing components is not officially supported by Splunk as

--- a/cmd/discoverybundler/templatefunctions.go
+++ b/cmd/discoverybundler/templatefunctions.go
@@ -21,8 +21,8 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 
-	"github.com/signalfx/splunk-otel-collector/internal/components"
 	"github.com/signalfx/splunk-otel-collector/internal/confmapprovider/discovery/properties"
+	"github.com/signalfx/splunk-otel-collector/pkg/components/defaults"
 )
 
 const defaultValue = "splunk.discovery.default"
@@ -52,7 +52,7 @@ func createConfigPropertyEnvVar(componentID component.ID) func(...string) (strin
 }
 
 func configPropertyForComponent(componentID component.ID, methodName string, args []string, stringer func(property *properties.Property) string) (string, error) {
-	factories, err := components.Get()
+	factories, err := defaults.Get()
 	if err != nil {
 		return "", fmt.Errorf("failed accessing distribution components: %w", err)
 	}

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -32,11 +32,11 @@ import (
 	"go.opentelemetry.io/collector/otelcol"
 	"go.uber.org/zap"
 
-	"github.com/signalfx/splunk-otel-collector/internal/components"
 	"github.com/signalfx/splunk-otel-collector/internal/configconverter"
 	"github.com/signalfx/splunk-otel-collector/internal/confmapprovider/configsource"
 	"github.com/signalfx/splunk-otel-collector/internal/settings"
 	"github.com/signalfx/splunk-otel-collector/internal/version"
+	"github.com/signalfx/splunk-otel-collector/pkg/components/defaults"
 	"github.com/signalfx/splunk-otel-collector/pkg/modularinput"
 )
 
@@ -118,7 +118,7 @@ func runFromCmdLine(args []string) {
 
 	serviceSettings := otelcol.CollectorSettings{
 		BuildInfo: info,
-		Factories: components.Get,
+		Factories: defaults.Get,
 		ConfigProviderSettings: otelcol.ConfigProviderSettings{
 			ResolverSettings: confmap.ResolverSettings{
 				URIs:               collectorSettings.ResolverURIs(),

--- a/examples/splunkinputs-on-windows/README.md
+++ b/examples/splunkinputs-on-windows/README.md
@@ -42,7 +42,7 @@ Before building the image, place a Windows collector binary named
 
 The `splunk_inputs` receiver this example depends on is only registered from
 `v0.158.0` onward (see the `enableTARunner` feature gate in
-[`internal/components/components.go`](../../internal/components/components.go)),
+[`pkg/components/defaults/components.go`](../../pkg/components/defaults/components.go)),
 so download the latest release from the
 [project's GitHub releases page](https://github.com/signalfx/splunk-otel-collector/releases)
 and fail fast if it predates that version:

--- a/internal/confmapprovider/discovery/discoverer.go
+++ b/internal/confmapprovider/discovery/discoverer.go
@@ -39,11 +39,11 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/signalfx/splunk-otel-collector/internal/common/discovery"
-	"github.com/signalfx/splunk-otel-collector/internal/components"
 	"github.com/signalfx/splunk-otel-collector/internal/confmapprovider/discovery/internal"
 	"github.com/signalfx/splunk-otel-collector/internal/confmapprovider/discovery/properties"
 	"github.com/signalfx/splunk-otel-collector/internal/receiver/discoveryreceiver"
 	"github.com/signalfx/splunk-otel-collector/internal/version"
+	"github.com/signalfx/splunk-otel-collector/pkg/components/defaults"
 )
 
 const logLevelEnvVar = "SPLUNK_DISCOVERY_LOG_LEVEL"
@@ -81,7 +81,7 @@ func newDiscoverer(logger *zap.Logger) (*discoverer, error) {
 		Command: "discovery",
 		Version: version.Version,
 	}
-	factories, err := components.Get()
+	factories, err := defaults.Get()
 	if err != nil {
 		return (*discoverer)(nil), err
 	}

--- a/internal/confmapprovider/discovery/provider_test.go
+++ b/internal/confmapprovider/discovery/provider_test.go
@@ -32,9 +32,9 @@ import (
 	"go.opentelemetry.io/collector/otelcol"
 	"go.opentelemetry.io/collector/pipeline"
 
-	"github.com/signalfx/splunk-otel-collector/internal/components"
 	"github.com/signalfx/splunk-otel-collector/internal/configconverter"
 	"github.com/signalfx/splunk-otel-collector/internal/receiver/discoveryreceiver"
+	"github.com/signalfx/splunk-otel-collector/pkg/components/defaults"
 )
 
 func TestConfigDProviderHappyPath(t *testing.T) {
@@ -134,7 +134,7 @@ func TestDiscoveryProvider_ContinuousDiscoveryConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, provider)
 
-	factories, err := components.Get()
+	factories, err := defaults.Get()
 	require.NoError(t, err)
 
 	conf, err := provider.Get(context.Background(), factories)
@@ -204,7 +204,7 @@ func TestDiscoveryProvider_HostObserverDisabled(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, provider)
 
-	factories, err := components.Get()
+	factories, err := defaults.Get()
 	require.NoError(t, err)
 
 	conf, err := provider.Get(context.Background(), factories)

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -103,6 +103,7 @@ type Settings struct {
 	discoveryProperties     []string
 	versionFlag             bool
 	featureGateCommand      bool
+	componentsCommand       bool
 	noConvertConfig         bool
 	configD                 bool
 	discoveryMode           bool
@@ -126,7 +127,7 @@ func New(args []string) (*Settings, error) {
 	}
 
 	// immediate exit paths, no further setup required
-	if s.versionFlag || s.featureGateCommand {
+	if s.versionFlag || s.featureGateCommand || s.componentsCommand {
 		return s, nil
 	}
 
@@ -288,8 +289,9 @@ func parseArgs(args []string) (*Settings, error) {
 	}
 
 	settings.featureGateCommand = len(args) > 0 && args[0] == "featuregate"
-	if settings.featureGateCommand {
-		// Leave the featuregate command and its arguments for the upstream Cobra command.
+	settings.componentsCommand = len(args) > 0 && args[0] == "components"
+	if settings.featureGateCommand || settings.componentsCommand {
+		// Leave the featuregate/components command and its arguments for the upstream Cobra command.
 		flagSet.SetInterspersed(false)
 	}
 
@@ -311,7 +313,7 @@ func parseArgs(args []string) (*Settings, error) {
 	// Pass flags that are handled by the collector core service as raw command line arguments.
 	colCoreCommands := []string{"validate"}
 	settings.colCoreArgs = flagSetToArgs(colCoreFlags, colCoreCommands, flagSet)
-	if settings.featureGateCommand {
+	if settings.featureGateCommand || settings.componentsCommand {
 		settings.colCoreArgs = append(settings.colCoreArgs, flagSet.Args()...)
 	}
 
@@ -324,6 +326,7 @@ func writeUsage(flagSet *flag.FlagSet) {
   otelcol [command]
 
 Available Commands:
+  components   Outputs available components in this collector distribution
   featuregate  Display feature gates information
   validate     Validates the config without running the collector
 

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -94,6 +94,7 @@ func TestWriteUsage(t *testing.T) {
 
 	usage := output.String()
 	require.Contains(t, usage, `Available Commands:
+  components   Outputs available components in this collector distribution
   featuregate  Display feature gates information
   validate     Validates the config without running the collector
 
@@ -245,6 +246,23 @@ func TestNewSettingsWithFeatureGate(t *testing.T) {
 			settings, err := New(args)
 			require.NoError(t, err)
 			require.NotNil(t, settings)
+			require.Equal(t, args, settings.ColCoreArgs())
+		})
+	}
+}
+
+func TestNewSettingsWithComponents(t *testing.T) {
+	t.Cleanup(clearEnv(t))
+	for _, args := range [][]string{
+		{"components"},
+		{"components", "--help"},
+		{"components", "-h"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			settings, err := New(args)
+			require.NoError(t, err)
+			require.NotNil(t, settings)
+			require.True(t, settings.componentsCommand)
 			require.Equal(t, args, settings.ColCoreArgs())
 		})
 	}

--- a/pkg/components/defaults/components.go
+++ b/pkg/components/defaults/components.go
@@ -1,0 +1,57 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package defaults registers every component that ships with this collector distribution.
+// Importing it pulls in that entire set of dependencies, including Splunk-internal packages
+// resolved only via this module's local replace directives; programs outside this module that
+// want to assemble their own, smaller set of components should depend on pkg/components
+// instead and never import this package.
+package defaults
+
+import (
+	"github.com/splunk/tarunner/pkg/splunkinputsreceiver"
+	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/otelcol"
+
+	"github.com/signalfx/splunk-otel-collector/pkg/components"
+)
+
+const (
+	enableTARunnerFeatureGateID = "enableTARunner"
+)
+
+var enableTARunner = featuregate.GlobalRegistry().MustRegister(
+	enableTARunnerFeatureGateID,
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("When enabled, the collector supports working with .conf configuration files via the `splunk_inputs` receiver. "+
+		"When disabled (default), the `splunk_inputs` receiver is not available and the collector will crash if it tries to run it."),
+	featuregate.WithRegisterFromVersion("v0.158.0"),
+)
+
+// Get returns this collector distribution's default set of component factories. It builds
+// a fresh components.Registries on every call, so it can be passed directly as
+// otelcol.CollectorSettings.Factories. Programs that want to customize the set of
+// components, e.g. by calling Register or Deregister, should call components.NewRegistries
+// and RegisterDefaults themselves instead of using Get.
+func Get() (otelcol.Factories, error) {
+	r := components.NewRegistries()
+	RegisterDefaults(r)
+
+	if enableTARunner.IsEnabled() {
+		r.Receivers.Register(splunkinputsreceiver.NewFactory())
+	}
+
+	return r.Build()
+}

--- a/pkg/components/defaults/components_test.go
+++ b/pkg/components/defaults/components_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package components
+package defaults
 
 import (
 	"testing"

--- a/pkg/components/defaults/defaults.go
+++ b/pkg/components/defaults/defaults.go
@@ -13,9 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package components
+package defaults
 
 import (
+	"github.com/signalfx/splunk-otel-collector/pkg/components"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
@@ -135,24 +137,16 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver"
-	"github.com/splunk/tarunner/pkg/splunkinputsreceiver"
-	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/connector/forwardconnector"
 	"go.opentelemetry.io/collector/exporter/debugexporter"
 	"go.opentelemetry.io/collector/exporter/nopexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	"go.opentelemetry.io/collector/extension/zpagesextension"
-	"go.opentelemetry.io/collector/featuregate"
-	"go.opentelemetry.io/collector/otelcol"
-	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
 	"go.opentelemetry.io/collector/processor/memorylimiterprocessor"
-	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/nopreceiver"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
-	"go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
-	"go.uber.org/multierr"
 
 	"github.com/signalfx/splunk-otel-collector/internal/extension/configsourcetelemetryextension"
 	"github.com/signalfx/splunk-otel-collector/internal/receiver/discoveryreceiver"
@@ -166,203 +160,153 @@ import (
 	"github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver"
 )
 
-const (
-	enableTARunnerFeatureGateID = "enableTARunner"
-)
+// RegisterDefaults registers every component that ships with this collector distribution
+// into r's Extensions, Receivers, Processors, Exporters, and Connectors registries. Callers
+// assembling a customized distribution typically call components.NewRegistries, then
+// RegisterDefaults, then Register or Deregister their own factories on the result before
+// calling Build.
+func RegisterDefaults(r *components.Registries) {
+	r.Extensions.Register(ackextension.NewFactory())
+	r.Extensions.Register(awsiamdbauthextension.NewFactory())
+	r.Extensions.Register(basicauthextension.NewFactory())
+	r.Extensions.Register(bearertokenauthextension.NewFactory())
+	r.Extensions.Register(configsourcetelemetryextension.NewFactory())
+	r.Extensions.Register(dockerobserver.NewFactory())
+	r.Extensions.Register(ecsobserver.NewFactory())
+	r.Extensions.Register(filestorage.NewFactory())
+	r.Extensions.Register(googlecloudlogentryencodingextension.NewFactory())
+	r.Extensions.Register(headerssetterextension.NewFactory())
+	r.Extensions.Register(healthcheckextension.NewFactory())
+	r.Extensions.Register(hostobserver.NewFactory())
+	r.Extensions.Register(httpforwarderextension.NewFactory())
+	r.Extensions.Register(k8sleaderelector.NewFactory())
+	r.Extensions.Register(k8sobserver.NewFactory())
+	r.Extensions.Register(oauth2clientauthextension.NewFactory())
+	r.Extensions.Register(opampextension.NewFactory())
+	r.Extensions.Register(pprofextension.NewFactory())
+	r.Extensions.Register(smartagentextension.NewFactory())
+	r.Extensions.Register(textencodingextension.NewFactory())
+	r.Extensions.Register(zpagesextension.NewFactory())
 
-var enableTARunner = featuregate.GlobalRegistry().MustRegister(
-	enableTARunnerFeatureGateID,
-	featuregate.StageAlpha,
-	featuregate.WithRegisterDescription("When enabled, the collector supports working with .conf configuration files via the `splunk_inputs` receiver. "+
-		"When disabled (default), the `splunk_inputs` receiver is not available and the collector will crash if it tries to run it."),
-	featuregate.WithRegisterFromVersion("v0.158.0"),
-)
+	r.Receivers.Register(activedirectorydsreceiver.NewFactory())
+	r.Receivers.Register(apachereceiver.NewFactory())
+	r.Receivers.Register(apachesparkreceiver.NewFactory())
+	r.Receivers.Register(awscloudwatchreceiver.NewFactory())
+	r.Receivers.Register(awscontainerinsightreceiver.NewFactory())
+	r.Receivers.Register(awsecscontainermetricsreceiver.NewFactory())
+	r.Receivers.Register(azureblobreceiver.NewFactory())
+	r.Receivers.Register(azureeventhubreceiver.NewFactory())
+	r.Receivers.Register(azuremonitorreceiver.NewFactory())
+	r.Receivers.Register(carbonreceiver.NewFactory())
+	r.Receivers.Register(chronyreceiver.NewFactory())
+	r.Receivers.Register(ciscoosreceiver.NewFactory())
+	r.Receivers.Register(cloudfoundryreceiver.NewFactory())
+	r.Receivers.Register(collectdreceiver.NewFactory())
+	r.Receivers.Register(discoveryreceiver.NewFactory())
+	r.Receivers.Register(dnscheckreceiver.NewFactory())
+	r.Receivers.Register(dockerstatsreceiver.NewFactory())
+	r.Receivers.Register(elasticsearchreceiver.NewFactory())
+	r.Receivers.Register(filelogreceiver.NewFactory())
+	r.Receivers.Register(filestatsreceiver.NewFactory())
+	r.Receivers.Register(fluentforwardreceiver.NewFactory())
+	r.Receivers.Register(gnmireceiver.NewFactory())
+	r.Receivers.Register(googlecloudpubsubreceiver.NewFactory())
+	r.Receivers.Register(haproxyreceiver.NewFactory())
+	r.Receivers.Register(hostmetricsreceiver.NewFactory())
+	r.Receivers.Register(httpcheckreceiver.NewFactory())
+	r.Receivers.Register(icmpcheckreceiver.NewFactory())
+	r.Receivers.Register(iisreceiver.NewFactory())
+	r.Receivers.Register(influxdbreceiver.NewFactory())
+	r.Receivers.Register(jaegerreceiver.NewFactory())
+	r.Receivers.Register(journaldreceiver.NewFactory())
+	r.Receivers.Register(k8sclusterreceiver.NewFactory())
+	r.Receivers.Register(k8seventsreceiver.NewFactory())
+	r.Receivers.Register(k8sobjectsreceiver.NewFactory())
+	r.Receivers.Register(kafkametricsreceiver.NewFactory())
+	r.Receivers.Register(kafkareceiver.NewFactory())
+	r.Receivers.Register(kubeletstatsreceiver.NewFactory())
+	r.Receivers.Register(lightprometheusreceiver.NewFactory())
+	r.Receivers.Register(memcachedreceiver.NewFactory())
+	r.Receivers.Register(mongodbatlasreceiver.NewFactory())
+	r.Receivers.Register(mongodbreceiver.NewFactory())
+	r.Receivers.Register(mysqlreceiver.NewFactory())
+	r.Receivers.Register(nginxreceiver.NewFactory())
+	r.Receivers.Register(nopreceiver.NewFactory())
+	r.Receivers.Register(ntpreceiver.NewFactory())
+	r.Receivers.Register(oracledbreceiver.NewFactory())
+	r.Receivers.Register(otlpreceiver.NewFactory())
+	r.Receivers.Register(postgresqlreceiver.NewFactory())
+	r.Receivers.Register(prometheusreceiver.NewFactory())
+	r.Receivers.Register(prometheusremotewritereceiver.NewFactory())
+	r.Receivers.Register(purefareceiver.NewFactory())
+	r.Receivers.Register(rabbitmqreceiver.NewFactory())
+	r.Receivers.Register(receivercreator.NewFactory())
+	r.Receivers.Register(redisreceiver.NewFactory())
+	r.Receivers.Register(saphanareceiver.NewFactory())
+	r.Receivers.Register(scriptedinputsreceiver.NewFactory())
+	r.Receivers.Register(signalfxgatewayprometheusremotewritereceiver.NewFactory())
+	r.Receivers.Register(simpleprometheusreceiver.NewFactory())
+	r.Receivers.Register(smartagentreceiver.NewFactory())
+	r.Receivers.Register(snmpreceiver.NewFactory())
+	r.Receivers.Register(snowflakereceiver.NewFactory())
+	r.Receivers.Register(solacereceiver.NewFactory())
+	r.Receivers.Register(splunkenterprisereceiver.NewFactory())
+	r.Receivers.Register(splunkhecreceiver.NewFactory())
+	r.Receivers.Register(sqlqueryreceiver.NewFactory())
+	r.Receivers.Register(sqlserverreceiver.NewFactory())
+	r.Receivers.Register(sshcheckreceiver.NewFactory())
+	r.Receivers.Register(statsdreceiver.NewFactory())
+	r.Receivers.Register(syslogreceiver.NewFactory())
+	r.Receivers.Register(systemdreceiver.NewFactory())
+	r.Receivers.Register(tcpcheckreceiver.NewFactory())
+	r.Receivers.Register(tcplogreceiver.NewFactory())
+	r.Receivers.Register(tlscheckreceiver.NewFactory())
+	r.Receivers.Register(udplogreceiver.NewFactory())
+	r.Receivers.Register(vcenterreceiver.NewFactory())
+	r.Receivers.Register(wavefrontreceiver.NewFactory())
+	r.Receivers.Register(windowseventlogreceiver.NewFactory())
+	r.Receivers.Register(windowsperfcountersreceiver.NewFactory())
+	r.Receivers.Register(windowsservicereceiver.NewFactory())
+	r.Receivers.Register(yanggrpcreceiver.NewFactory())
+	r.Receivers.Register(zipkinreceiver.NewFactory())
+	r.Receivers.Register(zookeeperreceiver.NewFactory())
 
-func Get() (otelcol.Factories, error) {
-	var errs []error
-	extensions, err := otelcol.MakeFactoryMap(
-		ackextension.NewFactory(),
-		awsiamdbauthextension.NewFactory(),
-		basicauthextension.NewFactory(),
-		bearertokenauthextension.NewFactory(),
-		configsourcetelemetryextension.NewFactory(),
-		dockerobserver.NewFactory(),
-		ecsobserver.NewFactory(),
-		filestorage.NewFactory(),
-		googlecloudlogentryencodingextension.NewFactory(),
-		headerssetterextension.NewFactory(),
-		healthcheckextension.NewFactory(),
-		hostobserver.NewFactory(),
-		httpforwarderextension.NewFactory(),
-		k8sleaderelector.NewFactory(),
-		k8sobserver.NewFactory(),
-		oauth2clientauthextension.NewFactory(),
-		opampextension.NewFactory(),
-		pprofextension.NewFactory(),
-		smartagentextension.NewFactory(),
-		textencodingextension.NewFactory(),
-		zpagesextension.NewFactory(),
-	)
-	if err != nil {
-		errs = append(errs, err)
-	}
+	r.Exporters.Register(awss3exporter.NewFactory())
+	r.Exporters.Register(debugexporter.NewFactory())
+	r.Exporters.Register(fileexporter.NewFactory())
+	r.Exporters.Register(googlecloudstorageexporter.NewFactory())
+	r.Exporters.Register(kafkaexporter.NewFactory())
+	r.Exporters.Register(loadbalancingexporter.NewFactory())
+	r.Exporters.Register(nopexporter.NewFactory())
+	r.Exporters.Register(otlpexporter.NewFactory())
+	r.Exporters.Register(otlphttpexporter.NewFactory())
+	r.Exporters.Register(prometheusremotewriteexporter.NewFactory())
+	r.Exporters.Register(signalfxexporter.NewFactory())
+	r.Exporters.Register(splunkhecexporter.NewFactory())
 
-	receiverFactories := []receiver.Factory{
-		activedirectorydsreceiver.NewFactory(),
-		apachereceiver.NewFactory(),
-		apachesparkreceiver.NewFactory(),
-		awscloudwatchreceiver.NewFactory(),
-		awscontainerinsightreceiver.NewFactory(),
-		awsecscontainermetricsreceiver.NewFactory(),
-		azureblobreceiver.NewFactory(),
-		azureeventhubreceiver.NewFactory(),
-		azuremonitorreceiver.NewFactory(),
-		carbonreceiver.NewFactory(),
-		chronyreceiver.NewFactory(),
-		ciscoosreceiver.NewFactory(),
-		cloudfoundryreceiver.NewFactory(),
-		collectdreceiver.NewFactory(),
-		discoveryreceiver.NewFactory(),
-		dnscheckreceiver.NewFactory(),
-		dockerstatsreceiver.NewFactory(),
-		elasticsearchreceiver.NewFactory(),
-		filelogreceiver.NewFactory(),
-		filestatsreceiver.NewFactory(),
-		fluentforwardreceiver.NewFactory(),
-		gnmireceiver.NewFactory(),
-		googlecloudpubsubreceiver.NewFactory(),
-		haproxyreceiver.NewFactory(),
-		hostmetricsreceiver.NewFactory(),
-		httpcheckreceiver.NewFactory(),
-		icmpcheckreceiver.NewFactory(),
-		iisreceiver.NewFactory(),
-		influxdbreceiver.NewFactory(),
-		jaegerreceiver.NewFactory(),
-		journaldreceiver.NewFactory(),
-		k8sclusterreceiver.NewFactory(),
-		k8seventsreceiver.NewFactory(),
-		k8sobjectsreceiver.NewFactory(),
-		kafkametricsreceiver.NewFactory(),
-		kafkareceiver.NewFactory(),
-		kubeletstatsreceiver.NewFactory(),
-		lightprometheusreceiver.NewFactory(),
-		memcachedreceiver.NewFactory(),
-		mongodbatlasreceiver.NewFactory(),
-		mongodbreceiver.NewFactory(),
-		mysqlreceiver.NewFactory(),
-		nginxreceiver.NewFactory(),
-		receiver.Factory(nopreceiver.NewFactory()),
-		ntpreceiver.NewFactory(),
-		oracledbreceiver.NewFactory(),
-		otlpreceiver.NewFactory(),
-		postgresqlreceiver.NewFactory(),
-		prometheusreceiver.NewFactory(),
-		prometheusremotewritereceiver.NewFactory(),
-		purefareceiver.NewFactory(),
-		rabbitmqreceiver.NewFactory(),
-		receivercreator.NewFactory(),
-		redisreceiver.NewFactory(),
-		saphanareceiver.NewFactory(),
-		scriptedinputsreceiver.NewFactory(),
-		signalfxgatewayprometheusremotewritereceiver.NewFactory(),
-		simpleprometheusreceiver.NewFactory(),
-		smartagentreceiver.NewFactory(),
-		snmpreceiver.NewFactory(),
-		snowflakereceiver.NewFactory(),
-		solacereceiver.NewFactory(),
-		splunkenterprisereceiver.NewFactory(),
-		splunkhecreceiver.NewFactory(),
-		sqlqueryreceiver.NewFactory(),
-		sqlserverreceiver.NewFactory(),
-		sshcheckreceiver.NewFactory(),
-		statsdreceiver.NewFactory(),
-		syslogreceiver.NewFactory(),
-		systemdreceiver.NewFactory(),
-		tcpcheckreceiver.NewFactory(),
-		tcplogreceiver.NewFactory(),
-		tlscheckreceiver.NewFactory(),
-		udplogreceiver.NewFactory(),
-		vcenterreceiver.NewFactory(),
-		wavefrontreceiver.NewFactory(),
-		windowseventlogreceiver.NewFactory(),
-		windowsperfcountersreceiver.NewFactory(),
-		windowsservicereceiver.NewFactory(),
-		yanggrpcreceiver.NewFactory(),
-		zipkinreceiver.NewFactory(),
-		zookeeperreceiver.NewFactory(),
-	}
+	r.Processors.Register(attributesprocessor.NewFactory())
+	r.Processors.Register(batchprocessor.NewFactory())
+	r.Processors.Register(cumulativetodeltaprocessor.NewFactory())
+	r.Processors.Register(filterprocessor.NewFactory())
+	r.Processors.Register(groupbyattrsprocessor.NewFactory())
+	r.Processors.Register(k8sattributesprocessor.NewFactory())
+	r.Processors.Register(logstransformprocessor.NewFactory())
+	r.Processors.Register(memorylimiterprocessor.NewFactory())
+	r.Processors.Register(metricsgenerationprocessor.NewFactory())
+	r.Processors.Register(metricstransformprocessor.NewFactory())
+	r.Processors.Register(probabilisticsamplerprocessor.NewFactory())
+	r.Processors.Register(redactionprocessor.NewFactory())
+	r.Processors.Register(resourcedetectionprocessor.NewFactory())
+	r.Processors.Register(resourceprocessor.NewFactory())
+	r.Processors.Register(spanprocessor.NewFactory())
+	r.Processors.Register(tailsamplingprocessor.NewFactory())
+	r.Processors.Register(timestampprocessor.NewFactory())
+	r.Processors.Register(rollingspanlatencyprocessor.NewFactory())
+	r.Processors.Register(transformprocessor.NewFactory())
 
-	if enableTARunner.IsEnabled() {
-		receiverFactories = append(receiverFactories, splunkinputsreceiver.NewFactory())
-	}
-
-	receivers, err := otelcol.MakeFactoryMap(receiverFactories...)
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	exporters, err := otelcol.MakeFactoryMap(
-		awss3exporter.NewFactory(),
-		debugexporter.NewFactory(),
-		fileexporter.NewFactory(),
-		googlecloudstorageexporter.NewFactory(),
-		kafkaexporter.NewFactory(),
-		loadbalancingexporter.NewFactory(),
-		nopexporter.NewFactory(),
-		otlpexporter.NewFactory(),
-		otlphttpexporter.NewFactory(),
-		prometheusremotewriteexporter.NewFactory(),
-		signalfxexporter.NewFactory(),
-		splunkhecexporter.NewFactory(),
-	)
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	processors, err := otelcol.MakeFactoryMap[processor.Factory](
-		attributesprocessor.NewFactory(),
-		batchprocessor.NewFactory(),
-		cumulativetodeltaprocessor.NewFactory(),
-		filterprocessor.NewFactory(),
-		groupbyattrsprocessor.NewFactory(),
-		k8sattributesprocessor.NewFactory(),
-		logstransformprocessor.NewFactory(),
-		memorylimiterprocessor.NewFactory(),
-		metricsgenerationprocessor.NewFactory(),
-		metricstransformprocessor.NewFactory(),
-		probabilisticsamplerprocessor.NewFactory(),
-		redactionprocessor.NewFactory(),
-		resourcedetectionprocessor.NewFactory(),
-		resourceprocessor.NewFactory(),
-		spanprocessor.NewFactory(),
-		tailsamplingprocessor.NewFactory(),
-		timestampprocessor.NewFactory(),
-		rollingspanlatencyprocessor.NewFactory(),
-		transformprocessor.NewFactory(),
-	)
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	connectors, err := otelcol.MakeFactoryMap(
-		countconnector.NewFactory(),
-		connector.Factory(forwardconnector.NewFactory()),
-		routingconnector.NewFactory(),
-		spanmetricsconnector.NewFactory(),
-		sumconnector.NewFactory(),
-	)
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	factories := otelcol.Factories{
-		Extensions: extensions,
-		Receivers:  receivers,
-		Processors: processors,
-		Exporters:  exporters,
-		Connectors: connectors,
-		Telemetry:  otelconftelemetry.NewFactory(),
-	}
-
-	return factories, multierr.Combine(errs...)
+	r.Connectors.Register(countconnector.NewFactory())
+	r.Connectors.Register(forwardconnector.NewFactory())
+	r.Connectors.Register(routingconnector.NewFactory())
+	r.Connectors.Register(spanmetricsconnector.NewFactory())
+	r.Connectors.Register(sumconnector.NewFactory())
 }

--- a/pkg/components/registry.go
+++ b/pkg/components/registry.go
@@ -1,0 +1,157 @@
+// Copyright Splunk, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package components defines Registry and Registries, a mutable set of component factories
+// that Build assembles into an otelcol.Factories value. It has no dependency beyond the
+// collector core, so any Go program can import it to assemble its own set of components by
+// calling NewRegistries, then Register or Deregister factories of its own before calling
+// Build. Programs that want this distribution's default set of components instead should
+// import pkg/components/defaults, which registers them via RegisterDefaults; that package
+// pulls in this distribution's full dependency graph, including Splunk-internal packages
+// resolved only through this module's local replace directives, so it cannot be imported
+// from outside this module.
+package components
+
+import (
+	"sort"
+	"sync"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/connector"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/otelcol"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
+	"go.uber.org/multierr"
+)
+
+// Registry is a mutable, concurrency-safe set of component factories of a single kind,
+// keyed by their canonical component.Type.
+type Registry[F component.Factory] struct {
+	mu        sync.RWMutex
+	factories map[component.Type]F
+}
+
+func newRegistry[F component.Factory]() *Registry[F] {
+	return &Registry[F]{
+		factories: make(map[component.Type]F),
+	}
+}
+
+// Register adds f to the registry, replacing any existing factory registered under the same
+// component type.
+func (r *Registry[F]) Register(f F) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.factories[f.Type()] = f
+}
+
+// Deregister removes the factory registered under name, if any. It returns an error only if
+// name is not a syntactically valid component type.
+func (r *Registry[F]) Deregister(name string) error {
+	t, err := component.NewType(name)
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.factories, t)
+	return nil
+}
+
+// Names returns the canonical type names currently registered, sorted alphabetically.
+func (r *Registry[F]) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.factories))
+	for t := range r.factories {
+		names = append(names, t.String())
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Factories returns a snapshot of the currently registered factories.
+func (r *Registry[F]) Factories() []F {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]F, 0, len(r.factories))
+	for _, f := range r.factories {
+		out = append(out, f)
+	}
+	return out
+}
+
+// Registries is a caller-owned set of Extensions, Receivers, Processors, Exporters, and
+// Connectors registries that Build assembles into an otelcol.Factories. Each Registries
+// value is independent: registering or deregistering a factory on one has no effect on any
+// other, so multiple distributions can be assembled concurrently without interfering with
+// each other.
+type Registries struct {
+	Extensions *Registry[extension.Factory]
+	Receivers  *Registry[receiver.Factory]
+	Processors *Registry[processor.Factory]
+	Exporters  *Registry[exporter.Factory]
+	Connectors *Registry[connector.Factory]
+}
+
+// NewRegistries returns an empty Registries. Call RegisterDefaults to populate it with the
+// components that ship with this collector distribution.
+func NewRegistries() *Registries {
+	return &Registries{
+		Extensions: newRegistry[extension.Factory](),
+		Receivers:  newRegistry[receiver.Factory](),
+		Processors: newRegistry[processor.Factory](),
+		Exporters:  newRegistry[exporter.Factory](),
+		Connectors: newRegistry[connector.Factory](),
+	}
+}
+
+// Build assembles an otelcol.Factories from the current contents of r's registries.
+func (r *Registries) Build() (otelcol.Factories, error) {
+	var errs []error
+
+	extensions, err := otelcol.MakeFactoryMap(r.Extensions.Factories()...)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	receivers, err := otelcol.MakeFactoryMap(r.Receivers.Factories()...)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	processors, err := otelcol.MakeFactoryMap(r.Processors.Factories()...)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	exporters, err := otelcol.MakeFactoryMap(r.Exporters.Factories()...)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	connectors, err := otelcol.MakeFactoryMap(r.Connectors.Factories()...)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	return otelcol.Factories{
+		Extensions: extensions,
+		Receivers:  receivers,
+		Processors: processors,
+		Exporters:  exporters,
+		Connectors: connectors,
+		Telemetry:  otelconftelemetry.NewFactory(),
+	}, multierr.Combine(errs...)
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

This change makes the splunk-otel-collector more extensible by allowing compile-time registration of components. This is an experiment seeking feedback.

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

I created another main.go (not in this PR) that consumes these changes and registers only a small subset of components.

**Documentation:** <Describe the documentation added.>
