### PR TITLE
Prepare mass deployment releases: Ansible ansible-v1.2.0, Chef chef-v0.21.0, Puppet puppet-v0.23.0

### DIFF
--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/CHANGELOG.md
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## ansible-v1.2.0
+
 ### 💡 Enhancements 💡
 
 - Recursively set the ownership of collector config (`/etc/otel/collector`) and state (`/var/lib/otelcol`) directories to the configured service user and group on Linux.

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/galaxy.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: signalfx
 name: splunk_otel_collector
 description: Ansible collection for Splunk OpenTelemetry Collector
-version: 1.1.0
+version: 1.2.0
 readme: README.md
 authors:
   - Splunk Inc.

--- a/deployments/chef/CHANGELOG.md
+++ b/deployments/chef/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## chef-v0.21.0
+
 ### 💡 Enhancements 💡
 
 - Recursively set the ownership of collector config (`/etc/otel/collector`) and state (`/var/lib/otelcol`) directories to the configured service user and group on Linux.

--- a/deployments/chef/metadata.rb
+++ b/deployments/chef/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Splunk, Inc.'
 maintainer_email 'signalfx-support@splunk.com'
 license 'Apache-2.0'
 description 'Install/Configure the Splunk OpenTelemetry Collector'
-version '0.20.0'
+version '0.21.0'
 chef_version '>= 16.0'
 
 supports 'amazon'

--- a/deployments/puppet/CHANGELOG.md
+++ b/deployments/puppet/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## puppet-v0.23.0
+
 ### 💡 Enhancements 💡
 
 - Recursively set the ownership of collector config (`/etc/otel/collector`) and state (`/var/lib/otelcol`) directories to the configured service user and group on Linux.

--- a/deployments/puppet/metadata.json
+++ b/deployments/puppet/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx-splunk_otel_collector",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "author": "Splunk, Inc.",
   "summary": "This module installs the Splunk OpenTelemetry Collector via distro packages and configures it.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prepare releases for the following mass deployments:

- Ansible ansible-v1.2.0
- Chef chef-v0.21.0
- Puppet puppet-v0.23.0