### PR TITLE
[chore] Adjust Puppet version

### DIFF
--- a/deployments/puppet/CHANGELOG.md
+++ b/deployments/puppet/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## Unreleased
 
-## puppet-v0.23.0
+## puppet-v0.22.0
+
+### 🧰 Bug fixes 🧰
+
+- Bug fix: Ensure the collector config directory ownership is set to the custom service user and group (if configured) rather than the default service owner (Linux only). 
 
 ### 💡 Enhancements 💡
 
 - Recursively set the ownership of collector config (`/etc/otel/collector`) and state (`/var/lib/otelcol`) directories to the configured service user and group on Linux.
-
-## puppet-v0.22.0
-
-- Bug fix: Ensure the collector config directory ownership is set to the custom service user and group (if configured) rather than the default service owner (Linux only) 
 
 ## puppet-v0.21.0
 

--- a/deployments/puppet/metadata.json
+++ b/deployments/puppet/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx-splunk_otel_collector",
-  "version": "0.23.0",
+  "version": "0.22.0",
   "author": "Splunk, Inc.",
   "summary": "This module installs the Splunk OpenTelemetry Collector via distro packages and configures it.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Adjust Puppet version to follow the versions published to https://splunk.jfrog.io/ui/repos/tree/General/puppet-splunk/signalfx/splunk_otel_collector

This should be merged only after #7990

Merging this PR will trigger the creation of the tag `puppet-v0.22.0` given the change at `deployments/puppet/metadata.json`, triggering a new publication attempt via GitLab.

