### PR TITLE
deprecate telegraf/dns

### DIFF
--- a/.chloggen/deprecate-telegraf-dns.yaml
+++ b/.chloggen/deprecate-telegraf-dns.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: telegraf/dns
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the telegraf/dns monitor
+
+# One or more tracking issues related to the change
+issues: [7983]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This monitor is deprecated and will be removed on or after October 2026. Please use the [DNS Check Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dnscheckreceiver) instead.

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/dns/dns.go
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/dns/dns.go
@@ -64,6 +64,7 @@ func (e *Emitter) AddError(err error) {
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
+	m.logger.Warn("This monitor is deprecated and will be removed on or after October 2026. Please use the [DNS check receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dnscheckreceiver) instead.")
 
 	plugin := telegrafInputs.Inputs["dns_query"]().(*telegrafPlugin.DnsQuery)
 	plugin.Domains = conf.Domains

--- a/internal/signalfx-agent/pkg/monitors/telegraf/monitors/dns/metadata.yaml
+++ b/internal/signalfx-agent/pkg/monitors/telegraf/monitors/dns/metadata.yaml
@@ -1,5 +1,6 @@
 monitors:
 - doc: |
+    **This monitor is deprecated and will be removed on or after October 2026. Please use the [DNS Check Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dnscheckreceiver) instead.**
     This is an embedded form of the [Telegraf DNS Query
     plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/dns_query).
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
deprecate telegraf/dns in favor of upstream otel dns check receiver

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
