### PR TITLE
Fix flaky TestRunStartsAndStopsOnSignal race condition

### DIFF
--- a/.chloggen/fix-early-signal-handler.yaml
+++ b/.chloggen/fix-early-signal-handler.yaml
@@ -1,0 +1,3 @@
+change_type: bug_fix
+component: splunk-connect-for-otlp
+note: Register SIGTERM/SIGINT signal handler early in startup, before blocking auth calls, to ensure graceful shutdown even on slow CI runners.

--- a/.chloggen/fix-early-signal-handler.yaml
+++ b/.chloggen/fix-early-signal-handler.yaml
@@ -1,3 +1,4 @@
 change_type: bug_fix
 component: splunk-connect-for-otlp
 note: Register SIGTERM/SIGINT signal handler early in startup, before blocking auth calls, to ensure graceful shutdown even on slow CI runners.
+issues: [8028]

--- a/.chloggen/fix-early-signal-handler.yaml
+++ b/.chloggen/fix-early-signal-handler.yaml
@@ -1,4 +1,4 @@
 change_type: bug_fix
 component: splunk-connect-for-otlp
-note: Register SIGTERM/SIGINT signal handler early in startup, before blocking auth calls, to ensure graceful shutdown even on slow CI runners.
+note: Register SIGTERM/SIGINT signal handler early in startup, before blocking auth calls.
 issues: [8028]

--- a/cmd/splunk-connect-for-otlp/host.go
+++ b/cmd/splunk-connect-for-otlp/host.go
@@ -29,7 +29,6 @@ func newTtyHost(extensions map[component.ID]component.Component) *ttyHost {
 		ErrStatus:  make(chan error, 1),
 		Extensions: extensions,
 	}
-	// Register signal handler early, before any blocking operations.
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
@@ -40,7 +39,6 @@ func newTtyHost(extensions map[component.ID]component.Component) *ttyHost {
 }
 
 func (t *ttyHost) Start() {
-	// Signal handler is now registered in the constructor.
 }
 
 func (t *ttyHost) Wait() error {

--- a/cmd/splunk-connect-for-otlp/host.go
+++ b/cmd/splunk-connect-for-otlp/host.go
@@ -24,13 +24,23 @@ type ttyHost struct {
 	shutdownOnce sync.Once
 }
 
-func (t *ttyHost) Start() {
+func newTtyHost(extensions map[component.ID]component.Component) *ttyHost {
+	t := &ttyHost{
+		ErrStatus:  make(chan error, 1),
+		Extensions: extensions,
+	}
+	// Register signal handler early, before any blocking operations.
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigs
 		t.Report(componentstatus.NewEvent(componentstatus.StatusStopping))
 	}()
+	return t
+}
+
+func (t *ttyHost) Start() {
+	// Signal handler is now registered in the constructor.
 }
 
 func (t *ttyHost) Wait() error {

--- a/cmd/splunk-connect-for-otlp/main.go
+++ b/cmd/splunk-connect-for-otlp/main.go
@@ -133,18 +133,17 @@ func run() error {
 
 	logger.Info("Configured OTLP receiver")
 
+	// Create host and register signal handler early, before blocking auth.New() call.
+	h := newTtyHost(map[component.ID]component.Component{})
+	h.Start()
+
 	var authExtension extension.Extension
 	if authExtension, err = auth.New(ctx, settings, xmlCfg.ServerURI, xmlCfg.SessionKey); err != nil {
 		return err
 	}
 
-	h := &ttyHost{
-		ErrStatus: make(chan error, 1),
-		Extensions: map[component.ID]component.Component{
-			extID: authExtension,
-		},
-	}
-	h.Start()
+	// Add auth extension to host after it's created.
+	h.Extensions[extID] = authExtension
 
 	if errStart := errors.Join(le.Start(ctx, h), me.Start(ctx, h), tracesExporter.Start(ctx, h), r.Start(ctx, h)); errStart != nil {
 		return errStart

--- a/cmd/splunk-connect-for-otlp/main.go
+++ b/cmd/splunk-connect-for-otlp/main.go
@@ -133,7 +133,6 @@ func run() error {
 
 	logger.Info("Configured OTLP receiver")
 
-	// Create host and register signal handler early, before blocking auth.New() call.
 	h := newTtyHost(map[component.ID]component.Component{})
 	h.Start()
 
@@ -142,7 +141,6 @@ func run() error {
 		return err
 	}
 
-	// Add auth extension to host after it's created.
 	h.Extensions[extID] = authExtension
 
 	if errStart := errors.Join(le.Start(ctx, h), me.Start(ctx, h), tracesExporter.Start(ctx, h), r.Start(ctx, h)); errStart != nil {


### PR DESCRIPTION
Register SIGTERM/SIGINT signal handler early in startup, before the blocking auth.New() HTTP call. Previously the handler was installed in h.Start() after auth.New(), creating a race window where a signal during the auth call would kill the process instead of triggering graceful shutdown.

On loaded CI runners, this window is wide enough to cause intermittent test failures. Moving signal registration to the ttyHost constructor ensures the handler is always in place before any blocking operations.