### PR TITLE
[chore][ci] Verify versions.yaml with multimod on every PR

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,6 +30,16 @@ jobs:
             exit 1
           fi
 
+  multimod-verify:
+    name: multimod-verify
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup-environment
+
+      - name: multimod-verify
+        run: make multimod-verify
+
   gofmt:
     name: gofmt
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -441,6 +441,11 @@ chlog-preview:
 chlog-update:
 	$(CHLOGGEN) update -v $(VERSION)
 
+.PHONY: multimod-verify
+multimod-verify:
+	@echo "Validating versions.yaml"
+	$(MULTIMOD) verify
+
 .PHONY: multimod-prerelease
 multimod-prerelease:
 	$(MULTIMOD) prerelease -s=true -b=false -v ./versions.yaml -m $(MODSET)


### PR DESCRIPTION
Add a `multimod-verify` make target (`multimod verify`) and run it as a job in `build-and-test`, matching core and contrib. `multimod verify` fails if any repo module is missing from `versions.yaml` or any listed module is missing from the repo, and validates the version strings.
