### PR TITLE
Update windows launcher shutdown behavior

### DIFF
--- a/.chloggen/fix-windows-launcher-shutdown.yaml
+++ b/.chloggen/fix-windows-launcher-shutdown.yaml
@@ -8,7 +8,7 @@ component: otelcollauncher
 note: Update the Windows launcher to report successful shutdown when forcible child-process termination succeeds and avoid hanging when forcible termination fails.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [8067]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix-windows-launcher-shutdown.yaml
+++ b/.chloggen/fix-windows-launcher-shutdown.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: otelcollauncher
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update the Windows launcher to report successful shutdown when forcible child-process termination succeeds and avoid hanging when forcible termination fails.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otelcollauncher/main_windows.go
+++ b/cmd/otelcollauncher/main_windows.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -94,6 +95,10 @@ func runInteractive(args, env []string, paths launcher.Paths) error {
 		return errors.Join(result.outputErr, result.waitErr)
 	case <-interrupt:
 		result := child.shutdown(gracefulShutdownTimeout)
+		// Log the non-fatal shutdown warnings here
+		if result.shutdownWarning != nil {
+			log.Printf("Warnings occurred while shutting down: %v\n", result.shutdownWarning)
+		}
 		return errors.Join(result.outputErr, result.waitErr)
 	}
 }
@@ -164,6 +169,9 @@ func (h *serviceHandler) Execute(serviceArgs []string, requests <-chan svc.Chang
 			case svc.Stop, svc.Shutdown:
 				status <- svc.Status{State: svc.StopPending, WaitHint: uint32(gracefulShutdownTimeout / time.Millisecond)}
 				result := child.shutdown(gracefulShutdownTimeout)
+				if result.shutdownWarning != nil {
+					_ = elog.Warning(2, fmt.Sprintf("warnings occurred while shutting down the service: %v", result.shutdownWarning))
+				}
 				if result.outputErr != nil {
 					_ = elog.Error(3, fmt.Sprintf("errors occurred while forwarding child output: %v", result.outputErr))
 				}
@@ -185,6 +193,7 @@ func (h *serviceHandler) Execute(serviceArgs []string, requests <-chan svc.Chang
 // to bridge service-mode child stdout and stderr.
 type windowsEventLog interface {
 	Info(eid uint32, msg string) error
+	Warning(eid uint32, msg string) error
 	Error(eid uint32, msg string) error
 }
 
@@ -202,11 +211,12 @@ func (s eventLogSink) Error(msg string) {
 	_ = s.elog.Error(3, msg)
 }
 
-// childResult keeps process wait errors separate from child output forwarding
-// errors so logging failures do not look like child process failures.
+// childResult separates fatal process and output errors from non-fatal
+// problems encountered while shutting down the child.
 type childResult struct {
-	waitErr   error
-	outputErr error
+	waitErr         error
+	outputErr       error
+	shutdownWarning error
 }
 
 // childProcess wraps the immediate child selected by the launcher. The child is
@@ -291,14 +301,21 @@ func (p *childProcess) shutdown(timeout time.Duration) childResult {
 	}
 
 	if err := sendShutdownSignal(p.cmd.Process); err != nil {
+		shutdownWarning := fmt.Errorf("failed to send graceful shutdown signal to child process: %w", err)
+		// A failed signal send is non-fatal if forcible termination succeeds.
+		// Recheck for a process exit, then kill immediately since the
+		// graceful shutdown signal was not delivered.
 		select {
 		case result := <-p.done:
-			result.waitErr = errors.Join(fmt.Errorf("failed to send graceful shutdown signal: %w", err), result.waitErr)
+			if isControlCExit(result.waitErr) {
+				result.waitErr = nil
+			}
+			result.shutdownWarning = shutdownWarning
 			return result
 		default:
 		}
 		result := p.killAndWait()
-		result.waitErr = errors.Join(fmt.Errorf("failed to send graceful shutdown signal: %w", err), result.waitErr)
+		result.shutdownWarning = shutdownWarning
 		return result
 	}
 
@@ -313,7 +330,13 @@ func (p *childProcess) shutdown(timeout time.Duration) childResult {
 		return result
 	case <-timer.C:
 		result := p.killAndWait()
-		result.waitErr = errors.Join(fmt.Errorf("child process did not exit within %s", timeout), result.waitErr)
+		if result.shutdownWarning != nil {
+			result.shutdownWarning = fmt.Errorf("child process did not exit within %s: %w", timeout, result.shutdownWarning)
+		} else if result.waitErr != nil {
+			result.shutdownWarning = fmt.Errorf("child process did not exit within %s and forcible termination failed", timeout)
+		} else {
+			result.shutdownWarning = fmt.Errorf("child process did not exit within %s and was forcibly terminated", timeout)
+		}
 		return result
 	}
 }
@@ -339,10 +362,47 @@ func (p *childProcess) killAndWait() childResult {
 	for _, closer := range p.outputClosers {
 		_ = closer.Close()
 	}
-	err := p.cmd.Process.Kill()
-	result := <-p.done
-	result.waitErr = errors.Join(err, result.waitErr)
+	killErr := p.cmd.Process.Kill()
+	return waitForKilledChild(killErr, p.done)
+}
+
+func waitForKilledChild(killErr error, done <-chan childResult) childResult {
+	// Return immediately when forcible termination fails to ensure launcher
+	// doesn't wait forever for an exit that will never come.
+	if killErr != nil && !isAlreadyTerminatedError(killErr) {
+		return childResult{waitErr: fmt.Errorf("failed to forcibly terminate child process: %w", killErr)}
+	}
+
+	result := <-done
+	if killErr != nil {
+		if isControlCExit(result.waitErr) {
+			result.waitErr = nil
+		}
+		result.shutdownWarning = errors.New("child exited before forcible termination was needed")
+		return result
+	}
+
+	if _, ok := errors.AsType[*exec.ExitError](result.waitErr); ok {
+		// A successful force-kill causes cmd.Wait to return an ExitError. That
+		// exit is expected during launcher-requested shutdown.
+		result.waitErr = nil
+	} else if result.waitErr != nil {
+		result.shutdownWarning = errors.New("forcible termination was requested but waiting for the child failed")
+	}
 	return result
+}
+
+func isAlreadyTerminatedError(err error) bool {
+	// Check for cases where process status is done or released
+	if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.EINVAL) {
+		return true
+	}
+
+	// After a process has terminated, calls to TerminateProcess fail with ERROR_ACCESS_DENIED
+	var syscallErr *os.SyscallError
+	return errors.As(err, &syscallErr) &&
+		syscallErr.Syscall == "TerminateProcess" &&
+		errors.Is(syscallErr.Err, windows.ERROR_ACCESS_DENIED)
 }
 
 // sendShutdownSignal uses the Windows console API because os.Interrupt is not

--- a/cmd/otelcollauncher/main_windows.go
+++ b/cmd/otelcollauncher/main_windows.go
@@ -300,8 +300,13 @@ func (p *childProcess) shutdown(timeout time.Duration) childResult {
 	default:
 	}
 
-	if err := sendShutdownSignal(p.cmd.Process); err != nil {
-		shutdownWarning := fmt.Errorf("failed to send graceful shutdown signal to child process: %w", err)
+	signalErr := sendShutdownSignal(p.cmd.Process)
+	return p.handleShutdownSignalResult(timeout, signalErr)
+}
+
+func (p *childProcess) handleShutdownSignalResult(timeout time.Duration, signalErr error) childResult {
+	if signalErr != nil {
+		shutdownWarning := fmt.Errorf("failed to send graceful shutdown signal to child process: %w", signalErr)
 		// A failed signal send is non-fatal if forcible termination succeeds.
 		// Recheck for a process exit, then kill immediately since the
 		// graceful shutdown signal was not delivered.

--- a/cmd/otelcollauncher/main_windows_test.go
+++ b/cmd/otelcollauncher/main_windows_test.go
@@ -209,35 +209,36 @@ func TestShutdown_PreservesAlreadyCompletedWaitError(t *testing.T) {
 }
 
 func TestShutdown_KillsImmediatelyWhenShutdownSignalFails(t *testing.T) {
+	signalErr := errors.New("signal failed")
 	readyFile := filepath.Join(t.TempDir(), "ready")
-	cmd := exec.Command(os.Args[0])
-	cmd.Env = append(os.Environ(),
-		launcherTestModeEnv+"="+ignoreInterruptsTestMode,
-		launcherTestReadyFileEnv+"="+readyFile,
-	)
-	require.NoError(t, cmd.Start())
+	child, err := startChild(launcher.Command{
+		Path: os.Args[0],
+		Env: append(os.Environ(),
+			launcherTestModeEnv+"="+ignoreInterruptsTestMode,
+			launcherTestReadyFileEnv+"="+readyFile,
+		),
+	}, nil)
+	require.NoError(t, err)
 	t.Cleanup(func() {
-		_ = cmd.Process.Kill()
+		_ = child.cmd.Process.Kill()
 	})
-
-	child := &childProcess{
-		cmd:  cmd,
-		done: waitForChild(nil, cmd.Wait),
-	}
 	require.Eventually(t, func() bool {
 		_, err := os.Stat(readyFile)
 		return err == nil
 	}, 10*time.Second, 10*time.Millisecond, "timed out waiting for child process to be ready")
 
-	result := waitForShutdown(t, child, gracefulShutdownTimeout)
+	result := waitForShutdown(t, func() childResult {
+		return child.handleShutdownSignalResult(gracefulShutdownTimeout, signalErr)
+	})
 
 	require.Error(t, result.shutdownWarning)
 	require.Contains(t, result.shutdownWarning.Error(), "failed to send graceful shutdown signal")
+	require.ErrorIs(t, result.shutdownWarning, signalErr)
 	require.NoError(t, result.outputErr)
 	require.NoError(t, result.waitErr)
 
-	require.NotNil(t, cmd.ProcessState)
-	require.True(t, cmd.ProcessState.Exited())
+	require.NotNil(t, child.cmd.ProcessState)
+	require.True(t, child.cmd.ProcessState.Exited())
 }
 
 func TestShutdown_KillsChildThatIgnoresShutdownSignal(t *testing.T) {
@@ -258,7 +259,9 @@ func TestShutdown_KillsChildThatIgnoresShutdownSignal(t *testing.T) {
 		return err == nil
 	}, 10*time.Second, 10*time.Millisecond, "timed out waiting for child process to be ready")
 
-	result := waitForShutdown(t, child, time.Second) // setting shorter grace period to not slow down tests too much
+	result := waitForShutdown(t, func() childResult {
+		return child.shutdown(time.Second) // setting shorter grace period to not slow down tests too much
+	})
 
 	require.Error(t, result.shutdownWarning)
 	require.Contains(t, result.shutdownWarning.Error(), "did not exit within 1s and was forcibly terminated")
@@ -269,12 +272,12 @@ func TestShutdown_KillsChildThatIgnoresShutdownSignal(t *testing.T) {
 	require.True(t, child.cmd.ProcessState.Exited())
 }
 
-func waitForShutdown(t *testing.T, child *childProcess, gracePeriod time.Duration) childResult {
+func waitForShutdown(t *testing.T, shutdown func() childResult) childResult {
 	t.Helper()
 
 	resultCh := make(chan childResult, 1)
 	go func() {
-		resultCh <- child.shutdown(gracePeriod)
+		resultCh <- shutdown()
 	}()
 
 	select {

--- a/cmd/otelcollauncher/main_windows_test.go
+++ b/cmd/otelcollauncher/main_windows_test.go
@@ -18,14 +18,46 @@ package main
 
 import (
 	"errors"
+	"os"
 	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/windows"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/signalfx/splunk-otel-collector/internal/opampsupervisor/launcher"
 )
+
+const (
+	launcherTestModeEnv      = "SPLUNK_OTEL_LAUNCHER_TEST_MODE"
+	launcherTestReadyFileEnv = "SPLUNK_OTEL_LAUNCHER_TEST_READY_FILE"
+	ignoreInterruptsTestMode = "ignore-interrupts"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv(launcherTestModeEnv) == ignoreInterruptsTestMode {
+		// Re-run this test binary as the child process so the test can verify the
+		// force shutdown. This will swallow shutdown signals so the process can only
+		// be terminated forcibly. Registers a handler rather than calling signal.Ignore
+		// since on Windows an unhandled console control event terminates the process
+		// with STATUS_CONTROL_C_EXIT instead of being ignored.
+		interrupts := make(chan os.Signal, 8)
+		signal.Notify(interrupts, os.Interrupt)
+		if err := os.WriteFile(os.Getenv(launcherTestReadyFileEnv), nil, 0o600); err != nil {
+			os.Exit(2)
+		}
+		for {
+			<-interrupts
+		}
+	}
+	os.Exit(m.Run())
+}
 
 func TestWaitForChildWaitsForOutputForwarding(t *testing.T) {
 	outputDone := make(chan error)
@@ -86,4 +118,170 @@ func TestIsControlCExitCode(t *testing.T) {
 
 func TestIsControlCExitWithEmptyExitError(t *testing.T) {
 	assert.False(t, isControlCExit(&exec.ExitError{}))
+}
+
+func TestWaitForKilledChild_PreservesUnexpectedWaitError(t *testing.T) {
+	waitErr := errors.New("wait failed")
+	done := make(chan childResult, 1)
+	done <- childResult{waitErr: waitErr}
+
+	result := waitForKilledChild(nil, done)
+
+	require.ErrorIs(t, result.waitErr, waitErr)
+	require.EqualError(t, result.shutdownWarning, "forcible termination was requested but waiting for the child failed")
+}
+
+func TestWaitForKilledChild_ReturnsImmediatelyWhenKillFails(t *testing.T) {
+	killErr := errors.New("kill failed")
+	resultCh := make(chan childResult, 1)
+	go func() {
+		resultCh <- waitForKilledChild(killErr, make(chan childResult))
+	}()
+
+	select {
+	case result := <-resultCh:
+		require.ErrorIs(t, result.waitErr, killErr)
+		require.NoError(t, result.shutdownWarning)
+	case <-time.After(time.Second):
+		t.Fatal("killAndWait blocked after the force-kill failed")
+	}
+}
+
+func TestWaitForKilledChild_PreservesAlreadyTerminatedWaitError(t *testing.T) {
+	tests := map[string]error{
+		"process done":          os.ErrProcessDone,
+		"process handle closed": syscall.EINVAL,
+		"process terminated": &os.SyscallError{
+			Syscall: "TerminateProcess",
+			Err:     windows.ERROR_ACCESS_DENIED,
+		},
+	}
+
+	for name, killErr := range tests {
+		t.Run(name, func(t *testing.T) {
+			waitErr := errors.New("wait failed")
+			done := make(chan childResult, 1)
+			done <- childResult{waitErr: waitErr}
+
+			result := waitForKilledChild(killErr, done)
+
+			require.ErrorIs(t, result.waitErr, waitErr)
+			require.EqualError(t, result.shutdownWarning, "child exited before forcible termination was needed")
+		})
+	}
+}
+
+func TestWaitForKilledChild_PreservesDuplicateHandleAccessDenied(t *testing.T) {
+	killErr := &os.SyscallError{
+		Syscall: "DuplicateHandle",
+		Err:     windows.ERROR_ACCESS_DENIED,
+	}
+
+	result := waitForKilledChild(killErr, make(chan childResult))
+
+	require.ErrorIs(t, result.waitErr, windows.ERROR_ACCESS_DENIED)
+	require.NoError(t, result.shutdownWarning)
+}
+
+func TestWaitForKilledChild_SuppressesExpectedForcedExit(t *testing.T) {
+	done := make(chan childResult, 1)
+	done <- childResult{waitErr: &exec.ExitError{}}
+
+	result := waitForKilledChild(nil, done)
+
+	require.NoError(t, result.waitErr)
+	require.NoError(t, result.shutdownWarning)
+}
+
+func TestShutdown_PreservesAlreadyCompletedWaitError(t *testing.T) {
+	waitErr := errors.New("wait failed")
+	done := make(chan childResult, 1)
+	done <- childResult{waitErr: waitErr}
+
+	child := &childProcess{
+		cmd:  &exec.Cmd{Process: &os.Process{Pid: 1234}},
+		done: done,
+	}
+	result := child.shutdown(time.Hour)
+
+	require.ErrorIs(t, result.waitErr, waitErr)
+	require.NoError(t, result.shutdownWarning)
+}
+
+func TestShutdown_KillsImmediatelyWhenShutdownSignalFails(t *testing.T) {
+	readyFile := filepath.Join(t.TempDir(), "ready")
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = append(os.Environ(),
+		launcherTestModeEnv+"="+ignoreInterruptsTestMode,
+		launcherTestReadyFileEnv+"="+readyFile,
+	)
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+	})
+
+	child := &childProcess{
+		cmd:  cmd,
+		done: waitForChild(nil, cmd.Wait),
+	}
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(readyFile)
+		return err == nil
+	}, 10*time.Second, 10*time.Millisecond, "timed out waiting for child process to be ready")
+
+	result := waitForShutdown(t, child, gracefulShutdownTimeout)
+
+	require.Error(t, result.shutdownWarning)
+	require.Contains(t, result.shutdownWarning.Error(), "failed to send graceful shutdown signal")
+	require.NoError(t, result.outputErr)
+	require.NoError(t, result.waitErr)
+
+	require.NotNil(t, cmd.ProcessState)
+	require.True(t, cmd.ProcessState.Exited())
+}
+
+func TestShutdown_KillsChildThatIgnoresShutdownSignal(t *testing.T) {
+	readyFile := filepath.Join(t.TempDir(), "ready")
+	child, err := startChild(launcher.Command{
+		Path: os.Args[0],
+		Env: append(os.Environ(),
+			launcherTestModeEnv+"="+ignoreInterruptsTestMode,
+			launcherTestReadyFileEnv+"="+readyFile,
+		),
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = child.cmd.Process.Kill()
+	})
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(readyFile)
+		return err == nil
+	}, 10*time.Second, 10*time.Millisecond, "timed out waiting for child process to be ready")
+
+	result := waitForShutdown(t, child, time.Second) // setting shorter grace period to not slow down tests too much
+
+	require.Error(t, result.shutdownWarning)
+	require.Contains(t, result.shutdownWarning.Error(), "did not exit within 1s and was forcibly terminated")
+	require.NoError(t, result.outputErr)
+	require.NoError(t, result.waitErr)
+
+	require.NotNil(t, child.cmd.ProcessState)
+	require.True(t, child.cmd.ProcessState.Exited())
+}
+
+func waitForShutdown(t *testing.T, child *childProcess, gracePeriod time.Duration) childResult {
+	t.Helper()
+
+	resultCh := make(chan childResult, 1)
+	go func() {
+		resultCh <- child.shutdown(gracePeriod)
+	}()
+
+	select {
+	case result := <-resultCh:
+		return result
+	case <-time.After(10 * time.Second):
+		t.Fatal("shutdown did not terminate the child process")
+		return childResult{}
+	}
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- Add the launcher into a Job Object to ensure child processes terminate if launcher crashes
- Cleaned up launcher handling of force kill of child processes (ensure kill error doesn't cause hanging, report successful shutdown if kill works)

**Testing:** <Describe what testing was performed and which tests were added.>
- Tested local dev build by simulating launcher crash via taskkill, verified all child processes stopped:
```
// Direct collector mode
PS C:\supervisor_poc\windows_launcher_tests> Get-CimInstance Win32_Service -Filter "Name='$Svc'" | Select-Object Name, State, PathName
Name                  State   PathName
----                  -----   --------
splunk-otel-collector Running "C:\Program Files\Splunk\OpenTelemetry Collector\otelcollauncher.exe" --config "C:\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml"

PS C:\supervisor_poc\windows_launcher_tests> Get-CimInstance Win32_Process | Where-Object {$_.Name -in @("otelcollauncher.exe", "otelcol.exe", "opampsupervisor.exe")} | Select-Object Name, ProcessId, ParentProcessId, CommandLine
Name                ProcessId ParentProcessId CommandLine
----                --------- --------------- -----------
otelcollauncher.exe     26636            1692 "C:\Program Files\Splunk\OpenTelemetry Collector\otelcollauncher.exe" --config "C:\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml"
otelcol.exe             22848           26636 "C:\Program Files\Splunk\OpenTelemetry Collector\otelcol.exe" --config "C:\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml"

PS C:\supervisor_poc\windows_launcher_tests> taskkill /f /pid 26636
SUCCESS: The process with PID 26636 has been terminated.
PS C:\supervisor_poc\windows_launcher_tests> Get-CimInstance Win32_Process | Where-Object {$_.Name -in @("otelcollauncher.exe", "otelcol.exe", "opampsupervisor.exe")} | Select-Object Name, ProcessId, ParentProcessId, CommandLine
PS C:\supervisor_poc\windows_launcher_tests> Get-CimInstance Win32_Service -Filter "Name='$Svc'" | Select-Object Name, State, PathName
Name                  State   PathName
----                  -----   --------
splunk-otel-collector Stopped "C:\Program Files\Splunk\OpenTelemetry Collector\otelcollauncher.exe" --config "C:\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml"

// OpAMP Supervisor mode 
PS C:\supervisor_poc\windows_launcher_tests> Get-CimInstance Win32_Process | Where-Object {$_.Name -in @("otelcollauncher.exe", "otelcol.exe", "opampsupervisor.exe")} | Select-Object Name, ProcessId, ParentProcessId, CommandLine
Name                ProcessId ParentProcessId CommandLine
----                --------- --------------- -----------
otelcollauncher.exe     13776            1692 "C:\Program Files\Splunk\OpenTelemetry Collector\otelcollauncher.exe" --config "C:\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml"
opampsupervisor.exe     22568           13776 "C:\Program Files\Splunk\OpenTelemetry Collector\opampsupervisor.exe" --config "C:\ProgramData\Splunk\OpenTelemetry Collector\supervisor\supervisor_runtime_config.yaml"
otelcol.exe             22604           22568 "C:\Program Files\Splunk\OpenTelemetry Collector\otelcol.exe" --config "C:\ProgramData\Splunk\OpenTelemetry Collector\supervisor\effective.yaml" --feature-gates service.Allo...

PS C:\supervisor_poc\windows_launcher_tests> taskkill /f /pid 13776
SUCCESS: The process with PID 13776 has been terminated.
PS C:\supervisor_poc\windows_launcher_tests> Get-CimInstance Win32_Process | Where-Object {$_.Name -in @("otelcollauncher.exe", "otelcol.exe", "opampsupervisor.exe")} | Select-Object Name, ProcessId, ParentProcessId, CommandLine
PS C:\supervisor_poc\windows_launcher_tests> Get-CimInstance Win32_Service -Filter "Name='$Svc'" | Select-Object Name, State, PathName
Name                  State   PathName
----                  -----   --------
splunk-otel-collector Stopped "C:\Program Files\Splunk\OpenTelemetry Collector\otelcollauncher.exe" --config "C:\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml" 
```
- Verified with a custom exe that ignores shutdown signals that launcher is able to forcibly terminate `otelcol`