### PR TITLE
Fix Windows unit-test panic in splunk_inputs receiver

### DIFF
--- a/pkg/receiver/splunkinputsreceiver/receiver.go
+++ b/pkg/receiver/splunkinputsreceiver/receiver.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fsnotify/fsnotify"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
@@ -22,7 +21,7 @@ const debounceDuration = 500 * time.Millisecond
 
 type splunkInputsReceiver struct {
 	handler    *observerHandler
-	watcher    *fsnotify.Watcher
+	watcher    fileWatcher
 	doneCh     chan struct{}
 	splunkHome string
 }
@@ -46,7 +45,7 @@ func (r *splunkInputsReceiver) Start(ctx context.Context, host component.Host) e
 		return addErr
 	}
 
-	watcher, err := fsnotify.NewWatcher()
+	watcher, err := newFSNotifyWatcher()
 	if err != nil {
 		return err
 	}
@@ -89,7 +88,7 @@ func (r *splunkInputsReceiver) watchLoop(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case event, ok := <-r.watcher.Events:
+		case event, ok := <-r.watcher.Events():
 			if !ok {
 				return
 			}
@@ -121,7 +120,7 @@ func (r *splunkInputsReceiver) watchLoop(ctx context.Context) {
 				}
 			}
 			debounce = time.After(debounceDuration)
-		case err, ok := <-r.watcher.Errors:
+		case err, ok := <-r.watcher.Errors():
 			if !ok {
 				return
 			}

--- a/pkg/receiver/splunkinputsreceiver/receiver_test.go
+++ b/pkg/receiver/splunkinputsreceiver/receiver_test.go
@@ -24,6 +24,41 @@ type testNopConsumer struct{}
 func (testNopConsumer) Capabilities() consumer.Capabilities          { return consumer.Capabilities{} }
 func (testNopConsumer) ConsumeLogs(context.Context, plog.Logs) error { return nil }
 
+// fakeWatcher is an in-memory fileWatcher for unit tests. It records the paths
+// passed to Add so reconcile can be exercised without spinning fsnotify's
+// background OS watcher, which panics on Windows under fsnotify v1.10.1.
+type fakeWatcher struct {
+	added  map[string]struct{}
+	events chan fsnotify.Event
+	errors chan error
+}
+
+func newFakeWatcher() *fakeWatcher {
+	return &fakeWatcher{
+		added:  map[string]struct{}{},
+		events: make(chan fsnotify.Event),
+		errors: make(chan error),
+	}
+}
+
+func (f *fakeWatcher) Add(name string) error {
+	f.added[name] = struct{}{}
+	return nil
+}
+
+func (f *fakeWatcher) Close() error { return nil }
+
+func (f *fakeWatcher) WatchList() []string {
+	list := make([]string, 0, len(f.added))
+	for name := range f.added {
+		list = append(list, name)
+	}
+	return list
+}
+
+func (f *fakeWatcher) Events() <-chan fsnotify.Event { return f.events }
+func (f *fakeWatcher) Errors() <-chan error          { return f.errors }
+
 // mockReceiver is a mock receiver.Logs that tracks Start and Shutdown calls.
 type mockReceiver struct {
 	startCount    int
@@ -71,19 +106,15 @@ func makeTA(t *testing.T, splunkHome, taName string) string {
 }
 
 // newTestSplunkInputsReceiver builds a splunkInputsReceiver wired with the given mock factory
-// and a real (but idle) fsnotify watcher so reconcile can call watcher.Add without panicking.
-func newTestSplunkInputsReceiver(t *testing.T, splunkHome string, factory *mockSubReceiverFactory) *splunkInputsReceiver {
-	t.Helper()
+// and a fake watcher so reconcile can call watcher.Add without spinning a real OS watcher.
+func newTestSplunkInputsReceiver(_ *testing.T, splunkHome string, factory *mockSubReceiverFactory) *splunkInputsReceiver {
 	options := newFactoryOptions(WithSubReceiver(factory))
 	settings := receiver.Settings{
 		ID:                component.MustNewID("splunk_inputs"),
 		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
 	}
-	watcher, err := fsnotify.NewWatcher()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = watcher.Close() })
 	r := newSplunkInputsReceiver(splunkHome, options, settings, testNopConsumer{})
-	r.watcher = watcher
+	r.watcher = newFakeWatcher()
 	return r
 }
 

--- a/pkg/receiver/splunkinputsreceiver/watcher.go
+++ b/pkg/receiver/splunkinputsreceiver/watcher.go
@@ -1,0 +1,41 @@
+// Copyright Splunk, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package splunkinputsreceiver
+
+import (
+	"github.com/fsnotify/fsnotify"
+)
+
+// fileWatcher abstracts the subset of *fsnotify.Watcher the receiver uses.
+// It lets tests drive reconcile logic with a fake instead of a real OS
+// watcher, which avoids spinning fsnotify's background I/O goroutine during
+// unit tests.
+type fileWatcher interface {
+	Add(name string) error
+	Close() error
+	WatchList() []string
+	Events() <-chan fsnotify.Event
+	Errors() <-chan error
+}
+
+// fsnotifyWatcher adapts *fsnotify.Watcher to fileWatcher. The Events and
+// Errors channels are exposed as accessor methods because fsnotify exposes
+// them as struct fields.
+type fsnotifyWatcher struct {
+	w *fsnotify.Watcher
+}
+
+func newFSNotifyWatcher() (*fsnotifyWatcher, error) {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	return &fsnotifyWatcher{w: w}, nil
+}
+
+func (f *fsnotifyWatcher) Add(name string) error         { return f.w.Add(name) }
+func (f *fsnotifyWatcher) Close() error                  { return f.w.Close() }
+func (f *fsnotifyWatcher) WatchList() []string           { return f.w.WatchList() }
+func (f *fsnotifyWatcher) Events() <-chan fsnotify.Event { return f.w.Events }
+func (f *fsnotifyWatcher) Errors() <-chan error          { return f.w.Errors }


### PR DESCRIPTION
The `splunk_inputs` receiver unit tests fail on both Windows amd64 (`test-windows-2025`) and arm64 (`test-windows-11-arm`) with a hard panic:

```
panic: windows: string with NUL passed to StringToUTF16
fsnotify.(*readDirChangesW).getDir -> StringToUTF16Ptr
fsnotify.(*readDirChangesW).addWatch
fsnotify.(*readDirChangesW).readEvents
```

`TestReconcile` builds the receiver with a real `fsnotify.NewWatcher()` and drives `Add`/`WatchList` against it. On Windows under fsnotify v1.10.1 that crashes inside fsnotify's background `readEvents` goroutine, taking down the whole test binary. v1.10.1 is the latest release, so there is no version to bump to, and v1.9.0 reintroduces the Windows race that 1.10.0 fixed.

`reconcile` is pure logic and shouldn't depend on a live OS watcher. This puts the watcher behind a small `fileWatcher` interface, wraps fsnotify for production (`fsnotifyWatcher`), and injects an in-memory `fakeWatcher` in the unit tests. The tests now run deterministically on all platforms without spinning fsnotify.

No production behavior change: `fsnotifyWatcher` is a thin pass-through, and `splunk_inputs` remains gated behind the alpha `enableTARunner` feature gate at development stability.