### PR TITLE
[chore] Fix failing lychee test due to needing slack auth

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -25,6 +25,7 @@ exclude = [
     "^http(s)?://example.com",
     "^https://dev.mysql.com",
     "https://developers.redhat.com/*", # Failing with 403 Forbidden
+    "https://cloud-native.slack.com/archives/*", # Channel archives require an authenticated Slack session
 ]
 
 include-fragments = true


### PR DESCRIPTION
**Description:** <Describe what has changed.>
lychee test is failing on the cncf slack archive links, which now require an authenticated session. Adding to exclude list

**Testing:** <Describe what testing was performed and which tests were added.>
