### PR TITLE
Set syslog identifier to otelcol for Linux journald logs

### DIFF
--- a/.chloggen/fix-syslog-identifier.yaml
+++ b/.chloggen/fix-syslog-identifier.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: packaging
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Set syslog identifier to otelcol to ensure Linux journald logs continue outputting with same tag as before.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/fix-syslog-identifier.yaml
+++ b/.chloggen/fix-syslog-identifier.yaml
@@ -8,7 +8,7 @@ component: packaging
 note: Set syslog identifier to otelcol to ensure Linux journald logs continue outputting with same tag as before.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [8012]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/packaging/fpm/splunk-otel-collector.service
+++ b/packaging/fpm/splunk-otel-collector.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 EnvironmentFile=/etc/otel/collector/splunk-otel-collector.conf
 ExecStart=/usr/bin/otelcollauncher $OTELCOL_OPTIONS
+SyslogIdentifier=otelcol
 KillMode=mixed
 Restart=on-failure
 Type=simple


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Issue was raised by support when running latest `v0.159.0` collector: 
> it changes the journald tag under which the collector logs from "otelcol" to "otelcollauncher". That had me scratching my head for 5 minutes, as journalctl -t otelcol no longer works

With the launcher as the new entrypoint, even though we use `exec` in Linux to replace the launcher process, the syslog identifier still uses the launcher process for tagging journald logs. Setting the syslog identifier to `otelcol` to ensure logs keep the same tag as before. Windows doesn't have this issue as event log uses the service name (which remained the same).

**Testing:** <Describe what testing was performed and which tests were added.>
- Build and ran local package, verified log output with `sudo journalctl -t otelcol`
```
// Direct collector mode
Sep 01 14:35:31 ubuntu2204.MJW401 otelcol[35705]: 2026-09-01T14:35:31.874-0700        info        service@v0.159.0/service.go:259        Starting otelcol...        {"resource": {"otelcol.service.mode": "agent", "service.instance.id": "3b5fedf2-cc14-4753-9ca6-301d8722d9b0", "service.name": "otelcol", "service.version": "09.01.1-dev"}, "Version": "09.01.1-dev", "NumCPU": 2}
Sep 01 14:35:31 ubuntu2204.MJW401 otelcol[35705]: 2026-09-01T14:35:31.875-0700        info        extensions/extensions.go:44        Starting extensions...        {"resource": {"otelcol.service.mode": "agent", "service.instance.id": "3b5fedf2-cc14-4753-9ca6-301d8722d9b0", "service.name": "otelcol", "service.version": "09.01.1-dev"}}

// OpAMP Supervisor mode
Sep 01 14:39:04 ubuntu2204.MJW401 otelcol[35749]: 2026-09-01T14:39:04.343-0700        info        supervisor.collector        commander/commander.go:197        {"level":"info","ts":"2026-09-01T14:39:04.343-0700","caller":"service@v0.159.0/service.go:282","msg":"Everything is ready. Begin running and processing data.","resource":{"host.arch":"amd64","host.name":"ubuntu2204.MJW401","os.description":"Ubuntu 22.04","os.type":"linux","otelcol.service.mode":"agent","service.instance.id":"01a05ee8-ffc4-7230-93f4-92f1941f2734","service.name":"otelcol","service.version":"09.01.1-dev"}}
Sep 01 14:39:04 ubuntu2204.MJW401 otelcol[35749]: 2026-09-01T14:39:04.349-0700        info        supervisor        supervisor/supervisor.go:1053        Connected to the OpAMP server.
```