### PR TITLE
[chore] Fix component stability doc

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -50,7 +50,7 @@ The distribution offers support for the following components.
 | [kafka](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkareceiver)                                                        | [beta]           |
 | [kafka_metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkametricsreceiver)                                         | [beta]           |
 | [kubelet_stats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver)                                         | [beta]           |
-| [lightprometheus](../internal/receiver/lightprometheusreceiver)                                                                                                    | [in development] |
+| [lightprometheus](../internal/receiver/lightprometheusreceiver)                                                                                                    | [deprecated] |
 | [memcached](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/memcachedreceiver)                                                | [beta]           |
 | [mongodb](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/mongodbreceiver)                                                    | [beta]           |
 | [mongodb_atlas](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/mongodbatlasreceiver)                                         | [beta]           |


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`lightPrometheus` receiver is deprecated https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/lightprometheusreceiver#light-prometheus-receiver, just fixing components.md with the correct stability.
