### PR TITLE
[chore] Update `splunk_inputs` Windows example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,11 @@ tests/receivers/istio/istio-*/
 # Splunk_TA_nix addon contents
 examples/splunkinputs/Splunk_TA_nix/
 
+# splunkinputs-on-windows example artifacts
+examples/splunkinputs-on-windows/otelcol.exe
+examples/splunkinputs-on-windows/ta/
+examples/splunkinputs-on-windows/splunk_home/
+
 # Splunk Connect for OTLP binaries, tgz and test file
 packaging/otlpinput/splunk-connect-for-otlp/linux_x86_64/bin/splunk-connect-for-otlp
 packaging/otlpinput/splunk-connect-for-otlp/windows_x86_64/bin/splunk-connect-for-otlp

--- a/examples/splunkinputs-on-windows/README.md
+++ b/examples/splunkinputs-on-windows/README.md
@@ -2,10 +2,30 @@
 
 This is the Windows counterpart to the [`splunkinputs`](../splunkinputs/README.md)
 example. It uses the [`splunk_inputs`](https://github.com/splunk/tarunner/tree/main/pkg/splunkinputsreceiver)
-receiver to read a TA's `inputs.conf`, `transforms.conf`, and `props.conf`
-directly, emulating its modular input(s) without running a real `splunkd`.
-Like `splunkinputs`'s `/var/ta`, `C:\var\ta` is a generic mount point for any
-TA; this example just happens to use the
+receiver and [`splunk_outputs`](https://github.com/splunk/tarunner/tree/main/pkg/splunkoutputsexporter)
+exporter together to read a TA's configuration and forward its logs without
+running a real `splunkd`.
+
+Both components use the same `base_dir`, which is the root of a standard
+Splunk Universal Forwarder directory tree:
+
+```
+C:\var\splunk_home\
+  etc\
+    apps\
+      Splunk_TA_windows\
+        default\
+        local\
+    system\
+      local\
+        outputs.conf
+```
+
+The script stages the TA under `etc/apps/Splunk_TA_windows`, enables its
+inputs, and writes `outputs.conf` under `etc/system/local` using the HEC URL
+and token supplied on the command line. Like `splunkinputs`'s
+`/var/splunk_home`, `C:\var\splunk_home` is a generic mount point; this example
+just happens to use the
 [Splunk Add-on for Microsoft Windows](https://splunkbase.splunk.com/app/742)
 as its example TA.
 
@@ -20,11 +40,11 @@ for this example to know that in advance.
 
 ## Download a TA
 
-`run-example.ps1` (below) takes the path to a TA package, extracts it to
-`C:\var\ta` in the container, and enables its inputs for you. This example
+`run-example.ps1` (below) takes the path to a TA package, extracts it into the
+staged Splunk home, and enables its inputs for you. This example
 uses the Splunk Add-on for Microsoft Windows, but any TA compatible with the
-`splunk_inputs` receiver can be used instead. The receiver only reads a
-single TA per configured path, so only one TA package can be used at a time.
+`splunk_inputs` receiver can be used instead. Only one TA package can be used
+at a time by this script.
 
 By default every stanza in the TA's `inputs.conf` is enabled. To keep some
 disabled, pass their stanza names (the part of the bracketed header before
@@ -40,8 +60,9 @@ automatically. Download it yourself as a `.tgz`/`.spl` file from
 Before building the image, place a Windows collector binary named
 `otelcol.exe` in this directory.
 
-The `splunk_inputs` receiver this example depends on is only registered from
-`v0.158.0` onward (see the `enableTARunner` feature gate in
+The `splunk_inputs` receiver and `splunk_outputs` exporter this example uses
+are only registered from `v0.158.0` onward (see the `enableTARunner` feature
+gate in
 [`internal/components/components.go`](../../internal/components/components.go)),
 so download the latest release from the
 [project's GitHub releases page](https://github.com/signalfx/splunk-otel-collector/releases)
@@ -89,11 +110,13 @@ you downloaded and the HEC endpoint/token to send data to:
 
 This extracts the TA to a local `ta` folder, copies its `default/` directory
 to `local/` and enables every input by rewriting `disabled = 1` to
-`disabled = 0`, then builds and runs the container with that folder mounted at
-`C:\var\ta` and the HEC endpoint/token passed in as environment variables.
+`disabled = 0`. It then stages the TA at
+`C:\var\splunk_home\etc\apps\Splunk_TA_windows`, writes
+`C:\var\splunk_home\etc\system\local\outputs.conf`, and builds and runs the
+container with the staged Splunk home mounted at `C:\var\splunk_home`.
 
-The container waits for the mounted TA, then starts the collector with the
-`splunk_inputs` receiver reading it and exporting to `splunk_hec`. See
+The container starts the collector with the `splunk_inputs` receiver reading
+the TA and the `splunk_outputs` exporter reading `outputs.conf`. See
 [`otel-collector-config.yaml`](./otel-collector-config.yaml) for the full
 configuration.
 
@@ -103,10 +126,10 @@ configuration.
   destination via Docker Compose, this example has no bundled destination.
   Point `-SplunkHecUrl`/`-SplunkHecToken` at any HEC endpoint reachable from
   the container, including a Splunk instance running on the host.
-- Like `splunkinputs`'s `/var/ta`, `C:\var\ta` is a generic mount point for
-  any TA compatible with the `splunk_inputs` receiver, not just the Splunk
-  Add-on for Microsoft Windows used here. The receiver reads a single TA per
-  configured path, so only one TA can be mounted there at a time.
+- Like `splunkinputs`'s `/var/splunk_home`, `C:\var\splunk_home` is a generic
+  mount point for any TA compatible with the `splunk_inputs` receiver, not just the Splunk
+  Add-on for Microsoft Windows used here. This script stages one TA, but the
+  receiver can discover multiple TAs under `etc/apps`.
 - The `splunk_inputs` receiver parses the TA's configuration files directly;
   no Splunk Universal Forwarder process runs in this container. See
   [`packaging/ta-v2`](../../packaging/ta-v2/) for examples that install and

--- a/examples/splunkinputs-on-windows/otel-collector-config.yaml
+++ b/examples/splunkinputs-on-windows/otel-collector-config.yaml
@@ -1,15 +1,14 @@
 receivers:
   # Reads a Splunk TA's inputs.conf, transforms.conf, and props.conf directly
-  # from C:\var\ta, emulating its modular input(s). C:\var\ta is a generic
-  # mount point; this example happens to mount the Splunk Add-on for
-  # Microsoft Windows there, but any TA can be used instead.
+  # from the Splunk home, emulating its modular input(s). The TA is mounted
+  # below C:\var\splunk_home\etc\apps.
   splunk_inputs:
-    path: C:\var\ta
+    base_dir: C:\var\splunk_home
 
 exporters:
-  splunk_hec:
-    endpoint: ${env:SPLUNK_HEC_URL}
-    token: ${env:SPLUNK_HEC_TOKEN}
+  # Reads outputs.conf from the same Splunk home to determine the destination.
+  splunk_outputs:
+    base_dir: C:\var\splunk_home
   debug:
     verbosity: detailed
 
@@ -17,4 +16,4 @@ service:
   pipelines:
     logs:
       receivers: [splunk_inputs]
-      exporters: [debug, splunk_hec]
+      exporters: [debug, splunk_outputs]

--- a/examples/splunkinputs-on-windows/run-example.ps1
+++ b/examples/splunkinputs-on-windows/run-example.ps1
@@ -1,6 +1,6 @@
-# Prepares a TA (by default, the Splunk Add-on for Microsoft Windows) and
-# runs this example in a single Windows container. See README.md for the
-# manual download step this script depends on.
+# Extracts a TA (by default, the Splunk Add-on for Microsoft Windows), stages
+# a Splunk home, and runs this example in a single Windows container. See
+# README.md for the manual download step this script depends on.
 
 param(
     [Parameter(Mandatory = $true)]
@@ -23,9 +23,10 @@ $ErrorActionPreference = 'Stop'
 $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 $CONTAINER_NAME = if ($env:CONTAINER_NAME) { $env:CONTAINER_NAME } else { "splunkinputs-on-windows" }
 $IMAGE_TAG = if ($env:IMAGE_TAG) { $env:IMAGE_TAG } else { "latest" }
-# Local staging directory for the extracted TA; mounted into the container at
-# C:\var\ta, the generic TA location the receiver reads.
+# Local staging directory for the complete Splunk home. It is mounted into the
+# container at C:\var\splunk_home.
 $TA_DIR = Join-Path $SCRIPT_DIR "ta"
+$SPLUNK_HOME_DIR = Join-Path $SCRIPT_DIR "splunk_home"
 
 $resolvedTaPackagePath = Resolve-Path -ErrorAction SilentlyContinue $TaPackagePath
 if (-not $resolvedTaPackagePath) {
@@ -46,6 +47,15 @@ if (Test-Path $TA_DIR) {
     Remove-Item -Path $TA_DIR -Recurse -Force
 }
 New-Item -ItemType Directory -Path $TA_DIR -Force | Out-Null
+
+if (Test-Path $SPLUNK_HOME_DIR) {
+    Write-Host "Removing previous staged Splunk home at $SPLUNK_HOME_DIR"
+    Remove-Item -Path $SPLUNK_HOME_DIR -Recurse -Force
+}
+$taAppDir = Join-Path $SPLUNK_HOME_DIR "etc\apps\Splunk_TA_windows"
+$outputsDir = Join-Path $SPLUNK_HOME_DIR "etc\system\local"
+New-Item -ItemType Directory -Path $taAppDir -Force | Out-Null
+New-Item -ItemType Directory -Path $outputsDir -Force | Out-Null
 
 Write-Host "Extracting $($resolvedTaPackagePath.Path) to $TA_DIR"
 tar -xzf $resolvedTaPackagePath.Path -C $TA_DIR --strip-components=1
@@ -75,6 +85,16 @@ $updatedLines = foreach ($line in Get-Content -Path $localInputsConf) {
 }
 $updatedLines | Set-Content -Path $localInputsConf
 
+# Stage the TA below etc/apps and configure splunk_outputs through the normal
+# Splunk outputs.conf mechanism.
+Copy-Item -Path (Join-Path $TA_DIR '*') -Destination $taAppDir -Recurse -Force
+$outputsConf = @"
+[httpout]
+uri = $SplunkHecUrl
+httpEventCollectorToken = $SplunkHecToken
+"@
+Set-Content -Path (Join-Path $outputsDir "outputs.conf") -Value $outputsConf -Encoding ascii
+
 # Stop and remove existing container if it exists
 $existingContainer = docker ps -a --format "{{.Names}}" | Where-Object { $_ -eq $CONTAINER_NAME }
 if ($existingContainer) {
@@ -91,9 +111,7 @@ if ($LASTEXITCODE -ne 0) {
 
 Write-Host "Launching container: $CONTAINER_NAME"
 docker run -d --name $CONTAINER_NAME `
-    -e SPLUNK_HEC_URL=$SplunkHecUrl `
-    -e SPLUNK_HEC_TOKEN=$SplunkHecToken `
-    -v "${TA_DIR}:C:\var\ta" `
+    -v "${SPLUNK_HOME_DIR}:C:\var\splunk_home" `
     "splunkinputs-on-windows:$IMAGE_TAG"
 if ($LASTEXITCODE -ne 0) {
     Write-Host "Error: Failed to launch container" -ForegroundColor Red

--- a/examples/splunkinputs-on-windows/start-example.ps1
+++ b/examples/splunkinputs-on-windows/start-example.ps1
@@ -1,20 +1,10 @@
 # Container entrypoint for the splunkinputs-on-windows example.
 #
-# Waits for a TA to be mounted at C:\var\ta (see run-example.ps1), then starts
-# the collector with the splunk_inputs receiver, which reads that TA's
-# inputs.conf, transforms.conf, and props.conf directly, emulating its
-# modular input(s) without running a real splunkd.
+# Starts the collector with the splunk_inputs receiver and splunk_outputs
+# exporter. The complete Splunk home, including the TA and outputs.conf, is
+# mounted at C:\var\splunk_home by run-example.ps1.
 
 $ErrorActionPreference = 'Stop'
-
-if (-not $env:SPLUNK_HEC_URL) {
-    Write-Host 'Error: SPLUNK_HEC_URL environment variable is required.' -ForegroundColor Red
-    exit 1
-}
-if (-not $env:SPLUNK_HEC_TOKEN) {
-    Write-Host 'Error: SPLUNK_HEC_TOKEN environment variable is required.' -ForegroundColor Red
-    exit 1
-}
 
 & C:\otelcol\otelcol.exe --config=C:\otelcol\otel-collector-config.yaml --feature-gates=+enableTARunner
 exit $LASTEXITCODE


### PR DESCRIPTION
First pass by Codex to catch up with #8058 I still have to test these changes on a Windows box.

## Summary
- Stage the Windows TA and `outputs.conf` in a standard Splunk home directory.
- Configure `splunk_inputs` and `splunk_outputs` to share the staged `base_dir`.
- Update documentation and ignore generated example artifacts.

## Testing
Not run (not requested)

Assisted-by: Codex