### PR TITLE
[chore] Fix failing windows chef tests

### DIFF
--- a/.github/workflows/chef-test.yml
+++ b/.github/workflows/chef-test.yml
@@ -245,6 +245,7 @@ jobs:
         shell: bash
         env:
           KITCHEN_YAML: kitchen.windows.yml
+          TMPDIR: ${{ runner.temp }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The latest `kitchen-docker` release introduced a change with escaping paths that seems to incorrectly apply to windows paths (adds escape to `~` which messes up temp dir parsing). For now, setting temp dir used by windows kitchen test step to the runner temp which doesn't have `~` in the path.

**Testing:** <Describe what testing was performed and which tests were added.>
