### PR TITLE
feat: run otel on dedicated Windows service user

### DIFF
--- a/.chloggen/windows-service-user.yaml
+++ b/.chloggen/windows-service-user.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: installer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Run OTel collector on dedicated service user instead of LocalSystem
+
+# One or more tracking issues related to the change
+issues: [8048]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Use a dedicated Windows virtual service account, NT SERVICE\splunk-otel-collector, for fresh Collector MSI installations.
+  Upgrades preserve the existing account by default and warn with the explicit migration command when remaining on LocalSystem.
+  Provision only receiver-required access for the virtual account: performance counters, Windows event logs including Security,
+  default file-log sources, and file-storage checkpoints.

--- a/cmd/otelcol/config/collector/splunk_logs_config_windows.yaml
+++ b/cmd/otelcol/config/collector/splunk_logs_config_windows.yaml
@@ -361,7 +361,7 @@ extensions:
     directory: "${ProgramData}/Splunk/OpenTelemetry Collector/FileStorage"
     compaction:
       on_start: true
-      directory: ${env:TEMP}
+      directory: "${ProgramData}/Splunk/OpenTelemetry Collector/FileStorage/Temp"
     create_directory: true
 
 service:

--- a/packaging/installer/install.ps1
+++ b/packaging/installer/install.ps1
@@ -111,6 +111,12 @@
     For information about the public MSI properties see https://learn.microsoft.com/en-us/windows/win32/msi/property-reference#configuration-properties
     .EXAMPLE
     .\install.ps1 -access_token "ACCESSTOKEN" -msi_public_properties "ARPCOMMENTS=DO_NOT_UNINSTALL" 
+.PARAMETER service_account_type
+    (OPTIONAL) Select the Windows service account type: `virtual` uses the dedicated, passwordless
+    `NT SERVICE\splunk-otel-collector` virtual account and `localsystem` uses LocalSystem. If omitted,
+    a fresh install uses the dedicated account and an upgrade preserves its current account.
+    .EXAMPLE
+    .\install.ps1 -access_token "ACCESSTOKEN" -service_account_type virtual
 .PARAMETER config_path
     (OPTIONAL) Specify a local path to an alternative configuration file for the Splunk OpenTelemetry Collector.
     If specified, the -mode parameter will be ignored.
@@ -154,6 +160,7 @@ param(
     [ValidateSet('test', 'beta', 'release')][string]$stage = "release",
     [string]$msi_path = "",
     [string]$msi_public_properties = "",
+    [string]$service_account_type = "",
     [string]$config_path = "",
     [bool]$preserve_prev_default_config = $false,
     [string]$collector_msi_url = "",
@@ -180,6 +187,12 @@ else {
 $format = "msi"
 $service_name = "splunk-otel-collector"
 $signalfx_dl = "https://dl.observability.splunkcloud.com"
+$virtual_service_account = "NT SERVICE\splunk-otel-collector"
+$previous_service_account = ""
+
+if ($service_account_type -ne "" -and $service_account_type -notin @("virtual", "localsystem")) {
+    throw "service_account_type must be either 'virtual' or 'localsystem'."
+}
 
 try {
     Resolve-Path $env:TEMP 2>&1>$null
@@ -512,6 +525,17 @@ if (-not (Get-Service -Name $service_name -ErrorAction SilentlyContinue)) {
 else {
     if (-not $uninstall_collector) {
         Write-Host "The $service_name service is already installed. Checking installation for automatic update."
+
+        $existing_service_account = (Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$service_name" -Name ObjectName).ObjectName
+        if ($existing_service_account -eq "LocalSystem" -or $existing_service_account -eq "NT AUTHORITY\SYSTEM") {
+            $previous_service_account = "LocalSystem"
+        }
+        elseif ($existing_service_account -eq $virtual_service_account) {
+            $previous_service_account = $virtual_service_account
+        }
+        elseif ($service_account_type -eq "") {
+            throw "The existing $service_name service uses '$existing_service_account'. Its password cannot be preserved by the installer. Rerun with -service_account_type virtual or -service_account_type localsystem."
+        }
     }
 
     $uninstall_collector_using_msi = $true
@@ -671,6 +695,13 @@ if ($PSBoundParameters.ContainsKey("access_token")) {
     $msi_public_properties = add_msi_public_property -properties $msi_public_properties -name "SPLUNK_ACCESS_TOKEN" -value $access_token
 }
 
+if ($service_account_type -ne "") {
+    $msi_public_properties = add_msi_public_property -properties $msi_public_properties -name "SPLUNK_SERVICE_ACCOUNT_TYPE" -value $service_account_type
+}
+elseif ($previous_service_account -ne "") {
+    $msi_public_properties = add_msi_public_property -properties $msi_public_properties -name "SPLUNK_PREVIOUS_SERVICE_ACCOUNT" -value $previous_service_account
+}
+
 if ($config_path -Ne "") {
     if (!(Test-Path -Path "$config_path")) {
         throw "Valid Collector configuration file not found at $config_path."
@@ -713,6 +744,10 @@ changes by restarting the system or running the following PowerShell commands:
   PS> Start-Service $service_name
 "
 echo "$message"
+
+if ($service_account_type -eq "" -and $previous_service_account -eq "LocalSystem") {
+    Write-Warning "The $CollectorServiceDisplayName service remains configured as LocalSystem. To use the dedicated service account, run: msiexec.exe /i `"$msi_path`" /qn SPLUNK_SERVICE_ACCOUNT_TYPE=virtual"
+}
 
 $otel_resource_attributes = ""
 if ($deployment_env -ne "") {

--- a/packaging/msi/SplunkCustomActions/src/AssemblyInfo.cs
+++ b/packaging/msi/SplunkCustomActions/src/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SplunkCustomActionsTests")]

--- a/packaging/msi/SplunkCustomActions/src/CustomActions.cs
+++ b/packaging/msi/SplunkCustomActions/src/CustomActions.cs
@@ -16,6 +16,86 @@ using WixToolset.Dtf.WindowsInstaller;
 
 public class CustomActions
 {
+    [CustomAction]
+    public static ActionResult DetectExistingServiceAccount(Session session)
+    {
+        if (session["REMOVE"] == "ALL")
+        {
+            return ActionResult.Success;
+        }
+
+        string existingAccount = session["SPLUNK_PREVIOUS_SERVICE_ACCOUNT"];
+        if (string.IsNullOrWhiteSpace(existingAccount))
+        {
+            existingAccount = ServiceAccountConfiguration.GetExistingServiceAccount();
+        }
+
+        session["DETECTED_SERVICE_ACCOUNT"] = existingAccount;
+        if (!string.IsNullOrWhiteSpace(existingAccount))
+        {
+            session.Log($"Info: Detected existing Splunk OpenTelemetry Collector service account: {existingAccount}");
+            try
+            {
+                ServiceAccountConfiguration.SelectAccount(session["SPLUNK_SERVICE_ACCOUNT_TYPE"], existingAccount);
+            }
+            catch (InvalidOperationException exception)
+            {
+                LogAndShowError(session, exception.Message);
+                return ActionResult.Failure;
+            }
+        }
+
+        return ActionResult.Success;
+    }
+
+    [CustomAction]
+    public static ActionResult ValidateServiceAccountType(Session session)
+    {
+        try
+        {
+            ServiceAccountConfiguration.ParseAccountType(session["SPLUNK_SERVICE_ACCOUNT_TYPE"]);
+            return ActionResult.Success;
+        }
+        catch (ArgumentException exception)
+        {
+            LogAndShowError(session, exception.Message);
+            return ActionResult.Failure;
+        }
+    }
+
+    [CustomAction]
+    public static ActionResult LogServiceAccountRecommendation(Session session)
+    {
+        if (string.IsNullOrWhiteSpace(session["SPLUNK_SERVICE_ACCOUNT_TYPE"]) &&
+            ServiceAccountConfiguration.IsLocalSystem(session["DETECTED_SERVICE_ACCOUNT"]))
+        {
+            session.Log("Warning: " + ServiceAccountConfiguration.LocalSystemRecommendation);
+        }
+
+        return ActionResult.Success;
+    }
+
+    [CustomAction]
+    public static ActionResult ConfigureServiceAccount(Session session)
+    {
+        try
+        {
+            string selectedAccount = ServiceAccountConfiguration.SelectAccount(
+                session.CustomActionData["SPLUNK_SERVICE_ACCOUNT_TYPE"],
+                session.CustomActionData["DETECTED_SERVICE_ACCOUNT"]);
+            ServiceAccountConfiguration.Configure(
+                selectedAccount,
+                session.CustomActionData["PROGRAMDATA"],
+                message => session.Log(message));
+            return ActionResult.Success;
+        }
+        catch (Exception exception)
+        {
+            session.Log("Error: " + exception.Message);
+            return ActionResult.Failure;
+        }
+    }
+
     /// <summary>
     /// Custom action to check if the launch conditions are met.
     /// </summary>

--- a/packaging/msi/SplunkCustomActions/src/ServiceAccountConfiguration.cs
+++ b/packaging/msi/SplunkCustomActions/src/ServiceAccountConfiguration.cs
@@ -1,0 +1,431 @@
+﻿// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Win32;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+internal enum ServiceAccountType
+{
+    Preserve,
+    LocalSystem,
+    Virtual,
+}
+
+internal static class ServiceAccountConfiguration
+{
+    internal const string ServiceName = "splunk-otel-collector";
+    internal const string VirtualAccountName = @"NT SERVICE\splunk-otel-collector";
+    internal const string LocalSystemAccountName = "LocalSystem";
+
+    private const uint ScManagerConnect = 0x0001;
+    private const uint ServiceChangeConfig = 0x0002;
+    private const uint ServiceNoChange = 0xffffffff;
+    private const uint ServiceConfigServiceSidInfo = 5;
+    private const uint ServiceSidTypeUnrestricted = 1;
+    private const uint PolicyCreateAccount = 0x0010;
+    private const uint PolicyLookupNames = 0x0800;
+    private const int ErrorMemberInAlias = 1378;
+    private const int ErrorNoSuchAlias = 1376;
+    private const int NerrGroupNotFound = 2220;
+
+    internal static ServiceAccountType ParseAccountType(string? accountType)
+    {
+        switch (accountType ?? string.Empty)
+        {
+            case "":
+                return ServiceAccountType.Preserve;
+            case "virtual":
+                return ServiceAccountType.Virtual;
+            case "localsystem":
+                return ServiceAccountType.LocalSystem;
+            default:
+                throw new ArgumentException("SPLUNK_SERVICE_ACCOUNT_TYPE must be empty, 'virtual', or 'localsystem'.", nameof(accountType));
+        }
+    }
+
+    internal static string SelectAccount(string? configuredAccountType, string? existingAccount)
+    {
+        string existingAccountName = existingAccount ?? string.Empty;
+        switch (ParseAccountType(configuredAccountType))
+        {
+            case ServiceAccountType.Virtual:
+                return VirtualAccountName;
+            case ServiceAccountType.LocalSystem:
+                return LocalSystemAccountName;
+            case ServiceAccountType.Preserve:
+                if (string.IsNullOrWhiteSpace(existingAccountName))
+                {
+                    return VirtualAccountName;
+                }
+
+                if (IsLocalSystem(existingAccountName))
+                {
+                    return LocalSystemAccountName;
+                }
+
+                if (string.Equals(existingAccountName, VirtualAccountName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return VirtualAccountName;
+                }
+
+                throw new InvalidOperationException(
+                    $"The existing service account '{existingAccountName}' cannot be preserved because Windows does not expose its password. " +
+                    "Set SPLUNK_SERVICE_ACCOUNT_TYPE to 'virtual' or 'localsystem' explicitly.");
+            default:
+                throw new InvalidOperationException("Unknown service account type.");
+        }
+    }
+
+    internal static bool IsLocalSystem(string accountName) =>
+        string.Equals(accountName, LocalSystemAccountName, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(accountName, @"NT AUTHORITY\SYSTEM", StringComparison.OrdinalIgnoreCase);
+
+    internal static string GetExistingServiceAccount()
+    {
+        using (RegistryKey? serviceKey = Registry.LocalMachine.OpenSubKey($@"SYSTEM\CurrentControlSet\Services\{ServiceName}"))
+        {
+            return serviceKey?.GetValue("ObjectName") as string ?? string.Empty;
+        }
+    }
+
+    internal static string LocalSystemRecommendation =>
+        "The Splunk OpenTelemetry Collector service remains configured as LocalSystem. " +
+        "To use the dedicated service account, run: msiexec.exe /i <path-to-splunk-otel-collector.msi> /qn SPLUNK_SERVICE_ACCOUNT_TYPE=virtual";
+
+    internal static void Configure(string selectedAccount, string programDataPath, Action<string> log)
+    {
+        ConfigureServiceAccount(selectedAccount);
+
+        if (!string.Equals(selectedAccount, VirtualAccountName, StringComparison.OrdinalIgnoreCase))
+        {
+            log($"Info: Splunk OpenTelemetry Collector service account is {selectedAccount}.");
+            return;
+        }
+
+        SetUnrestrictedServiceSid();
+        AddToLocalGroup("Performance Monitor Users", log);
+        AddToLocalGroup("Event Log Readers", log);
+
+        SecurityIdentifier serviceSid = ResolveVirtualAccountSid();
+        GrantSecurityEventLogPrivilege(serviceSid, log);
+        GrantFileAccess(
+            Path.Combine(programDataPath, "Splunk", "OpenTelemetry Collector"),
+            serviceSid,
+            FileSystemRights.ReadAndExecute,
+            true);
+
+        string fileStoragePath = Path.Combine(programDataPath, "Splunk", "OpenTelemetry Collector", "FileStorage");
+        GrantFileAccess(fileStoragePath, serviceSid, FileSystemRights.Modify, true);
+        GrantFileAccess(Path.Combine(fileStoragePath, "Temp"), serviceSid, FileSystemRights.Modify, true);
+
+        GrantDefaultFileLogAccess(serviceSid, log);
+        log($"Info: Configured dedicated service account {VirtualAccountName}.");
+    }
+
+    private static void ConfigureServiceAccount(string accountName)
+    {
+        string? password = string.Equals(accountName, VirtualAccountName, StringComparison.OrdinalIgnoreCase)
+            ? null
+            : string.Empty;
+        IntPtr scm = OpenSCManager(null, null, ScManagerConnect);
+        if (scm == IntPtr.Zero)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to open the Service Control Manager.");
+        }
+
+        try
+        {
+            IntPtr service = OpenService(scm, ServiceName, ServiceChangeConfig);
+            if (service == IntPtr.Zero)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), $"Failed to open the {ServiceName} service.");
+            }
+
+            try
+            {
+                if (!ChangeServiceConfig(
+                    service,
+                    ServiceNoChange,
+                    ServiceNoChange,
+                    ServiceNoChange,
+                    null,
+                    null,
+                    IntPtr.Zero,
+                    null,
+                    accountName,
+                    password,
+                    null))
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), $"Failed to configure {ServiceName} to run as {accountName}.");
+                }
+            }
+            finally
+            {
+                CloseServiceHandle(service);
+            }
+        }
+        finally
+        {
+            CloseServiceHandle(scm);
+        }
+    }
+
+    private static void SetUnrestrictedServiceSid()
+    {
+        IntPtr scm = OpenSCManager(null, null, ScManagerConnect);
+        if (scm == IntPtr.Zero)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to open the Service Control Manager.");
+        }
+
+        try
+        {
+            IntPtr service = OpenService(scm, ServiceName, ServiceChangeConfig);
+            if (service == IntPtr.Zero)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), $"Failed to open the {ServiceName} service.");
+            }
+
+            try
+            {
+                ServiceSidInfo sidInfo = new ServiceSidInfo { ServiceSidType = ServiceSidTypeUnrestricted };
+                IntPtr sidInfoPointer = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(ServiceSidInfo)));
+                try
+                {
+                    Marshal.StructureToPtr(sidInfo, sidInfoPointer, false);
+                    if (!ChangeServiceConfig2(service, ServiceConfigServiceSidInfo, sidInfoPointer))
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error(), $"Failed to configure an unrestricted service SID for {ServiceName}.");
+                    }
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(sidInfoPointer);
+                }
+            }
+            finally
+            {
+                CloseServiceHandle(service);
+            }
+        }
+        finally
+        {
+            CloseServiceHandle(scm);
+        }
+    }
+
+    private static void AddToLocalGroup(string groupName, Action<string> log)
+    {
+        LocalGroupMembersInfo3 member = new LocalGroupMembersInfo3 { DomainAndName = VirtualAccountName };
+        int result = NetLocalGroupAddMembers(null, groupName, 3, ref member, 1);
+        switch (result)
+        {
+            case 0:
+                log($"Info: Added {VirtualAccountName} to {groupName}.");
+                return;
+            case ErrorMemberInAlias:
+                log($"Info: {VirtualAccountName} is already a member of {groupName}.");
+                return;
+            case ErrorNoSuchAlias:
+            case NerrGroupNotFound:
+                log($"Warning: The local {groupName} group is unavailable. This is expected on a domain controller; grant the required receiver permissions explicitly.");
+                return;
+            default:
+                throw new Win32Exception(result, $"Failed to add {VirtualAccountName} to {groupName}.");
+        }
+    }
+
+    private static SecurityIdentifier ResolveVirtualAccountSid()
+    {
+        return (SecurityIdentifier)new NTAccount(VirtualAccountName).Translate(typeof(SecurityIdentifier));
+    }
+
+    private static void GrantSecurityEventLogPrivilege(SecurityIdentifier serviceSid, Action<string> log)
+    {
+        LsaObjectAttributes objectAttributes = new LsaObjectAttributes
+        {
+            Length = Marshal.SizeOf(typeof(LsaObjectAttributes)),
+        };
+        uint status = LsaOpenPolicy(IntPtr.Zero, ref objectAttributes, PolicyCreateAccount | PolicyLookupNames, out IntPtr policy);
+        if (status != 0)
+        {
+            throw new Win32Exception((int)LsaNtStatusToWinError(status), "Failed to open the local security policy.");
+        }
+
+        try
+        {
+            byte[] serviceSidBytes = new byte[serviceSid.BinaryLength];
+            serviceSid.GetBinaryForm(serviceSidBytes, 0);
+            IntPtr privilegeName = Marshal.StringToHGlobalUni("SeSecurityPrivilege");
+            try
+            {
+                LsaUnicodeString right = new LsaUnicodeString
+                {
+                    Buffer = privilegeName,
+                    Length = (ushort)("SeSecurityPrivilege".Length * sizeof(char)),
+                    MaximumLength = (ushort)(("SeSecurityPrivilege".Length + 1) * sizeof(char)),
+                };
+                status = LsaAddAccountRights(policy, serviceSidBytes, new[] { right }, 1);
+                if (status != 0)
+                {
+                    throw new Win32Exception((int)LsaNtStatusToWinError(status),
+                        $"Failed to grant SeSecurityPrivilege to {VirtualAccountName}.");
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(privilegeName);
+            }
+        }
+        finally
+        {
+            LsaClose(policy);
+        }
+
+        log($"Info: Granted SeSecurityPrivilege to {VirtualAccountName} for the Security event log receiver.");
+    }
+
+    private static void GrantDefaultFileLogAccess(SecurityIdentifier serviceSid, Action<string> log)
+    {
+        string windowsDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        GrantExistingFileAccess(Path.Combine(windowsDirectory, "System32", "DHCP"), serviceSid, true, log);
+        GrantExistingFileAccess(Path.Combine(windowsDirectory, "WindowsUpdate.log"), serviceSid, false, log);
+        GrantExistingFileAccess(Path.Combine(windowsDirectory, "debug", "netlogon.log"), serviceSid, false, log);
+        GrantExistingFileAccess(Path.Combine(windowsDirectory, "System32", "LogFiles", "Firewall"), serviceSid, true, log);
+    }
+
+    private static void GrantExistingFileAccess(string path, SecurityIdentifier serviceSid, bool isDirectory, Action<string> log)
+    {
+        if ((isDirectory && !Directory.Exists(path)) || (!isDirectory && !File.Exists(path)))
+        {
+            log($"Warning: Default file log path '{path}' does not exist; grant {VirtualAccountName} read access before enabling it.");
+            return;
+        }
+
+        GrantFileAccess(path, serviceSid, FileSystemRights.ReadAndExecute, isDirectory);
+    }
+
+    private static void GrantFileAccess(string path, SecurityIdentifier serviceSid, FileSystemRights rights, bool isDirectory)
+    {
+        if (isDirectory)
+        {
+            Directory.CreateDirectory(path);
+            DirectoryInfo directory = new DirectoryInfo(path);
+            DirectorySecurity security = directory.GetAccessControl();
+            security.AddAccessRule(new FileSystemAccessRule(
+                serviceSid,
+                rights,
+                InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                PropagationFlags.None,
+                AccessControlType.Allow));
+            directory.SetAccessControl(security);
+            return;
+        }
+
+        FileInfo file = new FileInfo(path);
+        FileSecurity fileSecurity = file.GetAccessControl();
+        fileSecurity.AddAccessRule(new FileSystemAccessRule(serviceSid, rights, AccessControlType.Allow));
+        file.SetAccessControl(fileSecurity);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ServiceSidInfo
+    {
+        public uint ServiceSidType;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct LocalGroupMembersInfo3
+    {
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string DomainAndName;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct LsaObjectAttributes
+    {
+        public int Length;
+        public IntPtr RootDirectory;
+        public IntPtr ObjectName;
+        public uint Attributes;
+        public IntPtr SecurityDescriptor;
+        public IntPtr SecurityQualityOfService;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct LsaUnicodeString
+    {
+        public ushort Length;
+        public ushort MaximumLength;
+        public IntPtr Buffer;
+    }
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr OpenSCManager(string? machineName, string? databaseName, uint desiredAccess);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr OpenService(IntPtr scm, string serviceName, uint desiredAccess);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool ChangeServiceConfig(
+        IntPtr service,
+        uint serviceType,
+        uint startType,
+        uint errorControl,
+        string? binaryPathName,
+        string? loadOrderGroup,
+        IntPtr tagId,
+        string? dependencies,
+        string? serviceStartName,
+        string? password,
+        string? displayName);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool ChangeServiceConfig2(IntPtr service, uint infoLevel, IntPtr info);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CloseServiceHandle(IntPtr serviceHandle);
+
+    [DllImport("Netapi32.dll", CharSet = CharSet.Unicode)]
+    private static extern int NetLocalGroupAddMembers(
+        string? serverName,
+        string groupName,
+        int level,
+        ref LocalGroupMembersInfo3 buffer,
+        int totalEntries);
+
+    [DllImport("advapi32.dll")]
+    private static extern uint LsaOpenPolicy(
+        IntPtr systemName,
+        ref LsaObjectAttributes objectAttributes,
+        uint desiredAccess,
+        out IntPtr policyHandle);
+
+    [DllImport("advapi32.dll")]
+    private static extern uint LsaAddAccountRights(
+        IntPtr policyHandle,
+        byte[] accountSid,
+        [In] LsaUnicodeString[] userRights,
+        uint countOfRights);
+
+    [DllImport("advapi32.dll")]
+    private static extern uint LsaNtStatusToWinError(uint status);
+
+    [DllImport("advapi32.dll")]
+    private static extern uint LsaClose(IntPtr objectHandle);
+}

--- a/packaging/msi/SplunkCustomActions/test/ServiceAccountConfigurationTests.cs
+++ b/packaging/msi/SplunkCustomActions/test/ServiceAccountConfigurationTests.cs
@@ -1,0 +1,57 @@
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+public class ServiceAccountConfigurationTests
+{
+    [Theory]
+    [InlineData("", ServiceAccountType.Preserve)]
+    [InlineData("virtual", ServiceAccountType.Virtual)]
+    [InlineData("localsystem", ServiceAccountType.LocalSystem)]
+    public void ParseAccountTypeAcceptsSupportedValues(string value, ServiceAccountType expected)
+    {
+        Assert.Equal(expected, ServiceAccountConfiguration.ParseAccountType(value));
+    }
+
+    [Fact]
+    public void ParseAccountTypeRejectsUnsupportedValue()
+    {
+        Assert.Throws<ArgumentException>(() => ServiceAccountConfiguration.ParseAccountType("domain-user"));
+    }
+
+    [Theory]
+    [InlineData("", "", ServiceAccountConfiguration.VirtualAccountName)]
+    [InlineData("", "LocalSystem", ServiceAccountConfiguration.LocalSystemAccountName)]
+    [InlineData("", "NT AUTHORITY\\SYSTEM", ServiceAccountConfiguration.LocalSystemAccountName)]
+    [InlineData("", "NT SERVICE\\splunk-otel-collector", ServiceAccountConfiguration.VirtualAccountName)]
+    [InlineData("virtual", "LocalSystem", ServiceAccountConfiguration.VirtualAccountName)]
+    [InlineData("localsystem", "NT SERVICE\\splunk-otel-collector", ServiceAccountConfiguration.LocalSystemAccountName)]
+    public void SelectAccountHandlesFreshInstallsUpgradesAndOverrides(string configuredType, string existingAccount, string expected)
+    {
+        Assert.Equal(expected, ServiceAccountConfiguration.SelectAccount(configuredType, existingAccount));
+    }
+
+    [Fact]
+    public void SelectAccountRequiresAnExplicitChoiceForAnUnsupportedExistingAccount()
+    {
+        Assert.Throws<InvalidOperationException>(() => ServiceAccountConfiguration.SelectAccount("", @"CONTOSO\collector"));
+    }
+
+    [Fact]
+    public void LocalSystemRecommendationHasTheExactMigrationCommand()
+    {
+        Assert.Contains(
+            "msiexec.exe /i <path-to-splunk-otel-collector.msi> /qn SPLUNK_SERVICE_ACCOUNT_TYPE=virtual",
+            ServiceAccountConfiguration.LocalSystemRecommendation);
+    }
+}

--- a/packaging/msi/splunk-otel-collector.wxs
+++ b/packaging/msi/splunk-otel-collector.wxs
@@ -21,12 +21,23 @@
       <!-- Load the Splunk custom actions -->
       <Binary Id="SplunkCustomActionsDll" SourceFile="$(sys.SOURCEFILEDIR)/SplunkCustomActions/bin/Release/SplunkCustomActions.CA.dll" />
       <CustomAction Id="CheckLaunchConditions" DllEntry="CheckLaunchConditions" Execute="immediate" BinaryRef="SplunkCustomActionsDll" />
+      <CustomAction Id="ValidateServiceAccountType" DllEntry="ValidateServiceAccountType" Execute="immediate" BinaryRef="SplunkCustomActionsDll" />
+      <CustomAction Id="DetectExistingServiceAccount" DllEntry="DetectExistingServiceAccount" Execute="immediate" BinaryRef="SplunkCustomActionsDll" />
+      <CustomAction Id="LogServiceAccountRecommendation" DllEntry="LogServiceAccountRecommendation" Execute="immediate" BinaryRef="SplunkCustomActionsDll" />
+      <CustomAction Id="ConfigureServiceAccountCustomActionData" Property="ConfigureServiceAccount" Value="SPLUNK_SERVICE_ACCOUNT_TYPE=[SPLUNK_SERVICE_ACCOUNT_TYPE];DETECTED_SERVICE_ACCOUNT=[DETECTED_SERVICE_ACCOUNT];PROGRAMDATA=[CommonAppDataFolder]" />
+      <CustomAction Id="ConfigureServiceAccount" DllEntry="ConfigureServiceAccount" Execute="deferred" Impersonate="no" BinaryRef="SplunkCustomActionsDll" />
       <CustomAction Id="AddOptionalConfigurationsCustomActionData" Property="AddOptionalConfigurations" Value="GODEBUG=[GODEBUG];GOMEMLIMIT=[GOMEMLIMIT];SPLUNK_GATEWAY_URL=[SPLUNK_GATEWAY_URL];SPLUNK_LISTEN_INTERFACE=[SPLUNK_LISTEN_INTERFACE];SPLUNK_MEMORY_LIMIT_MIB=[SPLUNK_MEMORY_LIMIT_MIB];SPLUNK_MEMORY_TOTAL_MIB=[SPLUNK_MEMORY_TOTAL_MIB];SPLUNK_OPAMP_SUPERVISOR_ENABLED=[SPLUNK_OPAMP_SUPERVISOR_ENABLED];SPLUNK_PLATFORM_URL=[SPLUNK_PLATFORM_URL];SPLUNK_PLATFORM_TOKEN=[SPLUNK_PLATFORM_TOKEN];SPLUNK_PLATFORM_LOGS_INDEX=[SPLUNK_PLATFORM_LOGS_INDEX];SPLUNK_PLATFORM_METRICS_INDEX=[SPLUNK_PLATFORM_METRICS_INDEX]" />
       <CustomAction Id="AddOptionalConfigurations" DllEntry="AddOptionalConfigurations" Execute="deferred" Impersonate="no" BinaryRef="SplunkCustomActionsDll" />
 
       <!-- Following name convention for this property to match upstream -->
       <!-- On upstream it is required and has a default value, here it is optional -->
       <Property Id="COLLECTOR_SVC_ARGS" Secure="yes" />
+
+      <!-- Selects the service identity for either a fresh install or an upgrade. -->
+      <Property Id="SPLUNK_SERVICE_ACCOUNT_TYPE" Secure="yes" />
+      <!-- Used only by install.ps1, which removes the old MSI before installing the new one. -->
+      <Property Id="SPLUNK_PREVIOUS_SERVICE_ACCOUNT" Secure="yes" />
+      <Property Id="DETECTED_SERVICE_ACCOUNT" Secure="yes" />
 
       <!-- SPLUNK setup control properties -->
       <Property Id="SPLUNK_SETUP_COLLECTOR_MODE" Value="agent" Secure="yes" />
@@ -52,6 +63,7 @@
 
       <Launch Condition="NOT SPLUNK_PLATFORM_URL OR SPLUNK_PLATFORM_TOKEN" Message="SPLUNK_PLATFORM_TOKEN is required when SPLUNK_PLATFORM_URL is set." />
       <Launch Condition="NOT SPLUNK_PLATFORM_TOKEN OR SPLUNK_PLATFORM_URL" Message="SPLUNK_PLATFORM_URL is required when SPLUNK_PLATFORM_TOKEN is set." />
+      <Launch Condition="NOT SPLUNK_SERVICE_ACCOUNT_TYPE OR SPLUNK_SERVICE_ACCOUNT_TYPE=&quot;virtual&quot; OR SPLUNK_SERVICE_ACCOUNT_TYPE=&quot;localsystem&quot;" Message="SPLUNK_SERVICE_ACCOUNT_TYPE must be empty, 'virtual', or 'localsystem'." />
 
       <CustomAction Id="SetDefaultConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="--config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\[SPLUNK_SETUP_COLLECTOR_MODE]_config.yaml&quot;" />
       <CustomAction Id="AppendDefaultConfigTo_COLLECTOR_SVC_ARGS" Property="COLLECTOR_SVC_ARGS" Value="[COLLECTOR_SVC_ARGS] --config &quot;[CommonAppDataFolder]Splunk\OpenTelemetry Collector\[SPLUNK_SETUP_COLLECTOR_MODE]_config.yaml&quot;" />
@@ -71,6 +83,9 @@
 
       <InstallExecuteSequence>
          <Custom Action="CheckLaunchConditions" After="LaunchConditions" />
+         <Custom Action="ValidateServiceAccountType" After="CheckLaunchConditions" Condition="NOT REMOVE=&quot;ALL&quot;" />
+         <Custom Action="DetectExistingServiceAccount" After="ValidateServiceAccountType" Condition="NOT REMOVE=&quot;ALL&quot;" />
+         <Custom Action="LogServiceAccountRecommendation" After="DetectExistingServiceAccount" Condition="NOT REMOVE=&quot;ALL&quot;" />
          <Custom Action="Set_SPLUNK_HEC_TOKEN" After="LaunchConditions" Condition="NOT SPLUNK_HEC_TOKEN" />
          <Custom Action="Set_SPLUNK_API_URL" After="LaunchConditions" Condition="NOT SPLUNK_API_URL" />
          <Custom Action="Set_SPLUNK_INGEST_URL" After="LaunchConditions" Condition="NOT SPLUNK_INGEST_URL" />
@@ -93,6 +108,8 @@
          <Custom Action="AddOptionalConfigurations" After="WriteRegistryValues" />
          <Custom Action="CopyConfig" After="InstallFiles" Condition="NOT CONFIG_FILE_EXISTS AND NOT Installed" />
          <Custom Action="DeleteProgramFilesConfig" After="CopyConfig" />
+         <Custom Action="ConfigureServiceAccountCustomActionData" Before="ConfigureServiceAccount" />
+         <Custom Action="ConfigureServiceAccount" After="InstallServices" Condition="NOT REMOVE=&quot;ALL&quot;" />
       </InstallExecuteSequence>
 
       <MajorUpgrade DowngradeErrorMessage="A later version of the Splunk OpenTelemetry Collector is already installed. Setup will now exit." />

--- a/tests/msi/msi_test.go
+++ b/tests/msi/msi_test.go
@@ -47,6 +47,11 @@ type msiTest struct {
 	skipSvcStop            bool
 }
 
+const (
+	localSystemServiceAccount = "LocalSystem"
+	virtualServiceAccount     = `NT SERVICE\splunk-otel-collector`
+)
+
 func TestMSI(t *testing.T) {
 	msiInstallerPath := getInstallerPath(t)
 
@@ -62,6 +67,13 @@ func TestMSI(t *testing.T) {
 			collectorMSIProperties: map[string]string{
 				"SPLUNK_ACCESS_TOKEN": "fakeToken",
 				"COLLECTOR_SVC_ARGS":  "--discovery --set=processors.batch.timeout=10s",
+			},
+		},
+		{
+			name: "localsystem-service-account",
+			collectorMSIProperties: map[string]string{
+				"SPLUNK_ACCESS_TOKEN":         "fakeToken",
+				"SPLUNK_SERVICE_ACCOUNT_TYPE": "localsystem",
 			},
 		},
 		{
@@ -551,6 +563,12 @@ func assertServiceConfiguration(t *testing.T, msiProperties map[string]string, s
 			return configErr == nil && runtimeConfigErr == nil
 		}, 10*time.Second, 500*time.Millisecond, "Supervisor configuration files were not created")
 	}
+
+	expectedServiceAccount := virtualServiceAccount
+	if msiProperties["SPLUNK_SERVICE_ACCOUNT_TYPE"] == "localsystem" {
+		expectedServiceAccount = localSystemServiceAccount
+	}
+	assert.Equal(t, expectedServiceAccount, svcConfig.ServiceStartName)
 }
 
 func optionalInstallPropertyOrDefault(msiProperties map[string]string, key, defaultValue string) string {

--- a/tests/windows-install-script/windows_install_script_test.go
+++ b/tests/windows-install-script/windows_install_script_test.go
@@ -64,6 +64,7 @@ func TestUpgradeAndUninstallFromNonMachineWideVersion(t *testing.T) {
 	t.Logf(" *** Installing old collector version %s", oldCollectorVersion)
 	installCollector(t, getTestDataFilePath(t, "install-before-platform-indexes.ps1"), oldCollectorVersion, "", zeroCodeArgs...)
 	verifyServiceExists(t, scm)
+	verifyServiceAccount(t, scm, "LocalSystem")
 	verifyServiceState(t, scm, svc.Running)
 	verifyZeroConfigResourceAttributes(t, 1, "deployment.environment=test")
 	legacySvcVersion := getCurrentServiceVersion(t)
@@ -76,6 +77,7 @@ func TestUpgradeAndUninstallFromNonMachineWideVersion(t *testing.T) {
 	t.Logf(" *** Installing collector from %q", msiInstallerPath)
 	installCollector(t, getFilePathFromEnvVar(t, "INSTALL_SCRIPT_PATH"), "", msiInstallerPath, zeroCodeArgs...)
 	verifyServiceExists(t, scm)
+	verifyServiceAccount(t, scm, "LocalSystem")
 	verifyServiceState(t, scm, svc.Running)
 	verifyZeroConfigResourceAttributes(t, 1, "deployment.environment.name=test")
 	latestSvcVersion := getCurrentServiceVersion(t)
@@ -206,6 +208,16 @@ func verifyServiceExists(t *testing.T, scm *mgr.Mgr) {
 	service, err := scm.OpenService(serviceName)
 	require.NoError(t, err)
 	service.Close()
+}
+
+func verifyServiceAccount(t *testing.T, scm *mgr.Mgr, expectedAccount string) {
+	service, err := scm.OpenService(serviceName)
+	require.NoError(t, err)
+	defer service.Close()
+
+	config, err := service.Config()
+	require.NoError(t, err)
+	require.Equal(t, expectedAccount, config.ServiceStartName)
 }
 
 func verifyServiceState(t *testing.T, scm *mgr.Mgr, desiredState svc.State) {


### PR DESCRIPTION

Use a dedicated Windows virtual service account, NT SERVICE\splunk-otel-collector, for fresh Collector MSI installations. 
Add SPLUNK_SERVICE_ACCOUNT_TYPE=virtual|localsystem and the corresponding install.ps1 -service_account_type option; upgrades preserve the existing account by default and warn with the explicit migration command when remaining on LocalSystem.

Provision only receiver-required access for the virtual account: performance counters, Windows event logs including Security, default file-log sources, and file-storage checkpoints. Add upgrade/account-selection coverage and custom-action unit tests.

<img width="1126" height="90" alt="Zrzut ekranu 2026-09-10 o 18 43 06" src="https://github.com/user-attachments/assets/49630396-4d01-4904-ac0a-fe1b9908e260" />
