### PR TITLE
[chore] Re-enable govet shadow for pkg/splunkta

### DIFF
--- a/pkg/splunkta/.golangci.yml
+++ b/pkg/splunkta/.golangci.yml
@@ -14,5 +14,5 @@ linters:
     - testifylint
   settings:
     govet:
-      disable:
+      enable:
         - shadow

--- a/pkg/splunkta/scriptedinput/input.go
+++ b/pkg/splunkta/scriptedinput/input.go
@@ -145,8 +145,8 @@ func (si *ScriptedInput) _execute(baseDir string, input conf.Input) error {
 				}
 				e := entry.New()
 				e.Body = string(b)
-				if err := si.Attribute(e); err != nil {
-					si.logger.Error("Error setting attributes", zap.Error(err))
+				if attrErr := si.Attribute(e); attrErr != nil {
+					si.logger.Error("Error setting attributes", zap.Error(attrErr))
 				}
 
 				if err = si.Write(context.Background(), e); err != nil {


### PR DESCRIPTION
Added explicit `enable: [shadow]` to `settings.govet` in `.golangci.yml` to re-enable the shadow analyzer. Fixed one variable shadowing issue in `scriptedinput/input.go` where the inner `err` variable at line 148 shadowed the outer `err` declared at line 119; renamed the inner one to `attrErr` for clarity.

Part of the pkg/splunkta lint cleanup; one linter per PR.