### PR TITLE
[chore] Re-enable nightly deps update

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -285,6 +285,16 @@ update-otel-deps:
     - .gitlab/install-gh-cli.sh
     - .gitlab/update-otel-deps.sh latest create-pull-request/update-deps
 
+update-otel-deps-nightly:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  extends: .go-cache
+  tags: [large]
+  needs: []
+  script:
+    - .gitlab/install-gh-cli.sh
+    - .gitlab/update-otel-deps.sh main create-pull-request/update-deps-nightly
+
 update-javaagent:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"


### PR DESCRIPTION
## Summary
- Restore the scheduled CI job to update OpenTelemetry dependencies from `main` nightly, see https://github.com/signalfx/splunk-otel-collector/pull/7657
