### PR TITLE
[chore] Generate baseline component set from ocb manifest

### DIFF
--- a/baseline/.gitignore
+++ b/baseline/.gitignore
@@ -1,0 +1,8 @@
+# ocb scratch output: `go generate` runs the OpenTelemetry Collector Builder into
+# this dir, rewrites it into components.go, then removes it. Only present if a
+# generate run was interrupted — never checked in.
+/internal/gen/ocb/
+
+# Compiled gen tool: a stray build artifact if the gen tool was `go build`-ed
+# here instead of `go run`. Never checked in.
+/gen

--- a/baseline/baseline.go
+++ b/baseline/baseline.go
@@ -15,9 +15,9 @@
 // Package baseline is the shared, upstream-only component set that every Splunk
 // OTel Collector flavor layers on top of.
 //
-// The component set lives in components.go. It is hand-maintained for now;
-// a follow-up adds an OpenTelemetry Collector Builder manifest and generator
-// that produce that file, after which it should not be edited by hand.
+// The component set is defined by builder-config.yaml (an OpenTelemetry
+// Collector Builder manifest) and generated into components.go by
+// `go generate ./...`. Edit the manifest, not the generated Go.
 //
 // A flavor composes its component set by starting from NewBaseline, adding its
 // own factories through the Add* methods, and calling Build:

--- a/baseline/builder-config.yaml
+++ b/baseline/builder-config.yaml
@@ -1,0 +1,163 @@
+# OCB baseline manifest — the SOURCE OF TRUTH for the shared baseline component set.
+#
+# This manifest generates baseline/components.go (the NewBaseline API) via
+# `go generate ./...` in this module: the OpenTelemetry Collector Builder (ocb)
+# renders a factory list from this file, which is then rewrapped into the public
+# baseline package. Edit this file to change the baseline; never hand-edit the
+# generated Go.
+#
+# It contains ONLY upstream core + contrib components supported by Splunk OTel
+# Collector distributions. Components specific to each flavor layered onto
+# the baseline in Go by the consuming module (see internal/components in
+# the root repo). Six of them live under internal/ and cannot be referenced
+# from an OCB manifest anyway.
+#
+# The version on each line is kept in sync with baseline/go.mod automatically by
+# ../update-deps. Don't bump versions here by hand. Editing the component *set*
+# (adding/removing a line) still requires `go generate ./...` to regenerate
+# components.go.
+
+dist:
+  name: otelcol-baseline
+  description: Shared baseline for Splunk OTel Collector flavors
+  otelcol_version: 0.159.0
+  output_path: ./internal/gen/ocb
+
+extensions:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/dbauth/awsiamdbauthextension v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension v0.159.0
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.159.0
+
+receivers:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dnscheckreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/icmpcheckreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver v0.159.0
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ntpreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver v0.159.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcpcheckreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.159.0
+
+processors:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.159.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor v0.159.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.159.0
+
+exporters:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.159.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.159.0
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.159.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.159.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.159.0
+
+connectors:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.159.0
+  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.159.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector v0.159.0

--- a/baseline/components.go
+++ b/baseline/components.go
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The baseline component set. Hand-maintained until a follow-up adds the
-// generator that produces this file from an ocb manifest.
+// Code generated from builder-config.yaml by "go generate"; DO NOT EDIT.
 
 package baseline
 

--- a/baseline/gen.go
+++ b/baseline/gen.go
@@ -1,0 +1,26 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package baseline
+
+// Regenerate components.go from builder-config.yaml. The OpenTelemetry
+// Collector Builder (ocb) renders a factory list into ./internal/gen/ocb, the
+// gen tool rewrites it into the public NewBaseline API, and the ocb scratch
+// output is removed. Requires `builder` (ocb) on PATH:
+//
+//	go install go.opentelemetry.io/collector/cmd/builder@latest
+//
+//go:generate builder --config builder-config.yaml --skip-compilation --skip-get-modules
+//go:generate go run ./internal/gen ./internal/gen/ocb/components.go components.go
+//go:generate rm -rf ./internal/gen/ocb

--- a/baseline/internal/gen/main.go
+++ b/baseline/internal/gen/main.go
@@ -1,0 +1,229 @@
+// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command gen transforms the OpenTelemetry Collector Builder (ocb) output into
+// the public baseline API. ocb emits a throwaway `package main` with an
+// unexported components() func that assembles factories via MakeFactoryMap; this
+// tool rewrites that into `package baseline`'s NewBaseline() constructor, which
+// returns the raw factory slices so flavors can append to them before Build().
+//
+// It is invoked by `go generate` after ocb runs — see baseline/gen.go.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+)
+
+// kind maps the otelcol.Factories field name (as referenced in ocb's
+// components() body) to the unexported Baseline slice field the generated
+// literal populates and the component-kind package used for its element type
+// (e.g. Receivers -> receivers []receiver.Factory).
+var kinds = []struct{ factoriesField, field, pkg string }{
+	{"Extensions", "extensions", "extension"},
+	{"Receivers", "receivers", "receiver"},
+	{"Processors", "processors", "processor"},
+	{"Exporters", "exporters", "exporter"},
+	{"Connectors", "connectors", "connector"},
+}
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: gen <ocb-components.go> <out.go>")
+		os.Exit(2)
+	}
+	src, out := os.Args[1], os.Args[2]
+	if err := run(src, out); err != nil {
+		fmt.Fprintln(os.Stderr, "gen:", err)
+		os.Exit(1)
+	}
+}
+
+func run(src, out string) error {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, src, nil, parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("parse %s: %w", src, err)
+	}
+
+	// Collect the aliased factory imports (alias -> path). ocb aliases every
+	// component import; the bare kind packages (receiver, exporter, …) and
+	// otelcol come in unaliased and are handled separately.
+	factoryImports := map[string]string{} // alias -> path
+	for _, imp := range f.Imports {
+		if imp.Name == nil {
+			continue // unaliased: kind packages + otelcol, added by us as needed
+		}
+		path := strings.Trim(imp.Path.Value, `"`)
+		factoryImports[imp.Name.Name] = path
+	}
+
+	// Find components() and extract, per kind, the ordered list of factory
+	// expressions passed to <kind>.MakeFactoryMap(...).
+	lists := map[string][]string{} // field -> ["ackextension.NewFactory()", …]
+	used := map[string]bool{}      // aliases actually referenced
+	fn := findFunc(f, "components")
+	if fn == nil {
+		return fmt.Errorf("%s: func components() not found", src)
+	}
+	for _, stmt := range fn.Body.List {
+		as, ok := stmt.(*ast.AssignStmt)
+		if !ok || len(as.Lhs) != 2 || len(as.Rhs) != 1 {
+			continue
+		}
+		field := factoriesField(as.Lhs[0]) // "Receivers" from factories.Receivers
+		if field == "" {
+			continue
+		}
+		call, ok := as.Rhs[0].(*ast.CallExpr)
+		if !ok || !isMakeFactoryMap(call.Fun) {
+			continue
+		}
+		for _, arg := range call.Args {
+			expr := exprString(fset, arg)
+			lists[field] = append(lists[field], expr)
+			if alias := leadingIdent(arg); alias != "" {
+				used[alias] = true
+			}
+		}
+	}
+
+	return writeFile(out, factoryImports, used, lists)
+}
+
+func writeFile(out string, factoryImports map[string]string, used map[string]bool, lists map[string][]string) error {
+	var b bytes.Buffer
+	b.WriteString(`// Copyright Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated from builder-config.yaml by "go generate"; DO NOT EDIT.
+
+package baseline
+
+import (
+`)
+	// Kind packages used by the slice-literal element types.
+	for _, k := range kinds {
+		fmt.Fprintf(&b, "\t\"go.opentelemetry.io/collector/%s\"\n", k.pkg)
+	}
+	b.WriteString("\n")
+	// Aliased factory imports, sorted by alias, only those referenced.
+	var aliases []string
+	for a := range used {
+		aliases = append(aliases, a)
+	}
+	sort.Strings(aliases)
+	for _, a := range aliases {
+		fmt.Fprintf(&b, "\t%s %q\n", a, factoryImports[a])
+	}
+	b.WriteString(")\n\n")
+
+	b.WriteString("// NewBaseline returns the shared baseline component set: upstream collector\n")
+	b.WriteString("// core and contrib components only, with no Splunk-specific components. It is\n")
+	b.WriteString("// the common denominator every flavor layers onto and is not shipped on its own.\n")
+	b.WriteString("func NewBaseline() *Baseline {\n")
+	b.WriteString("\treturn &Baseline{\n")
+	for _, k := range kinds {
+		fmt.Fprintf(&b, "\t\t%s: []%s.Factory{\n", k.field, k.pkg)
+		for _, e := range lists[k.factoriesField] {
+			fmt.Fprintf(&b, "\t\t\t%s,\n", e)
+		}
+		b.WriteString("\t\t},\n")
+	}
+	b.WriteString("\t}\n}\n")
+
+	formatted, err := format.Source(b.Bytes())
+	if err != nil {
+		return fmt.Errorf("gofmt generated source: %w\n%s", err, b.String())
+	}
+	return os.WriteFile(out, formatted, 0o600)
+}
+
+func findFunc(f *ast.File, name string) *ast.FuncDecl {
+	for _, d := range f.Decls {
+		if fn, ok := d.(*ast.FuncDecl); ok && fn.Name.Name == name && fn.Body != nil {
+			return fn
+		}
+	}
+	return nil
+}
+
+// factoriesField returns "Receivers" for an lhs of the form `factories.Receivers`.
+func factoriesField(lhs ast.Expr) string {
+	sel, ok := lhs.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	if id, ok := sel.X.(*ast.Ident); !ok || id.Name != "factories" {
+		return ""
+	}
+	return sel.Sel.Name
+}
+
+// isMakeFactoryMap reports whether fun is `<pkg>.MakeFactoryMap`, allowing for
+// the generic call form `<pkg>.MakeFactoryMap[T](...)` that ocb emits (v0.159+),
+// where the callee is an index expression wrapping the selector.
+func isMakeFactoryMap(fun ast.Expr) bool {
+	switch e := fun.(type) {
+	case *ast.IndexExpr:
+		return isMakeFactoryMap(e.X)
+	case *ast.IndexListExpr:
+		return isMakeFactoryMap(e.X)
+	case *ast.SelectorExpr:
+		return e.Sel.Name == "MakeFactoryMap"
+	default:
+		return false
+	}
+}
+
+// leadingIdent returns the package alias of an expression like `foo.NewFactory()`.
+func leadingIdent(arg ast.Expr) string {
+	call, ok := arg.(*ast.CallExpr)
+	if !ok {
+		return ""
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	id, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return id.Name
+}
+
+func exprString(fset *token.FileSet, e ast.Expr) string {
+	var b bytes.Buffer
+	_ = format.Node(&b, fset, e)
+	return b.String()
+}

--- a/update-deps
+++ b/update-deps
@@ -57,3 +57,45 @@ for gomod in $( find "$REPO_DIR" -name "go.mod" | grep -v "/examples/" | sort );
     update_gomod "$gomod" "$CONTRIB_PKGS" "$CONTRIB_VERSION"
     make -C "$REPO_DIR" tidy-all
 done
+
+# The baseline module pins the same OTel modules a second time, as hardcoded
+# versions in builder-config.yaml (the ocb manifest that generates
+# components.go). The go get loop above only touched go.mod, so re-sync the
+# manifest from the bumped go.mod: rewrite otelcol_version and every
+# `- gomod: <module> <version>` line from the resolved go.mod version.
+# components.go carries no version strings, so a version-only bump needs no
+# regeneration; run `go generate ./...` in ./baseline only when the component
+# set itself changes.
+cd "$REPO_DIR/baseline"
+
+# otelcol_version is the ocb dist version — the collector release, matching
+# the go.opentelemetry.io/collector/otelcol module minus the leading "v".
+otelcol_ver="$( go list -m -f '{{.Version}}' go.opentelemetry.io/collector/otelcol )"
+
+tmp="$( mktemp )"
+while IFS= read -r line; do
+    case "$line" in
+        *"otelcol_version:"*)
+            # Preserve leading indentation, replace the value.
+            printf '%s%s\n' "${line%%otelcol_version:*}" "otelcol_version: ${otelcol_ver#v}"
+            ;;
+        *"- gomod:"*)
+            # Line shape: "  - gomod: <module> <version>". Re-resolve
+            # <version> from go.mod; leave untouched if not a dependency.
+            mod="$( printf '%s\n' "$line" | awk '{print $3}' )"
+            ver="$( go list -m -f '{{.Version}}' "$mod" 2>/dev/null || true )"
+            if [ -n "$ver" ]; then
+                printf '%s- gomod: %s %s\n' "${line%%- gomod:*}" "$mod" "$ver"
+            else
+                printf '%s\n' "$line"
+            fi
+            ;;
+        *)
+            printf '%s\n' "$line"
+            ;;
+    esac
+done < builder-config.yaml > "$tmp"
+mv "$tmp" builder-config.yaml
+echo ">>> Synced builder-config.yaml versions to go.mod (otelcol_version: ${otelcol_ver#v})"
+
+cd "$CUR_DIR"


### PR DESCRIPTION
Follow-up to #7984. Switches `baseline/components.go` from hand-maintained to generated from an ocb manifest.

`builder-config.yaml` is now the source of truth for the baseline set. `go generate ./...` in the `baseline` module runs the OpenTelemetry Collector Builder into a scratch dir (`internal/gen/ocb`), the gen tool (`baseline/internal/gen`) rewrites ocb's throwaway `components()` into the public `NewBaseline()` constructor returning the raw factory slices, and the scratch output is removed. `components.go` now carries the `DO NOT EDIT` header; edit the manifest, not the Go.

`update-deps` re-syncs `builder-config.yaml` versions from the bumped `go.mod` after the `go get` sweep. `otelcol_version` and every `- gomod: <module> <version>` line are re-resolved from `go.mod`, so a version-only upgrade needs no regeneration. Regenerate with `go generate ./...` only when the component set itself changes.

No behavior change: the generated component set is byte-for-byte identical to the file that shipped in #7984 (verified by regenerating against ocb v0.159.0 and diffing).

## Related issues
- Follows #7984
- Part of #7954