### PR TITLE
[chore] Re-enable gocritic for pkg/splunkta

### DIFF
--- a/pkg/splunkta/.golangci.yml
+++ b/pkg/splunkta/.golangci.yml
@@ -7,7 +7,6 @@ run:
 # below are relaxed so the move lands as a pure copy; cleanup is a follow-up.
 linters:
   disable:
-    - gocritic
     - gosec
     - perfsprint
     - revive

--- a/pkg/splunkta/operator/prop/prop.go
+++ b/pkg/splunkta/operator/prop/prop.go
@@ -42,9 +42,9 @@ func CreateOperatorConfigs(pCfg conf.Prop, transforms []conf.Transform) []operat
 
 	if featuregates.CookFeatureGate.IsEnabled() {
 		// TODO implement a split parser.
-		//if !pCfg.ShouldLineMerge {
+		// if !pCfg.ShouldLineMerge {
 		//
-		//}
+		// }
 
 		for _, tCfg := range pCfg.Transforms {
 			for _, stanza := range tCfg.Stanza {


### PR DESCRIPTION
Re-enables the gocritic linter for pkg/splunkta (disabled during the verbatim move from github.com/splunk/tarunner). Fixed the one finding: corrected comment formatting to add space after //.

Part of the pkg/splunkta lint cleanup; one linter per PR.