### PR TITLE
[chore] Fix puppet release caused by incompatible versions in lockfile

### DIFF
--- a/deployments/puppet/Gemfile.lock
+++ b/deployments/puppet/Gemfile.lock
@@ -80,11 +80,11 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (5.1.1)
-    puppet (7.12.1)
+    puppet (7.34.0)
       concurrent-ruby (~> 1.0)
       deep_merge (~> 1.0)
       facter (> 2.0.1, < 5)
-      fast_gettext (~> 1.1)
+      fast_gettext (>= 1.1, < 3)
       hiera (>= 3.2.1, < 4)
       locale (~> 2.1)
       multi_json (~> 1.10)
@@ -255,6 +255,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   fast_gettext


### PR DESCRIPTION
Puppet release failed because the lockfile specifies `concurrent-ruby` and `puppet` versions that are incompatible - `puppet` used a private class from `concurrent-ruby` which was removed in a minor version update. A later `puppet` release removed use of this class, thus the fix is to update `puppet`. This was done by running `bundle update puppet --conservative`.

This failure does not reproduce in GitHub pipeline because it first runs `pdk update` which updates `puppet` to a version where this issue was fixed.