### PR TITLE
Prevent creation of invalid metrics pipeline by discovery

### DIFF
--- a/.chloggen/fix-invalid-discovery-pipeline.yaml
+++ b/.chloggen/fix-invalid-discovery-pipeline.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: discovery
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Prevent discovery from creating an invalid metrics pipeline when no default metrics pipeline is configured.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/fix-invalid-discovery-pipeline.yaml
+++ b/.chloggen/fix-invalid-discovery-pipeline.yaml
@@ -8,7 +8,7 @@ component: discovery
 note: Prevent discovery from creating an invalid metrics pipeline when no default metrics pipeline is configured.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [7977]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/internal/configconverter/discovery.go
+++ b/internal/configconverter/discovery.go
@@ -26,8 +26,9 @@ import (
 
 // SetupDiscovery will find `service::<extensions|receivers>/splunk.discovery` entries
 // provided by the discovery confmap.Provider and relocate them to
-// `service::extensions` and `service::pipelines::metrics::receivers`,
-// by appending them to existing sequences, if any.
+// `service::extensions` and, when the default metrics pipeline exists,
+// `service::pipelines::metrics::receivers`, by appending them to existing
+// sequences, if any.
 func SetupDiscovery(_ context.Context, in *confmap.Conf) error {
 	if in == nil {
 		return nil
@@ -70,7 +71,7 @@ func SetupDiscovery(_ context.Context, in *confmap.Conf) error {
 		return err
 	}
 
-	if len(discoReceivers) > 0 {
+	if len(discoReceivers) > 0 && metricsPipeline != nil {
 		metricsPipeline["receivers"] = appendUnique(metricsReceivers, discoReceivers)
 	}
 
@@ -129,11 +130,14 @@ func getDiscoReceivers(service map[string]any) (bool, []any, error) {
 }
 
 func getMetricsPipelineAndReceivers(pipelines map[string]any) (map[string]any, []any, error) {
-	metricsPipeline := map[string]any{}
-	if mp, ok := pipelines["metrics"]; ok && mp != nil {
-		metricsPipeline = mp.(map[string]any)
+	mp, ok := pipelines["metrics"]
+	if !ok || mp == nil {
+		return nil, nil, nil
 	}
-	pipelines["metrics"] = metricsPipeline
+	metricsPipeline, ok := mp.(map[string]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("metrics pipeline is of unexpected form (%T): %v", mp, mp)
+	}
 
 	var metricsReceivers []any
 	if mr, ok := metricsPipeline["receivers"]; ok && mr != nil {

--- a/internal/configconverter/discovery.go
+++ b/internal/configconverter/discovery.go
@@ -25,10 +25,10 @@ import (
 )
 
 // SetupDiscovery will find `service::<extensions|receivers>/splunk.discovery` entries
-// provided by the discovery confmap.Provider and relocate them to
-// `service::extensions` and, when the default metrics pipeline exists,
-// `service::pipelines::metrics::receivers`, by appending them to existing
-// sequences, if any.
+// provided by the discovery confmap.Provider and, when the default metrics pipeline
+// exists, relocate them to `service::extensions` and `service::pipelines::metrics::receivers`
+// by appending them to existing sequences, if any. Otherwise, it just removes the
+// temporary entries to avoid creating an invalid config.
 func SetupDiscovery(_ context.Context, in *confmap.Conf) error {
 	if in == nil {
 		return nil
@@ -56,22 +56,25 @@ func SetupDiscovery(_ context.Context, in *confmap.Conf) error {
 		return nil
 	}
 
-	if len(discoExtensions) > 0 {
-		service["extensions"] = appendUnique(serviceExtensions, discoExtensions)
-	}
-
-	pipelines := map[string]any{}
+	var pipelines map[string]any
 	if pl, ok := service["pipelines"]; ok && pl != nil {
 		pipelines = pl.(map[string]any)
 	}
-	service["pipelines"] = pipelines
 
 	metricsPipeline, metricsReceivers, err := getMetricsPipelineAndReceivers(pipelines)
 	if err != nil {
 		return err
 	}
+	if metricsPipeline == nil {
+		*in = *confmap.NewFromStringMap(out)
+		return nil
+	}
 
-	if len(discoReceivers) > 0 && metricsPipeline != nil {
+	if len(discoExtensions) > 0 {
+		service["extensions"] = appendUnique(serviceExtensions, discoExtensions)
+	}
+
+	if len(discoReceivers) > 0 {
 		metricsPipeline["receivers"] = appendUnique(metricsReceivers, discoReceivers)
 	}
 

--- a/internal/configconverter/discovery.go
+++ b/internal/configconverter/discovery.go
@@ -25,10 +25,12 @@ import (
 )
 
 // SetupDiscovery will find `service::<extensions|receivers>/splunk.discovery` entries
-// provided by the discovery confmap.Provider and, when the default metrics pipeline
-// exists, relocate them to `service::extensions` and `service::pipelines::metrics::receivers`
-// by appending them to existing sequences, if any. Otherwise, it just removes the
-// temporary entries to avoid creating an invalid config.
+// provided by the discovery confmap.Provider. When the default
+// `service::pipelines::metrics` or continuous discovery
+// `service::pipelines::logs/entities` pipeline exists, it relocates discovery
+// extensions to `service::extensions` and discovery receivers to the applicable
+// pipeline receiver by appending them to existing sequences, if any.
+// Otherwise, it removes the temporary entries to avoid creating an invalid config.
 func SetupDiscovery(_ context.Context, in *confmap.Conf) error {
 	if in == nil {
 		return nil
@@ -65,7 +67,8 @@ func SetupDiscovery(_ context.Context, in *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	if metricsPipeline == nil {
+	_, entitiesPipelineIsSet := pipelines["logs/entities"].(map[string]any)
+	if metricsPipeline == nil && !entitiesPipelineIsSet {
 		*in = *confmap.NewFromStringMap(out)
 		return nil
 	}
@@ -74,7 +77,7 @@ func SetupDiscovery(_ context.Context, in *confmap.Conf) error {
 		service["extensions"] = appendUnique(serviceExtensions, discoExtensions)
 	}
 
-	if len(discoReceivers) > 0 {
+	if len(discoReceivers) > 0 && metricsPipeline != nil {
 		metricsPipeline["receivers"] = appendUnique(metricsReceivers, discoReceivers)
 	}
 

--- a/internal/configconverter/discovery_test.go
+++ b/internal/configconverter/discovery_test.go
@@ -238,6 +238,147 @@ func TestDiscoveryEmptyReceivers(t *testing.T) {
 	require.Equal(t, expected.ToStringMap(), in.ToStringMap())
 }
 
+func TestDiscoveryMetricsPipelineHandling(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expected      string
+		expectedError string
+	}{
+		{
+			name: "without metrics pipeline",
+			input: `service:
+  extensions/splunk.discovery: [ext/one]
+  pipelines:
+    traces:
+      receivers: [recv/one]
+      exporters: [exp/one]
+  receivers/splunk.discovery: [discovery/host_observer]
+`,
+			expected: `service:
+  extensions: [ext/one]
+  pipelines:
+    traces:
+      receivers: [recv/one]
+      exporters: [exp/one]
+  telemetry:
+    resource:
+      attributes:
+        - name: splunk_autodiscovery
+          value: "true"
+`,
+		},
+		{
+			name: "without metrics pipeline still updates entities",
+			input: `service:
+  pipelines:
+    logs/entities:
+      receivers: [recv/one]
+      exporters: [exp/one]
+  receivers/splunk.discovery: [discovery/host_observer]
+`,
+			expected: `service:
+  pipelines:
+    logs/entities:
+      receivers: [recv/one, discovery/host_observer]
+      exporters: [exp/one]
+  telemetry:
+    resource:
+      attributes:
+        - name: splunk_autodiscovery
+          value: "true"
+`,
+		},
+		{
+			name: "does not use named metrics pipeline",
+			input: `service:
+  pipelines:
+    metrics/custom:
+      receivers: [recv/one]
+      exporters: [exp/one]
+  receivers/splunk.discovery: [discovery/host_observer]
+`,
+			expected: `service:
+  pipelines:
+    metrics/custom:
+      receivers: [recv/one]
+      exporters: [exp/one]
+  telemetry:
+    resource:
+      attributes:
+        - name: splunk_autodiscovery
+          value: "true"
+`,
+		},
+		{
+			name: "with null metrics pipeline",
+			input: `service:
+  pipelines:
+    metrics:
+    traces:
+      receivers: [recv/one]
+      exporters: [exp/one]
+  receivers/splunk.discovery: [discovery/host_observer]
+`,
+			expected: `service:
+  pipelines:
+    metrics:
+    traces:
+      receivers: [recv/one]
+      exporters: [exp/one]
+  telemetry:
+    resource:
+      attributes:
+        - name: splunk_autodiscovery
+          value: "true"
+`,
+		},
+		{
+			name: "with_empty metrics pipeline",
+			input: `service:
+  pipelines:
+    metrics: {}
+  receivers/splunk.discovery: [discovery/host_observer]
+`,
+			expected: `service:
+  pipelines:
+    metrics:
+      receivers: [discovery/host_observer]
+  telemetry:
+    resource:
+      attributes:
+        - name: splunk_autodiscovery
+          value: "true"
+`,
+		},
+		{
+			name: "with malformed metrics pipeline",
+			input: `service:
+  pipelines:
+    metrics: invalid
+  receivers/splunk.discovery: [discovery/host_observer]
+`,
+			expectedError: "metrics pipeline is of unexpected form (string): invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := confFromYaml(t, tt.input)
+
+			err := SetupDiscovery(context.Background(), in)
+			if tt.expectedError != "" {
+				require.EqualError(t, err, tt.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			expected := confFromYaml(t, tt.expected)
+			require.Equal(t, expected.ToStringMap(), in.ToStringMap())
+		})
+	}
+}
+
 func TestContinuousDiscoveryNoEntitiesPipeline(t *testing.T) {
 	in := confFromYaml(t, `service:
   pipelines:

--- a/internal/configconverter/discovery_test.go
+++ b/internal/configconverter/discovery_test.go
@@ -263,7 +263,7 @@ func TestDiscoveryMetricsPipelineHandling(t *testing.T) {
 `,
 		},
 		{
-			name: "without metrics pipeline does not update entities",
+			name: "without metrics pipeline still updates entities",
 			input: `service:
   pipelines:
     logs/entities:
@@ -274,8 +274,13 @@ func TestDiscoveryMetricsPipelineHandling(t *testing.T) {
 			expected: `service:
   pipelines:
     logs/entities:
-      receivers: [recv/one]
+      receivers: [recv/one, discovery/host_observer]
       exporters: [exp/one]
+  telemetry:
+    resource:
+      attributes:
+        - name: splunk_autodiscovery
+          value: "true"
 `,
 		},
 		{

--- a/internal/configconverter/discovery_test.go
+++ b/internal/configconverter/discovery_test.go
@@ -256,20 +256,14 @@ func TestDiscoveryMetricsPipelineHandling(t *testing.T) {
   receivers/splunk.discovery: [discovery/host_observer]
 `,
 			expected: `service:
-  extensions: [ext/one]
   pipelines:
     traces:
       receivers: [recv/one]
       exporters: [exp/one]
-  telemetry:
-    resource:
-      attributes:
-        - name: splunk_autodiscovery
-          value: "true"
 `,
 		},
 		{
-			name: "without metrics pipeline still updates entities",
+			name: "without metrics pipeline does not update entities",
 			input: `service:
   pipelines:
     logs/entities:
@@ -280,13 +274,8 @@ func TestDiscoveryMetricsPipelineHandling(t *testing.T) {
 			expected: `service:
   pipelines:
     logs/entities:
-      receivers: [recv/one, discovery/host_observer]
+      receivers: [recv/one]
       exporters: [exp/one]
-  telemetry:
-    resource:
-      attributes:
-        - name: splunk_autodiscovery
-          value: "true"
 `,
 		},
 		{
@@ -303,11 +292,6 @@ func TestDiscoveryMetricsPipelineHandling(t *testing.T) {
     metrics/custom:
       receivers: [recv/one]
       exporters: [exp/one]
-  telemetry:
-    resource:
-      attributes:
-        - name: splunk_autodiscovery
-          value: "true"
 `,
 		},
 		{
@@ -326,15 +310,10 @@ func TestDiscoveryMetricsPipelineHandling(t *testing.T) {
     traces:
       receivers: [recv/one]
       exporters: [exp/one]
-  telemetry:
-    resource:
-      attributes:
-        - name: splunk_autodiscovery
-          value: "true"
 `,
 		},
 		{
-			name: "with_empty metrics pipeline",
+			name: "with empty metrics pipeline",
 			input: `service:
   pipelines:
     metrics: {}

--- a/internal/confmapprovider/discovery/README.md
+++ b/internal/confmapprovider/discovery/README.md
@@ -97,7 +97,7 @@ Discovery mode will:
 [Discovery Receiver](../../receiver/discoveryreceiver/README.md) instance to receive discovery events from all
 successfully started observers.
 1. Wait 10s or the configured `SPLUNK_DISCOVERY_DURATION` environment variable [`time.Duration`](https://pkg.go.dev/time#ParseDuration).
-1. Embed any receiver instances' configs resulting in a `discovery.status` of `successful` inside a `receiver_creator/discovery` receiver's configuration to be passed to an existing `service::pipelines::metrics::receivers` sequence in the final Collector service config (or outputted w/ `--dry-run`). Discovery mode does not create a missing default metrics pipeline or select an exporter. Without a default metrics pipeline, discovered receivers and required observers are not activated in the Collector service.
+1. Embed any receiver instances' configs resulting in a `discovery.status` of `successful` inside a `receiver_creator/discovery` receiver's configuration to be passed to applicable existing `service::pipelines::metrics` and `service::pipelines::logs/entities` pipelines in the final Collector service config (or outputted w/ `--dry-run`). Discovery mode does not create a missing pipeline or select an exporter. When neither pipeline exists, discovered receivers and required observers are not activated in the Collector service.
 1. Log any receiver resulting in a `discovery.status` of `partial` with the configured guidance for setting any relevant discovery properties.
 1. Stop all temporary components before continuing on to the actual Collector service (or exiting early with `--dry-run`).
 

--- a/internal/confmapprovider/discovery/README.md
+++ b/internal/confmapprovider/discovery/README.md
@@ -97,7 +97,7 @@ Discovery mode will:
 [Discovery Receiver](../../receiver/discoveryreceiver/README.md) instance to receive discovery events from all
 successfully started observers.
 1. Wait 10s or the configured `SPLUNK_DISCOVERY_DURATION` environment variable [`time.Duration`](https://pkg.go.dev/time#ParseDuration).
-1. Embed any receiver instances' configs resulting in a `discovery.status` of `successful` inside a `receiver_creator/discovery` receiver's configuration to be passed to the final Collector service config in a new or existing `service::pipelines::metrics::receivers` sequence (or outputted w/ `--dry-run`). Any required observers will be added to `service::extensions`.
+1. Embed any receiver instances' configs resulting in a `discovery.status` of `successful` inside a `receiver_creator/discovery` receiver's configuration to be passed to an existing `service::pipelines::metrics::receivers` sequence in the final Collector service config (or outputted w/ `--dry-run`). Discovery mode does not create a missing default metrics pipeline or select an exporter. Any required observers will be added to `service::extensions`.
 1. Log any receiver resulting in a `discovery.status` of `partial` with the configured guidance for setting any relevant discovery properties.
 1. Stop all temporary components before continuing on to the actual Collector service (or exiting early with `--dry-run`).
 

--- a/internal/confmapprovider/discovery/README.md
+++ b/internal/confmapprovider/discovery/README.md
@@ -97,7 +97,7 @@ Discovery mode will:
 [Discovery Receiver](../../receiver/discoveryreceiver/README.md) instance to receive discovery events from all
 successfully started observers.
 1. Wait 10s or the configured `SPLUNK_DISCOVERY_DURATION` environment variable [`time.Duration`](https://pkg.go.dev/time#ParseDuration).
-1. Embed any receiver instances' configs resulting in a `discovery.status` of `successful` inside a `receiver_creator/discovery` receiver's configuration to be passed to an existing `service::pipelines::metrics::receivers` sequence in the final Collector service config (or outputted w/ `--dry-run`). Discovery mode does not create a missing default metrics pipeline or select an exporter. Any required observers will be added to `service::extensions`.
+1. Embed any receiver instances' configs resulting in a `discovery.status` of `successful` inside a `receiver_creator/discovery` receiver's configuration to be passed to an existing `service::pipelines::metrics::receivers` sequence in the final Collector service config (or outputted w/ `--dry-run`). Discovery mode does not create a missing default metrics pipeline or select an exporter. Without a default metrics pipeline, discovered receivers and required observers are not activated in the Collector service.
 1. Log any receiver resulting in a `discovery.status` of `partial` with the configured guidance for setting any relevant discovery properties.
 1. Stop all temporary components before continuing on to the actual Collector service (or exiting early with `--dry-run`).
 

--- a/internal/confmapprovider/discovery/provider_test.go
+++ b/internal/confmapprovider/discovery/provider_test.go
@@ -165,17 +165,16 @@ func TestDiscoveryProvider_ContinuousDiscoveryConfig(t *testing.T) {
 	assert.Equal(t, component.MustNewID("host_observer"), conf.Service.Extensions[0])
 
 	pipelines := conf.Service.Pipelines
-	assert.Len(t, pipelines, 2)
+	require.Len(t, pipelines, 1)
+	assert.NotContains(t, pipelines, pipeline.NewID(pipeline.SignalMetrics))
 
-	metricsReceivers := pipelines[pipeline.NewID(pipeline.SignalMetrics)].Receivers
-	require.Len(t, metricsReceivers, 1)
-	assert.Equal(t, component.MustNewIDWithName("discovery", "host_observer"), metricsReceivers[0])
-
-	logsReceivers := pipelines[pipeline.NewIDWithName(pipeline.SignalLogs, "entities")].Receivers
+	logsPipeline, ok := pipelines[pipeline.NewIDWithName(pipeline.SignalLogs, "entities")]
+	require.True(t, ok)
+	logsReceivers := logsPipeline.Receivers
 	require.Len(t, logsReceivers, 1)
 	assert.Equal(t, component.MustNewIDWithName("discovery", "host_observer"), logsReceivers[0])
 
-	logsExporters := pipelines[pipeline.NewIDWithName(pipeline.SignalLogs, "entities")].Exporters
+	logsExporters := logsPipeline.Exporters
 	require.Len(t, logsExporters, 1)
 	assert.Equal(t, component.MustNewIDWithName("otlp_http", "entities"), logsExporters[0])
 }

--- a/tests/package/package_test.go
+++ b/tests/package/package_test.go
@@ -142,9 +142,11 @@ func TestCollectorPackageInstallWithSupervisor(t *testing.T) {
 		expectedEnv []string
 	}{
 		{
-			name: "observability-cloud",
+			name:      "observability-cloud",
+			extraArgs: "--discovery",
 			expectedEnv: []string{
 				"SPLUNK_CONFIG=" + agentConfigPath,
+				`OTELCOL_OPTIONS="--discovery"`,
 			},
 		},
 		{


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Currently, discovery can create an invalid metrics pipeline if there is no default metrics pipeline configured. This results in the collector crashing with error: `invalid configuration: service::pipelines::metrics: must have at least one exporter`

This was seen in tests that enable both OpAMP Supervisor + discovery because supervisor will first create a nop bootstrap collector to get AgentDescription data. The nop collector doesn't have a metrics pipeline and would fail with this error.

Behavior after fix:
- `service::pipeline::metrics` exists: activate metrics discovery
- `service::pipelines::logs/entities` exists: activate continuous entity discovery
- Both exist: activate both
- Neither exists: cleanup-only return for Supervisor bootstrap

**Testing:** <Describe what testing was performed and which tests were added.>
- Added unit tests
- Added e2e test with `--discovery` flag with installer script
- Tested locally with dev build: verified supervisor and collector were able to start

