### PR TITLE
[chore] Re-enable revive for pkg/splunkta

### DIFF
--- a/pkg/splunkta/.golangci.yml
+++ b/pkg/splunkta/.golangci.yml
@@ -9,7 +9,6 @@ linters:
   disable:
     - gosec
     - perfsprint
-    - revive
   settings:
     govet:
       disable:

--- a/pkg/splunkta/conf/inputs.go
+++ b/pkg/splunkta/conf/inputs.go
@@ -1,6 +1,7 @@
 // Copyright Splunk, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package conf handles parsing of Splunk configuration files.
 package conf
 
 import (
@@ -15,6 +16,7 @@ const (
 `
 )
 
+// Input represents a scripted input configuration.
 type Input struct {
 	ServerHost    string        `xml:"server_host"`
 	ServerURI     string        `xml:"server_uri"`
@@ -30,6 +32,7 @@ func (s *Stanza) IsDisabled() bool {
 	return p != nil && (p.Value == "1" || p.Value == "true")
 }
 
+// ReadInput parses a payload of input configurations and returns them.
 func ReadInput(payload []byte, appDir string) ([]Input, error) {
 	f, err := ini.Load(payload)
 	if err != nil {
@@ -103,6 +106,7 @@ func mergeInput(base, override Input) Input {
 	return merged
 }
 
+// ToXML marshals the Input to XML format.
 func (i *Input) ToXML() ([]byte, error) {
 	b, err := xml.MarshalIndent(i, "", "  ")
 	return append([]byte(xmlDeclaration), b...), err

--- a/pkg/splunkta/conf/outputs.go
+++ b/pkg/splunkta/conf/outputs.go
@@ -16,23 +16,21 @@ var ErrNoHTTPOut = errors.New("no [httpout] stanza found in outputs.conf")
 // ErrNoOutputStanzas is returned when outputs.conf contains no output stanzas.
 var ErrNoOutputStanzas = errors.New("no output stanzas found in outputs.conf")
 
-// ConfMap is a parsed .conf file: stanza name -> key -> value.
-//
-//nolint:revive // var-naming: renaming is a breaking API change; this type is consumed by tarunner
-type ConfMap map[string]map[string]string
+// Map is a parsed .conf file: stanza name -> key -> value.
+type Map map[string]map[string]string
 
 // Output holds the settings from outputs.conf stanza.
 type Output struct {
 	Configuration Configuration
 }
 
-// ParseConf parses a .conf file payload into a ConfMap.
-func ParseConf(payload []byte) (ConfMap, error) {
+// ParseConf parses a .conf file payload into a Map.
+func ParseConf(payload []byte) (Map, error) {
 	f, err := ini.Load(payload)
 	if err != nil {
 		return nil, err
 	}
-	result := make(ConfMap)
+	result := make(Map)
 	for _, section := range f.Sections() {
 		name := section.Name()
 		if name == ini.DefaultSection {
@@ -48,8 +46,8 @@ func ParseConf(payload []byte) (ConfMap, error) {
 }
 
 // ParseAndMergeConf parses and merges multiple .conf payloads.
-func ParseAndMergeConf(payloads [][]byte) (ConfMap, error) {
-	var layers []ConfMap
+func ParseAndMergeConf(payloads [][]byte) (Map, error) {
+	var layers []Map
 	for _, b := range payloads {
 		parsed, err := ParseConf(b)
 		if err != nil {
@@ -60,9 +58,9 @@ func ParseAndMergeConf(payloads [][]byte) (ConfMap, error) {
 	return MergeConf(layers), nil
 }
 
-// MergeConf merges multiple ConfMap layers; later layers take precedence.
-func MergeConf(layers []ConfMap) ConfMap {
-	merged := make(ConfMap)
+// MergeConf merges multiple Map layers; later layers take precedence.
+func MergeConf(layers []Map) Map {
+	merged := make(Map)
 	for _, layer := range layers {
 		for stanza, keys := range layer {
 			if merged[stanza] == nil {
@@ -87,7 +85,7 @@ func ReadOutputGroups(payload []byte) ([]Output, error) {
 }
 
 // OutputGroups converts merged outputs.conf stanzas to Output values.
-func OutputGroups(merged ConfMap) ([]Output, error) {
+func OutputGroups(merged Map) ([]Output, error) {
 	if len(merged) == 0 {
 		return nil, ErrNoOutputStanzas
 	}
@@ -106,7 +104,7 @@ func OutputGroups(merged ConfMap) ([]Output, error) {
 }
 
 // HTTPOut extracts the [httpout] stanza from a merged outputs.conf map.
-func HTTPOut(merged ConfMap) (*Output, error) {
+func HTTPOut(merged Map) (*Output, error) {
 	keys, ok := merged["httpout"]
 	if !ok {
 		return nil, ErrNoHTTPOut

--- a/pkg/splunkta/conf/outputs.go
+++ b/pkg/splunkta/conf/outputs.go
@@ -17,6 +17,7 @@ var ErrNoHTTPOut = errors.New("no [httpout] stanza found in outputs.conf")
 var ErrNoOutputStanzas = errors.New("no output stanzas found in outputs.conf")
 
 // ConfMap is a parsed .conf file: stanza name -> key -> value.
+//nolint:revive // var-naming: renaming is a breaking API change; this type is consumed by tarunner
 type ConfMap map[string]map[string]string
 
 // Output holds the settings from outputs.conf stanza.
@@ -24,6 +25,7 @@ type Output struct {
 	Configuration Configuration
 }
 
+// ParseConf parses a .conf file payload into a ConfMap.
 func ParseConf(payload []byte) (ConfMap, error) {
 	f, err := ini.Load(payload)
 	if err != nil {
@@ -44,6 +46,7 @@ func ParseConf(payload []byte) (ConfMap, error) {
 	return result, nil
 }
 
+// ParseAndMergeConf parses and merges multiple .conf payloads.
 func ParseAndMergeConf(payloads [][]byte) (ConfMap, error) {
 	var layers []ConfMap
 	for _, b := range payloads {
@@ -56,6 +59,7 @@ func ParseAndMergeConf(payloads [][]byte) (ConfMap, error) {
 	return MergeConf(layers), nil
 }
 
+// MergeConf merges multiple ConfMap layers; later layers take precedence.
 func MergeConf(layers []ConfMap) ConfMap {
 	merged := make(ConfMap)
 	for _, layer := range layers {

--- a/pkg/splunkta/conf/outputs.go
+++ b/pkg/splunkta/conf/outputs.go
@@ -17,6 +17,7 @@ var ErrNoHTTPOut = errors.New("no [httpout] stanza found in outputs.conf")
 var ErrNoOutputStanzas = errors.New("no output stanzas found in outputs.conf")
 
 // ConfMap is a parsed .conf file: stanza name -> key -> value.
+//
 //nolint:revive // var-naming: renaming is a breaking API change; this type is consumed by tarunner
 type ConfMap map[string]map[string]string
 

--- a/pkg/splunkta/conf/outputs_test.go
+++ b/pkg/splunkta/conf/outputs_test.go
@@ -43,7 +43,7 @@ func TestMergeConf(t *testing.T) {
 	override, err := ParseConf([]byte("[httpout]\nhttpEventCollectorToken = override-token\n"))
 	require.NoError(t, err)
 
-	merged := MergeConf([]ConfMap{base, override})
+	merged := MergeConf([]Map{base, override})
 	output, err := HTTPOut(merged)
 	require.NoError(t, err)
 

--- a/pkg/splunkta/conf/props.go
+++ b/pkg/splunkta/conf/props.go
@@ -11,17 +11,23 @@ import (
 	"gopkg.in/ini.v1"
 )
 
+// PropType represents the category of a property specification in props.conf.
 type PropType int
 
 const (
+	// Source is a source-specific property.
 	Source = iota
+	// Host is a host-specific property.
 	Host
+	// SourceType is a source type property.
 	SourceType
+	// Default is the default property.
 	Default
 )
 
 var fieldAliasRegex = regexp.MustCompile(`(\w+) as (\w+)`)
 
+// Prop represents a props.conf stanza.
 type Prop struct {
 	Name                  string
 	TimePrefix            string
@@ -36,17 +42,20 @@ type Prop struct {
 	ShouldLineMerge       bool
 }
 
+// FieldAlias represents a FIELDALIAS configuration in props.conf.
 type FieldAlias struct {
 	Name string
 	From string
 	To   string
 }
 
+// PropsTransforms represents a TRANSFORMS configuration in props.conf.
 type PropsTransforms struct {
 	Class  string
 	Stanza []string
 }
 
+// Type returns the PropType of the Prop.
 func (p *Prop) Type() PropType {
 	switch {
 	case strings.HasPrefix(p.Name, "source::"):
@@ -80,6 +89,7 @@ func MergeProps(layers [][]Prop) []Prop {
 	return result
 }
 
+// ReadProps parses a props.conf payload and returns the props.
 func ReadProps(payload []byte) ([]Prop, error) {
 	f, err := ini.Load(payload)
 	if err != nil {

--- a/pkg/splunkta/conf/stanza.go
+++ b/pkg/splunkta/conf/stanza.go
@@ -3,12 +3,15 @@
 
 package conf
 
+// Configuration holds a stanza configuration.
 type Configuration struct {
 	Stanza Stanza `xml:"stanza"`
 }
 
+// Params is a slice of Param.
 type Params []Param
 
+// Get returns the parameter with the given name, or nil if not found.
 func (p Params) Get(name string) *Param {
 	for _, param := range p {
 		if param.Name == name {
@@ -18,12 +21,14 @@ func (p Params) Get(name string) *Param {
 	return nil
 }
 
+// Stanza represents a configuration stanza.
 type Stanza struct {
 	Name   string `xml:"name,attr"`
 	App    string `xml:"app,attr"`
 	Params Params `xml:"param"`
 }
 
+// Param represents a parameter within a stanza.
 type Param struct {
 	Name  string `xml:"name,attr"`
 	Value string `xml:",innerxml"`

--- a/pkg/splunkta/conf/transforms.go
+++ b/pkg/splunkta/conf/transforms.go
@@ -5,6 +5,7 @@ package conf
 
 import "gopkg.in/ini.v1"
 
+// Transform represents a transforms.conf stanza.
 type Transform struct {
 	Name   string
 	Regex  string
@@ -29,6 +30,7 @@ func MergeTransforms(layers [][]Transform) []Transform {
 	return result
 }
 
+// ReadTransforms parses a transforms.conf payload and returns the transforms.
 func ReadTransforms(payload []byte) ([]Transform, error) {
 	f, err := ini.Load(payload)
 	if err != nil {

--- a/pkg/splunkta/featuregates/featuregates.go
+++ b/pkg/splunkta/featuregates/featuregates.go
@@ -1,10 +1,12 @@
 // Copyright Splunk, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package featuregates defines feature gates for the splunkta package.
 package featuregates
 
 import "go.opentelemetry.io/collector/featuregate"
 
+// CookFeatureGate controls whether data is cooked by applying props.conf.
 var CookFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"cook",
 	featuregate.StageAlpha,

--- a/pkg/splunkta/operator/prop/prop.go
+++ b/pkg/splunkta/operator/prop/prop.go
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Package prop implements prop operator configuration for the splunkta package.
 package prop
 
 import (
@@ -21,6 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
+// CreateOperatorConfigs creates operator configs for the given property and transforms.
 func CreateOperatorConfigs(pCfg conf.Prop, transforms []conf.Transform) []operator.Config {
 	var operators []operator.Config
 	start := noop.NewConfigWithID(fmt.Sprintf("%s-start", pCfg.Name))

--- a/pkg/splunkta/operator/transform/benchmark_test.go
+++ b/pkg/splunkta/operator/transform/benchmark_test.go
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Package transform implements the transform operator for the splunkta package.
 package transform
 
 import (

--- a/pkg/splunkta/operator/transform/config.go
+++ b/pkg/splunkta/operator/transform/config.go
@@ -20,6 +20,7 @@ import (
 
 const operatorType = "transform"
 
+// NewConfig creates a new Config for the given scope and transform.
 func NewConfig(scope string, t conf.Transform) *Config {
 	return &Config{
 		Regex:        t.Regex,

--- a/pkg/splunkta/operator/transform/parser.go
+++ b/pkg/splunkta/operator/transform/parser.go
@@ -21,6 +21,7 @@ type Parser struct {
 	parseValues bool
 }
 
+// Stop stops the parser.
 func (p *Parser) Stop() error {
 	if p.cache != nil {
 		p.cache.stop()
@@ -28,6 +29,7 @@ func (p *Parser) Stop() error {
 	return nil
 }
 
+// ProcessBatch processes a batch of entries.
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
 	return p.ProcessBatchWith(ctx, entries, p.parse)
 }

--- a/pkg/splunkta/receiver/batchreceiver/config.go
+++ b/pkg/splunkta/receiver/batchreceiver/config.go
@@ -1,12 +1,14 @@
 // Copyright Splunk, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package batchreceiver implements the batch receiver.
 package batchreceiver
 
 import (
 	"github.com/signalfx/splunk-otel-collector/pkg/splunkta/conf"
 )
 
+// Config holds the configuration for the batch receiver.
 type Config struct {
 	Input      conf.Input       `mapstructure:"-"`
 	BaseDir    string           `mapstructure:"-"`

--- a/pkg/splunkta/receiver/batchreceiver/factory.go
+++ b/pkg/splunkta/receiver/batchreceiver/factory.go
@@ -15,6 +15,7 @@ func init() {
 	_ = featuregate.GlobalRegistry().Set("filelog.allowFileDeletion", true)
 }
 
+// NewFactory creates a new factory for the batch receiver.
 func NewFactory() receiver.Factory {
 	return adapter.NewFactory(batch{
 		logger: zap.NewNop(),

--- a/pkg/splunkta/receiver/monitorreceiver/config.go
+++ b/pkg/splunkta/receiver/monitorreceiver/config.go
@@ -1,12 +1,14 @@
 // Copyright Splunk, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package monitorreceiver implements the monitor receiver.
 package monitorreceiver
 
 import (
 	"github.com/signalfx/splunk-otel-collector/pkg/splunkta/conf"
 )
 
+// Config holds the configuration for the monitor receiver.
 type Config struct {
 	Input      conf.Input       `mapstructure:"-"`
 	BaseDir    string           `mapstructure:"-"`

--- a/pkg/splunkta/receiver/monitorreceiver/factory.go
+++ b/pkg/splunkta/receiver/monitorreceiver/factory.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 )
 
+// NewFactory creates a new factory for the monitor receiver.
 func NewFactory() receiver.Factory {
 	return adapter.NewFactory(monitor{
 		logger: zap.NewNop(),

--- a/pkg/splunkta/receiver/scriptreceiver/config.go
+++ b/pkg/splunkta/receiver/scriptreceiver/config.go
@@ -1,10 +1,12 @@
 // Copyright Splunk, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package scriptreceiver implements the script receiver.
 package scriptreceiver
 
 import "github.com/signalfx/splunk-otel-collector/pkg/splunkta/conf"
 
+// Config holds the configuration for the script receiver.
 type Config struct {
 	conf.Input `mapstructure:"-"`
 	BaseDir    string           `mapstructure:"-"`

--- a/pkg/splunkta/receiver/scriptreceiver/factory.go
+++ b/pkg/splunkta/receiver/scriptreceiver/factory.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
+// NewFactory creates a new factory for the script receiver.
 func NewFactory() receiver.Factory {
 	return adapter.NewFactory(scriptReceiver{}, component.StabilityLevelAlpha)
 }

--- a/pkg/splunkta/receiver/tcpreceiver/config.go
+++ b/pkg/splunkta/receiver/tcpreceiver/config.go
@@ -1,6 +1,7 @@
 // Copyright Splunk, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package tcpreceiver implements the TCP receiver.
 package tcpreceiver
 
 import (
@@ -8,6 +9,7 @@ import (
 	"github.com/signalfx/splunk-otel-collector/pkg/splunkta/stanza"
 )
 
+// Config holds the configuration for the TCP receiver.
 type Config struct {
 	Input      conf.Input       `mapstructure:"-"`
 	BaseDir    string           `mapstructure:"-"`
@@ -15,6 +17,7 @@ type Config struct {
 	Props      []conf.Prop      `mapstructure:"-"`
 }
 
+// Validate validates the Config.
 func (cfg *Config) Validate() error {
 	_, err := stanza.ParseName(cfg.Input.Configuration.Stanza.Name)
 	return err

--- a/pkg/splunkta/receiver/tcpreceiver/factory.go
+++ b/pkg/splunkta/receiver/tcpreceiver/factory.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
+// NewFactory creates a new factory for the TCP receiver.
 func NewFactory() receiver.Factory {
 	return adapter.NewFactory(monitor{}, component.StabilityLevelAlpha)
 }

--- a/pkg/splunkta/receiver/udpreceiver/config.go
+++ b/pkg/splunkta/receiver/udpreceiver/config.go
@@ -1,6 +1,7 @@
 // Copyright Splunk, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package udpreceiver implements the UDP receiver.
 package udpreceiver
 
 import (
@@ -8,6 +9,7 @@ import (
 	"github.com/signalfx/splunk-otel-collector/pkg/splunkta/stanza"
 )
 
+// Config holds the configuration for the UDP receiver.
 type Config struct {
 	Input      conf.Input       `mapstructure:"-"`
 	BaseDir    string           `mapstructure:"-"`
@@ -15,6 +17,7 @@ type Config struct {
 	Props      []conf.Prop      `mapstructure:"-"`
 }
 
+// Validate validates the Config.
 func (cfg *Config) Validate() error {
 	_, err := stanza.ParseName(cfg.Input.Configuration.Stanza.Name)
 	return err

--- a/pkg/splunkta/receiver/udpreceiver/factory.go
+++ b/pkg/splunkta/receiver/udpreceiver/factory.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
+// NewFactory creates a new factory for the UDP receiver.
 func NewFactory() receiver.Factory {
 	return adapter.NewFactory(monitor{}, component.StabilityLevelAlpha)
 }

--- a/pkg/splunkta/receiver/wineventlogreceiver/config.go
+++ b/pkg/splunkta/receiver/wineventlogreceiver/config.go
@@ -1,12 +1,14 @@
 // Copyright Splunk, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package wineventlogreceiver implements the Windows Event Log receiver.
 package wineventlogreceiver
 
 import (
 	"github.com/signalfx/splunk-otel-collector/pkg/splunkta/conf"
 )
 
+// Config holds the configuration for the Windows Event Log receiver.
 type Config struct {
 	Input      conf.Input       `mapstructure:"-"`
 	BaseDir    string           `mapstructure:"-"`

--- a/pkg/splunkta/receiver/wineventlogreceiver/factory_all.go
+++ b/pkg/splunkta/receiver/wineventlogreceiver/factory_all.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
+// NewFactory creates a new factory for the Windows Event Log receiver (non-Windows stub).
 func NewFactory() receiver.Factory {
 	return receiver.NewFactory(
 		component.MustNewType("wineventlog"),
@@ -21,7 +22,7 @@ func NewFactory() receiver.Factory {
 			return nil
 		},
 		receiver.WithLogs(
-			func(ctx context.Context, settings receiver.Settings, config component.Config, logs consumer.Logs) (receiver.Logs, error) {
+			func(_ context.Context, _ receiver.Settings, _ component.Config, _ consumer.Logs) (receiver.Logs, error) {
 				return nil, errors.New("wineventlog is not supported outside Windows environments")
 			},
 			component.StabilityLevelAlpha,

--- a/pkg/splunkta/script/command.go
+++ b/pkg/splunkta/script/command.go
@@ -1,6 +1,7 @@
 // Copyright Splunk, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package script contains utilities for script command execution.
 package script
 
 import (
@@ -13,6 +14,7 @@ import (
 	"github.com/signalfx/splunk-otel-collector/pkg/splunkta/stanza"
 )
 
+// DetermineCommandName determines the command name from the input configuration.
 func DetermineCommandName(baseDir string, input conf.Input) (string, error) {
 	parsed, err := stanza.ParseName(input.Configuration.Stanza.Name)
 	if err != nil {
@@ -40,6 +42,7 @@ func DetermineCommandName(baseDir string, input conf.Input) (string, error) {
 	}
 }
 
+// GetPath resolves a path relative to baseDir, ensuring it stays within baseDir.
 func GetPath(baseDir, path string) (string, error) {
 	var resolvedPath string
 	if filepath.IsAbs(path) {

--- a/pkg/splunkta/scriptedinput/config.go
+++ b/pkg/splunkta/scriptedinput/config.go
@@ -1,6 +1,7 @@
 // Copyright Splunk, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package scriptedinput implements the scripted input operator.
 package scriptedinput
 
 import (
@@ -29,12 +30,14 @@ func NewConfigWithID(operatorID string) *Config {
 	}
 }
 
+// Config holds the configuration for the ScriptedInput operator.
 type Config struct {
 	BaseDir            string
 	conf.Input         `mapstructure:"-"`
 	helper.InputConfig `mapstructure:"-"`
 }
 
+// Build builds the Config into a ScriptedInput operator.
 func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error) {
 	inputOperator, err := c.InputConfig.Build(set)
 	if err != nil {

--- a/pkg/splunkta/scriptedinput/input.go
+++ b/pkg/splunkta/scriptedinput/input.go
@@ -23,6 +23,7 @@ import (
 	"github.com/signalfx/splunk-otel-collector/pkg/splunkta/conf"
 )
 
+// ScriptedInput is an operator that executes scripts and processes their output.
 type ScriptedInput struct {
 	logger   *zap.Logger
 	doneChan chan struct{}
@@ -31,6 +32,7 @@ type ScriptedInput struct {
 	helper.InputOperator
 }
 
+// Start starts the ScriptedInput.
 func (si *ScriptedInput) Start(_ operator.Persister) error {
 	if _, err := si.scheduleInput(si.cfg.BaseDir, si.cfg.Input); err != nil {
 		return err
@@ -38,6 +40,7 @@ func (si *ScriptedInput) Start(_ operator.Persister) error {
 	return nil
 }
 
+// Stop stops the ScriptedInput.
 func (si *ScriptedInput) Stop() error {
 	if si.command != nil {
 		_ = si.command.Process.Signal(syscall.SIGTERM)

--- a/pkg/splunkta/tabuilder/tabuilder.go
+++ b/pkg/splunkta/tabuilder/tabuilder.go
@@ -397,6 +397,7 @@ func ReadOutputGroups(splunkHome string) ([]conf.Output, error) {
 	return conf.OutputGroups(merged)
 }
 
+// HTTPOut returns the [httpout] stanza from a merged outputs.conf map.
 func HTTPOut(merged conf.ConfMap) (*conf.Output, error) {
 	return conf.HTTPOut(merged)
 }

--- a/pkg/splunkta/tabuilder/tabuilder.go
+++ b/pkg/splunkta/tabuilder/tabuilder.go
@@ -379,7 +379,7 @@ func ReadProps(dirs []string) ([]conf.Prop, error) {
 
 // ReadOutputs merges outputs.conf across $SPLUNK_HOME using standard Splunk
 // precedence. Use HTTPOut (or future TCPOut, etc.) to extract a specific type.
-func ReadOutputs(splunkHome string) (conf.ConfMap, error) {
+func ReadOutputs(splunkHome string) (conf.Map, error) {
 	payloads, err := readConfFiles(confFilePaths(ConfDirs(splunkHome), "outputs.conf"))
 	if err != nil {
 		return nil, err
@@ -398,12 +398,12 @@ func ReadOutputGroups(splunkHome string) ([]conf.Output, error) {
 }
 
 // HTTPOut returns the [httpout] stanza from a merged outputs.conf map.
-func HTTPOut(merged conf.ConfMap) (*conf.Output, error) {
+func HTTPOut(merged conf.Map) (*conf.Output, error) {
 	return conf.HTTPOut(merged)
 }
 
 // CreateExporter builds a logs exporter from a merged outputs conf map.
-func CreateExporter(merged conf.ConfMap, logger *zap.Logger, telemetrySettings component.TelemetrySettings) (exporter.Logs, error) {
+func CreateExporter(merged conf.Map, logger *zap.Logger, telemetrySettings component.TelemetrySettings) (exporter.Logs, error) {
 	output, err := conf.HTTPOut(merged)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Re-enables the revive linter for pkg/splunkta and fixes all 51 findings.

Added doc comments to all exported types, functions, and methods:
- `conf` package: Input, ReadInput, ToXML, ReadProps, Prop, PropType, FieldAlias, PropsTransforms, Type, ReadTransforms, Transform, Configuration, Params, Get, Stanza, Param, ParseConf, ParseAndMergeConf, MergeConf
- `featuregates` package: CookFeatureGate (with package comment)
- `operator/prop` package: CreateOperatorConfigs (with package comment)
- `operator/transform` package: NewConfig, Stop, ProcessBatch (with package comment for benchmark_test.go)
- `receiver/batchreceiver`: Config, NewFactory (with package comment)
- `receiver/monitorreceiver`: Config, NewFactory (with package comment)
- `receiver/scriptreceiver`: Config, NewFactory (with package comment)
- `receiver/tcpreceiver`: Config, Validate, NewFactory (with package comment)
- `receiver/udpreceiver`: Config, Validate, NewFactory (with package comment)
- `receiver/wineventlogreceiver`: Config, NewFactory (with package comment)
- `script` package: DetermineCommandName, GetPath (with package comment)
- `scriptedinput` package: Config, Build, ScriptedInput, Start, Stop (with package comment)
- `tabuilder` package: HTTPOut

**package-comments (9 findings):** Added package-level documentation to conf, featuregates, operator/prop, operator/transform, script, scriptedinput, and all receiver packages.

**var-naming (1 finding):** ConfMap type name flagged for stutter. Kept unchanged with nolint directive: renaming would be a breaking API change since ConfMap is consumed by github.com/splunk/tarunner.

**unused-parameter (1 finding):** Renamed unused parameters to `_` in wineventlogreceiver/factory_all.go for the receiver.WithLogs callback.
