### PR TITLE
[chore] Prepare splunk-otel-collector for version v0.160.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,14 +31,14 @@ require (
 	github.com/prometheus/common v0.71.0
 	github.com/prometheus/prometheus v0.314.0
 	github.com/shirou/gopsutil/v4 v4.26.8
-	github.com/signalfx/splunk-otel-collector/baseline v0.0.0
-	github.com/signalfx/splunk-otel-collector/pkg/exporter/splunkoutputsexporter v0.0.0-00010101000000-000000000000
-	github.com/signalfx/splunk-otel-collector/pkg/extension/oracleencodingextension v0.0.0-00010101000000-000000000000
-	github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension v0.83.0
-	github.com/signalfx/splunk-otel-collector/pkg/processor/rollingspanlatencyprocessor v0.0.0-00010101000000-000000000000
-	github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocessor v0.0.0-00010101000000-000000000000
-	github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver v0.0.0-00010101000000-000000000000
-	github.com/signalfx/splunk-otel-collector/pkg/receiver/splunkinputsreceiver v0.0.0-00010101000000-000000000000
+	github.com/signalfx/splunk-otel-collector/baseline v0.160.0
+	github.com/signalfx/splunk-otel-collector/pkg/exporter/splunkoutputsexporter v0.160.0
+	github.com/signalfx/splunk-otel-collector/pkg/extension/oracleencodingextension v0.160.0
+	github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension v0.160.0
+	github.com/signalfx/splunk-otel-collector/pkg/processor/rollingspanlatencyprocessor v0.160.0
+	github.com/signalfx/splunk-otel-collector/pkg/processor/timestampprocessor v0.160.0
+	github.com/signalfx/splunk-otel-collector/pkg/receiver/smartagentreceiver v0.160.0
+	github.com/signalfx/splunk-otel-collector/pkg/receiver/splunkinputsreceiver v0.160.0
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.12.1

--- a/pkg/receiver/smartagentreceiver/go.mod
+++ b/pkg/receiver/smartagentreceiver/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657
 	github.com/signalfx/golib/v3 v3.5.0
 	github.com/signalfx/signalfx-agent v1.0.1-0.20230104182534-9eee411fe305
-	github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension v0.83.0
+	github.com/signalfx/splunk-otel-collector/pkg/extension/smartagentextension v0.160.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.12.1
 	go.opentelemetry.io/collector/component v1.66.0


### PR DESCRIPTION
Prerelease commit generated by `multimod prerelease` for the `splunk-otel-collector` module set at v0.160.0.

Bumps the intra-repo module dependencies in `go.mod` and `pkg/receiver/smartagentreceiver/go.mod` to `v0.160.0` ahead of tagging.