### PR TITLE
[chore] Re-enable testifylint for pkg/splunkta

### DIFF
--- a/pkg/splunkta/.golangci.yml
+++ b/pkg/splunkta/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - gosec
     - perfsprint
     - revive
-    - testifylint
   settings:
     govet:
       disable:

--- a/pkg/splunkta/conf/props_test.go
+++ b/pkg/splunkta/conf/props_test.go
@@ -111,8 +111,8 @@ func TestOrderProps(t *testing.T) {
 
 func TestParseFieldAliasExpr(t *testing.T) {
 	from, to := parseFieldAliasExpr("foo as bar")
-	assert.Equal(t, from, "foo")
-	assert.Equal(t, to, "bar")
+	assert.Equal(t, "foo", from)
+	assert.Equal(t, "bar", to)
 }
 
 func TestReadFieldAliases(t *testing.T) {

--- a/pkg/splunkta/operator/transform/cache_test.go
+++ b/pkg/splunkta/operator/transform/cache_test.go
@@ -183,7 +183,7 @@ func TestNewStartedAtomicLimiter(t *testing.T) {
 				// default
 				tc.interval = 5
 			}
-			require.Equal(t, float64(tc.interval), l.interval.Seconds())
+			require.InEpsilon(t, float64(tc.interval), l.interval.Seconds(), 1e-6)
 			require.Equal(t, uint64(0), l.currentCount())
 		})
 	}
@@ -245,7 +245,7 @@ func TestThrottledCache(t *testing.T) {
 	defer c.stop()
 	require.False(t, c.limiter.throttled())
 	require.Equal(t, 4, int(c.limiter.limit()), "expected limit be cache size + 1")
-	require.Equal(t, float64(120), c.limiter.resetInterval().Seconds(), "expected reset interval to be 120 seconds")
+	require.InEpsilon(t, float64(120), c.limiter.resetInterval().Seconds(), 1e-6, "expected reset interval to be 120 seconds")
 
 	// fill the cache and cause 100% evictions
 	for i := 1; i <= 6; i++ {

--- a/pkg/splunkta/receiver/batchreceiver/receiver_test.go
+++ b/pkg/splunkta/receiver/batchreceiver/receiver_test.go
@@ -5,7 +5,6 @@ package batchreceiver
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -73,7 +72,7 @@ func TestReadFile(t *testing.T) {
 	require.Equal(t, "foo\n", received.Body)
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
 		_, err = os.Stat(file)
-		require.True(tt, errors.Is(err, fs.ErrNotExist), err)
+		require.ErrorIs(tt, err, fs.ErrNotExist)
 	}, 1*time.Second, 100*time.Millisecond)
 }
 

--- a/pkg/splunkta/scriptedinput/config_test.go
+++ b/pkg/splunkta/scriptedinput/config_test.go
@@ -6,7 +6,6 @@ package scriptedinput
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 )
@@ -14,6 +13,6 @@ import (
 func TestBuild(t *testing.T) {
 	c := NewConfig()
 	o, err := c.Build(componenttest.NewNopTelemetrySettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, o)
 }

--- a/pkg/splunkta/scriptedinput/input_test.go
+++ b/pkg/splunkta/scriptedinput/input_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.uber.org/zap"
@@ -73,7 +72,7 @@ func Test_ScriptedInput(t *testing.T) {
 			settings := componenttest.NewNopTelemetrySettings()
 			settings.Logger, _ = zap.NewDevelopment()
 			o, err := c.Build(settings)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, o)
 			fakeOut := testutil.NewFakeOutput(t)
 			require.NoError(t, fakeOut.Start(nil))
@@ -97,7 +96,7 @@ func Test_ScriptedInput(t *testing.T) {
 				}
 			} else {
 				time.Sleep(time.Millisecond * 100)
-				require.Len(t, fakeOut.Received, 0)
+				require.Empty(t, fakeOut.Received)
 			}
 			require.NoError(t, o.Stop())
 		})


### PR DESCRIPTION
Fix 8 testifylint findings in pkg/splunkta test files: incorrect assert/require usage, float comparisons, and empty collection checks. Changes include switching error assertions to require, using InEpsilon for float comparisons, and using Empty for empty collection checks.

Part of the pkg/splunkta lint cleanup; one linter per PR.