### PR TITLE
Prepare mass deployment releases

### DIFF
--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/CHANGELOG.md
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## ansible-v1.3.0
+
 ### 🛑 Breaking changes 🛑
 
 - Linux auto-instrumentation now uses the official OpenTelemetry Injector for package versions newer than `0.159.0` (or `latest`). The role manages `/etc/opentelemetry/injector/` and `libotelinject.so`, removes the legacy `/etc/splunk/zeroconfig/` configuration during upgrades, and continues to support the legacy layout for package versions through `0.159.0`. .NET auto-instrumentation is also supported on arm64 for newer package versions.

--- a/deployments/ansible_collections/signalfx/splunk_otel_collector/galaxy.yml
+++ b/deployments/ansible_collections/signalfx/splunk_otel_collector/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: signalfx
 name: splunk_otel_collector
 description: Ansible collection for Splunk OpenTelemetry Collector
-version: 1.2.0
+version: 1.3.0
 readme: README.md
 authors:
   - Splunk Inc.

--- a/deployments/chef/CHANGELOG.md
+++ b/deployments/chef/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## chef-v0.22.0
+
 ### 🛑 Breaking changes 🛑
 
 - Linux auto-instrumentation now uses the official OpenTelemetry Injector for package versions newer than `0.159.0` (or `latest`). The cookbook manages `/etc/opentelemetry/injector/` and `libotelinject.so`, removes the legacy `/etc/splunk/zeroconfig/` configuration during upgrades, and continues to support the legacy layout for package versions through `0.159.0`. .NET auto-instrumentation is also supported on arm64 for newer package versions.

--- a/deployments/chef/metadata.rb
+++ b/deployments/chef/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Splunk, Inc.'
 maintainer_email 'signalfx-support@splunk.com'
 license 'Apache-2.0'
 description 'Install/Configure the Splunk OpenTelemetry Collector'
-version '0.21.0'
+version '0.22.0'
 chef_version '>= 16.0'
 
 supports 'amazon'

--- a/deployments/puppet/CHANGELOG.md
+++ b/deployments/puppet/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## puppet-v0.23.0
+
 ### 🛑 Breaking changes 🛑
 
 - Linux auto-instrumentation now uses the official OpenTelemetry Injector for package versions newer than `0.159.0` (or `latest`). The module manages `/etc/opentelemetry/injector/` and `libotelinject.so`, removes the legacy `/etc/splunk/zeroconfig/` configuration during upgrades, and continues to support the legacy layout for package versions through `0.159.0`. .NET auto-instrumentation is also supported on arm64 for newer package versions.

--- a/deployments/puppet/metadata.json
+++ b/deployments/puppet/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx-splunk_otel_collector",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "author": "Splunk, Inc.",
   "summary": "This module installs the Splunk OpenTelemetry Collector via distro packages and configures it.",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is needed for the migration to `libotelinject.so`